### PR TITLE
CAP-08: add command-palette quick-capture e2e regression

### DIFF
--- a/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
@@ -172,6 +172,31 @@ test('capture hotkey should save item and route to inbox', async ({ page }) => {
   await expect(page.locator('.td-inbox-row__excerpt').first()).toContainText(captureText)
 })
 
+test('command palette capture action should save item and route to inbox', async ({ page }) => {
+  await gotoBoardsWorkspace(page)
+
+  const captureText = `Palette capture item ${Date.now()}`
+
+  await page.keyboard.press('Control+K')
+  const palette = page.getByRole('dialog', { name: 'Command palette' })
+  await expect(palette).toBeVisible()
+
+  const paletteInput = palette.getByPlaceholder('Type a command or search...')
+  await expect(paletteInput).toBeFocused()
+  await paletteInput.fill('new capture')
+  await paletteInput.press('Enter')
+
+  const captureModal = page.getByRole('dialog', { name: 'Capture item' })
+  await expect(captureModal).toBeVisible()
+  await expect(palette).toHaveCount(0)
+
+  await captureModal.getByPlaceholder('Capture a thought, task, or follow-up...').fill(captureText)
+  await captureModal.getByPlaceholder('Capture a thought, task, or follow-up...').press('Control+Enter')
+
+  await expect(page).toHaveURL(/\/workspace\/inbox$/)
+  await expect(page.locator('.td-inbox-row__excerpt').first()).toContainText(captureText)
+})
+
 test('activity view selectors should support board and entity discovery without raw IDs', async ({ page }) => {
   const boardName = `Activity Board ${Date.now()}`
   const columnName = `Activity Column ${Date.now()}`


### PR DESCRIPTION
## Summary
- add a smoke e2e that exercises command-palette capture (`Ctrl+K` -> `new capture` -> `Enter`)
- verify the capture modal opens, palette closes, submit succeeds, and navigation returns to inbox
- assert the newly captured text appears in the inbox list

Closes #207

## Testing
- `npm run typecheck`
- `npm run build`
- `npx vitest --run`
- Attempted: `npx playwright test tests/e2e/smoke.spec.ts --grep "command palette capture action should save item and route to inbox" --reporter=line`
  - blocked in this environment because Vite cannot bind localhost (`listen EACCES` on `127.0.0.1`/`::1`)