### PR TITLE
UX-19: Sticky action footer and constrained card height for review cards

### DIFF
--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -1295,8 +1295,8 @@ watch(
   z-index: 2;
   background: var(--td-surface-container-low);
   padding-block: var(--td-space-2);
-  margin-inline: calc(-1 * var(--td-space-5, 1.25rem));
-  padding-inline: var(--td-space-5, 1.25rem);
+  margin-inline: calc(-1 * var(--td-space-5));
+  padding-inline: var(--td-space-5);
   border-top: 1px solid var(--td-border-ghost);
 }
 
@@ -1469,8 +1469,8 @@ watch(
   .td-review-card__actions {
     flex-direction: column;
     align-items: stretch;
-    margin-inline: calc(-1 * var(--td-space-4, 1rem));
-    padding-inline: var(--td-space-4, 1rem);
+    margin-inline: calc(-1 * var(--td-space-4));
+    padding-inline: var(--td-space-4);
   }
 
   .td-review-card__actions .td-btn {


### PR DESCRIPTION
## Summary

- Adds `max-height` (70vh desktop, 80vh mobile) with `overflow-y: auto` to review proposal cards so tall cards become scrollable rather than pushing the entire page down
- Makes the action footer (`View Diff` / `Approve` / `Reject` / `Apply to board`) sticky at the bottom of each card with `position: sticky; bottom: 0` and a solid background, so buttons remain visible regardless of how much detail content the card has
- Caps expanded entity list and operation list sections at `12rem` with inner scroll to prevent unbounded growth
- Adjusts mobile (640px) breakpoint to match the smaller card padding for the sticky footer margins

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] `npx vitest --run` -- all 1491 tests pass across 134 files
- [x] `npm run lint` -- 0 errors (159 pre-existing warnings, none new)
- [ ] Manual: verify action buttons stay visible when expanding all collapsible sections on a card with many affected entities
- [ ] Manual: verify sticky footer background matches card background (no transparency gap)
- [ ] Manual: verify mobile viewport (640px) renders action buttons full-width with correct padding
- [ ] Manual: verify scrolling within a card does not interfere with page-level scroll when card content is short

Closes #613