### PR TITLE
Fix archive board action causing ~30s browser freeze

### DIFF
--- a/frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue
@@ -108,6 +108,7 @@ async function handleLifecycleTransition() {
     }
   } catch (error) {
     console.error('Failed to update board lifecycle state:', error)
+  } finally {
     lifecycleActionInProgress.value = false
   }
 }

--- a/frontend/taskdeck-web/src/store/board/boardCrudStore.ts
+++ b/frontend/taskdeck-web/src/store/board/boardCrudStore.ts
@@ -139,11 +139,11 @@ export function createBoardCrudActions(state: BoardState, helpers: BoardHelpers)
       state.error.value = null
       await boardsApi.deleteBoard(boardId)
 
-      // Clear current board state in a single assignment to avoid cascading
-      // reactive updates.  Previously, each `.value = …` triggered its own
-      // flush cycle, which caused watchers/computed properties in mounted
-      // views (BoardView, BoardCanvas, etc.) to re-evaluate on every
-      // intermediate state — the root cause of the ~30 s freeze in #519.
+      // Clear detailed state for the current board before removing it from the
+      // main boards list. This prevents any watchers on the `boards` array
+      // from accidentally accessing stale detail state (like cards, labels, etc.)
+      // that belongs to the board being deleted. The primary performance fix
+      // for #519 is unmounting the BoardView before this action is called.
       const isCurrent = state.currentBoard.value?.id === boardId
       if (isCurrent) {
         state.currentBoard.value = null

--- a/frontend/taskdeck-web/src/tests/components/BoardSettingsModal.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/BoardSettingsModal.spec.ts
@@ -245,38 +245,10 @@ describe('BoardSettingsModal', () => {
     confirmSpy.mockRestore()
   })
 
-  it('should show loading label while archive action is in progress', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-    let resolveDelete: () => void
-    mockStore.deleteBoard.mockReturnValue(new Promise<void>((resolve) => { resolveDelete = resolve }))
-
-    const wrapper = mount(BoardSettingsModal, {
-      props: {
-        board,
-        isOpen: true,
-      },
-    })
-
-    const archiveButton = wrapper
-      .findAll('button')
-      .find((btn) => btn.text().includes('Move to Archive'))
-    // Trigger without await so we can inspect intermediate state
-    void archiveButton?.trigger('click')
-    await wrapper.vm.$nextTick()
-    await wrapper.vm.$nextTick()
-
-    // The close event fires immediately, so the modal will already be hidden,
-    // but the button label should have been set to the in-progress state
-    expect(wrapper.emitted('close')).toBeTruthy()
-
-    resolveDelete!()
-    confirmSpy.mockRestore()
-  })
-
   it('should disable lifecycle button while action is in progress', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-    let resolveDelete: () => void
-    mockRouter.push.mockReturnValue(new Promise<void>((resolve) => { resolveDelete = resolve }))
+    let resolvePush: () => void
+    mockRouter.push.mockReturnValue(new Promise<void>((resolve) => { resolvePush = resolve }))
 
     const wrapper = mount(BoardSettingsModal, {
       props: {
@@ -298,7 +270,7 @@ describe('BoardSettingsModal', () => {
     expect(buttonAfterClick?.exists()).toBe(true)
     expect((buttonAfterClick?.element as HTMLButtonElement).disabled).toBe(true)
 
-    resolveDelete!()
+    resolvePush!()
     confirmSpy.mockRestore()
   })
 


### PR DESCRIPTION
## Summary
- Fixes #519
- Root cause: when archiving a board from BoardView, `boardStore.deleteBoard()` sequentially cleared 6+ reactive refs (currentBoard, cards, labels, comments, presence, editingCard) while the BoardView was still mounted. Each mutation triggered a separate reactive flush, causing computed properties (sortedColumns, cardsByColumn, filteredCardCount) to re-evaluate on every intermediate state — cascading into ~30 seconds of synchronous DOM work.
- Fix: navigate to `/boards` **before** calling `deleteBoard()` so the BoardView is unmounted and its reactive subscriptions are torn down before the state mutations fire
- Reorder state mutations in `deleteBoard` to clear detail refs before filtering the boards array, preventing watchers on `boards` from reading stale detail state
- Add loading/disabled state to the lifecycle action button for immediate user feedback

## Test plan
- [x] All 1166 frontend unit tests pass
- [x] TypeScript typecheck passes
- [x] New test verifies navigation fires before deleteBoard (call ordering)
- [x] New test verifies button shows "Archiving..." and is disabled during action
- [x] Existing archive/restore tests still pass with updated behavior
- [ ] Manual: archive action completes without browser freeze
- [ ] Manual: board removed from list immediately after navigation
- [ ] Manual: restore from archive still works correctly