### PR TITLE
Add useEscapeToClose unit tests

### DIFF
--- a/frontend/taskdeck-web/src/tests/composables/useEscapeToClose.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useEscapeToClose.spec.ts
@@ -24,45 +24,63 @@ function mountWithEscapeToClose(initialOpen = true) {
 }
 
 describe('useEscapeToClose', () => {
+  let wrapper: ReturnType<typeof mountWithEscapeToClose>['wrapper'] | undefined
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+  })
+
   it('calls the close callback when Escape is pressed while open', () => {
-    const { wrapper, onClose } = mountWithEscapeToClose()
+    const ctx = mountWithEscapeToClose()
+    wrapper = ctx.wrapper
 
     pressKey('Escape')
 
-    expect(onClose).toHaveBeenCalledTimes(1)
-    wrapper.unmount()
+    expect(ctx.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call the close callback when initially closed', () => {
+    const ctx = mountWithEscapeToClose(false)
+    wrapper = ctx.wrapper
+
+    pressKey('Escape')
+
+    expect(ctx.onClose).not.toHaveBeenCalled()
   })
 
   it('does not call the close callback for non-Escape keys', () => {
-    const { wrapper, onClose } = mountWithEscapeToClose()
+    const ctx = mountWithEscapeToClose()
+    wrapper = ctx.wrapper
 
     pressKey('Enter')
 
-    expect(onClose).not.toHaveBeenCalled()
-    wrapper.unmount()
+    expect(ctx.onClose).not.toHaveBeenCalled()
   })
 
   it('removes the escape listener on cleanup', async () => {
-    const { wrapper, isOpen, onClose } = mountWithEscapeToClose()
+    const ctx = mountWithEscapeToClose()
+    wrapper = ctx.wrapper
 
-    isOpen.value = false
+    ctx.isOpen.value = false
     await nextTick()
 
     pressKey('Escape')
-    expect(onClose).not.toHaveBeenCalled()
+    expect(ctx.onClose).not.toHaveBeenCalled()
 
-    isOpen.value = true
+    ctx.isOpen.value = true
     await nextTick()
     pressKey('Escape')
-    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(ctx.onClose).toHaveBeenCalledTimes(1)
 
-    wrapper.unmount()
+    ctx.wrapper.unmount()
+    wrapper = undefined
     pressKey('Escape')
 
-    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(ctx.onClose).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- add mounted composable coverage for `useEscapeToClose`
- verify Escape-triggered close behavior, non-Escape no-op behavior, and cleanup/unmount listener removal

## Testing
- `cd frontend/taskdeck-web && npx vitest --run -t "useEscapeToClose"`
- `cd frontend/taskdeck-web && npx eslint src/tests/composables/useEscapeToClose.spec.ts`

Closes #419