### PR TITLE
Add data-testid and data-capture-id attributes to Inbox items

### DIFF
--- a/frontend/taskdeck-web/src/views/InboxView.vue
+++ b/frontend/taskdeck-web/src/views/InboxView.vue
@@ -520,6 +520,8 @@ onUnmounted(() => {
             :key="item.id"
             :id="`td-inbox-option-${index}`"
             :data-inbox-index="index"
+            data-testid="inbox-item"
+            :data-capture-id="item.id"
             :class="[
               'td-inbox-row',
               index === activeItemIndex ? 'td-inbox-row--active' : '',

--- a/frontend/taskdeck-web/tests/e2e/capture-loop.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/capture-loop.spec.ts
@@ -28,7 +28,7 @@ test('capture triage should create proposal and apply card with provenance links
   const captureId = createdCapture.id
 
   await page.goto('/workspace/inbox')
-  const captureRow = page.locator('.td-inbox-row').filter({ hasText: checklistTaskTitle }).first()
+  const captureRow = page.locator('[data-testid="inbox-item"]').filter({ hasText: checklistTaskTitle }).first()
   await expect(captureRow).toBeVisible()
   await captureRow.click()
 

--- a/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
@@ -101,9 +101,9 @@ test('first-run path should guide home to capture to review to execute to board'
   await expect(page.getByRole('heading', { name: 'Inbox', exact: true })).toBeVisible()
   await expect(page.getByText(`Showing capture items linked to board ${boardId}.`)).toBeVisible()
   await expect(page.getByText('What is Inbox for?')).toBeVisible()
-  await expect(page.locator('.td-inbox-row').filter({ hasText: controlCardTitle })).toHaveCount(0)
+  await expect(page.locator('[data-testid="inbox-item"]').filter({ hasText: controlCardTitle })).toHaveCount(0)
 
-  const captureRow = page.locator('.td-inbox-row').filter({ hasText: cardTitle }).first()
+  const captureRow = page.locator('[data-testid="inbox-item"]').filter({ hasText: cardTitle }).first()
   await expect(captureRow).toBeVisible()
   await captureRow.click()
 
@@ -159,8 +159,8 @@ test('first-run path should guide home to capture to review to execute to board'
   await expect(page).toHaveURL(new RegExp(`/workspace/inbox\\?boardId=${boardId}#capture-${captureId}$`))
   await expect(page.getByRole('heading', { name: 'Inbox', exact: true })).toBeVisible()
   await expect(page.getByText(`Showing capture items linked to board ${boardId}.`)).toBeVisible()
-  await expect(page.locator('.td-inbox-row').filter({ hasText: controlCardTitle })).toHaveCount(0)
-  await expect(page.locator('.td-inbox-row').filter({ hasText: cardTitle })).toHaveClass(/td-inbox-row--selected/)
+  await expect(page.locator('[data-testid="inbox-item"]').filter({ hasText: controlCardTitle })).toHaveCount(0)
+  await expect(page.locator('[data-testid="inbox-item"]').filter({ hasText: cardTitle })).toHaveClass(/td-inbox-row--selected/)
   await expect(page.locator('.td-inbox-detail__text')).toContainText(captureText)
 })
 


### PR DESCRIPTION
## Summary
- Adds `data-testid="inbox-item"` and `data-capture-id="{uuid}"` attributes to each Inbox row in `InboxView.vue` for reliable Playwright selection.
- Updates E2E tests (`first-run.spec.ts`, `capture-loop.spec.ts`) to use `[data-testid="inbox-item"]` instead of `.td-inbox-row` class selectors.

Closes #393

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npx vitest --run` passes (670 tests)
- [ ] E2E tests using inbox selectors still pass
- [ ] Verify `data-testid="inbox-item"` and `data-capture-id` attributes appear in DOM via browser DevTools