### PR TITLE
Fix login returning 400 instead of 401 for invalid requests

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -34,10 +34,10 @@ public class AuthController : ControllerBase
         {
             return Unauthorized(new ApiErrorResponse(
                 ErrorCodes.AuthenticationFailed,
-                "Invalid username/email or password."));
+                "Invalid username/email or password"));
         }
 
-        var result = await _authService.LoginAsync(dto);
+        var result = await _authService.LoginAsync(dto!);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 

--- a/backend/src/Taskdeck.Api/Filters/SuppressModelStateValidationAttribute.cs
+++ b/backend/src/Taskdeck.Api/Filters/SuppressModelStateValidationAttribute.cs
@@ -4,10 +4,9 @@ namespace Taskdeck.Api.Filters;
 
 /// <summary>
 /// Suppresses the automatic 400 response that <c>[ApiController]</c> triggers
-/// when model state is invalid. The action method is still invoked and can
-/// inspect <c>ModelState</c> or the bound parameter manually.
-/// Applied as an action filter that runs before the built-in
-/// <c>ModelStateInvalidFilter</c> (order -2000) and clears any validation errors.
+/// when model state is invalid. Clears validation errors so the action method
+/// is still invoked and can inspect the bound parameter directly.
+/// Runs before the built-in <c>ModelStateInvalidFilter</c> (order -2000).
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class SuppressModelStateValidationAttribute : Attribute, IOrderedFilter, IActionFilter

--- a/backend/tests/Taskdeck.Api.Tests/ApiErrorContractApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiErrorContractApiTests.cs
@@ -57,7 +57,7 @@ public class ApiErrorContractApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
-    public async Task Login_ShouldReturn401_WhenRequestBodyIsEmpty()
+    public async Task Login_ShouldReturn401_WhenRequestBodyIsEmptyJsonObject()
     {
         using var client = _factory.CreateClient();
 
@@ -69,7 +69,7 @@ public class ApiErrorContractApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
-    public async Task Login_ShouldReturn401_WhenRequestBodyIsNull()
+    public async Task Login_ShouldReturn401_WhenRequestBodyIsJsonNull()
     {
         using var client = _factory.CreateClient();
 


### PR DESCRIPTION
## Summary
- Adds a `SuppressModelStateValidation` action filter that prevents ASP.NET's automatic 400 response on the login endpoint
- Login action now returns 401 with `ApiErrorResponse` for empty, null, or missing-field request bodies — consistent with invalid credentials
- Adds two integration tests covering empty `{}` and `null` login request bodies

Closes #392

## Test plan
- [x] `Login_ShouldReturn401_WhenRequestBodyIsEmpty` — sends `{}`, expects 401
- [x] `Login_ShouldReturn401_WhenRequestBodyIsNull` — sends `null`, expects 401
- [x] All 13 existing ApiErrorContract tests still pass