### PR TITLE
TST-25: Add opt-in headed manual-audit Playwright pack

### DIFF
--- a/docs/testing/MANUAL_AUDIT_PACK.md
+++ b/docs/testing/MANUAL_AUDIT_PACK.md
@@ -64,7 +64,7 @@ Screenshots are saved as `01-home.png`, `02-inbox-with-capture.png`, etc. in the
 
 ## CI Exclusion
 
-The `manual-audit.spec.ts` file is listed in `playwright.config.ts` under `testIgnore`, so `npm run test:e2e` (the default CI command) skips it. The dedicated `npm run test:e2e:audit:headed` script explicitly targets the file, bypassing `testIgnore`.
+All tests in `manual-audit.spec.ts` are gated behind `TASKDECK_RUN_AUDIT=1`. When `npm run test:e2e` runs in CI, the env var is unset and all audit tests are skipped. The dedicated `npm run test:e2e:audit:headed` script sets the env var automatically.
 
 ## Configuration
 

--- a/frontend/taskdeck-web/package.json
+++ b/frontend/taskdeck-web/package.json
@@ -23,7 +23,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "node -e \"require('fs').mkdirSync('test-results',{recursive:true})\" && vitest run --coverage --reporter=default --reporter=junit --outputFile.junit=./test-results/vitest.coverage.junit.xml",
     "test:e2e": "playwright test",
-    "test:e2e:audit:headed": "playwright test tests/e2e/manual-audit.spec.ts --headed --reporter=line",
+    "test:e2e:audit:headed": "node -e \"process.env.TASKDECK_RUN_AUDIT='1';require('child_process').execSync('npx playwright test tests/e2e/manual-audit.spec.ts --headed --reporter=line',{stdio:'inherit',env:process.env})\"",
     "test:e2e:concurrency": "playwright test tests/e2e/concurrency.spec.ts --reporter=line",
     "test:e2e:live-llm:headed": "playwright test tests/e2e/live-llm.spec.ts --headed --reporter=line",
     "test:e2e:headed": "playwright test --headed"

--- a/frontend/taskdeck-web/playwright.config.ts
+++ b/frontend/taskdeck-web/playwright.config.ts
@@ -41,7 +41,6 @@ for (const [index, origin] of backendCorsOrigins.entries()) {
 
 export default defineConfig({
   testDir: './tests/e2e',
-  testIgnore: ['**/manual-audit.spec.ts'],
   forbidOnly: !!process.env.CI,
   fullyParallel: false,
   workers: process.env.CI ? 1 : undefined,

--- a/frontend/taskdeck-web/tests/e2e/manual-audit.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/manual-audit.spec.ts
@@ -13,6 +13,9 @@
  *
  * This pack is NOT part of required CI. It is intended for local operator audits,
  * pre-release sanity checks, and visual debugging sessions.
+ *
+ * Gated behind TASKDECK_RUN_AUDIT=1. The npm script sets this automatically:
+ *   npm run test:e2e:audit:headed
  */
 
 import { expect, test } from '@playwright/test'
@@ -25,6 +28,8 @@ import {
   waitForCardWithTitle,
   waitForProposalCreated,
 } from './support/captureFlow'
+
+const runAudit = parseTrueishEnv(process.env.TASKDECK_RUN_AUDIT)
 
 test.use({
   screenshot: 'on',
@@ -41,6 +46,7 @@ test.beforeEach(async ({ page, request }) => {
 })
 
 test.describe('Core loop: Home -> Inbox/Capture -> Review -> Board', () => {
+  test.skip(!runAudit, 'Set TASKDECK_RUN_AUDIT=1 or use npm run test:e2e:audit:headed')
   test('full capture-triage-review-apply loop with screenshots', async ({ page, request }, testInfo) => {
     // Step 1: Home landing
     await page.goto('/workspace/home')
@@ -131,6 +137,8 @@ test.describe('Core loop: Home -> Inbox/Capture -> Review -> Board', () => {
 })
 
 test.describe('Advanced checks', () => {
+  test.skip(!runAudit, 'Set TASKDECK_RUN_AUDIT=1 or use npm run test:e2e:audit:headed')
+
   test('command palette search navigates to inbox', async ({ page }, testInfo) => {
     await page.goto('/workspace/boards')
     await expect(page.getByRole('button', { name: '+ New Board' })).toBeVisible()
@@ -218,6 +226,7 @@ test.describe('Advanced checks', () => {
 })
 
 test.describe('Live LLM provider probe', () => {
+  test.skip(!runAudit, 'Set TASKDECK_RUN_AUDIT=1 or use npm run test:e2e:audit:headed')
   test.skip(
     !parseTrueishEnv(process.env.TASKDECK_RUN_LIVE_LLM_TESTS),
     'Set TASKDECK_RUN_LIVE_LLM_TESTS=1 to run the opt-in live-provider probe.',


### PR DESCRIPTION
## Summary

Closes #369

- Add `tests/e2e/manual-audit.spec.ts` covering the core `Home -> Inbox/Capture -> Review -> Board` loop with numbered screenshots at each milestone, plus advanced checks (command palette, capture hotkey, board/filter lifecycle) and an opt-in live LLM provider probe
- Update `test:e2e:audit:headed` npm script to use the new dedicated audit spec
- Add `docs/testing/MANUAL_AUDIT_PACK.md` documenting when to use vs stakeholder demo recorder vs default smoke

## Design decisions

- Headed mode with 250ms slow motion for operator visibility
- Screenshots captured at every meaningful step (18 total across all tests)
- Live LLM probe gated behind `TASKDECK_RUN_LIVE_LLM_TESTS=1` env var
- NOT added to CI — local/operator-focused only
- Uses existing `registerAndAttachSession` auth pattern — no demo seed required

## Test plan

- [ ] Run `npm run test:e2e:audit:headed` locally with backend running
- [ ] Verify headed browser opens with visible slow motion
- [ ] Verify screenshots appear in test output directory
- [ ] Verify live LLM tests skip by default (no env var)
- [ ] Verify `TASKDECK_RUN_LIVE_LLM_TESTS=1 npm run test:e2e:audit:headed` runs LLM probe (requires configured provider)
- [ ] Verify existing `npm run test:e2e` is unaffected