### PR TITLE
Add labelsApi unit tests

### DIFF
--- a/frontend/taskdeck-web/src/tests/api/labelsApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/labelsApi.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import http from '../../api/http'
 import { labelsApi } from '../../api/labelsApi'
+import type { CreateLabelDto, UpdateLabelDto } from '../../types/board'
 
 vi.mock('../../api/http', () => ({
   default: {
@@ -26,20 +27,20 @@ describe('labelsApi', () => {
   })
 
   it('createLabel sends POST with label payload', async () => {
-    const label = { name: 'Feature', color: '#00ff00' }
+    const label: CreateLabelDto = { name: 'Feature', colorHex: '#00ff00' }
     vi.mocked(http.post).mockResolvedValue({ data: { id: '2', ...label } })
 
-    const result = await labelsApi.createLabel('board-1', label as any)
+    const result = await labelsApi.createLabel('board-1', label)
 
     expect(http.post).toHaveBeenCalledWith('/boards/board-1/labels', label)
     expect(result).toEqual({ id: '2', ...label })
   })
 
   it('updateLabel sends PATCH with label payload', async () => {
-    const update = { name: 'Bugfix' }
+    const update: UpdateLabelDto = { name: 'Bugfix' }
     vi.mocked(http.patch).mockResolvedValue({ data: { id: '1', name: 'Bugfix' } })
 
-    const result = await labelsApi.updateLabel('board-1', 'label-1', update as any)
+    const result = await labelsApi.updateLabel('board-1', 'label-1', update)
 
     expect(http.patch).toHaveBeenCalledWith('/boards/board-1/labels/label-1', update)
     expect(result).toEqual({ id: '1', name: 'Bugfix' })


### PR DESCRIPTION
## Summary
- Add unit tests for all 4 `labelsApi` methods: `getLabels`, `createLabel`, `updateLabel`, `deleteLabel`
- Follow existing `archiveApi.spec.ts` pattern (mock HTTP, verify URL/payload)

## Test plan
- [x] All 4 tests pass (`npx vitest --run src/tests/api/labelsApi.spec.ts`)
- [x] No lint warnings

Closes #415