### PR TITLE
Extract WorkspaceHelpCallout CSS magic numbers into local custom properties

### DIFF
--- a/frontend/taskdeck-web/src/components/workspace/WorkspaceHelpCallout.vue
+++ b/frontend/taskdeck-web/src/components/workspace/WorkspaceHelpCallout.vue
@@ -57,10 +57,13 @@ const { isVisible, dismiss, replay } = useWorkspaceHelp(props.topic)
   flex-direction: column;
   gap: var(--td-space-3);
   padding: var(--td-space-4);
-  border: 1px solid color-mix(in srgb, var(--td-color-primary) 18%, var(--td-border-default));
+  --_callout-primary-mix-border: 18%;
+  --_callout-primary-mix-bg: 9%;
+  --_callout-gradient-stop: 52%;
+  border: 1px solid color-mix(in srgb, var(--td-color-primary) var(--_callout-primary-mix-border), var(--td-border-default));
   border-radius: var(--td-radius-lg);
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--td-color-primary) 9%, var(--td-surface-container-high)), transparent 52%),
+    linear-gradient(135deg, color-mix(in srgb, var(--td-color-primary) var(--_callout-primary-mix-bg), var(--td-surface-container-high)), transparent var(--_callout-gradient-stop)),
     var(--td-surface-primary);
 }
 


### PR DESCRIPTION
## Summary
- Replaces inline `color-mix` percentages (`18%`, `9%`) and gradient stop (`52%`) in `WorkspaceHelpCallout.vue` with scoped CSS custom properties (`--_callout-primary-mix-border`, `--_callout-primary-mix-bg`, `--_callout-gradient-stop`)
- Improves maintainability by grouping tuning values at the top of the rule block
- No visual change; build verified clean

## Test plan
- [x] `npm run build` passes
- [ ] Visual spot-check: help callouts on Home, Today, Inbox, Review render identically