### PR TITLE
UX-24: Inbox color-coded status tags and text fatigue reduction

### DIFF
--- a/frontend/taskdeck-web/src/views/InboxView.vue
+++ b/frontend/taskdeck-web/src/views/InboxView.vue
@@ -1387,7 +1387,7 @@ onUnmounted(() => {
     font-size: var(--td-font-sm);
     line-height: 1.5;
     display: -webkit-box;
-    -webkit-line-clamp: 3;
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
   }


### PR DESCRIPTION
## Summary
- Status chips in InboxView now use semantic color-coding: Failed (red/error), Applied to Board (green/success), Triaging/Triaged/Ready for review (amber/warning), New (ember), Ignored (muted gray, unchanged)
- Excerpt text truncated to 2 lines via `line-clamp` with `font-weight: 400` to reduce visual density
- Alternating row backgrounds (`nth-child(even)`) for improved scanability

## Test plan
- [ ] Verify status chips render with correct colors for each status value (New, Triaging, Triaged, Ready for review, Applied to board, Ignored, Failed)
- [ ] Verify excerpt text truncates at 2 lines for long content
- [ ] Verify alternating row backgrounds appear in the inbox list
- [ ] Verify active/selected row styles still override alternating backgrounds
- [ ] Verify light mode and dark mode both look correct (tokens have both variants)
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes

Closes #624