### PR TITLE
Add hardening and tech-debt labels to docs

### DIFF
--- a/docs/TASKDECK_HUMAN_OPERATIONS.md
+++ b/docs/TASKDECK_HUMAN_OPERATIONS.md
@@ -42,7 +42,7 @@ Do in GitHub UI:
 Create a Project (or use Issues):
 - Views: `Now`, `Next`, `Blocked`, `Review`, `Done`
 - WIP: cap “Now/In Progress” to 1 major item
-- Labels: `security`, `backend`, `frontend`, `ux`, `testing`, `docs`, `refactor`, `starter-packs`, `llm`
+- Labels: `security`, `hardening`, `backend`, `frontend`, `ux`, `testing`, `docs`, `refactor`, `tech-debt`, `starter-packs`, `llm`
 
 ## A3) Secrets: GitHub PAT and environment variables (for GitHub MCP)
 You must create and manage tokens:

--- a/docs/TaskdeckNextWorkChecklist.md
+++ b/docs/TaskdeckNextWorkChecklist.md
@@ -3,7 +3,7 @@
 ## Project Setup
 - [ ] OPS-01 Create GitHub Project views (Now, Next, Blocked, Review, Done)  
   AC: all items below imported as project items.
-- [ ] OPS-02 Add labels (`security`, `backend`, `frontend`, `ux`, `testing`, `docs`, `refactor`, `starter-packs`, `llm`)  
+- [ ] OPS-02 Add labels (`security`, `hardening`, `backend`, `frontend`, `ux`, `testing`, `docs`, `refactor`, `tech-debt`, `starter-packs`, `llm`)  
   AC: each checklist item has at least one label.
 - [ ] OPS-03 Add PR template gates (tests run, docs updated, risk notes)  
   AC: PRs cannot be merged without all three checked.


### PR DESCRIPTION
Update project label lists in docs/TASKDECK_HUMAN_OPERATIONS.md and docs/TaskdeckNextWorkChecklist.md to include the new `hardening` and `tech-debt` labels, ensuring label consistency across the project's setup instructions and checklist.

## Summary

<!-- What changed and why -->

## Verification

- [ ] `dotnet test backend/Taskdeck.sln -c Release`
- [ ] `cd frontend/taskdeck-web && npm run typecheck && npm run build && npx vitest --run`
- [ ] Playwright smoke/E2E executed (if UI or cross-surface behavior changed)

## Documentation

- [ ] `docs/STATUS.md` updated (if shipped behavior changed)
- [ ] `docs/IMPLEMENTATION_MASTERPLAN.md` updated (if roadmap or priorities changed)
- [ ] `docs/TESTING_GUIDE.md` / `docs/MANUAL_TEST_CHECKLIST.md` updated (if verification flow changed)

## Risk Notes

- Security impact:
- Behavior/regression risk:
- Follow-up tasks:
