### PR TITLE
CAP-06: lock deterministic failed-triage persistence semantics

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
@@ -351,6 +351,17 @@ public class CaptureApiTests : IClassFixture<TestWebApplicationFactory>
 
         var failedItem = await WaitForCaptureStatusAsync(created.Id, CaptureStatus.Failed);
         failedItem.Status.Should().Be(CaptureStatus.Failed);
+        failedItem.Provenance.Should().NotBeNull();
+        failedItem.Provenance!.ProposalId.Should().BeNull();
+        failedItem.Provenance.TriageRunId.Should().BeNull();
+        failedItem.Provenance.PromptVersion.Should().BeNull();
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var persistedItem = await db.LlmRequests.SingleAsync(request => request.Id == created.Id);
+        persistedItem.Status.Should().Be(RequestStatus.Failed);
+        persistedItem.RetryCount.Should().Be(1);
+        persistedItem.ErrorMessage.Should().Contain("BoardId is required");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #205

## Summary
- extended `CaptureApiTests.Triage_ShouldFailDeterministically_WhenCaptureHasNoBoard` to assert persisted queue-state semantics for deterministic validation failures:
  - capture detail remains `Failed`
  - provenance does not contain proposal/triage/prompt linkage fields
  - persisted queue request is `RequestStatus.Failed`
  - persisted failed-attempt count is exactly one (`RetryCount == 1` from `MarkAsFailed`, with no retry reset/schedule)
  - persisted error message retains the validation reason (`BoardId is required`)

## Why
CAP-06 requires deterministic validation failure behavior. Existing tests checked status only; this locks the worker persistence behavior so validation failures cannot drift into retry/requeue behavior unnoticed.

## Verification
- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release --filter "FullyQualifiedName~CaptureApiTests"`