### PR TITLE
Migrate StarterPackCatalogModal to design tokens

### DIFF
--- a/frontend/taskdeck-web/src/components/board/StarterPackCatalogModal.vue
+++ b/frontend/taskdeck-web/src/components/board/StarterPackCatalogModal.vue
@@ -1125,7 +1125,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
 }
 
 .sp-pack-card:hover {
-  border-color: var(--td-border-ghost);
+  border-color: var(--td-border-default);
   background: var(--td-surface-tertiary);
 }
 


### PR DESCRIPTION
## Summary
- Replaced all hardcoded Tailwind color classes (`bg-white`, `text-gray-*`, `border-gray-*`, `bg-blue-*`, `bg-red-*`, `bg-green-*`, `bg-amber-*`, etc.) in `StarterPackCatalogModal.vue` with scoped CSS classes that reference `--td-*` design tokens.
- Added a `<style scoped>` block with semantic class names (`sp-panel`, `sp-tab`, `sp-btn-primary`, `sp-tone-success`, `sp-callout-error`, etc.) that map to design tokens from `design-tokens.css`.
- The modal now correctly respects dark/light theme switching via `data-theme`.
- Computed status-indicator classes (`outcomeSummaryToneClass`, `conflictSeverityBadgeClass`) now return semantic class names instead of Tailwind color utilities.

Closes #612

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes (typecheck + vite build)
- [x] Verified zero remaining hardcoded Tailwind color classes via grep
- [ ] Visual verification: open Starter Packs modal in both dark and light themes
- [ ] Verify status indicators (success/error/warning/info tones) render correctly
- [ ] Verify tab active state uses primary accent color
- [ ] Verify pack card selection highlight uses primary accent