### PR TITLE
Ensure SQLite-safe chat session ordering and add ordering regression test

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/ChatApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ChatApiTests.cs
@@ -74,6 +74,42 @@ public class ChatApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task GetMySessions_ShouldReturnMostRecentlyUpdatedSessionFirst()
+    {
+        await AuthenticateAsync("chat-list-order");
+
+        var olderSessionResponse = await _client.PostAsJsonAsync(
+            "/api/llm/chat/sessions",
+            new CreateChatSessionDto("Older session"));
+        olderSessionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var olderSession = await olderSessionResponse.Content.ReadFromJsonAsync<ChatSessionDto>();
+        olderSession.Should().NotBeNull();
+
+        var newerSessionResponse = await _client.PostAsJsonAsync(
+            "/api/llm/chat/sessions",
+            new CreateChatSessionDto("Newer session"));
+        newerSessionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var newerSession = await newerSessionResponse.Content.ReadFromJsonAsync<ChatSessionDto>();
+        newerSession.Should().NotBeNull();
+
+        var bumpOlderSessionResponse = await _client.PostAsJsonAsync(
+            $"/api/llm/chat/sessions/{olderSession!.Id}/messages",
+            new SendChatMessageDto("Bump updated-at ordering"));
+        bumpOlderSessionResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var listSessionsResponse = await _client.GetAsync("/api/llm/chat/sessions");
+        listSessionsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var sessions = await listSessionsResponse.Content.ReadFromJsonAsync<List<ChatSessionDto>>();
+        sessions.Should().NotBeNull();
+
+        sessions!
+            .Select(session => session.Id)
+            .Take(2)
+            .Should()
+            .ContainInOrder(olderSession.Id, newerSession!.Id);
+    }
+
+    [Fact]
     public async Task GetSession_ShouldReturnForbidden_ForDifferentUser()
     {
         var userOneId = await AuthenticateAsync("chat-owner");


### PR DESCRIPTION
### Motivation
- Address inconsistent ordering of chat session lists on SQLite by ensuring returned sessions are ordered by `UpdatedAt` (most-recent first).
- Add regression coverage to prevent regressions where bumping a session (adding a message) does not surface it to the top of the list.

### Description
- Update `backend/src/Taskdeck.Infrastructure/Repositories/ChatSessionRepository.cs` to centralize listing logic in a `GetLimitedOrderedByUpdatedAtAsync` helper that materializes the query and then orders by `UpdatedAt` descending before applying the limit, avoiding SQLite-specific ordering pitfalls.
- Add an API integration test `GetMySessions_ShouldReturnMostRecentlyUpdatedSessionFirst` to `backend/tests/Taskdeck.Api.Tests/ChatApiTests.cs` that creates two sessions, posts a message to the older session to update its `UpdatedAt`, and asserts the bumped session appears ahead of the other in the returned list.
- Leave existing authenticated-session retrieval coverage intact in `backend/tests/Taskdeck.Api.Tests/ChatApiTests.cs`.

### Testing
- Attempted to run the focused API tests with: `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release --filter "FullyQualifiedName~ChatApiTests.GetMySessions"`, but the command could not be executed in this environment because `dotnet` is not installed (failure: `bash: command not found: dotnet`).
- No automated tests were executed here due to the environment limitation; please run the full backend verification locally or in CI with `dotnet test backend/Taskdeck.sln -c Release` or the filtered command above to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cb09d74ac833388cd102fb6b0704d)