### PR TITLE
Stabilize webhook delivery worker API tests by removing DNS dependency

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
@@ -14,13 +14,17 @@ namespace Taskdeck.Api.Tests;
 
 public class OutboundWebhookDeliveryWorkerTests
 {
+    // Use a literal public TEST-NET address so host-policy tests do not depend on DNS behavior.
+    private const string AllowedWebhookEndpoint = "https://203.0.113.10/webhook";
+    private const string InsecureAllowedWebhookEndpoint = "http://203.0.113.10/webhook";
+
     [Fact]
     public async Task ProcessDueDeliveriesAsync_ShouldNotSend_WhenClaimFails()
     {
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "https://example.com/webhook",
+            AllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         var delivery = CreateDeliveryWithSubscription(subscription);
@@ -53,7 +57,7 @@ public class OutboundWebhookDeliveryWorkerTests
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "https://example.com/webhook",
+            AllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         var delivery = CreateDeliveryWithSubscription(subscription);
@@ -96,7 +100,7 @@ public class OutboundWebhookDeliveryWorkerTests
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "https://example.com/webhook",
+            AllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         subscription.Revoke(Guid.NewGuid());
@@ -131,7 +135,7 @@ public class OutboundWebhookDeliveryWorkerTests
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "http://example.com/webhook",
+            InsecureAllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         var delivery = CreateDeliveryWithSubscription(subscription);
@@ -165,7 +169,7 @@ public class OutboundWebhookDeliveryWorkerTests
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "https://example.com/webhook",
+            AllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         var delivery = CreateDeliveryWithSubscription(subscription);
@@ -200,7 +204,7 @@ public class OutboundWebhookDeliveryWorkerTests
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "https://example.com/webhook",
+            AllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         var delivery = CreateDeliveryWithSubscription(subscription);
@@ -247,7 +251,7 @@ public class OutboundWebhookDeliveryWorkerTests
         var subscription = new OutboundWebhookSubscription(
             Guid.NewGuid(),
             Guid.NewGuid(),
-            "https://example.com/webhook",
+            AllowedWebhookEndpoint,
             "secret",
             ["card.*"]);
         var delivery = CreateDeliveryWithSubscription(subscription);


### PR DESCRIPTION
## Summary
Fixes flaky API integration behavior in `OutboundWebhookDeliveryWorkerTests` where DNS resolution for `example.com` could return blocked/empty host-policy results in CI, causing cancellation-path assertions to fail with `Webhook endpoint host is not allowed.` instead of the expected shutdown requeue message.

## What changed
- Updated `backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs` to use a literal public TEST-NET endpoint for allowed-host scenarios:
  - `https://203.0.113.10/webhook`
  - `http://203.0.113.10/webhook` for insecure-scheme test
- Added constants at the top of the test class and replaced hard-coded `example.com` URLs.

## Why this works
- Host-policy validation treats literal public IP addresses deterministically and does not require DNS lookup.
- The tests still exercise the same worker behavior paths (claim/requeue/retry/dead-letter), but no longer depend on environment-specific DNS behavior.

## Validation
- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release --filter "FullyQualifiedName~OutboundWebhookDeliveryWorkerTests.ProcessDueDeliveriesAsync_ShouldRequeueDelivery_WhenCancellationOccursDuringSend"`
- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release`

Both passed locally (`274/274` in API integration suite).