### PR TITLE
LLM-02: Expand board context with card IDs and structured reference

### DIFF
--- a/backend/src/Taskdeck.Application/Services/BoardContextBuilder.cs
+++ b/backend/src/Taskdeck.Application/Services/BoardContextBuilder.cs
@@ -59,14 +59,16 @@ public class BoardContextBuilder : IBoardContextBuilder
             sb.Append("Columns: ").AppendLine(
                 string.Join(" → ", columns.Select(c => c.Name)));
 
+            // Single query for all board cards, grouped by column in memory (avoids N+1)
+            var cardsByColumn = (await _unitOfWork.Cards.GetByBoardIdAsync(boardId, ct))
+                .GroupBy(c => c.ColumnId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderByDescending(c => c.UpdatedAt).Take(MaxCardsPerColumn).ToList());
+
             foreach (var column in columns)
             {
-                var columnCards = (await _unitOfWork.Cards.GetByColumnIdAsync(column.Id, ct))
-                    .OrderByDescending(c => c.UpdatedAt)
-                    .Take(MaxCardsPerColumn)
-                    .ToList();
-
-                if (columnCards.Count == 0)
+                if (!cardsByColumn.TryGetValue(column.Id, out var columnCards) || columnCards.Count == 0)
                     continue;
 
                 sb.Append("Cards in \"").Append(column.Name).AppendLine("\":");

--- a/backend/tests/Taskdeck.Application.Tests/Services/BoardContextBuilderTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/BoardContextBuilderTests.cs
@@ -65,9 +65,7 @@ public class BoardContextBuilderTests
 
         _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
         _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { col1, col2, col3 });
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col1.Id, default)).ReturnsAsync(Array.Empty<Card>());
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col2.Id, default)).ReturnsAsync(Array.Empty<Card>());
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col3.Id, default)).ReturnsAsync(Array.Empty<Card>());
+        _cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Card>());
         _labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Label>());
 
         var result = await _builder.BuildContextAsync(boardId);
@@ -89,7 +87,7 @@ public class BoardContextBuilderTests
 
         _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
         _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { col });
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(colId, default)).ReturnsAsync(new[] { card1, card2 });
+        _cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { card1, card2 });
         _labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Label>());
 
         var result = await _builder.BuildContextAsync(boardId);
@@ -141,7 +139,7 @@ public class BoardContextBuilderTests
 
         _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
         _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { col });
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(colId, default)).ReturnsAsync(cards);
+        _cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(cards);
         _labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Label>());
 
         var result = await _builder.BuildContextAsync(boardId);
@@ -168,15 +166,14 @@ public class BoardContextBuilderTests
             .Select(i => new Label(boardId, $"Label-{i}", "#FF0000"))
             .ToList();
 
+        var allCards = columns.SelectMany(col =>
+            Enumerable.Range(0, 10)
+                .Select(j => new Card(boardId, col.Id, $"A card with a fairly long title in column {col.Name} number {j}"))
+        ).ToList();
+
         _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
         _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(columns);
-        foreach (var col in columns)
-        {
-            var colCards = Enumerable.Range(0, 10)
-                .Select(j => new Card(boardId, col.Id, $"A card with a fairly long title in column {col.Name} number {j}"))
-                .ToList();
-            _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col.Id, default)).ReturnsAsync(colCards);
-        }
+        _cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(allCards);
         _labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(labels);
 
         var result = await _builder.BuildContextAsync(boardId);
@@ -228,8 +225,7 @@ public class BoardContextBuilderTests
 
         _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
         _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { col1, col2 });
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col1.Id, default)).ReturnsAsync(Array.Empty<Card>());
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col2.Id, default)).ReturnsAsync(new[] { card });
+        _cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { card });
         _labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Label>());
 
         var result = await _builder.BuildContextAsync(boardId);
@@ -261,7 +257,7 @@ public class BoardContextBuilderTests
 
         _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
         _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { col });
-        _cardRepoMock.Setup(r => r.GetByColumnIdAsync(col.Id, default)).ReturnsAsync(new[] { card });
+        _cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { card });
         _labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { label });
 
         var result = await _builder.BuildContextAsync(boardId);


### PR DESCRIPTION
## Summary
- Expand `BoardContextBuilder` to include short card IDs (first 8 hex chars of GUID) in bracket notation, enabling the LLM to generate `move card <id>` style instructions
- Restructure context format: column flow line (`A -> B -> C`), per-column card groupings with `Cards in "Column":` headings, card-level label annotations
- Increase context budget from 2000 to 4000 characters to accommodate the richer card metadata
- Skip empty columns in card listing section to conserve budget
- Add `FormatShortId` helper with deterministic output (no-hyphen hex prefix)

Closes #617

## Test plan
- [x] All 15 BoardContextBuilder tests pass (including 4 new tests)
- [x] Full backend test suite passes (530+ tests, 0 failures)
- [x] New tests cover: short ID formatting, card-level labels in output, empty column skipping, budget constant verification
- [x] Existing truncation and budget tests still pass with the increased limit