### PR TITLE
UX-27: Soften Home primary action card color

### DIFF
--- a/frontend/taskdeck-web/src/views/HomeView.vue
+++ b/frontend/taskdeck-web/src/views/HomeView.vue
@@ -564,7 +564,7 @@ onActivated(refreshHomeSummary)
 }
 
 .td-home-action--primary:hover {
-  background: rgba(255, 77, 77, 0.18);
+  background: color-mix(in srgb, var(--td-color-ember) 18%, transparent);
   box-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- Replace full ember-red (`--td-color-ember-glow`) background on `.td-home-action--primary` with subtle `--td-color-ember-dim` (10% opacity) background
- Add `border-left: 3px solid var(--td-color-ember)` accent for visual hierarchy without alarm
- Soften hover state: lighter rgba overlay instead of full ember + red glow box-shadow
- Reserve full-red backgrounds for actual urgency (overdue, blocked items)

Closes #627

## Test plan
- [ ] Visual check: Home view "Next Step" card should appear as a subtle ember-tinted card, not alarming red
- [ ] Hover state should slightly darken the ember tint without a red glow
- [ ] Light mode: verify ember-dim token renders correctly (uses different opacity)
- [ ] No regressions on secondary action cards