### PR TITLE
docs: sync STATUS and TESTING_GUIDE to 2026-02-17 baseline

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Taskdeck Status (Source of Truth)
 
-Last Updated: 2026-02-16  
+Last Updated: 2026-02-17  
 Status Owner: Repository maintainers  
 Authoritative Scope: Current implementation, verified test execution, and active phase progress
 
@@ -98,7 +98,7 @@ Remaining for Phase 4 completion:
 
 ## Test Status (Executed)
 
-Verification Date: 2026-02-16
+Verification Date: 2026-02-17
 
 ### Backend (Executed)
 
@@ -107,11 +107,11 @@ Command:
 
 Result:
 - Domain: 93/93 passing
-- Application: 256/256 passing
-- API integration: 108/108 passing
+- Application: 259/259 passing
+- API integration: 109/109 passing
 - CLI contract: 4/4 passing
 - Architecture boundaries: 4/4 passing
-- Backend Total: 461/461 passing
+- Backend Total: 469/469 passing
 
 ### Frontend Unit + Build (Executed)
 
@@ -128,14 +128,14 @@ Result:
 ### Frontend E2E (Executed)
 
 Command:
-- `cd frontend/taskdeck-web && TASKDECK_E2E_DB=taskdeck.e2e.docsrefresh2.db npx playwright test --reporter=line`
+- `cd frontend/taskdeck-web && npx playwright test`
 
 Result:
 - E2E smoke + automation/ops flow: 11/11 passing
 
 ### Total
 
-- Combined automated total: 717/717 passing
+- Combined automated total: 725/725 passing
 
 ## CI Status
 
@@ -164,6 +164,7 @@ Automation and data:
 Observability and scalability:
 - `LogQueryService` currently performs broad in-memory composition paths (now emits duration/result-size diagnostics)
 - nullable warnings (`CS8618`) remain in domain entities
+- local build environment is currently Node 22.11.0; Vite warns that 22.12+ is preferred (build still passes)
 
 UX and operability (reconciled from product notes):
 - archive board lifecycle behavior is not yet fully coherent with archive/recovery UX

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -2,17 +2,17 @@
 
 This is the active testing guide for Taskdeck.
 
-## Current Verified Totals (2026-02-16)
+## Current Verified Totals (2026-02-17)
 
-- Backend: 461/461 passing
+- Backend: 469/469 passing
   - Domain: 93
-  - Application: 256
-  - API integration: 108
+  - Application: 259
+  - API integration: 109
   - CLI contract: 4
   - Architecture boundaries: 4
 - Frontend unit: 245/245 passing
 - Frontend E2E (smoke + automation/ops): 11/11 passing
-- Combined automated total: 717/717 passing
+- Combined automated total: 725/725 passing
 
 ## Backend Commands
 
@@ -57,7 +57,7 @@ Run E2E suite:
 
 ```bash
 cd frontend/taskdeck-web
-TASKDECK_E2E_DB=taskdeck.e2e.local.db npx playwright test --reporter=line
+npx playwright test --reporter=line
 ```
 
 ## CI Gates


### PR DESCRIPTION
## Summary
- Sync active baseline docs to the latest verification run recorded in `#42`.
- Update `docs/STATUS.md` test snapshot date/totals and backend breakdown counts.
- Update `docs/TESTING_GUIDE.md` verified totals and backend breakdown counts.
- Align E2E command references with the command that was actually executed.

## Tracking
Closes #42

## Verification
- `node scripts/check-docs-governance.mjs`
- `node scripts/check-github-ops-governance.mjs`

## Baseline Recorded
- Backend: 469/469
- Frontend unit: 245/245
- Frontend E2E: 11/11
- Combined total: 725/725