### PR TITLE
UX-22: Today - reduce card density and add visual hierarchy

### DIFF
--- a/frontend/taskdeck-web/src/views/TodayView.vue
+++ b/frontend/taskdeck-web/src/views/TodayView.vue
@@ -296,7 +296,7 @@ onActivated(refreshTodaySummary)
           v-for="stat in activeStats"
           :key="stat.id"
           class="td-panel td-today-stat"
-          :class="{ 'td-today-stat--urgent': stat.id === 'review' || stat.id === 'overdue' }"
+          :class="{ 'td-today-stat--urgent': ['review', 'overdue', 'triage'].includes(stat.id) }"
         >
           <span class="td-today-stat__label">{{ stat.label }}</span>
           <span class="td-today-stat__value">{{ stat.value }}</span>


### PR DESCRIPTION
## Summary
- **Zero-count collapse**: Stats with count=0 now render as a compact chip row instead of full cards, reducing visual noise when things are clear
- **Visual hierarchy**: Ember accent left-border on urgent stat cards (review, overdue) and agenda sections; muted styling for zero-count badges
- **Progressive disclosure**: Only the first 3 agenda sections are expanded by default; remaining sections hidden behind a "Show more" button
- **Spacing**: Increased gaps from `space-3`/`space-4` to `space-5`/`space-6` (~1.1-1.3rem) for better breathing room
- **Card differentiation**: Left-border color coding - ember for urgent sections (review, capture, overdue), neutral for informational (due today, blocked)

Closes #622

## Test plan
- [ ] Verify stats with non-zero counts render as full cards with ember left-border on review/overdue
- [ ] Verify stats with zero counts render as compact chip row below the stats grid
- [ ] Verify only first 3 agenda sections are visible initially
- [ ] Verify "Show more" button appears and reveals remaining sections when clicked
- [ ] Verify ember left-border on review/capture/overdue agenda cards
- [ ] Verify neutral left-border on due-today/blocked agenda cards
- [ ] Verify zero-count badge uses muted styling instead of red
- [ ] Verify increased spacing between sections is visually coherent
- [ ] Verify responsive behavior at mobile breakpoint (768px)
- [ ] Run `npm run typecheck` and `npm run build` - both pass