### PR TITLE
ci: add developer-portal job to nightly lane (#609)

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -26,6 +26,13 @@ jobs:
     with:
       dotnet-version: 8.0.x
 
+  developer-portal:
+    name: Developer Portal
+    uses: ./.github/workflows/reusable-developer-portal.yml
+    with:
+      dotnet-version: 8.0.x
+      node-version: 24.13.1
+
   backend-solution:
     name: Backend Solution Regression
     uses: ./.github/workflows/reusable-backend-solution.yml


### PR DESCRIPTION
## Summary
- Wires `reusable-developer-portal.yml` into `ci-nightly.yml` so the Redoc HTML API docs are regenerated nightly and uploaded as the `developer-portal` CI artifact
- No change to `ci-extended` — spec drift is already caught by `openapi-guardrail` running unconditionally on every PR

## What developer-portal does
Builds the API, starts it, fetches `/swagger/v1/swagger.json`, then runs `@redocly/cli build-docs` to produce static HTML. Uploads `artifacts/developer-portal/` including integration docs from `docs/api/`.

## Not addressed here
The committed `artifacts/openapi/taskdeck-api.json` artifact (stale since 2025-02-24) still needs regeneration by running `./scripts/ci/generate-openapi-artifact.ps1` locally against a running API instance. That is a developer action, not a CI config change.

Partial close of #609