### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Taskdeck Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -191,3 +191,7 @@ Rebranding/thesis alignment inputs:
 - Open or pick a GitHub issue before larger changes.
 - Keep PRs scoped and include verification evidence.
 - For contribution guidance and repo rules, see `AGENTS.md`.
+
+## License
+
+Taskdeck is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- Adds standard MIT LICENSE file at repo root
- Adds License section to README.md referencing the LICENSE file
- Closes #547

## Test plan
- [ ] LICENSE file exists at repo root
- [ ] Content matches MIT license template
- [ ] Copyright year is 2026 and holder is "Taskdeck Contributors"
- [ ] README.md has a License section linking to the LICENSE file
- [ ] GitHub detects and displays the license badge on the repository page