### PR TITLE
OPS-19: Bootstrap CI required workflow topology

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -20,21 +20,9 @@ env:
 jobs:
   docs-governance:
     name: Docs Governance
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.13.1
-
-      - name: Validate docs governance invariants
-        run: node scripts/check-docs-governance.mjs
-
-      - name: Validate GitHub operations governance invariants
-        run: node scripts/check-github-ops-governance.mjs
+    uses: ./.github/workflows/reusable-docs-governance.yml
+    with:
+      node-version: 24.13.1
 
   backend-architecture:
     name: Backend Architecture

--- a/.github/workflows/reusable-docs-governance.yml
+++ b/.github/workflows/reusable-docs-governance.yml
@@ -1,0 +1,32 @@
+name: Reusable Docs Governance
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version for docs governance checks
+        required: false
+        default: "24.13.1"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  docs-governance:
+    name: Docs Governance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Validate docs governance invariants
+        run: node scripts/check-docs-governance.mjs
+
+      - name: Validate GitHub operations governance invariants
+        run: node scripts/check-github-ops-governance.mjs

--- a/docs/DEPLOYMENT_CONTAINERS.md
+++ b/docs/DEPLOYMENT_CONTAINERS.md
@@ -143,7 +143,7 @@ Health endpoint routing:
 
 ## CI Packaging
 
-CI workflow `.github/workflows/ci.yml` includes `container-images` job that:
+CI workflow `.github/workflows/ci-required.yml` includes `container-images` job that:
 - validates compose rendering
 - builds backend and frontend images from repo root
 - exports compressed image artifacts and checksums

--- a/docs/IMPLEMENTATION_MASTERPLAN.md
+++ b/docs/IMPLEMENTATION_MASTERPLAN.md
@@ -168,6 +168,9 @@ Delivered in the latest cycle:
    - enhanced MCP profile validation script with optional-server prerequisite diagnostics (missing secret/config classification)
    - codified strict/warning/skip behavior for optional integrations and documented CI-friendly command patterns
    - added deterministic CI status output contract (`PASS`, `PASS_WITH_WARNINGS`, `FAIL`) for MCP profile validation flows
+39. OPS-19 CI topology first-pass delivery:
+   - migrated required CI entrypoint from `.github/workflows/ci.yml` to `.github/workflows/ci-required.yml` with equivalent gate behavior
+   - extracted docs governance lane into reusable workflow `.github/workflows/reusable-docs-governance.yml` as baseline for incremental workflow decomposition
 
 ## Roadmap by Horizon
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -190,7 +190,7 @@ Result:
 
 ## CI Status
 
-Workflow: `.github/workflows/ci.yml`
+Workflow: `.github/workflows/ci-required.yml`
 
 - `docs-governance` (Ubuntu)
 - `backend-architecture` (Ubuntu)
@@ -245,6 +245,7 @@ Security/compliance hardening backlog added from research cross-check:
 - Reconciled active docs and test totals after PR #23 merge.
 - Archived `REFACTOR_AUDIT_AND_ACTION_PLAN_2026-02-13.md` into `docs/archive/2026-02-13_phase4-doc-consolidation/audits-and-history/`.
 - Added CI hardening parity updates: concurrency cancellation, frontend typecheck/build enforcement, TRX/JUnit failure artifacts, and package/browser caches.
+- Delivered OPS-19 CI topology first pass (`#168`): migrated required pipeline entrypoint to `.github/workflows/ci-required.yml` and extracted docs-governance lane into reusable workflow `.github/workflows/reusable-docs-governance.yml`.
 - Added docs governance script and architecture boundary tests as CI invariants.
 - Added GitHub operations governance script to enforce issue-template label hygiene and project-automation doc invariants in CI.
 - Retrofitted boards controller family to claims-first authz with integration coverage for 401/403/cross-user/happy path.

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -112,7 +112,7 @@ powershell -File ./scripts/mcp/Test-DockerMcpProfile.ps1 -IncludeOptional -FailO
 
 ## CI Gates
 
-Workflow: `.github/workflows/ci.yml`
+Workflow: `.github/workflows/ci-required.yml`
 
 - `docs-governance`
   - Enforces required active docs and docs index invariants

--- a/docs/analysis/2026-02-21_ci-github-actions-expansion-plan.md
+++ b/docs/analysis/2026-02-21_ci-github-actions-expansion-plan.md
@@ -6,13 +6,13 @@ Authoring context: Local workflow/config scan + GitHub issue reconciliation + ta
 
 ## Purpose
 
-Define a pragmatic expansion strategy for `.github/workflows/ci.yml` so the pipeline scales with the already-seeded testing/security/ops issues without turning PR feedback into a bottleneck.
+Define a pragmatic expansion strategy for `.github/workflows/ci-required.yml` so the pipeline scales with the already-seeded testing/security/ops issues without turning PR feedback into a bottleneck.
 
 This plan is non-authoritative by itself. `docs/STATUS.md` and `docs/IMPLEMENTATION_MASTERPLAN.md` remain the canonical sources of truth.
 
 ## Current-State Snapshot
 
-Current CI workflow (`.github/workflows/ci.yml`) is strong and already above baseline:
+Current CI workflow (`.github/workflows/ci-required.yml`) is strong and already above baseline:
 
 - Single workflow with clear job decomposition:
   - docs governance


### PR DESCRIPTION
## Summary
First-pass delivery for `#168` to start CI topology decomposition with low risk.

## What Changed
- Renamed required CI entrypoint from `.github/workflows/ci.yml` to `.github/workflows/ci-required.yml`.
- Added reusable workflow `.github/workflows/reusable-docs-governance.yml`.
- Routed `docs-governance` lane in `ci-required.yml` through reusable workflow.
- Updated active docs to reference the new required workflow path:
  - `docs/STATUS.md`
  - `docs/TESTING_GUIDE.md`
  - `docs/DEPLOYMENT_CONTAINERS.md`
- Recorded OPS-19 first-pass delivery notes in:
  - `docs/STATUS.md`
  - `docs/IMPLEMENTATION_MASTERPLAN.md`
- Kept CI expansion analysis doc aligned to new path:
  - `docs/analysis/2026-02-21_ci-github-actions-expansion-plan.md`

## Verification
- `node scripts/check-docs-governance.mjs` (pass)
- `node scripts/check-github-ops-governance.mjs` (pass)

## Notes
- This PR intentionally preserves current required CI behavior while introducing reusable workflow structure for incremental extraction.

Refs #168