### PR TITLE
Fix inbox triage detail auto-refresh after enqueue

### DIFF
--- a/frontend/taskdeck-web/src/store/captureStore.ts
+++ b/frontend/taskdeck-web/src/store/captureStore.ts
@@ -1,7 +1,8 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { captureApi } from '../api/captureApi'
-import type { CaptureItem, CaptureItemSummary, CaptureListQuery, CaptureStatusValue, CreateCaptureItemDto } from '../types/capture'
+import { isTriageTerminalStatus } from '../types/capture'
+import type { CaptureItem, CaptureItemSummary, CaptureListQuery, CreateCaptureItemDto } from '../types/capture'
 import { useToastStore } from './toastStore'
 import { getErrorDisplay } from '../composables/useErrorMapper'
 
@@ -24,19 +25,6 @@ type DetailLoadOptions = {
   showToast?: boolean
   syncSummary?: boolean
 }
-
-const TRIAGE_TERMINAL_STATUSES: readonly CaptureStatusValue[] = [
-  'Triaged',
-  2,
-  'ProposalCreated',
-  3,
-  'Converted',
-  4,
-  'Ignored',
-  5,
-  'Failed',
-  6,
-]
 
 export const useCaptureStore = defineStore('capture', () => {
   const toast = useToastStore()
@@ -199,11 +187,8 @@ export const useCaptureStore = defineStore('capture', () => {
     }
   }
 
-  function isTriageTerminalStatus(status: CaptureStatusValue): boolean {
-    return TRIAGE_TERMINAL_STATUSES.includes(status)
-  }
-
   const triagePollingItemId = ref<string | null>(null)
+  let activeTriagePollStop: (() => void) | null = null
 
   function pollTriageCompletion(itemId: string): () => void {
     const POLL_INTERVAL_MS = 2_000
@@ -211,6 +196,10 @@ export const useCaptureStore = defineStore('capture', () => {
     let pollCount = 0
     let stopped = false
     let timerId: ReturnType<typeof setTimeout> | null = null
+
+    if (activeTriagePollStop) {
+      activeTriagePollStop()
+    }
 
     triagePollingItemId.value = itemId
 
@@ -244,11 +233,15 @@ export const useCaptureStore = defineStore('capture', () => {
         clearTimeout(timerId)
         timerId = null
       }
+      if (activeTriagePollStop === stop) {
+        activeTriagePollStop = null
+      }
       if (triagePollingItemId.value === itemId) {
         triagePollingItemId.value = null
       }
     }
 
+    activeTriagePollStop = stop
     timerId = setTimeout(tick, POLL_INTERVAL_MS)
     return stop
   }

--- a/frontend/taskdeck-web/src/tests/store/captureStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/captureStore.spec.ts
@@ -702,6 +702,37 @@ describe('captureStore', () => {
 
       vi.useRealTimers()
     })
+
+    it('stops any existing poll before starting a new one', async () => {
+      vi.useFakeTimers()
+      const store = useCaptureStore()
+
+      vi.mocked(captureApi.getItem).mockImplementation(async (itemId: string) => ({
+        id: itemId,
+        userId: 'u1',
+        boardId: null,
+        status: 'Triaging',
+        source: 'Typed',
+        textExcerpt: `${itemId} excerpt`,
+        rawText: `${itemId} full text`,
+        createdAt: new Date().toISOString(),
+        processedAt: null,
+        retryCount: 0,
+      }))
+
+      store.pollTriageCompletion('poll-old')
+      store.pollTriageCompletion('poll-new')
+
+      expect(store.triagePollingItemId).toBe('poll-new')
+
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      expect(captureApi.getItem).toHaveBeenCalledTimes(1)
+      expect(captureApi.getItem).toHaveBeenCalledWith('poll-new')
+      expect(store.triagePollingItemId).toBe('poll-new')
+
+      vi.useRealTimers()
+    })
   })
 
   it('emits a single triage error toast when detail refresh fails after enqueue', async () => {

--- a/frontend/taskdeck-web/src/tests/views/InboxView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/InboxView.spec.ts
@@ -790,6 +790,48 @@ describe('InboxView', () => {
     expect(mockCaptureStore.pollTriageCompletion).not.toHaveBeenCalled()
   })
 
+  it('stops the previous triage poll before retrying triage, even when the retry fails', async () => {
+    const stopFirstPoll = vi.fn()
+    mockCaptureStore.fetchDetail.mockImplementationOnce(async (itemId: string) => {
+      mockCaptureStore.detailById[itemId] = {
+        id: itemId,
+        userId: 'user-1',
+        boardId: 'board-1',
+        status: 'New',
+        source: 'Typed',
+        textExcerpt: `Excerpt for ${itemId}`,
+        rawText: `Full text for ${itemId}`,
+        createdAt: new Date().toISOString(),
+        processedAt: null,
+        retryCount: 0,
+        provenance: null,
+      }
+    })
+
+    mockCaptureStore.pollTriageCompletion
+      .mockImplementationOnce(() => stopFirstPoll)
+      .mockImplementation(() => () => {})
+
+    const wrapper = mount(InboxView)
+    await waitForUi()
+
+    await wrapper.get('[role="option"]').trigger('click')
+    await waitForUi()
+
+    const triageButton = () => wrapper.findAll('button').find((node) => node.text() === 'Start Triage')
+
+    await triageButton()?.trigger('click')
+    await waitForUi()
+
+    mockCaptureStore.triageItem.mockRejectedValueOnce(new Error('retry failed'))
+
+    await triageButton()?.trigger('click')
+    await waitForUi()
+
+    expect(mockCaptureStore.triageItem).toHaveBeenCalledTimes(2)
+    expect(stopFirstPoll).toHaveBeenCalledTimes(1)
+  })
+
   it('navigates to linked proposal route when detail includes proposal provenance', async () => {
     mockCaptureStore.fetchDetail.mockImplementationOnce(async (itemId: string) => {
       mockCaptureStore.detailById[itemId] = {

--- a/frontend/taskdeck-web/src/types/capture.ts
+++ b/frontend/taskdeck-web/src/types/capture.ts
@@ -9,6 +9,23 @@ export type CaptureStatus =
 
 export type CaptureStatusValue = CaptureStatus | number
 
+export const TRIAGE_TERMINAL_STATUSES: readonly CaptureStatusValue[] = [
+  'Triaged',
+  2,
+  'ProposalCreated',
+  3,
+  'Converted',
+  4,
+  'Ignored',
+  5,
+  'Failed',
+  6,
+]
+
+export function isTriageTerminalStatus(status: CaptureStatusValue): boolean {
+  return TRIAGE_TERMINAL_STATUSES.includes(status)
+}
+
 export type CaptureSource =
   | 'Typed'
   | 'Paste'

--- a/frontend/taskdeck-web/src/views/InboxView.vue
+++ b/frontend/taskdeck-web/src/views/InboxView.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
 import { useCaptureStore } from '../store/captureStore'
+import { isTriageTerminalStatus } from '../types/capture'
 import type { CaptureItem, CaptureItemSummary, CaptureSourceValue, CaptureStatusValue } from '../types/capture'
 import { registerEscapeHandler } from '../composables/useEscapeStack'
 import { normalizeBoardIdQueryParam } from '../utils/navigation'
@@ -69,10 +70,6 @@ function sourceLabel(source: CaptureSourceValue): string {
   if (source === 4 || source === 'Voice') return 'Voice'
   if (source === 5 || source === 'MeetingIntegration') return 'Meeting'
   return String(source)
-}
-
-function isTriageTerminalStatus(status: CaptureStatusValue): boolean {
-  return ['Triaged', 2, 'ProposalCreated', 3, 'Converted', 4, 'Ignored', 5, 'Failed', 6].includes(status)
 }
 
 async function loadInbox() {
@@ -307,12 +304,13 @@ async function triageSelected() {
     return
   }
 
+  if (stopTriagePolling) {
+    stopTriagePolling()
+    stopTriagePolling = null
+  }
+
   try {
     await captureStore.triageItem(itemId)
-    if (stopTriagePolling) {
-      stopTriagePolling()
-      stopTriagePolling = null
-    }
 
     const latestStatus = captureStore.detailById[itemId]?.status
     if (latestStatus !== undefined && isTriageTerminalStatus(latestStatus)) {
@@ -321,6 +319,10 @@ async function triageSelected() {
 
     stopTriagePolling = captureStore.pollTriageCompletion(itemId)
   } catch {
+    if (stopTriagePolling) {
+      stopTriagePolling()
+      stopTriagePolling = null
+    }
     // Store handles toast + error state.
   }
 }


### PR DESCRIPTION
Closes #365

## Summary
- Add `pollTriageCompletion()` to `captureStore` — polls capture detail every 2s (up to 30s) after triage enqueue, stopping on terminal status (`ProposalCreated`, `Triaged`, `Converted`, `Ignored`, `Failed`)
- Wire polling into `InboxView`: starts after successful triage, stops on item change or unmount
- Triage button shows "Triaging (checking...)" while polling is active
- Add 4 unit tests covering: terminal-status stop, manual stop, max-poll exhaustion, and transient error retry

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npx vitest --run` — 607 tests pass (4 new polling tests)
- [ ] Manual: triage an inbox item and confirm detail auto-transitions without clicking "Refresh Detail"
- [ ] E2E: `npx playwright test tests/e2e/capture-loop.spec.ts` (existing flow should still pass; no longer depends on manual refresh timing)