### PR TITLE
Fix breaking API changes for FluentAssertions v8 and EF Core v9 Dependabot upgrades

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/KnowledgeChunkRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/KnowledgeChunkRepository.cs
@@ -25,8 +25,8 @@ public class KnowledgeChunkRepository : Repository<KnowledgeChunk>, IKnowledgeCh
         Guid documentId,
         CancellationToken cancellationToken = default)
     {
-        await _dbSet
-            .Where(c => c.DocumentId == documentId)
-            .ExecuteDeleteAsync(cancellationToken);
+        await RelationalQueryableExtensions.ExecuteDeleteAsync(
+            _dbSet.Where(c => c.DocumentId == documentId),
+            cancellationToken);
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/ArchiveApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ArchiveApiTests.cs
@@ -98,7 +98,7 @@ public class ArchiveApiTests : IClassFixture<TestWebApplicationFactory>
 
         var items = await response.Content.ReadFromJsonAsync<List<ArchiveItemDto>>();
         items.Should().NotBeNull();
-        items!.Count.Should().BeLessOrEqualTo(5);
+        items!.Count.Should().BeLessThanOrEqualTo(5);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/HealthApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/HealthApiTests.cs
@@ -73,7 +73,7 @@ public class HealthApiTests : IClassFixture<TestWebApplicationFactory>
         var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
         var queue = payload.GetProperty("checks").GetProperty("queue");
         queue.GetProperty("depth").GetInt32().Should().Be(0);
-        queue.GetProperty("captureDepth").GetInt32().Should().BeGreaterOrEqualTo(3);
-        queue.GetProperty("totalDepth").GetInt32().Should().BeGreaterOrEqualTo(3);
+        queue.GetProperty("captureDepth").GetInt32().Should().BeGreaterThanOrEqualTo(3);
+        queue.GetProperty("totalDepth").GetInt32().Should().BeGreaterThanOrEqualTo(3);
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/LlmQuotaApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQuotaApiTests.cs
@@ -103,7 +103,7 @@ public class LlmQuotaApiTests : IClassFixture<TestWebApplicationFactory>
         var json = JsonSerializer.Deserialize<JsonElement>(body);
         json.TryGetProperty("globalKilled", out _).Should().BeTrue();
         json.TryGetProperty("entries", out var entries).Should().BeTrue();
-        entries.GetArrayLength().Should().BeGreaterOrEqualTo(1);
+        entries.GetArrayLength().Should().BeGreaterThanOrEqualTo(1);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/LlmQuotaIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQuotaIntegrationTests.cs
@@ -306,9 +306,9 @@ public class LlmUsageRecordingIntegrationTests : IClassFixture<TestWebApplicatio
         var usage = await usageResponse.Content.ReadFromJsonAsync<JsonElement>();
 
         usage.GetProperty("totalRequests").GetInt64().Should().Be(messageCount);
-        usage.GetProperty("totalTokens").GetInt64().Should().BeGreaterOrEqualTo(0);
-        usage.GetProperty("totalInputTokens").GetInt64().Should().BeGreaterOrEqualTo(0);
-        usage.GetProperty("totalOutputTokens").GetInt64().Should().BeGreaterOrEqualTo(0);
+        usage.GetProperty("totalTokens").GetInt64().Should().BeGreaterThanOrEqualTo(0);
+        usage.GetProperty("totalInputTokens").GetInt64().Should().BeGreaterThanOrEqualTo(0);
+        usage.GetProperty("totalOutputTokens").GetInt64().Should().BeGreaterThanOrEqualTo(0);
 
         // Verify window boundaries are present
         usage.TryGetProperty("windowStart", out _).Should().BeTrue();
@@ -342,7 +342,7 @@ public class LlmUsageRecordingIntegrationTests : IClassFixture<TestWebApplicatio
         afterResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var after = await afterResponse.Content.ReadFromJsonAsync<JsonElement>();
         after.GetProperty("requestsThisHour").GetInt64().Should().Be(1);
-        after.GetProperty("tokensUsedToday").GetInt64().Should().BeGreaterOrEqualTo(0);
+        after.GetProperty("tokensUsedToday").GetInt64().Should().BeGreaterThanOrEqualTo(0);
     }
 }
 

--- a/backend/tests/Taskdeck.Api.Tests/OpsCliApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OpsCliApiTests.cs
@@ -134,7 +134,7 @@ public class OpsCliApiTests : IClassFixture<TestWebApplicationFactory>
             var payload = await response.Content.ReadFromJsonAsync<CommandRunDto>();
             payload.Should().NotBeNull();
             payload!.CorrelationId.Should().NotBe(invalidCorrelationId);
-            payload.CorrelationId.Length.Should().BeLessOrEqualTo(100);
+            payload.CorrelationId.Length.Should().BeLessThanOrEqualTo(100);
 
             response.Headers.TryGetValues("X-Request-Id", out var responseRequestIds).Should().BeTrue();
             responseRequestIds!.Single().Should().Be(payload.CorrelationId);

--- a/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
@@ -102,12 +102,8 @@ public static class ApiTestHarness
         }
         catch (JsonException ex)
         {
-            Execute.Assertion.FailWith(
-                "Expected a JSON error contract body for {0}, but parsing failed: {1}. Body: {2}",
-                expectedStatus,
-                ex.Message,
-                rawBody);
-            return;
+            throw new XunitException(
+                $"Expected a JSON error contract body for {expectedStatus}, but parsing failed: {ex.Message}. Body: {rawBody}");
         }
 
         payload.ValueKind.Should().Be(JsonValueKind.Object);


### PR DESCRIPTION
## Summary

Compatibility fixes to unblock Dependabot dependency upgrade PRs:

- **FluentAssertions v8**: Renames `BeLessOrEqualTo` → `BeLessThanOrEqualTo`, `BeGreaterOrEqualTo` → `BeGreaterThanOrEqualTo`, and removes `Execute.Assertion` (replaced with `throw new XunitException`)
- **EF Core v9**: Adds `ExecuteDeleteAsync` to `EntityFrameworkQueryableExtensions` alongside the existing `RelationalQueryableExtensions`, creating an ambiguous call in `KnowledgeChunkRepository.DeleteByDocumentIdAsync`. Fixed by calling `RelationalQueryableExtensions.ExecuteDeleteAsync` explicitly.

## Affected Dependabot PRs
- #491 (FluentAssertions 6→8)
- #494 (Microsoft.EntityFrameworkCore 8→9)
- #495 (Microsoft.EntityFrameworkCore.Design 8→9)
- #496 (Microsoft.EntityFrameworkCore.Sqlite 8→9)

## Test plan
- [ ] CI passes on this PR (Backend Unit, API Integration, Backend Architecture)
- [ ] After merge, `@dependabot rebase` on PRs #491, #494, #495, #496 to pick up these fixes