### PR TITLE
Consolidate advanced services hardening, tests, and auth rollout design

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AuditController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuditController.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuditController : ControllerBase
+{
+    private readonly HistoryService _historyService;
+
+    public AuditController(HistoryService historyService)
+    {
+        _historyService = historyService;
+    }
+
+    [HttpGet("boards/{boardId}")]
+    public async Task<IActionResult> GetBoardHistory(Guid boardId, [FromQuery] int limit = 100)
+    {
+        var result = await _historyService.GetBoardHistoryAsync(boardId, limit);
+        if (!result.IsSuccess)
+            return MapError(result.ErrorCode, result.ErrorMessage);
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("entities/{entityType}/{entityId}")]
+    public async Task<IActionResult> GetEntityHistory(string entityType, Guid entityId, [FromQuery] int limit = 100)
+    {
+        var result = await _historyService.GetEntityHistoryAsync(entityType, entityId, limit);
+        if (!result.IsSuccess)
+            return MapError(result.ErrorCode, result.ErrorMessage);
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("users/{userId}")]
+    public async Task<IActionResult> GetUserHistory(Guid userId, [FromQuery] int limit = 100)
+    {
+        var result = await _historyService.GetUserHistoryAsync(userId, limit);
+        if (!result.IsSuccess)
+            return MapError(result.ErrorCode, result.ErrorMessage);
+
+        return Ok(result.Value);
+    }
+
+    private IActionResult MapError(string errorCode, string message)
+    {
+        return errorCode switch
+        {
+            "ValidationError" => BadRequest(new { errorCode, message }),
+            "NotFound" => NotFound(new { errorCode, message }),
+            _ => Problem(message, statusCode: 500)
+        };
+    }
+}

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+public record ChangePasswordRequest(Guid UserId, string CurrentPassword, string NewPassword);
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    private readonly AuthenticationService _authService;
+
+    public AuthController(AuthenticationService authService)
+    {
+        _authService = authService;
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginDto dto)
+    {
+        var result = await _authService.LoginAsync(dto);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] CreateUserDto dto)
+    {
+        var result = await _authService.RegisterAsync(dto);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost("change-password")]
+    public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request)
+    {
+        var result = await _authService.ChangePasswordAsync(request.UserId, request.CurrentPassword, request.NewPassword);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return NoContent();
+    }
+}

--- a/backend/src/Taskdeck.Api/Controllers/BoardAccessController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/BoardAccessController.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+[ApiController]
+[Route("api/boards/{boardId}/access")]
+public class BoardAccessController : ControllerBase
+{
+    private readonly BoardAccessService _boardAccessService;
+
+    public BoardAccessController(BoardAccessService boardAccessService)
+    {
+        _boardAccessService = boardAccessService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetBoardAccess(Guid boardId)
+    {
+        var result = await _boardAccessService.GetBoardAccessListAsync(boardId);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> GrantAccess(Guid boardId, [FromBody] GrantAccessDto dto, [FromQuery] Guid grantedBy)
+    {
+        var dtoWithBoardId = dto with { BoardId = boardId };
+        var result = await _boardAccessService.GrantAccessAsync(dtoWithBoardId, grantedBy);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPut("{accessId}")]
+    public async Task<IActionResult> UpdateAccess(Guid boardId, Guid accessId, [FromBody] UpdateAccessDto dto, [FromQuery] Guid updatedBy)
+    {
+        var result = await _boardAccessService.UpdateAccessAsync(boardId, accessId, dto, updatedBy);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpDelete("{accessId}")]
+    public async Task<IActionResult> RevokeAccess(Guid boardId, Guid accessId, [FromQuery] Guid revokedBy)
+    {
+        var result = await _boardAccessService.RevokeAccessAsync(boardId, accessId, revokedBy);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return NoContent();
+    }
+}

--- a/backend/src/Taskdeck.Api/Controllers/ExportController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/ExportController.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+[ApiController]
+[Route("api")]
+public class ExportController : ControllerBase
+{
+    private readonly ExportImportService _exportImportService;
+
+    public ExportController(ExportImportService exportImportService)
+    {
+        _exportImportService = exportImportService;
+    }
+
+    [HttpGet("export/boards/{boardId}")]
+    public async Task<IActionResult> ExportBoard(Guid boardId, [FromQuery] Guid userId)
+    {
+        var result = await _exportImportService.ExportBoardAsync(boardId, userId);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("export/boards/{boardId}/json")]
+    public async Task<IActionResult> ExportBoardAsJson(Guid boardId, [FromQuery] Guid userId)
+    {
+        var result = await _exportImportService.ExportBoardToJsonAsync(boardId, userId);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Content(result.Value, "application/json");
+    }
+
+    [HttpPost("import/boards")]
+    public async Task<IActionResult> ImportBoard([FromBody] ImportBoardDto dto, [FromQuery] Guid userId)
+    {
+        var result = await _exportImportService.ImportBoardAsync(dto, userId);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost("import/boards/json")]
+    public async Task<IActionResult> ImportBoardFromJson([FromBody] JsonElement json, [FromQuery] Guid userId)
+    {
+        var result = await _exportImportService.ImportBoardFromJsonAsync(json.GetRawText(), userId);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+}

--- a/backend/src/Taskdeck.Api/Controllers/LlmQueueController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/LlmQueueController.cs
@@ -1,0 +1,105 @@
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Enums;
+
+namespace Taskdeck.Api.Controllers;
+
+[ApiController]
+[Route("api/llm-queue")]
+public class LlmQueueController : ControllerBase
+{
+    private readonly LlmQueueService _llmQueueService;
+
+    public LlmQueueController(LlmQueueService llmQueueService)
+    {
+        _llmQueueService = llmQueueService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> AddToQueue([FromBody] CreateLlmRequestDto dto)
+    {
+        var result = await _llmQueueService.AddToQueueAsync(dto);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("user/{userId}")]
+    public async Task<IActionResult> GetUserQueue(Guid userId)
+    {
+        var result = await _llmQueueService.GetUserQueueAsync(userId);
+        return result.IsSuccess ? Ok(result.Value) : Problem(result.ErrorMessage, statusCode: 500);
+    }
+
+    [HttpGet("status/{status}")]
+    public async Task<IActionResult> GetByStatus(string status)
+    {
+        if (!Enum.TryParse<RequestStatus>(status, true, out var parsedStatus) || !Enum.IsDefined(parsedStatus))
+            return BadRequest(new { errorCode = "ValidationError", message = $"Invalid status value: {status}" });
+
+        var result = await _llmQueueService.GetQueueByStatusAsync(parsedStatus);
+        return result.IsSuccess ? Ok(result.Value) : Problem(result.ErrorMessage, statusCode: 500);
+    }
+
+    [HttpPost("{requestId}/cancel")]
+    public async Task<IActionResult> CancelRequest(Guid requestId, [FromQuery] Guid userId)
+    {
+        var result = await _llmQueueService.CancelRequestAsync(requestId, userId);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost("process-next")]
+    public async Task<IActionResult> ProcessNext()
+    {
+        var result = await _llmQueueService.ProcessNextRequestAsync();
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("stats")]
+    public async Task<IActionResult> GetQueueStats()
+    {
+        var result = await _llmQueueService.GetQueueStatsAsync();
+        return result.IsSuccess ? Ok(result.Value) : Problem(result.ErrorMessage, statusCode: 500);
+    }
+}

--- a/backend/src/Taskdeck.Api/Controllers/UsersController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/UsersController.cs
@@ -1,0 +1,150 @@
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly UserService _userService;
+
+    public UsersController(UserService userService)
+    {
+        _userService = userService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetUsers()
+    {
+        var result = await _userService.ListUsersAsync();
+        return result.IsSuccess ? Ok(result.Value) : Problem(result.ErrorMessage, statusCode: 500);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetUser(Guid id)
+    {
+        var result = await _userService.GetUserByIdAsync(id);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpGet("by-username/{username}")]
+    public async Task<IActionResult> GetUserByUsername(string username)
+    {
+        var result = await _userService.GetUserByUsernameAsync(username);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateUser([FromBody] CreateUserDto dto)
+    {
+        var result = await _userService.CreateUserAsync(dto);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return CreatedAtAction(nameof(GetUser), new { id = result.Value.Id }, result.Value);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateUser(Guid id, [FromBody] UpdateUserDto dto)
+    {
+        var result = await _userService.UpdateUserAsync(id, dto);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    [HttpPost("{id}/deactivate")]
+    public async Task<IActionResult> DeactivateUser(Guid id)
+    {
+        var result = await _userService.DeactivateUserAsync(id);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return NoContent();
+    }
+
+    [HttpPost("{id}/activate")]
+    public async Task<IActionResult> ActivateUser(Guid id)
+    {
+        var result = await _userService.ActivateUserAsync(id);
+
+        if (!result.IsSuccess)
+        {
+            return result.ErrorCode switch
+            {
+                "NotFound" => NotFound(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "ValidationError" => BadRequest(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "AuthenticationFailed" => Unauthorized(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Forbidden" => StatusCode(403, new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                "Conflict" => Conflict(new { errorCode = result.ErrorCode, message = result.ErrorMessage }),
+                _ => Problem(result.ErrorMessage, statusCode: 500)
+            };
+        }
+
+        return NoContent();
+    }
+}

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -1,4 +1,7 @@
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
 using Taskdeck.Application.Services;
 using Taskdeck.Infrastructure;
 using Taskdeck.Infrastructure.Persistence;
@@ -18,6 +21,39 @@ builder.Services.AddScoped<BoardService>();
 builder.Services.AddScoped<ColumnService>();
 builder.Services.AddScoped<CardService>();
 builder.Services.AddScoped<LabelService>();
+builder.Services.AddScoped<AuthenticationService>();
+builder.Services.AddScoped<AuthorizationService>();
+builder.Services.AddScoped<UserService>();
+builder.Services.AddScoped<BoardAccessService>();
+builder.Services.AddScoped<ExportImportService>();
+builder.Services.AddScoped<LlmQueueService>();
+builder.Services.AddScoped<HistoryService>();
+
+// Add JwtSettings (required by AuthenticationService)
+var jwtSettings = builder.Configuration.GetSection("Jwt").Get<JwtSettings>() ?? new JwtSettings();
+builder.Services.AddSingleton(jwtSettings);
+
+// Add JWT Authentication
+if (!string.IsNullOrWhiteSpace(jwtSettings.SecretKey) &&
+    jwtSettings.SecretKey.Length >= 32 &&
+    !string.IsNullOrWhiteSpace(jwtSettings.Issuer) &&
+    !string.IsNullOrWhiteSpace(jwtSettings.Audience))
+{
+    builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        .AddJwtBearer(options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = jwtSettings.Issuer,
+                ValidAudience = jwtSettings.Audience,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SecretKey))
+            };
+        });
+}
 
 // Add CORS
 builder.Services.AddCors(options =>
@@ -47,6 +83,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseCors("AllowFrontend");
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/backend/src/Taskdeck.Api/Taskdeck.Api.csproj
+++ b/backend/src/Taskdeck.Api/Taskdeck.Api.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/backend/src/Taskdeck.Api/appsettings.Development.json
+++ b/backend/src/Taskdeck.Api/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Debug",
       "Microsoft.AspNetCore": "Information"
     }
+  },
+  "Jwt": {
+    "SecretKey": "TaskdeckDevelopmentOnlySecretKeyChangeMe123!",
+    "Issuer": "Taskdeck",
+    "Audience": "TaskdeckUsers",
+    "ExpirationMinutes": 1440
   }
 }

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -1,0 +1,241 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class AuthenticationService : IAuthenticationService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly JwtSettings _jwtSettings;
+
+    public AuthenticationService(IUnitOfWork unitOfWork, JwtSettings jwtSettings)
+    {
+        _unitOfWork = unitOfWork;
+        _jwtSettings = jwtSettings;
+    }
+
+    public async Task<Result<AuthResultDto>> LoginAsync(LoginDto dto)
+    {
+        try
+        {
+            if (!TryValidateJwtSettings(out var jwtValidationError))
+                return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, jwtValidationError);
+
+            var user = await _unitOfWork.Users.GetByUsernameAsync(dto.UsernameOrEmail);
+            user ??= await _unitOfWork.Users.GetByEmailAsync(dto.UsernameOrEmail);
+
+            if (user == null)
+                return Result.Failure<AuthResultDto>(ErrorCodes.AuthenticationFailed, "Invalid username/email or password");
+
+            if (!user.IsActive)
+                return Result.Failure<AuthResultDto>(ErrorCodes.Forbidden, "User account is inactive");
+
+            if (!BCrypt.Net.BCrypt.Verify(dto.Password, user.PasswordHash))
+                return Result.Failure<AuthResultDto>(ErrorCodes.AuthenticationFailed, "Invalid username/email or password");
+
+            var token = GenerateJwtToken(user);
+            return Result.Success(new AuthResultDto(token, MapToDto(user)));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<AuthResultDto>(ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, $"Login failed: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<AuthResultDto>> RegisterAsync(CreateUserDto dto)
+    {
+        try
+        {
+            if (!TryValidateJwtSettings(out var jwtValidationError))
+                return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, jwtValidationError);
+
+            var exists = await _unitOfWork.Users.ExistsAsync(dto.Username, dto.Email);
+            if (exists)
+                return Result.Failure<AuthResultDto>(ErrorCodes.Conflict, "A user with that username or email already exists");
+
+            var passwordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password);
+            var user = new User(dto.Username, dto.Email, passwordHash, dto.DefaultRole);
+
+            await _unitOfWork.Users.AddAsync(user);
+            await _unitOfWork.SaveChangesAsync();
+
+            var token = GenerateJwtToken(user);
+            return Result.Success(new AuthResultDto(token, MapToDto(user)));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<AuthResultDto>(ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, $"Registration failed: {ex.Message}");
+        }
+    }
+
+    public async Task<Result> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword)
+    {
+        try
+        {
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+            if (!user.IsActive)
+                return Result.Failure(ErrorCodes.Forbidden, "User account is inactive");
+
+            if (!BCrypt.Net.BCrypt.Verify(currentPassword, user.PasswordHash))
+                return Result.Failure(ErrorCodes.AuthenticationFailed, "Current password is incorrect");
+
+            var newHash = BCrypt.Net.BCrypt.HashPassword(newPassword);
+            user.UpdatePassword(newHash);
+
+            await _unitOfWork.SaveChangesAsync();
+            return Result.Success();
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<UserDto>> ValidateTokenAsync(string token)
+    {
+        try
+        {
+            if (!TryValidateJwtSettings(out var jwtValidationError))
+                return Result.Failure<UserDto>(ErrorCodes.UnexpectedError, jwtValidationError);
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.UTF8.GetBytes(_jwtSettings.SecretKey);
+
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(key),
+                ValidateIssuer = true,
+                ValidIssuer = _jwtSettings.Issuer,
+                ValidateAudience = true,
+                ValidAudience = _jwtSettings.Audience,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.Zero
+            };
+
+            var result = await tokenHandler.ValidateTokenAsync(token, validationParameters);
+            if (!result.IsValid)
+                return Result.Failure<UserDto>(ErrorCodes.Unauthorized, "Invalid or expired token");
+
+            var userIdClaim = result.ClaimsIdentity.FindFirst(JwtRegisteredClaimNames.Sub)
+                              ?? result.ClaimsIdentity.FindFirst(ClaimTypes.NameIdentifier);
+
+            if (userIdClaim == null || !Guid.TryParse(userIdClaim.Value, out var userId))
+                return Result.Failure<UserDto>(ErrorCodes.Unauthorized, "Invalid token claims");
+
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure<UserDto>(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+            if (!user.IsActive)
+                return Result.Failure<UserDto>(ErrorCodes.Forbidden, "User account is inactive");
+
+            return Result.Success(MapToDto(user));
+        }
+        catch (SecurityTokenException)
+        {
+            return Result.Failure<UserDto>(ErrorCodes.Unauthorized, "Invalid or expired token");
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<UserDto>(ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<UserDto>(ErrorCodes.UnexpectedError, $"Token validation failed: {ex.Message}");
+        }
+    }
+
+    private string GenerateJwtToken(User user)
+    {
+        if (!TryValidateJwtSettings(out var jwtValidationError))
+            throw new DomainException(ErrorCodes.UnexpectedError, jwtValidationError);
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.SecretKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new Claim("username", user.Username),
+            new Claim("email", user.Email),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtSettings.Issuer,
+            audience: _jwtSettings.Audience,
+            claims: claims,
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(_jwtSettings.ExpirationMinutes),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private bool TryValidateJwtSettings(out string errorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(_jwtSettings.SecretKey))
+        {
+            errorMessage = "JWT configuration is missing a SecretKey";
+            return false;
+        }
+
+        if (_jwtSettings.SecretKey.Length < 32)
+        {
+            errorMessage = "JWT SecretKey must be at least 32 characters";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_jwtSettings.Issuer))
+        {
+            errorMessage = "JWT configuration is missing an Issuer";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(_jwtSettings.Audience))
+        {
+            errorMessage = "JWT configuration is missing an Audience";
+            return false;
+        }
+
+        if (_jwtSettings.ExpirationMinutes <= 0)
+        {
+            errorMessage = "JWT ExpirationMinutes must be greater than 0";
+            return false;
+        }
+
+        errorMessage = string.Empty;
+        return true;
+    }
+
+    private static UserDto MapToDto(User user)
+    {
+        return new UserDto(
+            user.Id,
+            user.Username,
+            user.Email,
+            user.DefaultRole,
+            user.IsActive,
+            user.CreatedAt,
+            user.UpdatedAt);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/AuthorizationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthorizationService.cs
@@ -1,0 +1,81 @@
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class AuthorizationService : IAuthorizationService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AuthorizationService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<bool>> CanReadBoardAsync(Guid userId, Guid boardId)
+    {
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board is null)
+            return Result.Failure<bool>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        if (board.OwnerId is null || board.OwnerId == userId)
+            return Result.Success(true);
+
+        var access = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(boardId, userId);
+        return Result.Success(access is not null && access.CanRead());
+    }
+
+    public async Task<Result<bool>> CanWriteBoardAsync(Guid userId, Guid boardId)
+    {
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board is null)
+            return Result.Failure<bool>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        if (board.OwnerId is null || board.OwnerId == userId)
+            return Result.Success(true);
+
+        var access = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(boardId, userId);
+        return Result.Success(access is not null && access.CanWrite());
+    }
+
+    public async Task<Result<bool>> CanManageBoardAccessAsync(Guid userId, Guid boardId)
+    {
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board is null)
+            return Result.Failure<bool>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        if (board.OwnerId is null || board.OwnerId == userId)
+            return Result.Success(true);
+
+        var access = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(boardId, userId);
+        return Result.Success(access is not null && access.CanManageAccess());
+    }
+
+    public async Task<Result<bool>> CanDeleteBoardAsync(Guid userId, Guid boardId)
+    {
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board is null)
+            return Result.Failure<bool>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        if (board.OwnerId is null || board.OwnerId == userId)
+            return Result.Success(true);
+
+        var access = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(boardId, userId);
+        return Result.Success(access is not null && access.CanDelete());
+    }
+
+    public async Task<Result<UserRole?>> GetUserRoleForBoardAsync(Guid userId, Guid boardId)
+    {
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board is null)
+            return Result.Failure<UserRole?>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        if (board.OwnerId is null || board.OwnerId == userId)
+            return Result.Success<UserRole?>(UserRole.Owner);
+
+        var access = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(boardId, userId);
+        return Result.Success<UserRole?>(access?.Role);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/BoardAccessService.cs
+++ b/backend/src/Taskdeck.Application/Services/BoardAccessService.cs
@@ -1,0 +1,163 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class BoardAccessService : IBoardAccessService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public BoardAccessService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<BoardAccessDto>> GrantAccessAsync(GrantAccessDto dto, Guid grantedBy)
+    {
+        try
+        {
+            var board = await _unitOfWork.Boards.GetByIdAsync(dto.BoardId);
+            if (board == null)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.NotFound, $"Board with ID {dto.BoardId} not found");
+
+            var grantingUser = await _unitOfWork.Users.GetByIdAsync(grantedBy);
+            if (grantingUser == null)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.NotFound, $"Granting user with ID {grantedBy} not found");
+
+            var canManage = await EnsureCanManageBoardAccessAsync(board, grantedBy);
+            if (!canManage.IsSuccess)
+                return Result.Failure<BoardAccessDto>(canManage.ErrorCode, canManage.ErrorMessage);
+
+            var user = await _unitOfWork.Users.GetByIdAsync(dto.UserId);
+            if (user == null)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.NotFound, $"User with ID {dto.UserId} not found");
+
+            var existingAccess = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(dto.BoardId, dto.UserId);
+            if (existingAccess != null)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.Conflict, $"User already has access to this board");
+
+            var access = new BoardAccess(dto.BoardId, dto.UserId, dto.Role, grantedBy);
+            await _unitOfWork.BoardAccesses.AddAsync(access);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(MapToDto(access));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<BoardAccessDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<BoardAccessDto>> UpdateAccessAsync(Guid boardId, Guid accessId, UpdateAccessDto dto, Guid updatedBy)
+    {
+        try
+        {
+            var access = await _unitOfWork.BoardAccesses.GetByIdAsync(accessId);
+            if (access == null || access.BoardId != boardId)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.NotFound, $"Board access with ID {accessId} not found");
+
+            var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+            if (board == null)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+            var updatingUser = await _unitOfWork.Users.GetByIdAsync(updatedBy);
+            if (updatingUser == null)
+                return Result.Failure<BoardAccessDto>(ErrorCodes.NotFound, $"Updating user with ID {updatedBy} not found");
+
+            var canManage = await EnsureCanManageBoardAccessAsync(board, updatedBy);
+            if (!canManage.IsSuccess)
+                return Result.Failure<BoardAccessDto>(canManage.ErrorCode, canManage.ErrorMessage);
+
+            access.UpdateRole(dto.Role, updatedBy);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(MapToDto(access));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<BoardAccessDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result> RevokeAccessAsync(Guid boardId, Guid accessId, Guid revokedBy)
+    {
+        var access = await _unitOfWork.BoardAccesses.GetByIdAsync(accessId);
+        if (access == null || access.BoardId != boardId)
+            return Result.Failure(ErrorCodes.NotFound, $"Board access with ID {accessId} not found");
+
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board == null)
+            return Result.Failure(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        var revokingUser = await _unitOfWork.Users.GetByIdAsync(revokedBy);
+        if (revokingUser == null)
+            return Result.Failure(ErrorCodes.NotFound, $"Revoking user with ID {revokedBy} not found");
+
+        var canManage = await EnsureCanManageBoardAccessAsync(board, revokedBy);
+        if (!canManage.IsSuccess)
+            return Result.Failure(canManage.ErrorCode, canManage.ErrorMessage);
+
+        await _unitOfWork.BoardAccesses.DeleteAsync(access);
+        await _unitOfWork.SaveChangesAsync();
+
+        return Result.Success();
+    }
+
+    public async Task<Result<IEnumerable<BoardAccessDto>>> GetBoardAccessListAsync(Guid boardId)
+    {
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId);
+        if (board == null)
+            return Result.Failure<IEnumerable<BoardAccessDto>>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+        var accesses = await _unitOfWork.BoardAccesses.GetByBoardIdAsync(boardId);
+        return Result.Success(accesses.Select(MapToDto));
+    }
+
+    public async Task<Result<IEnumerable<BoardDto>>> GetUserBoardsAsync(Guid userId)
+    {
+        var user = await _unitOfWork.Users.GetByIdAsync(userId);
+        if (user == null)
+            return Result.Failure<IEnumerable<BoardDto>>(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+        var accesses = await _unitOfWork.BoardAccesses.GetByUserIdAsync(userId);
+        return Result.Success(accesses.Select(a => MapToBoardDto(a.Board)));
+    }
+
+    private async Task<Result> EnsureCanManageBoardAccessAsync(Board board, Guid actingUserId)
+    {
+        // Backward compatibility: legacy boards without owner remain open.
+        if (board.OwnerId is null || board.OwnerId == actingUserId)
+            return Result.Success();
+
+        var actingAccess = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(board.Id, actingUserId);
+        if (actingAccess == null || !actingAccess.CanManageAccess())
+            return Result.Failure(ErrorCodes.Forbidden, "You do not have permission to manage board access");
+
+        return Result.Success();
+    }
+
+    private static BoardAccessDto MapToDto(BoardAccess access)
+    {
+        return new BoardAccessDto(
+            access.Id,
+            access.BoardId,
+            access.UserId,
+            access.Role,
+            access.GrantedBy,
+            access.GrantedAt);
+    }
+
+    private static BoardDto MapToBoardDto(Board board)
+    {
+        return new BoardDto(
+            board.Id,
+            board.Name,
+            board.Description,
+            board.IsArchived,
+            board.CreatedAt,
+            board.UpdatedAt);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/ExportImportService.cs
+++ b/backend/src/Taskdeck.Application/Services/ExportImportService.cs
@@ -1,0 +1,358 @@
+using System.Text.Json;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class ExportImportService : IExportImportService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public ExportImportService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<ExportBoardDto>> ExportBoardAsync(Guid boardId, Guid userId)
+    {
+        try
+        {
+            var requestingUser = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (requestingUser == null)
+                return Result.Failure<ExportBoardDto>(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+            var board = await _unitOfWork.Boards.GetByIdWithDetailsAsync(boardId);
+            if (board == null)
+                return Result.Failure<ExportBoardDto>(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
+
+            var canRead = await CanUserReadBoardAsync(board, userId);
+            if (!canRead)
+                return Result.Failure<ExportBoardDto>(ErrorCodes.Forbidden, "You do not have access to export this board");
+
+            var accesses = await _unitOfWork.BoardAccesses.GetByBoardIdAsync(boardId);
+
+            var boardDto = MapToBoardDto(board);
+
+            var columns = board.Columns
+                .OrderBy(c => c.Position)
+                .Select(c => new ColumnDto(
+                    c.Id,
+                    c.BoardId,
+                    c.Name,
+                    c.Position,
+                    c.WipLimit,
+                    c.Cards.Count,
+                    c.CreatedAt,
+                    c.UpdatedAt))
+                .ToList();
+
+            var cards = board.Columns
+                .OrderBy(c => c.Position)
+                .SelectMany(c => c.Cards.OrderBy(card => card.Position))
+                .Select(MapToCardDto)
+                .ToList();
+
+            var labels = board.Labels
+                .Select(l => new LabelDto(
+                    l.Id,
+                    l.BoardId,
+                    l.Name,
+                    l.ColorHex,
+                    l.CreatedAt,
+                    l.UpdatedAt))
+                .ToList();
+
+            var accessDtos = accesses
+                .Select(a => new BoardAccessDto(
+                    a.Id,
+                    a.BoardId,
+                    a.UserId,
+                    a.Role,
+                    a.GrantedBy,
+                    a.GrantedAt))
+                .ToList();
+
+            var exportDto = new ExportBoardDto(
+                boardDto,
+                columns,
+                cards,
+                labels,
+                accessDtos,
+                DateTimeOffset.UtcNow,
+                requestingUser.Username);
+
+            return Result.Success(exportDto);
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<ExportBoardDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<string>> ExportBoardToJsonAsync(Guid boardId, Guid userId)
+    {
+        var exportResult = await ExportBoardAsync(boardId, userId);
+        if (!exportResult.IsSuccess)
+            return Result.Failure<string>(exportResult.ErrorCode, exportResult.ErrorMessage);
+
+        var json = JsonSerializer.Serialize(exportResult.Value, JsonOptions);
+        return Result.Success(json);
+    }
+
+    public async Task<Result<ImportResultDto>> ImportBoardAsync(ImportBoardDto dto, Guid userId)
+    {
+        try
+        {
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure<ImportResultDto>(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+            await _unitOfWork.BeginTransactionAsync();
+
+            var labels = dto.Labels ?? Enumerable.Empty<ImportLabelDto>();
+            var columns = dto.Columns ?? Enumerable.Empty<ImportColumnDto>();
+            var cards = dto.Cards ?? Enumerable.Empty<ImportCardDto>();
+
+            var board = new Board(dto.Name, dto.Description, userId);
+            await _unitOfWork.Boards.AddAsync(board);
+
+            // Create labels and track by name
+            var labelsByName = new Dictionary<string, Label>(StringComparer.OrdinalIgnoreCase);
+            foreach (var importLabel in labels)
+            {
+                if (labelsByName.ContainsKey(importLabel.Name))
+                    throw new DomainException(ErrorCodes.ValidationError, $"Duplicate label name '{importLabel.Name}' in import payload");
+
+                var label = new Label(board.Id, importLabel.Name, importLabel.Color);
+                await _unitOfWork.Labels.AddAsync(label);
+                labelsByName[importLabel.Name] = label;
+            }
+
+            // Create columns and track by name
+            var columnsByName = new Dictionary<string, Column>(StringComparer.OrdinalIgnoreCase);
+            foreach (var importColumn in columns.OrderBy(c => c.Position))
+            {
+                if (columnsByName.ContainsKey(importColumn.Name))
+                    throw new DomainException(ErrorCodes.ValidationError, $"Duplicate column name '{importColumn.Name}' in import payload");
+
+                var column = new Column(board.Id, importColumn.Name, importColumn.Position, importColumn.WipLimit);
+                await _unitOfWork.Columns.AddAsync(column);
+                columnsByName[importColumn.Name] = column;
+            }
+
+            // Create cards with label associations
+            var cardsImported = 0;
+            foreach (var importCard in cards.OrderBy(c => c.Position))
+            {
+                if (!columnsByName.TryGetValue(importCard.ColumnName, out var column))
+                    throw new DomainException(ErrorCodes.ValidationError, $"Column '{importCard.ColumnName}' referenced by card '{importCard.Title}' was not found");
+
+                var card = new Card(board.Id, column.Id, importCard.Title, importCard.Description, importCard.DueDate, importCard.Position);
+
+                foreach (var labelName in importCard.Labels ?? Enumerable.Empty<string>())
+                {
+                    if (!labelsByName.TryGetValue(labelName, out var label))
+                    {
+                        throw new DomainException(
+                            ErrorCodes.ValidationError,
+                            $"Label '{labelName}' referenced by card '{importCard.Title}' was not found");
+                    }
+
+                    var cardLabel = new CardLabel(card.Id, label.Id);
+                    card.AddLabel(cardLabel);
+                }
+
+                await _unitOfWork.Cards.AddAsync(card);
+                cardsImported++;
+            }
+
+            await _unitOfWork.SaveChangesAsync();
+            await _unitOfWork.CommitTransactionAsync();
+
+            var result = new ImportResultDto(
+                true,
+                board.Id,
+                null,
+                columnsByName.Count,
+                cardsImported,
+                labelsByName.Count);
+
+            return Result.Success(result);
+        }
+        catch (DomainException ex)
+        {
+            await _unitOfWork.RollbackTransactionAsync();
+            return Result.Failure<ImportResultDto>(ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            await _unitOfWork.RollbackTransactionAsync();
+            return Result.Failure<ImportResultDto>(ErrorCodes.UnexpectedError, $"Import failed: {ex.Message}");
+        }
+    }
+
+    public async Task<Result<ImportResultDto>> ImportBoardFromJsonAsync(string json, Guid userId)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return Result.Failure<ImportResultDto>(ErrorCodes.ValidationError, "Import JSON payload cannot be empty");
+
+        try
+        {
+            var dto = TryDeserializeImportDto(json);
+            if (dto is null)
+                return Result.Failure<ImportResultDto>(ErrorCodes.ValidationError, "Failed to deserialize import data");
+
+            return await ImportBoardAsync(dto, userId);
+        }
+        catch (JsonException ex)
+        {
+            return Result.Failure<ImportResultDto>(ErrorCodes.ValidationError, $"Invalid JSON format: {ex.Message}");
+        }
+    }
+
+    public Task<Result<byte[]>> ExportDatabaseAsync(Guid userId)
+    {
+        return Task.FromResult(Result.Failure<byte[]>(ErrorCodes.ValidationError, "Database export is not yet implemented"));
+    }
+
+    public Task<Result> ImportDatabaseAsync(byte[] dbFile, Guid userId)
+    {
+        return Task.FromResult(Result.Failure(ErrorCodes.ValidationError, "Database import is not yet implemented"));
+    }
+
+    private async Task<bool> CanUserReadBoardAsync(Board board, Guid userId)
+    {
+        if (board.OwnerId is null || board.OwnerId == userId)
+            return true;
+
+        var access = await _unitOfWork.BoardAccesses.GetByBoardAndUserAsync(board.Id, userId);
+        return access is not null && access.CanRead();
+    }
+
+    private static ImportBoardDto? TryDeserializeImportDto(string json)
+    {
+        ImportBoardDto? importDto = null;
+        try
+        {
+            importDto = JsonSerializer.Deserialize<ImportBoardDto>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            // Ignore and try export payload shape below.
+        }
+
+        if (importDto is not null && !string.IsNullOrWhiteSpace(importDto.Name))
+            return importDto;
+
+        ExportBoardDto? exportDto = null;
+        try
+        {
+            exportDto = JsonSerializer.Deserialize<ExportBoardDto>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        return exportDto is null ? null : ConvertExportToImportDto(exportDto);
+    }
+
+    private static ImportBoardDto ConvertExportToImportDto(ExportBoardDto exportDto)
+    {
+        if (exportDto.Board is null)
+            throw new JsonException("Export payload is missing board metadata");
+
+        var columns = exportDto.Columns?
+            .OrderBy(c => c.Position)
+            .Select(c => new ImportColumnDto(c.Name, c.Position, c.WipLimit))
+            .ToList()
+            ?? new List<ImportColumnDto>();
+
+        var labels = exportDto.Labels?
+            .Select(l => new ImportLabelDto(l.Name, l.ColorHex))
+            .ToList()
+            ?? new List<ImportLabelDto>();
+
+        var columnNameById = (exportDto.Columns ?? Enumerable.Empty<ColumnDto>())
+            .ToDictionary(c => c.Id, c => c.Name);
+
+        var cards = new List<ImportCardDto>();
+        foreach (var card in exportDto.Cards ?? Enumerable.Empty<CardDto>())
+        {
+            if (!columnNameById.TryGetValue(card.ColumnId, out var columnName))
+            {
+                throw new JsonException(
+                    $"Export payload references unknown column ID '{card.ColumnId}' for card '{card.Title}'");
+            }
+
+            var labelNames = (card.Labels ?? Enumerable.Empty<LabelDto>())
+                .Select(l => l.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            cards.Add(new ImportCardDto(
+                card.Title,
+                card.Description,
+                columnName,
+                card.Position,
+                card.DueDate,
+                labelNames));
+        }
+
+        return new ImportBoardDto(
+            exportDto.Board.Name,
+            exportDto.Board.Description,
+            columns,
+            cards,
+            labels);
+    }
+
+    private static BoardDto MapToBoardDto(Board board)
+    {
+        return new BoardDto(
+            board.Id,
+            board.Name,
+            board.Description,
+            board.IsArchived,
+            board.CreatedAt,
+            board.UpdatedAt);
+    }
+
+    private static CardDto MapToCardDto(Card card)
+    {
+        var labels = card.CardLabels
+            .Where(cl => cl.Label is not null)
+            .Select(cl => new LabelDto(
+                cl.Label.Id,
+                cl.Label.BoardId,
+                cl.Label.Name,
+                cl.Label.ColorHex,
+                cl.Label.CreatedAt,
+                cl.Label.UpdatedAt))
+            .ToList();
+
+        return new CardDto(
+            card.Id,
+            card.BoardId,
+            card.ColumnId,
+            card.Title,
+            card.Description,
+            card.DueDate,
+            card.IsBlocked,
+            card.BlockReason,
+            card.Position,
+            labels,
+            card.CreatedAt,
+            card.UpdatedAt);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/HistoryService.cs
+++ b/backend/src/Taskdeck.Application/Services/HistoryService.cs
@@ -1,0 +1,89 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class HistoryService : IHistoryService
+{
+    private const int MaxHistoryLimit = 1000;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public HistoryService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<IEnumerable<AuditLogDto>>> GetBoardHistoryAsync(Guid boardId, int limit = 100)
+    {
+        if (boardId == Guid.Empty)
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, "Board ID cannot be empty");
+
+        if (!IsValidLimit(limit))
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, $"Limit must be between 1 and {MaxHistoryLimit}");
+
+        var logs = await _unitOfWork.AuditLogs.GetByBoardAsync(boardId, limit);
+        return Result.Success(logs.Select(MapToDto));
+    }
+
+    public async Task<Result<IEnumerable<AuditLogDto>>> GetEntityHistoryAsync(string entityType, Guid entityId, int limit = 100)
+    {
+        if (string.IsNullOrWhiteSpace(entityType))
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, "Entity type cannot be empty");
+
+        if (entityId == Guid.Empty)
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, "Entity ID cannot be empty");
+
+        if (!IsValidLimit(limit))
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, $"Limit must be between 1 and {MaxHistoryLimit}");
+
+        var logs = await _unitOfWork.AuditLogs.GetByEntityAsync(entityType, entityId, limit);
+        return Result.Success(logs.Select(MapToDto));
+    }
+
+    public async Task<Result<IEnumerable<AuditLogDto>>> GetUserHistoryAsync(Guid userId, int limit = 100)
+    {
+        if (userId == Guid.Empty)
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, "User ID cannot be empty");
+
+        if (!IsValidLimit(limit))
+            return Result.Failure<IEnumerable<AuditLogDto>>(ErrorCodes.ValidationError, $"Limit must be between 1 and {MaxHistoryLimit}");
+
+        var logs = await _unitOfWork.AuditLogs.GetByUserAsync(userId, limit);
+        return Result.Success(logs.Select(MapToDto));
+    }
+
+    public async Task<Result> LogActionAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
+    {
+        try
+        {
+            var auditLog = new AuditLog(entityType, entityId, action, userId, changes);
+            await _unitOfWork.AuditLogs.AddAsync(auditLog);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success();
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    private static AuditLogDto MapToDto(AuditLog log)
+    {
+        return new AuditLogDto(
+            log.Id,
+            log.EntityType,
+            log.EntityId,
+            log.Action,
+            log.UserId,
+            log.User?.Username,
+            log.Changes,
+            log.Timestamp);
+    }
+
+    private static bool IsValidLimit(int limit) => limit is >= 1 and <= MaxHistoryLimit;
+}

--- a/backend/src/Taskdeck.Application/Services/IBoardAccessService.cs
+++ b/backend/src/Taskdeck.Application/Services/IBoardAccessService.cs
@@ -10,8 +10,8 @@ namespace Taskdeck.Application.Services;
 public interface IBoardAccessService
 {
     Task<Result<BoardAccessDto>> GrantAccessAsync(GrantAccessDto dto, Guid grantedBy);
-    Task<Result<BoardAccessDto>> UpdateAccessAsync(Guid accessId, UpdateAccessDto dto, Guid updatedBy);
-    Task<Result> RevokeAccessAsync(Guid accessId, Guid revokedBy);
+    Task<Result<BoardAccessDto>> UpdateAccessAsync(Guid boardId, Guid accessId, UpdateAccessDto dto, Guid updatedBy);
+    Task<Result> RevokeAccessAsync(Guid boardId, Guid accessId, Guid revokedBy);
     Task<Result<IEnumerable<BoardAccessDto>>> GetBoardAccessListAsync(Guid boardId);
     Task<Result<IEnumerable<BoardDto>>> GetUserBoardsAsync(Guid userId);
 }

--- a/backend/src/Taskdeck.Application/Services/JwtSettings.cs
+++ b/backend/src/Taskdeck.Application/Services/JwtSettings.cs
@@ -1,0 +1,9 @@
+namespace Taskdeck.Application.Services;
+
+public class JwtSettings
+{
+    public string SecretKey { get; set; } = string.Empty;
+    public string Issuer { get; set; } = "Taskdeck";
+    public string Audience { get; set; } = "TaskdeckUsers";
+    public int ExpirationMinutes { get; set; } = 1440; // 24 hours
+}

--- a/backend/src/Taskdeck.Application/Services/LlmQueueService.cs
+++ b/backend/src/Taskdeck.Application/Services/LlmQueueService.cs
@@ -1,0 +1,128 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class LlmQueueService : ILlmQueueService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public LlmQueueService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<LlmRequestDto>> AddToQueueAsync(CreateLlmRequestDto dto)
+    {
+        try
+        {
+            var user = await _unitOfWork.Users.GetByIdAsync(dto.UserId);
+            if (user == null)
+                return Result.Failure<LlmRequestDto>(ErrorCodes.NotFound, $"User with ID {dto.UserId} not found");
+
+            if (dto.BoardId.HasValue)
+            {
+                var board = await _unitOfWork.Boards.GetByIdAsync(dto.BoardId.Value);
+                if (board == null)
+                    return Result.Failure<LlmRequestDto>(ErrorCodes.NotFound, $"Board with ID {dto.BoardId.Value} not found");
+            }
+
+            var request = new LlmRequest(dto.UserId, dto.RequestType, dto.Payload, dto.BoardId);
+            await _unitOfWork.LlmQueue.AddAsync(request);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(MapToDto(request));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<LlmRequestDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<IEnumerable<LlmRequestDto>>> GetUserQueueAsync(Guid userId)
+    {
+        var requests = await _unitOfWork.LlmQueue.GetByUserAsync(userId);
+        return Result.Success(requests.Select(MapToDto));
+    }
+
+    public async Task<Result<IEnumerable<LlmRequestDto>>> GetQueueByStatusAsync(RequestStatus status)
+    {
+        var requests = await _unitOfWork.LlmQueue.GetByStatusAsync(status);
+        return Result.Success(requests.Select(MapToDto));
+    }
+
+    public async Task<Result> CancelRequestAsync(Guid requestId, Guid userId)
+    {
+        try
+        {
+            var request = await _unitOfWork.LlmQueue.GetByIdAsync(requestId);
+            if (request == null)
+                return Result.Failure(ErrorCodes.NotFound, $"Request with ID {requestId} not found");
+
+            if (request.UserId != userId)
+                return Result.Failure(ErrorCodes.Forbidden, "You do not have permission to cancel this request");
+
+            request.Cancel();
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success();
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<LlmRequestDto>> ProcessNextRequestAsync()
+    {
+        try
+        {
+            var request = await _unitOfWork.LlmQueue.GetNextPendingAsync();
+            if (request == null)
+                return Result.Failure<LlmRequestDto>(ErrorCodes.NotFound, "No pending requests in the queue");
+
+            request.MarkAsProcessing();
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(MapToDto(request));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<LlmRequestDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<QueueStatsDto>> GetQueueStatsAsync()
+    {
+        var pending = await _unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Pending);
+        var processing = await _unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Processing);
+        var completed = await _unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Completed);
+        var failed = await _unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Failed);
+
+        var stats = new QueueStatsDto(
+            pending.Count(),
+            processing.Count(),
+            completed.Count(),
+            failed.Count());
+
+        return Result.Success(stats);
+    }
+
+    private static LlmRequestDto MapToDto(LlmRequest request)
+    {
+        return new LlmRequestDto(
+            request.Id,
+            request.UserId,
+            request.BoardId,
+            request.RequestType,
+            request.Status,
+            request.ErrorMessage,
+            request.CreatedAt,
+            request.ProcessedAt,
+            request.RetryCount);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/UserService.cs
+++ b/backend/src/Taskdeck.Application/Services/UserService.cs
@@ -1,0 +1,150 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class UserService : IUserService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UserService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<UserDto>> CreateUserAsync(CreateUserDto dto)
+    {
+        try
+        {
+            var exists = await _unitOfWork.Users.ExistsAsync(dto.Username, dto.Email);
+            if (exists)
+                return Result.Failure<UserDto>(ErrorCodes.Conflict, "A user with the same username or email already exists");
+
+            var passwordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password);
+            var user = new User(dto.Username, dto.Email, passwordHash, dto.DefaultRole);
+
+            await _unitOfWork.Users.AddAsync(user);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(MapToDto(user));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<UserDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<UserDto>> GetUserByIdAsync(Guid userId)
+    {
+        var user = await _unitOfWork.Users.GetByIdAsync(userId);
+        if (user == null)
+            return Result.Failure<UserDto>(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+        return Result.Success(MapToDto(user));
+    }
+
+    public async Task<Result<UserDto>> GetUserByUsernameAsync(string username)
+    {
+        var user = await _unitOfWork.Users.GetByUsernameAsync(username);
+        if (user == null)
+            return Result.Failure<UserDto>(ErrorCodes.NotFound, $"User with username '{username}' not found");
+
+        return Result.Success(MapToDto(user));
+    }
+
+    public async Task<Result<UserDto>> GetUserByEmailAsync(string email)
+    {
+        var user = await _unitOfWork.Users.GetByEmailAsync(email);
+        if (user == null)
+            return Result.Failure<UserDto>(ErrorCodes.NotFound, $"User with email '{email}' not found");
+
+        return Result.Success(MapToDto(user));
+    }
+
+    public async Task<Result<UserDto>> UpdateUserAsync(Guid userId, UpdateUserDto dto)
+    {
+        try
+        {
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure<UserDto>(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+            if (!string.IsNullOrWhiteSpace(dto.Username))
+            {
+                var existingByUsername = await _unitOfWork.Users.GetByUsernameAsync(dto.Username);
+                if (existingByUsername is not null && existingByUsername.Id != userId)
+                {
+                    return Result.Failure<UserDto>(
+                        ErrorCodes.Conflict,
+                        $"Username '{dto.Username}' is already in use");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(dto.Email))
+            {
+                var existingByEmail = await _unitOfWork.Users.GetByEmailAsync(dto.Email);
+                if (existingByEmail is not null && existingByEmail.Id != userId)
+                {
+                    return Result.Failure<UserDto>(
+                        ErrorCodes.Conflict,
+                        $"Email '{dto.Email}' is already in use");
+                }
+            }
+
+            user.UpdateProfile(dto.Username, dto.Email);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(MapToDto(user));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<UserDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result> DeactivateUserAsync(Guid userId)
+    {
+        var user = await _unitOfWork.Users.GetByIdAsync(userId);
+        if (user == null)
+            return Result.Failure(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+        user.Deactivate();
+        await _unitOfWork.SaveChangesAsync();
+
+        return Result.Success();
+    }
+
+    public async Task<Result> ActivateUserAsync(Guid userId)
+    {
+        var user = await _unitOfWork.Users.GetByIdAsync(userId);
+        if (user == null)
+            return Result.Failure(ErrorCodes.NotFound, $"User with ID {userId} not found");
+
+        user.Activate();
+        await _unitOfWork.SaveChangesAsync();
+
+        return Result.Success();
+    }
+
+    public async Task<Result<IEnumerable<UserDto>>> ListUsersAsync()
+    {
+        var users = await _unitOfWork.Users.GetAllAsync();
+        return Result.Success(users.Select(MapToDto));
+    }
+
+    private static UserDto MapToDto(User user)
+    {
+        return new UserDto(
+            user.Id,
+            user.Username,
+            user.Email,
+            user.DefaultRole,
+            user.IsActive,
+            user.CreatedAt,
+            user.UpdatedAt
+        );
+    }
+}

--- a/backend/src/Taskdeck.Application/Taskdeck.Application.csproj
+++ b/backend/src/Taskdeck.Application/Taskdeck.Application.csproj
@@ -11,7 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
   </ItemGroup>
 
 </Project>

--- a/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
@@ -36,6 +36,8 @@ public class BoardRepository : Repository<Board>, IBoardRepository
         return await _dbSet
             .Include(b => b.Columns)
                 .ThenInclude(c => c.Cards)
+                    .ThenInclude(card => card.CardLabels)
+                        .ThenInclude(cardLabel => cardLabel.Label)
             .Include(b => b.Labels)
             .FirstOrDefaultAsync(b => b.Id == id, cancellationToken);
     }

--- a/backend/tests/Taskdeck.Api.Tests/AdvancedFeaturesApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AdvancedFeaturesApiTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public class AdvancedFeaturesApiTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+
+    public AdvancedFeaturesApiTests(TestWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnToken_ForRegisteredUser()
+    {
+        var (username, email, password, _) = await RegisterUserAsync("authlogin");
+
+        var response = await _client.PostAsJsonAsync("/api/auth/login", new LoginDto(username, password));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<AuthResultDto>();
+        payload.Should().NotBeNull();
+        payload!.Token.Should().NotBeNullOrWhiteSpace();
+        payload.User.Email.Should().Be(email);
+    }
+
+    [Fact]
+    public async Task ImportBoardFromJson_ShouldAcceptExportPayloadShape()
+    {
+        var (_, _, _, importingUserId) = await RegisterUserAsync("importer");
+        var now = DateTimeOffset.UtcNow;
+        var boardId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+        var labelId = Guid.NewGuid();
+
+        var exportPayload = new ExportBoardDto(
+            new BoardDto(boardId, "Imported from Export", "description", false, now, now),
+            new[] { new ColumnDto(columnId, boardId, "Todo", 0, null, 1, now, now) },
+            new[]
+            {
+                new CardDto(
+                    Guid.NewGuid(),
+                    boardId,
+                    columnId,
+                    "Imported Card",
+                    string.Empty,
+                    null,
+                    false,
+                    null,
+                    0,
+                    new List<LabelDto> { new LabelDto(labelId, boardId, "Bug", "#FF0000", now, now) },
+                    now,
+                    now)
+            },
+            new[] { new LabelDto(labelId, boardId, "Bug", "#FF0000", now, now) },
+            new List<BoardAccessDto>(),
+            now,
+            "exporter");
+
+        var response = await _client.PostAsJsonAsync($"/api/import/boards/json?userId={importingUserId}", exportPayload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var importResult = await response.Content.ReadFromJsonAsync<ImportResultDto>();
+        importResult.Should().NotBeNull();
+        importResult!.Success.Should().BeTrue();
+        importResult.ColumnsImported.Should().Be(1);
+        importResult.CardsImported.Should().Be(1);
+        importResult.LabelsImported.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task UpdateAccess_ShouldReturnNotFound_WhenAccessBelongsToDifferentBoard()
+    {
+        var (_, _, _, granterId) = await RegisterUserAsync("granter");
+        var (_, _, _, targetUserId) = await RegisterUserAsync("target");
+        var board1 = await CreateBoardAsync("board1");
+        var board2 = await CreateBoardAsync("board2");
+
+        var grantResponse = await _client.PostAsJsonAsync(
+            $"/api/boards/{board2.Id}/access?grantedBy={granterId}",
+            new GrantAccessDto(board2.Id, targetUserId, UserRole.Viewer));
+        grantResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var createdAccess = await grantResponse.Content.ReadFromJsonAsync<BoardAccessDto>();
+        createdAccess.Should().NotBeNull();
+
+        var updateResponse = await _client.PutAsJsonAsync(
+            $"/api/boards/{board1.Id}/access/{createdAccess!.Id}?updatedBy={granterId}",
+            new UpdateAccessDto(UserRole.Editor));
+
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var errorPayload = await updateResponse.Content.ReadFromJsonAsync<JsonElement>();
+        errorPayload.GetProperty("errorCode").GetString().Should().Be("NotFound");
+    }
+
+    private async Task<(string Username, string Email, string Password, Guid UserId)> RegisterUserAsync(string stem)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var username = $"{stem}_{suffix}";
+        var email = $"{stem}_{suffix}@example.com";
+        const string password = "password123";
+
+        var response = await _client.PostAsJsonAsync(
+            "/api/auth/register",
+            new CreateUserDto(username, email, password));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var payload = await response.Content.ReadFromJsonAsync<AuthResultDto>();
+        payload.Should().NotBeNull();
+
+        return (username, email, password, payload!.User.Id);
+    }
+
+    private async Task<BoardDto> CreateBoardAsync(string stem)
+    {
+        var response = await _client.PostAsJsonAsync(
+            "/api/boards",
+            new CreateBoardDto($"{stem}-{Guid.NewGuid():N}", null));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var board = await response.Content.ReadFromJsonAsync<BoardDto>();
+        board.Should().NotBeNull();
+        return board!;
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/AuthenticationServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AuthenticationServiceTests.cs
@@ -1,0 +1,148 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class AuthenticationServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+
+    public AuthenticationServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _userRepoMock = new Mock<IUserRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnToken_WhenCredentialsAreValid()
+    {
+        var password = "password123";
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword(password));
+        var service = CreateService();
+
+        _userRepoMock.Setup(r => r.GetByUsernameAsync(user.Username, default)).ReturnsAsync(user);
+
+        var result = await service.LoginAsync(new LoginDto(user.Username, password));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Token.Should().NotBeNullOrWhiteSpace();
+        result.Value.User.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ShouldReturnUnexpectedError_WhenJwtConfigIsInvalid()
+    {
+        var service = CreateService(new JwtSettings
+        {
+            SecretKey = string.Empty,
+            Issuer = "Taskdeck",
+            Audience = "TaskdeckUsers",
+            ExpirationMinutes = 60
+        });
+
+        var result = await service.LoginAsync(new LoginDto("someone", "password"));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.UnexpectedError);
+        _userRepoMock.Verify(r => r.GetByUsernameAsync(It.IsAny<string>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ShouldReturnConflict_WhenUserAlreadyExists()
+    {
+        var service = CreateService();
+        var dto = new CreateUserDto("existing", "existing@example.com", "password123");
+
+        _userRepoMock.Setup(r => r.ExistsAsync(dto.Username, dto.Email, default)).ReturnsAsync(true);
+
+        var result = await service.RegisterAsync(dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        _userRepoMock.Verify(r => r.AddAsync(It.IsAny<User>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ShouldNotCreateUser_WhenJwtConfigIsInvalid()
+    {
+        var service = CreateService(new JwtSettings
+        {
+            SecretKey = "short-secret",
+            Issuer = "Taskdeck",
+            Audience = "TaskdeckUsers",
+            ExpirationMinutes = 60
+        });
+
+        var result = await service.RegisterAsync(new CreateUserDto("newuser", "newuser@example.com", "password123"));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.UnexpectedError);
+        _userRepoMock.Verify(r => r.ExistsAsync(It.IsAny<string>(), It.IsAny<string>(), default), Times.Never);
+        _userRepoMock.Verify(r => r.AddAsync(It.IsAny<User>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_ShouldReturnForbidden_WhenUserIsInactive()
+    {
+        var service = CreateService();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("password123"));
+        user.Deactivate();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default)).ReturnsAsync(user);
+
+        var result = await service.ChangePasswordAsync(user.Id, "password123", "newpassword123");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+    }
+
+    [Fact]
+    public async Task ValidateTokenAsync_ShouldReturnUser_WhenTokenIsValid()
+    {
+        var service = CreateService();
+        var password = "password123";
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword(password));
+
+        _userRepoMock.Setup(r => r.GetByUsernameAsync(user.Username, default)).ReturnsAsync(user);
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default)).ReturnsAsync(user);
+
+        var loginResult = await service.LoginAsync(new LoginDto(user.Username, password));
+        var validationResult = await service.ValidateTokenAsync(loginResult.Value.Token);
+
+        validationResult.IsSuccess.Should().BeTrue();
+        validationResult.Value.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task ValidateTokenAsync_ShouldReturnUnauthorized_WhenTokenIsInvalid()
+    {
+        var service = CreateService();
+
+        var result = await service.ValidateTokenAsync("invalid-token");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Unauthorized);
+    }
+
+    private AuthenticationService CreateService(JwtSettings? jwtSettings = null)
+    {
+        jwtSettings ??= new JwtSettings
+        {
+            SecretKey = "TaskdeckTestsOnlySecretKeyMustBeLongEnough123!",
+            Issuer = "TaskdeckTests",
+            Audience = "TaskdeckUsers",
+            ExpirationMinutes = 60
+        };
+
+        return new AuthenticationService(_unitOfWorkMock.Object, jwtSettings);
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/AuthorizationServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AuthorizationServiceTests.cs
@@ -1,0 +1,281 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class AuthorizationServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IBoardRepository> _boardRepoMock;
+    private readonly Mock<IBoardAccessRepository> _boardAccessRepoMock;
+    private readonly AuthorizationService _service;
+
+    public AuthorizationServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _boardRepoMock = new Mock<IBoardRepository>();
+        _boardAccessRepoMock = new Mock<IBoardAccessRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Boards).Returns(_boardRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.BoardAccesses).Returns(_boardAccessRepoMock.Object);
+
+        _service = new AuthorizationService(_unitOfWorkMock.Object);
+    }
+
+    #region CanReadBoardAsync Tests
+
+    [Fact]
+    public async Task CanReadBoardAsync_ShouldReturnTrue_WhenBoardHasNullOwnerId()
+    {
+        // Arrange
+        var board = new Board("Test Board");
+        var userId = Guid.NewGuid();
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+
+        // Act
+        var result = await _service.CanReadBoardAsync(userId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanReadBoardAsync_ShouldReturnTrue_WhenUserIsOwner()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+
+        // Act
+        var result = await _service.CanReadBoardAsync(ownerId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanReadBoardAsync_ShouldReturnTrue_WhenUserHasBoardAccess()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+        var access = new BoardAccess(board.Id, userId, UserRole.Viewer, ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, userId, default))
+            .ReturnsAsync(access);
+
+        // Act
+        var result = await _service.CanReadBoardAsync(userId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanReadBoardAsync_ShouldReturnFalse_WhenUserHasNoAccess()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, userId, default))
+            .ReturnsAsync((BoardAccess?)null);
+
+        // Act
+        var result = await _service.CanReadBoardAsync(userId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CanReadBoardAsync_ShouldReturnNotFound_WhenBoardDoesNotExist()
+    {
+        // Arrange
+        var boardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default))
+            .ReturnsAsync((Board?)null);
+
+        // Act
+        var result = await _service.CanReadBoardAsync(userId, boardId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    #endregion
+
+    #region CanWriteBoardAsync Tests
+
+    [Fact]
+    public async Task CanWriteBoardAsync_ShouldReturnTrue_WhenUserIsOwner()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+
+        // Act
+        var result = await _service.CanWriteBoardAsync(ownerId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanWriteBoardAsync_ShouldReturnFalse_WhenUserIsViewer()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+        var access = new BoardAccess(board.Id, userId, UserRole.Viewer, ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, userId, default))
+            .ReturnsAsync(access);
+
+        // Act
+        var result = await _service.CanWriteBoardAsync(userId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region CanDeleteBoardAsync Tests
+
+    [Fact]
+    public async Task CanDeleteBoardAsync_ShouldReturnTrue_WhenUserIsOwner()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+
+        // Act
+        var result = await _service.CanDeleteBoardAsync(ownerId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanDeleteBoardAsync_ShouldReturnFalse_WhenUserIsEditor()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+        var access = new BoardAccess(board.Id, userId, UserRole.Editor, ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, userId, default))
+            .ReturnsAsync(access);
+
+        // Act
+        var result = await _service.CanDeleteBoardAsync(userId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region GetUserRoleForBoardAsync Tests
+
+    [Fact]
+    public async Task GetUserRoleForBoardAsync_ShouldReturnOwner_WhenUserIsOwner()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+
+        // Act
+        var result = await _service.GetUserRoleForBoardAsync(ownerId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(UserRole.Owner);
+    }
+
+    [Fact]
+    public async Task GetUserRoleForBoardAsync_ShouldReturnNull_WhenUserHasNoAccess()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = new Board("Test Board", ownerId: ownerId);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default))
+            .ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, userId, default))
+            .ReturnsAsync((BoardAccess?)null);
+
+        // Act
+        var result = await _service.GetUserRoleForBoardAsync(userId, board.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetUserRoleForBoardAsync_ShouldReturnNotFound_WhenBoardDoesNotExist()
+    {
+        // Arrange
+        var boardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default))
+            .ReturnsAsync((Board?)null);
+
+        // Act
+        var result = await _service.GetUserRoleForBoardAsync(userId, boardId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/BoardAccessServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/BoardAccessServiceTests.cs
@@ -1,0 +1,213 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class BoardAccessServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IBoardAccessRepository> _boardAccessRepoMock;
+    private readonly Mock<IBoardRepository> _boardRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly BoardAccessService _service;
+
+    public BoardAccessServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _boardAccessRepoMock = new Mock<IBoardAccessRepository>();
+        _boardRepoMock = new Mock<IBoardRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+
+        _unitOfWorkMock.Setup(u => u.BoardAccesses).Returns(_boardAccessRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Boards).Returns(_boardRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+
+        _service = new BoardAccessService(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task GrantAccessAsync_ShouldReturnSuccess_WithValidData()
+    {
+        var granter = CreateUser("granter");
+        var targetUser = CreateUser("target");
+        var board = new Board("Test Board", ownerId: granter.Id);
+        var dto = new GrantAccessDto(board.Id, targetUser.Id, UserRole.Editor);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _userRepoMock.Setup(r => r.GetByIdAsync(granter.Id, default)).ReturnsAsync(granter);
+        _userRepoMock.Setup(r => r.GetByIdAsync(targetUser.Id, default)).ReturnsAsync(targetUser);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, targetUser.Id, default))
+            .ReturnsAsync((BoardAccess?)null);
+        _boardAccessRepoMock.Setup(r => r.AddAsync(It.IsAny<BoardAccess>(), default))
+            .ReturnsAsync((BoardAccess a, CancellationToken ct) => a);
+
+        var result = await _service.GrantAccessAsync(dto, granter.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.BoardId.Should().Be(board.Id);
+        result.Value.UserId.Should().Be(targetUser.Id);
+        result.Value.Role.Should().Be(UserRole.Editor);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task GrantAccessAsync_ShouldReturnForbidden_WhenGranterCannotManageAccess()
+    {
+        var owner = CreateUser("owner");
+        var granter = CreateUser("viewer");
+        var targetUser = CreateUser("target");
+        var board = new Board("Test Board", ownerId: owner.Id);
+        var granterAccess = new BoardAccess(board.Id, granter.Id, UserRole.Viewer, owner.Id);
+        var dto = new GrantAccessDto(board.Id, targetUser.Id, UserRole.Editor);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _userRepoMock.Setup(r => r.GetByIdAsync(granter.Id, default)).ReturnsAsync(granter);
+        _userRepoMock.Setup(r => r.GetByIdAsync(targetUser.Id, default)).ReturnsAsync(targetUser);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, granter.Id, default))
+            .ReturnsAsync(granterAccess);
+
+        var result = await _service.GrantAccessAsync(dto, granter.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task GrantAccessAsync_ShouldReturnConflict_WhenAccessAlreadyExists()
+    {
+        var granter = CreateUser("granter");
+        var targetUser = CreateUser("target");
+        var board = new Board("Test Board", ownerId: granter.Id);
+        var existingAccess = new BoardAccess(board.Id, targetUser.Id, UserRole.Viewer, granter.Id);
+        var dto = new GrantAccessDto(board.Id, targetUser.Id, UserRole.Editor);
+
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _userRepoMock.Setup(r => r.GetByIdAsync(granter.Id, default)).ReturnsAsync(granter);
+        _userRepoMock.Setup(r => r.GetByIdAsync(targetUser.Id, default)).ReturnsAsync(targetUser);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, targetUser.Id, default))
+            .ReturnsAsync(existingAccess);
+
+        var result = await _service.GrantAccessAsync(dto, granter.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateAccessAsync_ShouldReturnSuccess_WhenUpdatingRole()
+    {
+        var owner = CreateUser("owner");
+        var targetUser = CreateUser("target");
+        var board = new Board("Test Board", ownerId: owner.Id);
+        var access = new BoardAccess(board.Id, targetUser.Id, UserRole.Viewer, owner.Id);
+        var dto = new UpdateAccessDto(UserRole.Editor);
+
+        _boardAccessRepoMock.Setup(r => r.GetByIdAsync(access.Id, default)).ReturnsAsync(access);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _userRepoMock.Setup(r => r.GetByIdAsync(owner.Id, default)).ReturnsAsync(owner);
+
+        var result = await _service.UpdateAccessAsync(board.Id, access.Id, dto, owner.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Role.Should().Be(UserRole.Editor);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAccessAsync_ShouldReturnNotFound_WhenAccessDoesNotBelongToBoard()
+    {
+        var owner = CreateUser("owner");
+        var board = new Board("Board 1", ownerId: owner.Id);
+        var otherBoard = new Board("Board 2", ownerId: owner.Id);
+        var access = new BoardAccess(otherBoard.Id, Guid.NewGuid(), UserRole.Viewer, owner.Id);
+
+        _boardAccessRepoMock.Setup(r => r.GetByIdAsync(access.Id, default)).ReturnsAsync(access);
+
+        var result = await _service.UpdateAccessAsync(board.Id, access.Id, new UpdateAccessDto(UserRole.Editor), owner.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task RevokeAccessAsync_ShouldReturnSuccess_WhenAccessExistsAndUserCanManage()
+    {
+        var owner = CreateUser("owner");
+        var targetUser = CreateUser("target");
+        var board = new Board("Test Board", ownerId: owner.Id);
+        var access = new BoardAccess(board.Id, targetUser.Id, UserRole.Editor, owner.Id);
+
+        _boardAccessRepoMock.Setup(r => r.GetByIdAsync(access.Id, default)).ReturnsAsync(access);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _userRepoMock.Setup(r => r.GetByIdAsync(owner.Id, default)).ReturnsAsync(owner);
+
+        var result = await _service.RevokeAccessAsync(board.Id, access.Id, owner.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        _boardAccessRepoMock.Verify(r => r.DeleteAsync(access, default), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task RevokeAccessAsync_ShouldReturnForbidden_WhenUserCannotManage()
+    {
+        var owner = CreateUser("owner");
+        var viewer = CreateUser("viewer");
+        var targetUser = CreateUser("target");
+        var board = new Board("Test Board", ownerId: owner.Id);
+        var access = new BoardAccess(board.Id, targetUser.Id, UserRole.Editor, owner.Id);
+        var viewerAccess = new BoardAccess(board.Id, viewer.Id, UserRole.Viewer, owner.Id);
+
+        _boardAccessRepoMock.Setup(r => r.GetByIdAsync(access.Id, default)).ReturnsAsync(access);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _userRepoMock.Setup(r => r.GetByIdAsync(viewer.Id, default)).ReturnsAsync(viewer);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, viewer.Id, default))
+            .ReturnsAsync(viewerAccess);
+
+        var result = await _service.RevokeAccessAsync(board.Id, access.Id, viewer.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _boardAccessRepoMock.Verify(r => r.DeleteAsync(It.IsAny<BoardAccess>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetBoardAccessListAsync_ShouldReturnNotFound_WhenBoardDoesNotExist()
+    {
+        var boardId = Guid.NewGuid();
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync((Board?)null);
+
+        var result = await _service.GetBoardAccessListAsync(boardId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task GetUserBoardsAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        var userId = Guid.NewGuid();
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync((User?)null);
+
+        var result = await _service.GetUserBoardsAsync(userId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    private static User CreateUser(string stem)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        return new User($"{stem}_{suffix}", $"{stem}_{suffix}@example.com", "hashedpassword");
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/ExportImportServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ExportImportServiceTests.cs
@@ -1,0 +1,217 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class ExportImportServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IBoardRepository> _boardRepoMock;
+    private readonly Mock<IBoardAccessRepository> _boardAccessRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly Mock<IColumnRepository> _columnRepoMock;
+    private readonly Mock<ICardRepository> _cardRepoMock;
+    private readonly Mock<ILabelRepository> _labelRepoMock;
+    private readonly ExportImportService _service;
+
+    public ExportImportServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _boardRepoMock = new Mock<IBoardRepository>();
+        _boardAccessRepoMock = new Mock<IBoardAccessRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _columnRepoMock = new Mock<IColumnRepository>();
+        _cardRepoMock = new Mock<ICardRepository>();
+        _labelRepoMock = new Mock<ILabelRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Boards).Returns(_boardRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.BoardAccesses).Returns(_boardAccessRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(_columnRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(_cardRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Labels).Returns(_labelRepoMock.Object);
+
+        _service = new ExportImportService(_unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task ExportBoardAsync_ShouldReturnForbidden_WhenUserCannotReadBoard()
+    {
+        var owner = CreateUser("owner");
+        var requester = CreateUser("requester");
+        var board = new Board("Secure Board", ownerId: owner.Id);
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(requester.Id, default)).ReturnsAsync(requester);
+        _boardRepoMock.Setup(r => r.GetByIdWithDetailsAsync(board.Id, default)).ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardAndUserAsync(board.Id, requester.Id, default))
+            .ReturnsAsync((BoardAccess?)null);
+
+        var result = await _service.ExportBoardAsync(board.Id, requester.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+    }
+
+    [Fact]
+    public async Task ExportBoardAsync_ShouldIncludeCardLabels_WhenDataIsAvailable()
+    {
+        var owner = CreateUser("owner");
+        var board = new Board("Board", ownerId: owner.Id);
+        var column = new Column(board.Id, "Todo", 0);
+        var card = new Card(board.Id, column.Id, "Card 1", position: 0);
+        var label = new Label(board.Id, "Bug", "#FF0000");
+        var cardLabel = new CardLabel(card.Id, label.Id);
+        SetNavigation(cardLabel, "Label", label);
+        AddToPrivateCollection(card, "_cardLabels", cardLabel);
+        AddToPrivateCollection(column, "_cards", card);
+        AddToPrivateCollection(board, "_columns", column);
+        AddToPrivateCollection(board, "_labels", label);
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(owner.Id, default)).ReturnsAsync(owner);
+        _boardRepoMock.Setup(r => r.GetByIdWithDetailsAsync(board.Id, default)).ReturnsAsync(board);
+        _boardAccessRepoMock.Setup(r => r.GetByBoardIdAsync(board.Id, default))
+            .ReturnsAsync(new List<BoardAccess>());
+
+        var result = await _service.ExportBoardAsync(board.Id, owner.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Cards.Should().HaveCount(1);
+        result.Value.Cards.Single().Labels.Should().ContainSingle(l => l.Name == "Bug");
+    }
+
+    [Fact]
+    public async Task ImportBoardFromJsonAsync_ShouldImport_WhenPayloadIsExportShape()
+    {
+        var importingUser = CreateUser("importer");
+        var columnId = Guid.NewGuid();
+        var exportPayload = new ExportBoardDto(
+            new BoardDto(Guid.NewGuid(), "Imported Board", "Description", false, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+            new[]
+            {
+                new ColumnDto(columnId, Guid.NewGuid(), "Todo", 0, null, 1, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+            },
+            new[]
+            {
+                new CardDto(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    columnId,
+                    "Card From Export",
+                    "Description",
+                    null,
+                    false,
+                    null,
+                    0,
+                    new List<LabelDto> { new LabelDto(Guid.NewGuid(), Guid.NewGuid(), "Bug", "#FF0000", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow) },
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow)
+            },
+            new[]
+            {
+                new LabelDto(Guid.NewGuid(), Guid.NewGuid(), "Bug", "#FF0000", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+            },
+            new List<BoardAccessDto>(),
+            DateTimeOffset.UtcNow,
+            "tester");
+
+        var json = JsonSerializer.Serialize(exportPayload, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(importingUser.Id, default)).ReturnsAsync(importingUser);
+        _boardRepoMock.Setup(r => r.AddAsync(It.IsAny<Board>(), default))
+            .ReturnsAsync((Board b, CancellationToken ct) => b);
+        _columnRepoMock.Setup(r => r.AddAsync(It.IsAny<Column>(), default))
+            .ReturnsAsync((Column c, CancellationToken ct) => c);
+        _cardRepoMock.Setup(r => r.AddAsync(It.IsAny<Card>(), default))
+            .ReturnsAsync((Card c, CancellationToken ct) => c);
+        _labelRepoMock.Setup(r => r.AddAsync(It.IsAny<Label>(), default))
+            .ReturnsAsync((Label l, CancellationToken ct) => l);
+
+        var result = await _service.ImportBoardFromJsonAsync(json, importingUser.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ColumnsImported.Should().Be(1);
+        result.Value.CardsImported.Should().Be(1);
+        result.Value.LabelsImported.Should().Be(1);
+        _unitOfWorkMock.Verify(u => u.BeginTransactionAsync(default), Times.Once);
+        _unitOfWorkMock.Verify(u => u.CommitTransactionAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportBoardAsync_ShouldReturnNotFound_WhenImportingUserDoesNotExist()
+    {
+        var userId = Guid.NewGuid();
+        var dto = new ImportBoardDto(
+            "Board",
+            "Description",
+            new List<ImportColumnDto>(),
+            new List<ImportCardDto>(),
+            new List<ImportLabelDto>());
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync((User?)null);
+
+        var result = await _service.ImportBoardAsync(dto, userId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        _unitOfWorkMock.Verify(u => u.BeginTransactionAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportBoardAsync_ShouldRollback_WhenCardReferencesUnknownColumn()
+    {
+        var user = CreateUser("importer");
+        var dto = new ImportBoardDto(
+            "Board",
+            "Description",
+            new[] { new ImportColumnDto("Todo", 0, null) },
+            new[] { new ImportCardDto("Card", null, "MissingColumn", 0, null, null) },
+            new List<ImportLabelDto>());
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default)).ReturnsAsync(user);
+        _boardRepoMock.Setup(r => r.AddAsync(It.IsAny<Board>(), default))
+            .ReturnsAsync((Board b, CancellationToken ct) => b);
+        _columnRepoMock.Setup(r => r.AddAsync(It.IsAny<Column>(), default))
+            .ReturnsAsync((Column c, CancellationToken ct) => c);
+
+        var result = await _service.ImportBoardAsync(dto, user.Id);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _unitOfWorkMock.Verify(u => u.BeginTransactionAsync(default), Times.Once);
+        _unitOfWorkMock.Verify(u => u.RollbackTransactionAsync(default), Times.Once);
+        _unitOfWorkMock.Verify(u => u.CommitTransactionAsync(default), Times.Never);
+    }
+
+    private static User CreateUser(string stem)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        return new User($"{stem}_{suffix}", $"{stem}_{suffix}@example.com", "hashedpassword");
+    }
+
+    private static void AddToPrivateCollection<T>(object target, string fieldName, T value)
+    {
+        var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+        var collection = field?.GetValue(target) as IList<T>;
+        collection.Should().NotBeNull($"field '{fieldName}' should exist on {target.GetType().Name}");
+        collection!.Add(value);
+    }
+
+    private static void SetNavigation(object target, string propertyName, object value)
+    {
+        var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        property.Should().NotBeNull($"property '{propertyName}' should exist on {target.GetType().Name}");
+        property!.SetValue(target, value);
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/HistoryServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/HistoryServiceTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class HistoryServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IAuditLogRepository> _auditLogRepoMock;
+    private readonly HistoryService _service;
+
+    public HistoryServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _auditLogRepoMock = new Mock<IAuditLogRepository>();
+
+        _unitOfWorkMock.Setup(u => u.AuditLogs).Returns(_auditLogRepoMock.Object);
+
+        _service = new HistoryService(_unitOfWorkMock.Object);
+    }
+
+    #region GetBoardHistoryAsync Tests
+
+    [Fact]
+    public async Task GetBoardHistoryAsync_ShouldReturnAuditLogs()
+    {
+        // Arrange
+        var boardId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var logs = new List<AuditLog>
+        {
+            new AuditLog("Board", boardId, AuditAction.Created, userId, "changes"),
+            new AuditLog("Board", boardId, AuditAction.Updated, userId, "updated")
+        };
+
+        _auditLogRepoMock.Setup(r => r.GetByBoardAsync(boardId, 100, default))
+            .ReturnsAsync(logs);
+
+        // Act
+        var result = await _service.GetBoardHistoryAsync(boardId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetBoardHistoryAsync_ShouldReturnValidationError_WhenLimitIsOutOfRange()
+    {
+        var result = await _service.GetBoardHistoryAsync(Guid.NewGuid(), limit: 0);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _auditLogRepoMock.Verify(r => r.GetByBoardAsync(It.IsAny<Guid>(), It.IsAny<int>(), default), Times.Never);
+    }
+
+    #endregion
+
+    #region GetEntityHistoryAsync Tests
+
+    [Fact]
+    public async Task GetEntityHistoryAsync_ShouldReturnAuditLogs()
+    {
+        // Arrange
+        var entityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var logs = new List<AuditLog>
+        {
+            new AuditLog("Card", entityId, AuditAction.Created, userId, "created card"),
+            new AuditLog("Card", entityId, AuditAction.Moved, userId, "moved card")
+        };
+
+        _auditLogRepoMock.Setup(r => r.GetByEntityAsync("Card", entityId, 100, default))
+            .ReturnsAsync(logs);
+
+        // Act
+        var result = await _service.GetEntityHistoryAsync("Card", entityId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetEntityHistoryAsync_ShouldReturnValidationError_WhenEntityTypeIsEmpty()
+    {
+        var result = await _service.GetEntityHistoryAsync(string.Empty, Guid.NewGuid(), 10);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _auditLogRepoMock.Verify(
+            r => r.GetByEntityAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), default),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region GetUserHistoryAsync Tests
+
+    [Fact]
+    public async Task GetUserHistoryAsync_ShouldReturnAuditLogs()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var entityId = Guid.NewGuid();
+        var logs = new List<AuditLog>
+        {
+            new AuditLog("Board", entityId, AuditAction.Created, userId, "created board")
+        };
+
+        _auditLogRepoMock.Setup(r => r.GetByUserAsync(userId, 100, default))
+            .ReturnsAsync(logs);
+
+        // Act
+        var result = await _service.GetUserHistoryAsync(userId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetUserHistoryAsync_ShouldReturnValidationError_WhenUserIdIsEmpty()
+    {
+        var result = await _service.GetUserHistoryAsync(Guid.Empty, 10);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _auditLogRepoMock.Verify(r => r.GetByUserAsync(It.IsAny<Guid>(), It.IsAny<int>(), default), Times.Never);
+    }
+
+    #endregion
+
+    #region LogActionAsync Tests
+
+    [Fact]
+    public async Task LogActionAsync_ShouldReturnSuccess_WhenCreatingLogEntry()
+    {
+        // Arrange
+        var entityId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        _auditLogRepoMock.Setup(r => r.AddAsync(It.IsAny<AuditLog>(), default))
+            .ReturnsAsync((AuditLog a, CancellationToken ct) => a);
+
+        // Act
+        var result = await _service.LogActionAsync("Board", entityId, AuditAction.Created, userId, "changes");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _auditLogRepoMock.Verify(r => r.AddAsync(It.IsAny<AuditLog>(), default), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/LlmQueueServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LlmQueueServiceTests.cs
@@ -1,0 +1,260 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class LlmQueueServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<ILlmQueueRepository> _llmQueueRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly Mock<IBoardRepository> _boardRepoMock;
+    private readonly LlmQueueService _service;
+
+    public LlmQueueServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _llmQueueRepoMock = new Mock<ILlmQueueRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _boardRepoMock = new Mock<IBoardRepository>();
+
+        _unitOfWorkMock.Setup(u => u.LlmQueue).Returns(_llmQueueRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Boards).Returns(_boardRepoMock.Object);
+
+        _service = new LlmQueueService(_unitOfWorkMock.Object);
+    }
+
+    #region AddToQueueAsync Tests
+
+    [Fact]
+    public async Task AddToQueueAsync_ShouldReturnSuccess_WithValidData()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+        var board = new Board("Test Board");
+        var dto = new CreateLlmRequestDto(userId, "voicenote", "payload text", boardId);
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default))
+            .ReturnsAsync(user);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default))
+            .ReturnsAsync(board);
+        _llmQueueRepoMock.Setup(r => r.AddAsync(It.IsAny<LlmRequest>(), default))
+            .ReturnsAsync((LlmRequest r, CancellationToken ct) => r);
+
+        // Act
+        var result = await _service.AddToQueueAsync(dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.UserId.Should().Be(userId);
+        result.Value.RequestType.Should().Be("voicenote");
+        result.Value.Status.Should().Be(RequestStatus.Pending);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddToQueueAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var dto = new CreateLlmRequestDto(userId, "voicenote", "payload text");
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.AddToQueueAsync(dto);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        result.ErrorMessage.Should().Contain("User");
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    #endregion
+
+    #region GetUserQueueAsync Tests
+
+    [Fact]
+    public async Task GetUserQueueAsync_ShouldReturnRequests()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requests = new List<LlmRequest>
+        {
+            new LlmRequest(userId, "voicenote", "payload text", boardId),
+            new LlmRequest(userId, "transcript", "another payload", boardId)
+        };
+
+        _llmQueueRepoMock.Setup(r => r.GetByUserAsync(userId, default))
+            .ReturnsAsync(requests);
+
+        // Act
+        var result = await _service.GetUserQueueAsync(userId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+    }
+
+    #endregion
+
+    #region GetQueueByStatusAsync Tests
+
+    [Fact]
+    public async Task GetQueueByStatusAsync_ShouldReturnRequests()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var requests = new List<LlmRequest>
+        {
+            new LlmRequest(userId, "voicenote", "payload text")
+        };
+
+        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
+            .ReturnsAsync(requests);
+
+        // Act
+        var result = await _service.GetQueueByStatusAsync(RequestStatus.Pending);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+    }
+
+    #endregion
+
+    #region CancelRequestAsync Tests
+
+    [Fact]
+    public async Task CancelRequestAsync_ShouldReturnSuccess_WhenUserOwnsRequest()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new LlmRequest(userId, "voicenote", "payload text");
+
+        _llmQueueRepoMock.Setup(r => r.GetByIdAsync(request.Id, default))
+            .ReturnsAsync(request);
+
+        // Act
+        var result = await _service.CancelRequestAsync(request.Id, userId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task CancelRequestAsync_ShouldReturnForbidden_WhenUserDoesNotOwnRequest()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var request = new LlmRequest(ownerId, "voicenote", "payload text");
+
+        _llmQueueRepoMock.Setup(r => r.GetByIdAsync(request.Id, default))
+            .ReturnsAsync(request);
+
+        // Act
+        var result = await _service.CancelRequestAsync(request.Id, otherUserId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    #endregion
+
+    #region ProcessNextRequestAsync Tests
+
+    [Fact]
+    public async Task ProcessNextRequestAsync_ShouldReturnSuccess_WhenRequestExists()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new LlmRequest(userId, "voicenote", "payload text");
+
+        _llmQueueRepoMock.Setup(r => r.GetNextPendingAsync(default))
+            .ReturnsAsync(request);
+
+        // Act
+        var result = await _service.ProcessNextRequestAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(RequestStatus.Processing);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessNextRequestAsync_ShouldReturnNotFound_WhenQueueIsEmpty()
+    {
+        // Arrange
+        _llmQueueRepoMock.Setup(r => r.GetNextPendingAsync(default))
+            .ReturnsAsync((LlmRequest?)null);
+
+        // Act
+        var result = await _service.ProcessNextRequestAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    #endregion
+
+    #region GetQueueStatsAsync Tests
+
+    [Fact]
+    public async Task GetQueueStatsAsync_ShouldReturnCorrectCounts()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var pendingRequests = new List<LlmRequest>
+        {
+            new LlmRequest(userId, "voicenote", "payload1"),
+            new LlmRequest(userId, "voicenote", "payload2")
+        };
+        var processingRequests = new List<LlmRequest>
+        {
+            new LlmRequest(userId, "voicenote", "payload3")
+        };
+        var completedRequests = new List<LlmRequest>();
+        var failedRequests = new List<LlmRequest>();
+
+        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
+            .ReturnsAsync(pendingRequests);
+        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Processing, default))
+            .ReturnsAsync(processingRequests);
+        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Completed, default))
+            .ReturnsAsync(completedRequests);
+        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Failed, default))
+            .ReturnsAsync(failedRequests);
+
+        // Act
+        var result = await _service.GetQueueStatsAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.PendingCount.Should().Be(2);
+        result.Value.ProcessingCount.Should().Be(1);
+        result.Value.CompletedCount.Should().Be(0);
+        result.Value.FailedCount.Should().Be(0);
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/UserServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/UserServiceTests.cs
@@ -1,0 +1,405 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class UserServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly UserService _service;
+
+    public UserServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _userRepoMock = new Mock<IUserRepository>();
+
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+
+        _service = new UserService(_unitOfWorkMock.Object);
+    }
+
+    #region CreateUserAsync Tests
+
+    [Fact]
+    public async Task CreateUserAsync_ShouldReturnSuccess_WithValidData()
+    {
+        // Arrange
+        var dto = new CreateUserDto("testuser", "test@example.com", "password123");
+
+        _userRepoMock.Setup(r => r.ExistsAsync(dto.Username, dto.Email, default))
+            .ReturnsAsync(false);
+        _userRepoMock.Setup(r => r.AddAsync(It.IsAny<User>(), default))
+            .ReturnsAsync((User u, CancellationToken ct) => u);
+
+        // Act
+        var result = await _service.CreateUserAsync(dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Username.Should().Be("testuser");
+        result.Value.Email.Should().Be("test@example.com");
+        result.Value.DefaultRole.Should().Be(UserRole.Editor);
+        result.Value.IsActive.Should().BeTrue();
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_ShouldReturnConflict_WhenUsernameOrEmailAlreadyExists()
+    {
+        // Arrange
+        var dto = new CreateUserDto("existinguser", "existing@example.com", "password123");
+
+        _userRepoMock.Setup(r => r.ExistsAsync(dto.Username, dto.Email, default))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _service.CreateUserAsync(dto);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_ShouldReturnValidationError_WhenUsernameIsEmpty()
+    {
+        // Arrange
+        var dto = new CreateUserDto("", "test@example.com", "password123");
+
+        _userRepoMock.Setup(r => r.ExistsAsync(dto.Username, dto.Email, default))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _service.CreateUserAsync(dto);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    #endregion
+
+    #region GetUserByIdAsync Tests
+
+    [Fact]
+    public async Task GetUserByIdAsync_ShouldReturnUser_WhenExists()
+    {
+        // Arrange
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.GetUserByIdAsync(user.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Id.Should().Be(user.Id);
+        result.Value.Username.Should().Be("testuser");
+    }
+
+    [Fact]
+    public async Task GetUserByIdAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.GetUserByIdAsync(userId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    #endregion
+
+    #region GetUserByUsernameAsync Tests
+
+    [Fact]
+    public async Task GetUserByUsernameAsync_ShouldReturnUser_WhenExists()
+    {
+        // Arrange
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+
+        _userRepoMock.Setup(r => r.GetByUsernameAsync("testuser", default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.GetUserByUsernameAsync("testuser");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Username.Should().Be("testuser");
+    }
+
+    [Fact]
+    public async Task GetUserByUsernameAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        _userRepoMock.Setup(r => r.GetByUsernameAsync("nonexistent", default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.GetUserByUsernameAsync("nonexistent");
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    #endregion
+
+    #region GetUserByEmailAsync Tests
+
+    [Fact]
+    public async Task GetUserByEmailAsync_ShouldReturnUser_WhenExists()
+    {
+        // Arrange
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+
+        _userRepoMock.Setup(r => r.GetByEmailAsync("test@example.com", default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.GetUserByEmailAsync("test@example.com");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Email.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public async Task GetUserByEmailAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        _userRepoMock.Setup(r => r.GetByEmailAsync("notfound@example.com", default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.GetUserByEmailAsync("notfound@example.com");
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    #endregion
+
+    #region UpdateUserAsync Tests
+
+    [Fact]
+    public async Task UpdateUserAsync_ShouldUpdateUsername()
+    {
+        // Arrange
+        var user = new User("olduser", "test@example.com", "hashedpassword");
+        var dto = new UpdateUserDto(Username: "newuser");
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.UpdateUserAsync(user.Id, dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Username.Should().Be("newuser");
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var dto = new UpdateUserDto(Username: "newuser");
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.UpdateUserAsync(userId, dto);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        result.ErrorMessage.Should().Contain("User");
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_ShouldReturnValidationError_WhenUsernameIsInvalid()
+    {
+        // Arrange
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+        var dto = new UpdateUserDto(Username: "ab"); // Too short, must be at least 3 chars
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.UpdateUserAsync(user.Id, dto);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_ShouldReturnConflict_WhenUsernameBelongsToAnotherUser()
+    {
+        var user = new User("currentuser", "current@example.com", "hashedpassword");
+        var existing = new User("takenuser", "taken@example.com", "hashedpassword");
+        var dto = new UpdateUserDto(Username: existing.Username);
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default)).ReturnsAsync(user);
+        _userRepoMock.Setup(r => r.GetByUsernameAsync(existing.Username, default)).ReturnsAsync(existing);
+
+        var result = await _service.UpdateUserAsync(user.Id, dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_ShouldReturnConflict_WhenEmailBelongsToAnotherUser()
+    {
+        var user = new User("currentuser", "current@example.com", "hashedpassword");
+        var existing = new User("takenuser", "taken@example.com", "hashedpassword");
+        var dto = new UpdateUserDto(Email: existing.Email);
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default)).ReturnsAsync(user);
+        _userRepoMock.Setup(r => r.GetByEmailAsync(existing.Email, default)).ReturnsAsync(existing);
+
+        var result = await _service.UpdateUserAsync(user.Id, dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    #endregion
+
+    #region DeactivateUserAsync Tests
+
+    [Fact]
+    public async Task DeactivateUserAsync_ShouldDeactivateUser_WhenExists()
+    {
+        // Arrange
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+        user.IsActive.Should().BeTrue(); // Confirm initially active
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.DeactivateUserAsync(user.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeFalse();
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeactivateUserAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.DeactivateUserAsync(userId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    #endregion
+
+    #region ActivateUserAsync Tests
+
+    [Fact]
+    public async Task ActivateUserAsync_ShouldActivateUser_WhenExists()
+    {
+        // Arrange
+        var user = new User("testuser", "test@example.com", "hashedpassword");
+        user.Deactivate();
+        user.IsActive.Should().BeFalse(); // Confirm deactivated
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(user.Id, default))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _service.ActivateUserAsync(user.Id);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        user.IsActive.Should().BeTrue();
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ActivateUserAsync_ShouldReturnNotFound_WhenUserDoesNotExist()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default))
+            .ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _service.ActivateUserAsync(userId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    #endregion
+
+    #region ListUsersAsync Tests
+
+    [Fact]
+    public async Task ListUsersAsync_ShouldReturnAllUsers()
+    {
+        // Arrange
+        var users = new List<User>
+        {
+            new User("user1", "user1@example.com", "hashedpassword"),
+            new User("user2", "user2@example.com", "hashedpassword")
+        };
+
+        _userRepoMock.Setup(r => r.GetAllAsync(default))
+            .ReturnsAsync(users);
+
+        // Act
+        var result = await _service.ListUsersAsync();
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+    }
+
+    #endregion
+}

--- a/docs/IMPLEMENTATION_MASTERPLAN.md
+++ b/docs/IMPLEMENTATION_MASTERPLAN.md
@@ -1,6 +1,6 @@
 # Taskdeck Implementation Masterplan
 
-Last Updated: 2026-02-11  
+Last Updated: 2026-02-12  
 Planning Horizon: Next 8 to 12 weeks  
 Companion Status Doc: `docs/STATUS.md`
 
@@ -45,9 +45,29 @@ Delivered in this cycle:
    - domain entities, repository contracts, service interfaces
    - infrastructure repositories and migration
    - foundational domain tests
+9. Scaffolding service implementations completed:
+   - UserService with BCrypt password hashing
+   - AuthenticationService with JWT token generation/validation
+   - AuthorizationService with role-based permission checks and backward compatibility
+   - BoardAccessService for board-level permission management
+   - HistoryService for audit log queries and action logging
+   - LlmQueueService for offline request queue management
+   - ExportImportService for board export/import via JSON
+10. API controllers added for all new services:
+    - AuthController, UsersController, BoardAccessController
+    - ExportController, LlmQueueController, AuditController
+11. JWT Bearer authentication middleware configured in Program.cs
+12. Unit tests added for new service implementations (51 new tests, 241 total backend tests)
+13. Merge-readiness hardening for side-track implementation:
+    - board-access update/revoke now enforce route-board scoping
+    - board-access grant/update/revoke validate acting user and manage-access permission
+    - export/import hardened with board read-permission checks and export-shape JSON import compatibility
+    - JWT configuration safety checks added to auth service and API startup wiring
+    - history limit/input validation added and wired to HTTP 400 mappings
+    - additional automated coverage: +17 application tests and +3 API integration tests
 
 Note:
-- Item 8 is intentional side-track prep and does not replace the primary roadmap sequence below.
+- Items 8-13 are intentional side-track prep and do not replace the primary roadmap sequence below.
 
 ## Roadmap by Horizon
 
@@ -109,18 +129,24 @@ Exit Criteria:
 
 ## Parallel Track (Sidecar): Scaffolding Activation Plan
 
-This track remains sidecar until primary Horizon A/B stability goals are met.
+This track has progressed from pure scaffolding to functional service implementations.
 
-Prepared foundations:
-- Multi-user roles and board-level access model
-- Export/import interfaces for board/database portability
-- LLM queue entities/contracts for offline submission and later processing
-- Audit/history foundations
+Completed foundations:
+- Multi-user roles and board-level access model (entities + services + API)
+- Export/import interfaces and service for board/database portability
+- LLM queue entities/contracts/service for offline submission and later processing
+- Audit/history service with API endpoints
+- JWT authentication infrastructure with configurable settings
+- Unit tests covering new service implementations
+- Merge-readiness hardening and regression tests for side-track correctness paths
 
-Activation gates:
-1. Horizon A exit criteria are met.
-2. CLI reliability and JSON contract work is stable.
-3. Explicit roadmap re-prioritization is approved.
+Remaining activation work:
+1. Enforce authentication on existing API endpoints (add [Authorize] attributes) using the endpoint matrix in `docs/PR_MERGE_READINESS_REPORT_2026-02-12.md`.
+2. Wire authorization checks into existing BoardService, CardService, ColumnService, LabelService per the defined read/write/delete role model.
+3. Implement LLM queue background processor (IHostedService).
+4. Add automatic audit logging to existing service operations.
+5. Implement database-level export/import (SQLite file copy).
+6. Frontend integration with login/register and permission-aware UI.
 
 ## Active Backlog (Prioritized)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,8 @@ This directory is the canonical documentation entrypoint for Taskdeck.
   - End-to-end manual validation checklist with expected outcomes.
 - `DEVELOPMENT_HISTORY.md`
   - Complete development journey from conception to current state, with phase breakdown, milestones, and lessons learned.
+- `PR_MERGE_READINESS_REPORT_2026-02-12.md`
+  - Consolidated audit artifact covering PR findings, corrections, tests, and remaining risks.
 
 ## Reference Material
 

--- a/docs/PR_MERGE_READINESS_REPORT_2026-02-12.md
+++ b/docs/PR_MERGE_READINESS_REPORT_2026-02-12.md
@@ -1,0 +1,183 @@
+# PR Merge-Readiness Report (2026-02-12)
+
+## Scope Reviewed
+
+- Branch diff against `main` for:
+  - backend services/controllers related to auth, board access, export/import, history, LLM queue
+  - new and existing backend tests
+  - `docs/STATUS.md`
+  - `docs/IMPLEMENTATION_MASTERPLAN.md`
+- Runtime validation via backend, frontend unit, and frontend E2E suites.
+
+## What Was Found
+
+1. Board-access update/revoke operations did not enforce route `boardId` ownership of `accessId`.
+2. Board-access grant/update/revoke flows did not validate acting user existence/permission.
+3. Export/import JSON round-trip was broken:
+   - export JSON shape and import JSON shape were incompatible.
+   - `/api/import/boards/json` used `string` body binding, which rejects normal JSON object payloads.
+4. Export service lacked board read-permission checks.
+5. Auth service could fail at runtime when JWT config was missing/invalid (default app settings had no JWT section).
+6. History querying accepted unsafe/unbounded limits and weak input validation.
+7. New side-track features were under-tested (missing authentication/export-import coverage and API-level coverage).
+8. Docs had directional drift risk: wording implied side-track capabilities were fully active runtime behavior.
+
+## What Was Changed
+
+### Backend code hardening
+
+- Board-access:
+  - Added board-route scope enforcement in update/revoke service methods.
+  - Added acting-user existence checks.
+  - Added manage-access permission checks (owner/admin path; legacy ownerless-board compatibility preserved).
+  - Added board existence checks to list access by board and user existence checks to list boards by user.
+- Export/import:
+  - Added requester existence/read-permission checks for export.
+  - Added importer existence checks.
+  - Added export-shape JSON -> import DTO conversion path for true export/import round-trip compatibility.
+  - Added duplicate/invalid reference validation (duplicate labels/columns, unknown column/label references).
+  - Added tolerant deserialization fallback between import-shape and export-shape payloads.
+- API controllers:
+  - `BoardAccessController` now calls board-scoped update/revoke service signatures.
+  - `AuditController` now maps validation/not-found errors explicitly and supports validated `limit` query usage.
+  - `ExportController` now accepts JSON object payloads for `/api/import/boards/json` via `JsonElement`.
+  - `LlmQueueController` now rejects undefined enum values for status filter.
+- Auth:
+  - Added JWT configuration validation guardrails (secret length, issuer/audience, expiration sanity).
+  - Added inactive-user guard for password change.
+  - Added development JWT settings in `backend/src/Taskdeck.Api/appsettings.Development.json` for local/test usability.
+  - Added safer startup gating for JWT middleware configuration in `Program.cs`.
+- Repository loading:
+  - Extended board detail eager-loading to include card-label relationships for export correctness.
+
+### Test suite expansion/revision
+
+- Added:
+  - `backend/tests/Taskdeck.Application.Tests/Services/AuthenticationServiceTests.cs`
+  - `backend/tests/Taskdeck.Application.Tests/Services/ExportImportServiceTests.cs`
+  - `backend/tests/Taskdeck.Api.Tests/AdvancedFeaturesApiTests.cs`
+- Revised:
+  - `backend/tests/Taskdeck.Application.Tests/Services/BoardAccessServiceTests.cs`
+  - `backend/tests/Taskdeck.Application.Tests/Services/HistoryServiceTests.cs`
+  - `backend/tests/Taskdeck.Application.Tests/Services/UserServiceTests.cs`
+
+## Vision Preservation Check (Docs Diff Intent)
+
+Cross-checking `docs/STATUS.md` and `docs/IMPLEMENTATION_MASTERPLAN.md` against `main`:
+
+Preserved:
+- Primary Phase 4 direction remains CI/reliability/CLI hardening first.
+- Agent-compatible safety model (proposal/review/diff/rollback) remains the strategic end state.
+- Side-track (auth/permissions/export-import/queue/audit) remains a sidecar track, not promoted over primary roadmap.
+
+Corrected to avoid drift:
+- Status wording now clarifies side-track features are implemented slices, not fully activated runtime behavior.
+- Added explicit residual gaps (auth enforcement across legacy endpoints, ownerless legacy boards, query/body actor IDs).
+- Added this hardening pass outcomes without changing roadmap priority.
+
+## Focused Auth Rollout Design (Boards/Columns/Cards/Labels)
+
+Scope in this pass is design-only for existing endpoints; no authorization rollout code was applied to these endpoints yet.
+
+### Target authorization model
+
+1. Authentication gate:
+   - Require JWT auth for all board/column/card/label endpoints.
+   - Derive actor identity only from token claims (`sub`), not query/body user IDs.
+2. Resource authorization:
+   - Use `AuthorizationService` as the single board permission source.
+   - Enforce board-level permissions before each mutable/read action.
+3. Backward-compatibility boundary:
+   - Keep legacy `OwnerId == null` behavior explicit during transition.
+   - Do not silently tighten ownerless boards without migration/backfill plan.
+
+### Endpoint permission matrix
+
+| Endpoint | Permission |
+|---|---|
+| `GET /api/boards` | Authenticated; return only boards with `CanReadBoard` true |
+| `GET /api/boards/{id}` | `CanReadBoard` |
+| `POST /api/boards` | Authenticated; creator becomes owner (`OwnerId = currentUserId`) |
+| `PUT /api/boards/{id}` | `CanWriteBoard` for content edits; `CanDeleteBoard` for archive/unarchive state changes |
+| `DELETE /api/boards/{id}` | `CanDeleteBoard` |
+| `GET /api/boards/{boardId}/columns` | `CanReadBoard` |
+| `POST /api/boards/{boardId}/columns` | `CanWriteBoard` |
+| `PATCH /api/boards/{boardId}/columns/{columnId}` | `CanWriteBoard` |
+| `DELETE /api/boards/{boardId}/columns/{columnId}` | `CanWriteBoard` |
+| `POST /api/boards/{boardId}/columns/reorder` | `CanWriteBoard` |
+| `GET /api/boards/{boardId}/cards` | `CanReadBoard` |
+| `POST /api/boards/{boardId}/cards` | `CanWriteBoard` |
+| `PATCH /api/boards/{boardId}/cards/{cardId}` | `CanWriteBoard` |
+| `POST /api/boards/{boardId}/cards/{cardId}/move` | `CanWriteBoard` |
+| `DELETE /api/boards/{boardId}/cards/{cardId}` | `CanWriteBoard` |
+| `GET /api/boards/{boardId}/labels` | `CanReadBoard` |
+| `POST /api/boards/{boardId}/labels` | `CanWriteBoard` |
+| `PATCH /api/boards/{boardId}/labels/{labelId}` | `CanWriteBoard` |
+| `DELETE /api/boards/{boardId}/labels/{labelId}` | `CanWriteBoard` |
+
+### Rollout sequence (low-risk)
+
+1. Identity plumbing:
+   - Add `ICurrentUserContext` abstraction in API layer.
+   - Resolve current user ID from JWT `sub`; fail with `401` if missing/invalid.
+2. Controller gating:
+   - Add `[Authorize]` on `BoardsController`, `ColumnsController`, `CardsController`, `LabelsController`.
+   - Remove any future actor query/body parameters for these endpoints.
+3. Service-level authorization enforcement:
+   - Inject `AuthorizationService` into `BoardService`, `ColumnService`, `CardService`, `LabelService`.
+   - Execute permission checks before repository mutations/reads.
+4. Ownership consistency:
+   - Update board creation flow to set `OwnerId = currentUserId`.
+   - Decide and execute ownerless-board migration strategy before strict enforcement in production.
+5. Contract cleanup:
+   - Standardize `403` payload shape for authorization failures.
+   - Keep `404` for true missing board/resource, avoid permission leaks where needed.
+
+### Required test additions for rollout implementation
+
+1. API integration:
+   - 401 for missing token on all four controller surfaces.
+   - 403 for authenticated-but-unauthorized board access.
+   - Positive cases per role (`Owner`, `Admin`, `Editor`, `Viewer`) for read/write/delete semantics.
+2. Application/service tests:
+   - Permission checks invoked before mutation.
+   - Archive/delete split behavior on board update/delete.
+3. Migration/compatibility:
+   - Ownerless-board behavior explicitly tested until migration complete.
+   - Post-migration strict ownership tests added.
+
+## Test Evidence Executed
+
+- Backend:
+  - `dotnet test backend/Taskdeck.sln`
+  - Result:
+    - Domain: 68/68
+    - Application: 155/155
+    - API integration: 34/34
+    - CLI contract: 4/4
+- Frontend:
+  - `cd frontend/taskdeck-web; npx vitest run`
+    - 115/115 passing
+  - `cd frontend/taskdeck-web; $env:TASKDECK_E2E_DB='taskdeck.e2e.local.db'; npx playwright test`
+    - 8/8 passing
+
+Combined automated total after this pass: **384/384 passing**.
+
+## Remaining Risks (Not Claimed as Solved Here)
+
+1. Full `[Authorize]` rollout on legacy board/column/card/label endpoints is still pending.
+2. Actor identity still relies on query/body IDs in side-track endpoints until claim-based enforcement is adopted.
+3. `ExportDatabaseAsync` / `ImportDatabaseAsync` remain stubbed.
+4. LLM queue background processor (`IHostedService`) is still pending.
+5. Automatic audit logging integration into existing CRUD flows is still pending.
+
+## Final Verification of This Artifact
+
+Checklist completed in this pass:
+
+1. Facts cross-checked against current branch code and test outputs.
+2. Test totals and commands in this artifact match latest executed runs.
+3. Direction check confirmed:
+   - primary roadmap preserved
+   - side-track not promoted over core Phase 4 track
+4. Auth rollout section now explicitly covers only board/column/card/label endpoint design and rollout sequencing.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Taskdeck Status (Source of Truth)
 
-Last Updated: 2026-02-11  
+Last Updated: 2026-02-12  
 Status Owner: Repository maintainers  
 Authoritative Scope: Current implementation, verified test execution, and active phase progress
 
@@ -8,7 +8,7 @@ Authoritative Scope: Current implementation, verified test execution, and active
 
 Taskdeck is a local-first Kanban system with a .NET 8 backend and a Vue 3 frontend.
 Current implementation supports boards, columns, cards, labels, WIP rules, filters, keyboard workflows, drag/drop, toasts, and automation-oriented CLI output.
-Recent scaffolding for multi-user/export-import/history/LLM queue is present as a parallel foundation, not yet promoted to the primary runtime track.
+Multi-user/permissions, export-import, history/audit, and LLM queue capabilities are implemented as side-track service/API slices with JWT infrastructure, while full runtime enforcement and UI activation remain pending.
 
 ## Current Implementation Snapshot
 
@@ -32,6 +32,22 @@ Recent scaffolding for multi-user/export-import/history/LLM queue is present as 
   - board ownership field: `Board.OwnerId`
   - repository/service contracts for permissions, export/import, history, queue
   - infrastructure repositories and migration: `20260211082334_AddUserPermissionsAuditQueue`
+- Service implementations delivered:
+  - `UserService` - user CRUD with BCrypt password hashing
+  - `AuthenticationService` - JWT login/register/validate with configuration safety checks
+  - `AuthorizationService` - role-based permission checking with backward compatibility
+  - `BoardAccessService` - board access grant/revoke/list with board-route and permission validation
+  - `HistoryService` - audit log queries and action logging with limit/input validation
+  - `LlmQueueService` - queue management and processing
+  - `ExportImportService` - board export/import via JSON with export-shape import compatibility
+- API controllers delivered:
+  - `AuthController` - `/api/auth/login`, `/api/auth/register`, `/api/auth/change-password`
+  - `UsersController` - `/api/users` CRUD endpoints
+  - `BoardAccessController` - `/api/boards/{boardId}/access` management with board-bound access checks
+  - `ExportController` - `/api/export/boards/{boardId}`, `/api/import/boards`
+  - `LlmQueueController` - `/api/llm-queue` management
+  - `AuditController` - `/api/audit` history endpoints
+- JWT Bearer authentication middleware configured in Program.cs
 
 ### Frontend
 
@@ -62,7 +78,7 @@ Progress is tracked against `filesAndResources/taskdeck_technical_design_documen
 1. Phase 1 - Core Data Model and API: COMPLETE (100%)
 2. Phase 2 - Basic Web UI: COMPLETE (100%)
 3. Phase 3 - UX Improvements: COMPLETE (100%)
-4. Phase 4 - Advanced Features: IN PROGRESS (60%)
+4. Phase 4 - Advanced Features: IN PROGRESS (70%)
    Completed:
    - card and column drag/drop
    - CLI primary track expansion
@@ -70,6 +86,16 @@ Progress is tracked against `filesAndResources/taskdeck_technical_design_documen
    - CI quality gates for backend unit, API integration, frontend unit, and E2E smoke
    - broader negative-path integration coverage
    - side-track scaffolding for multi-user/export-import/history/LLM queue
+   - service implementations for authentication, authorization, board access, history, LLM queue, export/import
+   - API controllers for all new services
+   - JWT authentication middleware
+   - unit tests for new service implementations (51 new tests)
+   - merge-readiness hardening pass:
+     - board-route scope checks for board access update/revoke
+     - export/import JSON compatibility and permission checks
+     - JWT configuration guards and inactive-user password-change protection
+     - history and queue input validation hardening
+   - additional automated coverage (+20 tests: 17 application, 3 API integration)
    Pending (primary track):
    - CI drift monitoring and reliability follow-through
    - CLI parity and JSON contract hardening
@@ -77,35 +103,34 @@ Progress is tracked against `filesAndResources/taskdeck_technical_design_documen
    - analytics dashboard
    - recurring tasks
    Pending (side-track activation):
-   - authentication/authorization implementation and enforcement
-   - export/import behavior implementation
-   - queue processing and audit/history runtime integration
+   - authentication/authorization enforcement on existing endpoints
+   - frontend integration with auth/permissions
+   - queue processing background service
+   - audit logging integration into existing service operations
 
 ## Test Status (Reconciled and Verified)
 
-Verification Date: 2026-02-11
+Verification Date: 2026-02-12
 
 ### Backend Unit (Executed)
 
 Commands:
-- `dotnet test backend/tests/Taskdeck.Domain.Tests/Taskdeck.Domain.Tests.csproj`
-- `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj`
+- `dotnet test backend/Taskdeck.sln`
 
 Result:
 - Domain: 68/68 passing
-- Application: 87/87 passing
-- Backend Unit Total: 155/155 passing
+- Application: 155/155 passing
+- Backend Unit Total: 223/223 passing
 
 ### Backend Integration + CLI Contracts (Executed)
 
 Commands:
-- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj`
-- `dotnet test backend/tests/Taskdeck.Cli.Tests/Taskdeck.Cli.Tests.csproj`
+- `dotnet test backend/Taskdeck.sln`
 
 Result:
-- API integration: 31/31 passing
+- API integration: 34/34 passing
 - CLI contract: 4/4 passing
-- Integration/Contract Total: 35/35 passing
+- Integration/Contract Total: 38/38 passing
 
 ### Frontend Unit (Executed)
 
@@ -127,7 +152,7 @@ Result:
 
 ### Total
 
-- Combined automated total: 313/313 passing
+- Combined automated total: 384/384 passing
 
 ## CI Status
 
@@ -161,7 +186,12 @@ Current state:
 - CI first-run monitoring is partially blocked locally (`gh` CLI unavailable in this environment).
 - E2E remains smoke-level; deeper regression/performance paths still need coverage.
 - Agent-compatible safety model (proposal queue, approvals, audit trail, rollback) is still design-stage.
-- Scaffolding track is not yet enforced in runtime behavior and should not be treated as shipped feature behavior.
+- JWT authentication is configured but not yet enforced across existing board/column/card/label endpoints.
+- Current side-track endpoints still accept actor/user IDs via query/body; claim-based identity enforcement is pending full auth rollout.
+- Boards created through legacy create-board flow still default to `OwnerId = null` for backward compatibility.
+- Export/import database-level operations (ExportDatabaseAsync, ImportDatabaseAsync) are stubbed.
+- LLM queue background processor is not yet implemented (manual ProcessNextRequestAsync available).
+- Audit logging is not yet automatically integrated into existing board/card/column operations.
 
 ## Canonical Documentation Policy
 


### PR DESCRIPTION
## Summary

This PR consolidates the advanced side-track implementation into a single squashed commit and finalizes merge-readiness hardening across auth/permissions, board access, export/import, history, and queue surfaces, plus documentation
reconciliation.

This branch was force-pushed with --force-with-lease after squash to keep PR history clean.
Current branch tip: https://github.com/Chris0Jeky/Taskdeck/commit/9b254762393598fbf2670a959fe2af675723a3e1.

What Changed
Added side-track API controllers:
AuthController, UsersController, BoardAccessController, ExportController, LlmQueueController, AuditController
Added side-track application services:
AuthenticationService, AuthorizationService, UserService, BoardAccessService, ExportImportService, HistoryService, LlmQueueService, JwtSettings
Hardening fixes applied:
Board-access update/revoke now enforce route board scope and acting-user permission checks
Export/import JSON round-trip compatibility fixed (export-shape payload can be imported)
/api/import/boards/json now accepts JSON object payloads correctly
Export now enforces board read permission checks
JWT config safety checks added (service + startup guardrails)
History input/limit validation and improved API error mapping
Queue status parsing rejects undefined enum values
User update enforces username/email conflict checks
Board detail eager-loading includes card-label relationships needed for export correctness
Tests Added/Updated
New tests:
backend/tests/Taskdeck.Application.Tests/Services/AuthenticationServiceTests.cs
backend/tests/Taskdeck.Application.Tests/Services/ExportImportServiceTests.cs
backend/tests/Taskdeck.Api.Tests/AdvancedFeaturesApiTests.cs
Revised tests:
BoardAccessServiceTests, HistoryServiceTests, UserServiceTests
Existing new side-track tests remain included (Authorization/LlmQueue/etc.)
Final Verification (Executed)
dotnet test backend/Taskdeck.sln
Domain: 68/68
Application: 155/155
API integration: 34/34
CLI contract: 4/4
cd frontend/taskdeck-web && npx vitest run
115/115
cd frontend/taskdeck-web && TASKDECK_E2E_DB=taskdeck.e2e.local.db npx playwright test
8/8
Combined automated total: 384/384 passing

Documentation Updates
docs/STATUS.md refreshed with corrected claims and verified totals
docs/IMPLEMENTATION_MASTERPLAN.md updated with hardening outcomes and auth rollout linkage
Consolidated artifact added:
docs/PR_MERGE_READINESS_REPORT_2026-02-12.md
Indexed in docs/INDEX.md
Notes / Remaining Known Gaps
Full [Authorize] rollout for legacy boards/columns/cards/labels remains pending implementation (design captured in artifact)
Claim-based identity replacement for query/body actor IDs remains pending
DB-level export/import methods are still stubbed
Queue background processor and automatic audit integration are still pending