### PR TITLE
Fix Swashbuckle 6.9 IFormFile schema generation error in ExportController

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/ExportController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/ExportController.cs
@@ -83,6 +83,7 @@ public class ExportController : AuthenticatedControllerBase
     }
 
     [HttpPost("import/database")]
+    [Consumes("multipart/form-data")]
     public async Task<IActionResult> ImportDatabase([FromForm] IFormFile? file)
     {
         if (!TryGetCurrentUserId(out var userId, out var errorResult))


### PR DESCRIPTION
## Summary

Swashbuckle.AspNetCore 6.9.0 introduced stricter validation: actions using `[FromForm]` with `IFormFile` must explicitly declare `[Consumes("multipart/form-data")]`, otherwise OpenAPI generation throws a `SwaggerGeneratorException` at runtime when fetching `swagger.json`.

**Root cause:** `ExportController.ImportDatabase` uses `[FromForm] IFormFile? file` without the `[Consumes]` attribute.
**Fix:** Add `[Consumes("multipart/form-data")]` to the action.

## Affected Dependabot PR
- #489 (dotnet-minor-patch group, includes Swashbuckle.AspNetCore 6.5.0 → 6.9.0)

## Test plan
- [ ] CI passes (OpenAPI Guardrail passes — the /swagger/v1/swagger.json endpoint returns 200)
- [ ] After merge, `@dependabot rebase` on PR #489