### PR TITLE
AGT-01-FOLLOWUP: Replace raw SQL with LINQ in AgentRunRepository

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/AgentRunRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AgentRunRepository.cs
@@ -17,14 +17,6 @@ public class AgentRunRepository : Repository<AgentRun>, IAgentRunRepository
     {
         var boundedLimit = limit <= 0 ? DefaultLimit : limit;
 
-        if (_context.Database.IsSqlite())
-        {
-            return await _dbSet
-                .FromSqlInterpolated(
-                    $"SELECT * FROM AgentRuns WHERE AgentProfileId = {agentProfileId} ORDER BY CreatedAt DESC LIMIT {boundedLimit}")
-                .ToListAsync(cancellationToken);
-        }
-
         return await _dbSet
             .Where(ar => ar.AgentProfileId == agentProfileId)
             .OrderByDescending(ar => ar.CreatedAt)


### PR DESCRIPTION
## Summary
- Remove `FromSqlInterpolated` raw SQL branch in `GetByAgentProfileIdAsync`
- Use standard LINQ `.Where().OrderByDescending().Take()` which EF Core translates correctly for SQLite

Closes #451

## Test plan
- [ ] `dotnet test backend/Taskdeck.sln -c Release -m:1` passes (969 tests, 0 failures)
- [ ] Query behavior unchanged — same results for agent run lookups