### PR TITLE
CLD-03 follow-up: DB-backed auth codes, PKCE, account linking

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -1,5 +1,5 @@
-using System.Collections.Concurrent;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +11,7 @@ using Taskdeck.Api.RateLimiting;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Exceptions;
 using AuthenticationService = Taskdeck.Application.Services.AuthenticationService;
 
@@ -18,6 +19,7 @@ namespace Taskdeck.Api.Controllers;
 
 public record ChangePasswordRequest(string CurrentPassword, string NewPassword);
 public record ExchangeCodeRequest(string Code);
+public record LinkExchangeRequest(string Code);
 
 /// <summary>
 /// Authentication endpoints — register, login, change password, and GitHub OAuth flow.
@@ -30,16 +32,14 @@ public class AuthController : AuthenticatedControllerBase
 {
     private readonly AuthenticationService _authService;
     private readonly GitHubOAuthSettings _gitHubOAuthSettings;
+    private readonly IUnitOfWork _unitOfWork;
 
-    // Short-lived, single-use authorization codes to avoid exposing JWT in URLs.
-    // Key: code, Value: (token, expiry). Codes expire after 60 seconds.
-    private static readonly ConcurrentDictionary<string, (AuthResultDto Result, DateTimeOffset Expiry)> _authCodes = new();
-
-    public AuthController(AuthenticationService authService, GitHubOAuthSettings gitHubOAuthSettings, IUserContext userContext)
+    public AuthController(AuthenticationService authService, GitHubOAuthSettings gitHubOAuthSettings, IUserContext userContext, IUnitOfWork unitOfWork)
         : base(userContext)
     {
         _authService = authService;
         _gitHubOAuthSettings = gitHubOAuthSettings;
+        _unitOfWork = unitOfWork;
     }
 
     /// <summary>
@@ -117,10 +117,11 @@ public class AuthController : AuthenticatedControllerBase
 
     /// <summary>
     /// Initiates GitHub OAuth login flow. Only available when GitHub OAuth is configured.
+    /// Pass mode=link to start an account-linking flow instead of login.
     /// </summary>
     [HttpGet("github/login")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
-    public IActionResult GitHubLogin([FromQuery] string? returnUrl = null)
+    public IActionResult GitHubLogin([FromQuery] string? returnUrl = null, [FromQuery] string? mode = null)
     {
         if (!_gitHubOAuthSettings.IsConfigured)
             return NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "GitHub OAuth is not configured"));
@@ -131,9 +132,15 @@ public class AuthController : AuthenticatedControllerBase
 
         var properties = new Microsoft.AspNetCore.Authentication.AuthenticationProperties
         {
-            RedirectUri = Url.Action(nameof(GitHubCallback), new { returnUrl }),
+            RedirectUri = Url.Action(nameof(GitHubCallback), new { returnUrl, mode }),
             Items = { { "LoginProvider", "GitHub" } }
         };
+
+        // Store mode in the auth properties so the callback can detect linking
+        if (mode == "link")
+        {
+            properties.Items["mode"] = "link";
+        }
 
         return Challenge(properties, "GitHub");
     }
@@ -143,7 +150,7 @@ public class AuthController : AuthenticatedControllerBase
     /// </summary>
     [HttpGet("github/callback")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
-    public async Task<IActionResult> GitHubCallback([FromQuery] string? returnUrl = null)
+    public async Task<IActionResult> GitHubCallback([FromQuery] string? returnUrl = null, [FromQuery] string? mode = null)
     {
         if (!_gitHubOAuthSettings.IsConfigured)
             return NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "GitHub OAuth is not configured"));
@@ -171,6 +178,38 @@ public class AuthController : AuthenticatedControllerBase
                 "GitHub did not return a user identifier"));
         }
 
+        // Sign out the temporary cookie used during the OAuth handshake
+        await HttpContext.SignOutAsync("GitHub");
+
+        // Account linking flow: store the GitHub identity as a link code
+        if (mode == "link")
+        {
+            var linkCode = GenerateAuthCode();
+            var providerData = JsonSerializer.Serialize(new
+            {
+                provider = "GitHub",
+                providerUserId,
+                displayName,
+                avatarUrl
+            });
+
+            var linkAuthCode = OAuthAuthCode.CreateForLinking(
+                code: linkCode,
+                providerData: providerData,
+                expiresAt: DateTimeOffset.UtcNow.AddSeconds(60));
+
+            await _unitOfWork.OAuthAuthCodes.AddAsync(linkAuthCode);
+            await _unitOfWork.SaveChangesAsync();
+
+            var linkReturnUrl = !string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl)
+                ? returnUrl
+                : "/";
+
+            var linkSeparator = linkReturnUrl.Contains('?') ? "&" : "?";
+            return Redirect($"{linkReturnUrl}{linkSeparator}oauth_link_code={Uri.EscapeDataString(linkCode)}");
+        }
+
+        // Normal login flow
         // GitHub may not return an email if user's email is private
         if (string.IsNullOrWhiteSpace(email))
             email = $"{providerUserId}@users.noreply.github.com";
@@ -191,14 +230,20 @@ public class AuthController : AuthenticatedControllerBase
         if (!result.IsSuccess)
             return result.ToErrorActionResult();
 
-        // Sign out the temporary cookie used during the OAuth handshake
-        await HttpContext.SignOutAsync("GitHub");
-
-        // Security: Do NOT put the JWT in the URL. Use a short-lived, single-use
-        // authorization code that the frontend exchanges via POST.
+        // Store the authorization code in the database instead of in-memory.
+        // This survives restarts and works with multi-instance deployments.
         var code = GenerateAuthCode();
-        _authCodes[code] = (result.Value, DateTimeOffset.UtcNow.AddSeconds(60));
-        CleanupExpiredCodes();
+        var authCode = new OAuthAuthCode(
+            code: code,
+            userId: result.Value.User.Id,
+            token: result.Value.Token,
+            expiresAt: DateTimeOffset.UtcNow.AddSeconds(60));
+
+        await _unitOfWork.OAuthAuthCodes.AddAsync(authCode);
+        await _unitOfWork.SaveChangesAsync();
+
+        // Best-effort cleanup of expired codes
+        _ = CleanupExpiredCodesAsync();
 
         var safeReturnUrl = !string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl)
             ? returnUrl
@@ -214,18 +259,137 @@ public class AuthController : AuthenticatedControllerBase
     /// </summary>
     [HttpPost("github/exchange")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
-    public IActionResult ExchangeCode([FromBody] ExchangeCodeRequest request)
+    public async Task<IActionResult> ExchangeCode([FromBody] ExchangeCodeRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.Code))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Code is required"));
 
-        if (!_authCodes.TryRemove(request.Code, out var entry))
+        var authCode = await _unitOfWork.OAuthAuthCodes.GetByCodeAsync(request.Code);
+        if (authCode == null)
             return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
 
-        if (DateTimeOffset.UtcNow > entry.Expiry)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Code has expired"));
+        if (authCode.IsLinkingCode)
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "This code is for account linking, not login"));
 
-        return Ok(entry.Result);
+        if (!authCode.TryConsume())
+        {
+            var message = authCode.IsExpired ? "Code has expired" : "Invalid or expired code";
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, message));
+        }
+
+        await _unitOfWork.SaveChangesAsync();
+
+        // Look up the user to build the AuthResultDto
+        var user = await _unitOfWork.Users.GetByIdAsync(authCode.UserId);
+        if (user == null)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "User not found"));
+
+        var userDto = new UserDto(
+            user.Id,
+            user.Username,
+            user.Email,
+            user.DefaultRole,
+            user.IsActive,
+            user.CreatedAt,
+            user.UpdatedAt);
+
+        return Ok(new AuthResultDto(authCode.Token, userDto));
+    }
+
+    /// <summary>
+    /// Exchanges a link code and associates the GitHub account with the authenticated user.
+    /// Requires a valid JWT session.
+    /// </summary>
+    [HttpPost("github/link")]
+    [Authorize]
+    [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
+    [ProducesResponseType(typeof(LinkedAccountDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> LinkGitHub([FromBody] LinkExchangeRequest request)
+    {
+        if (!_gitHubOAuthSettings.IsConfigured)
+            return NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "GitHub OAuth is not configured"));
+
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        if (string.IsNullOrWhiteSpace(request.Code))
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code is required"));
+
+        // Look up and consume the link code
+        var authCode = await _unitOfWork.OAuthAuthCodes.GetByCodeAsync(request.Code);
+        if (authCode == null)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
+
+        if (!authCode.IsLinkingCode)
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "This code is for login, not account linking"));
+
+        if (!authCode.TryConsume())
+        {
+            var message = authCode.IsExpired ? "Link code has expired" : "Invalid or expired link code";
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, message));
+        }
+
+        await _unitOfWork.SaveChangesAsync();
+
+        // Parse the provider data from the link code
+        if (string.IsNullOrWhiteSpace(authCode.ProviderData))
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code contains no provider data"));
+
+        var providerInfo = JsonSerializer.Deserialize<JsonElement>(authCode.ProviderData);
+        var provider = providerInfo.GetProperty("provider").GetString() ?? "GitHub";
+        var providerUserId = providerInfo.GetProperty("providerUserId").GetString();
+        var displayName = providerInfo.TryGetProperty("displayName", out var dn) ? dn.GetString() : null;
+        var avatarUrl = providerInfo.TryGetProperty("avatarUrl", out var av) ? av.GetString() : null;
+
+        if (string.IsNullOrWhiteSpace(providerUserId))
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Provider user ID is missing from link code"));
+
+        var result = await _authService.CompleteAccountLinkAsync(callerUserId, provider, providerUserId, displayName, avatarUrl);
+        return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
+    }
+
+    /// <summary>
+    /// Unlinks a GitHub account from the authenticated user.
+    /// </summary>
+    [HttpDelete("github/link")]
+    [Authorize]
+    [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UnlinkGitHub()
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var result = await _authService.UnlinkExternalLoginAsync(callerUserId, "GitHub");
+        return result.IsSuccess ? NoContent() : result.ToErrorActionResult();
+    }
+
+    /// <summary>
+    /// Returns the external logins linked to the authenticated user.
+    /// </summary>
+    [HttpGet("linked-accounts")]
+    [Authorize]
+    [ProducesResponseType(typeof(IEnumerable<LinkedAccountDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetLinkedAccounts()
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var logins = await _unitOfWork.ExternalLogins.GetByUserIdAsync(callerUserId);
+        var dtos = logins.Select(l => new LinkedAccountDto(
+            l.Provider,
+            l.ProviderUserId,
+            l.ProviderDisplayName,
+            l.AvatarUrl,
+            l.CreatedAt));
+
+        return Ok(dtos);
     }
 
     /// <summary>
@@ -246,13 +410,15 @@ public class AuthController : AuthenticatedControllerBase
         return Convert.ToBase64String(bytes).Replace("+", "-").Replace("/", "_").TrimEnd('=');
     }
 
-    private static void CleanupExpiredCodes()
+    private async Task CleanupExpiredCodesAsync()
     {
-        var now = DateTimeOffset.UtcNow;
-        foreach (var kvp in _authCodes)
+        try
         {
-            if (now > kvp.Value.Expiry)
-                _authCodes.TryRemove(kvp.Key, out _);
+            await _unitOfWork.OAuthAuthCodes.DeleteExpiredAsync(DateTimeOffset.UtcNow);
+        }
+        catch
+        {
+            // Cleanup failure is non-critical
         }
     }
 }

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -371,15 +371,32 @@ public class AuthController : AuthenticatedControllerBase
         if (!consumed)
             return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
-        // Parse the provider data from the link code
+        // Parse the provider data from the link code.
+        // Wrap in try-catch to prevent 500 errors from malformed JSON (should not happen in normal
+        // operation, but defensive coding for any unexpected data corruption).
         if (string.IsNullOrWhiteSpace(authCode.ProviderData))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code contains no provider data"));
 
-        var providerInfo = JsonSerializer.Deserialize<JsonElement>(authCode.ProviderData);
-        var provider = providerInfo.GetProperty("provider").GetString() ?? "GitHub";
-        var providerUserId = providerInfo.GetProperty("providerUserId").GetString();
-        var displayName = providerInfo.TryGetProperty("displayName", out var dn) ? dn.GetString() : null;
-        var avatarUrl = providerInfo.TryGetProperty("avatarUrl", out var av) ? av.GetString() : null;
+        string? provider;
+        string? providerUserId;
+        string? displayName;
+        string? avatarUrl;
+        try
+        {
+            var providerInfo = JsonSerializer.Deserialize<JsonElement>(authCode.ProviderData);
+            provider = providerInfo.GetProperty("provider").GetString() ?? "GitHub";
+            providerUserId = providerInfo.GetProperty("providerUserId").GetString();
+            displayName = providerInfo.TryGetProperty("displayName", out var dn) ? dn.GetString() : null;
+            avatarUrl = providerInfo.TryGetProperty("avatarUrl", out var av) ? av.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code contains invalid provider data"));
+        }
+        catch (KeyNotFoundException)
+        {
+            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code is missing required provider fields"));
+        }
 
         if (string.IsNullOrWhiteSpace(providerUserId))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Provider user ID is missing from link code"));

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -264,6 +264,7 @@ public class AuthController : AuthenticatedControllerBase
         if (string.IsNullOrWhiteSpace(request.Code))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Code is required"));
 
+        // Read the code first to check purpose and expiry
         var authCode = await _unitOfWork.OAuthAuthCodes.GetByCodeAsync(request.Code);
         if (authCode == null)
             return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
@@ -271,13 +272,16 @@ public class AuthController : AuthenticatedControllerBase
         if (authCode.IsLinkingCode)
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "This code is for account linking, not login"));
 
-        if (!authCode.TryConsume())
-        {
-            var message = authCode.IsExpired ? "Code has expired" : "Invalid or expired code";
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, message));
-        }
+        if (authCode.IsExpired)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Code has expired"));
 
-        await _unitOfWork.SaveChangesAsync();
+        if (authCode.IsConsumed)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
+
+        // Atomically consume the code — prevents race conditions with concurrent requests
+        var consumed = await _unitOfWork.OAuthAuthCodes.TryConsumeAtomicAsync(request.Code);
+        if (!consumed)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
 
         // Look up the user to build the AuthResultDto
         var user = await _unitOfWork.Users.GetByIdAsync(authCode.UserId);
@@ -318,7 +322,7 @@ public class AuthController : AuthenticatedControllerBase
         if (string.IsNullOrWhiteSpace(request.Code))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code is required"));
 
-        // Look up and consume the link code
+        // Look up and validate the link code
         var authCode = await _unitOfWork.OAuthAuthCodes.GetByCodeAsync(request.Code);
         if (authCode == null)
             return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
@@ -326,13 +330,16 @@ public class AuthController : AuthenticatedControllerBase
         if (!authCode.IsLinkingCode)
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "This code is for login, not account linking"));
 
-        if (!authCode.TryConsume())
-        {
-            var message = authCode.IsExpired ? "Link code has expired" : "Invalid or expired link code";
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, message));
-        }
+        if (authCode.IsExpired)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Link code has expired"));
 
-        await _unitOfWork.SaveChangesAsync();
+        if (authCode.IsConsumed)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
+
+        // Atomically consume the code
+        var consumed = await _unitOfWork.OAuthAuthCodes.TryConsumeAtomicAsync(request.Code);
+        if (!consumed)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
 
         // Parse the provider data from the link code
         if (string.IsNullOrWhiteSpace(authCode.ProviderData))

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -118,6 +118,8 @@ public class AuthController : AuthenticatedControllerBase
     /// <summary>
     /// Initiates GitHub OAuth login flow. Only available when GitHub OAuth is configured.
     /// Pass mode=link to start an account-linking flow instead of login.
+    /// When mode=link, the caller MUST be authenticated (JWT required) so the link code
+    /// is bound to their identity, preventing CSRF attacks.
     /// </summary>
     [HttpGet("github/login")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
@@ -132,14 +134,18 @@ public class AuthController : AuthenticatedControllerBase
 
         var properties = new Microsoft.AspNetCore.Authentication.AuthenticationProperties
         {
-            RedirectUri = Url.Action(nameof(GitHubCallback), new { returnUrl, mode }),
+            RedirectUri = Url.Action(nameof(GitHubCallback), new { returnUrl }),
             Items = { { "LoginProvider", "GitHub" } }
         };
 
-        // Store mode in the auth properties so the callback can detect linking
+        // Account-linking mode: require authentication and bind to caller's identity
         if (mode == "link")
         {
+            if (!TryGetCurrentUserId(out var callerUserId, out _))
+                return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Authentication required for account linking"));
+
             properties.Items["mode"] = "link";
+            properties.Items["link_user_id"] = callerUserId.ToString();
         }
 
         return Challenge(properties, "GitHub");
@@ -150,7 +156,7 @@ public class AuthController : AuthenticatedControllerBase
     /// </summary>
     [HttpGet("github/callback")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
-    public async Task<IActionResult> GitHubCallback([FromQuery] string? returnUrl = null, [FromQuery] string? mode = null)
+    public async Task<IActionResult> GitHubCallback([FromQuery] string? returnUrl = null)
     {
         if (!_gitHubOAuthSettings.IsConfigured)
             return NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "GitHub OAuth is not configured"));
@@ -181,17 +187,30 @@ public class AuthController : AuthenticatedControllerBase
         // Sign out the temporary cookie used during the OAuth handshake
         await HttpContext.SignOutAsync("GitHub");
 
-        // Determine if this is a link flow. Prefer the OAuth state (tamper-proof)
-        // over the query string parameter, but fall back to query string for compat.
-        var isLinkMode = mode == "link";
-        if (authenticateResult.Properties?.Items.TryGetValue("mode", out var stateMode) == true)
+        // Determine if this is a link flow from the tamper-proof OAuth state ONLY.
+        // Never trust the query string for mode detection -- attacker could append ?mode=link.
+        var isLinkMode = false;
+        Guid linkUserId = Guid.Empty;
+        if (authenticateResult.Properties?.Items.TryGetValue("mode", out var stateMode) == true
+            && stateMode == "link")
         {
-            isLinkMode = stateMode == "link";
+            isLinkMode = true;
+            if (authenticateResult.Properties.Items.TryGetValue("link_user_id", out var linkUserIdStr)
+                && Guid.TryParse(linkUserIdStr, out var parsedLinkUserId))
+            {
+                linkUserId = parsedLinkUserId;
+            }
         }
 
-        // Account linking flow: store the GitHub identity as a link code
+        // Account linking flow: store the GitHub identity as a link code bound to the user
         if (isLinkMode)
         {
+            if (linkUserId == Guid.Empty)
+            {
+                return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError,
+                    "Account linking requires an authenticated session"));
+            }
+
             var linkCode = GenerateAuthCode();
             var providerData = JsonSerializer.Serialize(new
             {
@@ -203,6 +222,7 @@ public class AuthController : AuthenticatedControllerBase
 
             var linkAuthCode = OAuthAuthCode.CreateForLinking(
                 code: linkCode,
+                initiatingUserId: linkUserId,
                 providerData: providerData,
                 expiresAt: DateTimeOffset.UtcNow.AddSeconds(60));
 
@@ -238,19 +258,19 @@ public class AuthController : AuthenticatedControllerBase
         if (!result.IsSuccess)
             return result.ToErrorActionResult();
 
-        // Store the authorization code in the database instead of in-memory.
-        // This survives restarts and works with multi-instance deployments.
+        // Store only the user ID in the auth code -- JWT is re-issued at exchange time.
+        // This avoids storing plaintext JWTs in the database.
         var code = GenerateAuthCode();
         var authCode = new OAuthAuthCode(
             code: code,
             userId: result.Value.User.Id,
-            token: result.Value.Token,
+            token: "placeholder", // Not stored; JWT re-issued at exchange
             expiresAt: DateTimeOffset.UtcNow.AddSeconds(60));
 
         await _unitOfWork.OAuthAuthCodes.AddAsync(authCode);
         await _unitOfWork.SaveChangesAsync();
 
-        // Best-effort cleanup of expired codes (runs in the same request scope)
+        // Best-effort cleanup of expired/consumed codes (runs in the same request scope)
         await CleanupExpiredCodesAsync();
 
         var safeReturnUrl = !string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl)
@@ -264,37 +284,34 @@ public class AuthController : AuthenticatedControllerBase
     /// <summary>
     /// Exchanges a short-lived OAuth authorization code for a JWT token.
     /// The code is single-use and expires after 60 seconds.
+    /// JWT is re-issued fresh at exchange time -- never stored in the database.
     /// </summary>
     [HttpPost("github/exchange")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public async Task<IActionResult> ExchangeCode([FromBody] ExchangeCodeRequest request)
     {
+        // Use a single generic error message for all failure modes to prevent
+        // attackers from enumerating codes or determining their state.
+        const string genericError = "Invalid or expired code";
+
         if (string.IsNullOrWhiteSpace(request.Code))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Code is required"));
 
-        // Read the code first to check purpose and expiry
+        // Read the code to check purpose (pre-filter before atomic consume)
         var authCode = await _unitOfWork.OAuthAuthCodes.GetByCodeAsync(request.Code);
-        if (authCode == null)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
+        if (authCode == null || authCode.IsLinkingCode || authCode.IsExpired || authCode.IsConsumed)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
-        if (authCode.IsLinkingCode)
-            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "This code is for account linking, not login"));
-
-        if (authCode.IsExpired)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Code has expired"));
-
-        if (authCode.IsConsumed)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
-
-        // Atomically consume the code — prevents race conditions with concurrent requests
+        // Atomically consume the code — prevents race conditions with concurrent requests.
+        // The SQL also enforces expiry check to close the TOCTOU window.
         var consumed = await _unitOfWork.OAuthAuthCodes.TryConsumeAtomicAsync(request.Code);
         if (!consumed)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired code"));
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
-        // Look up the user to build the AuthResultDto
+        // Look up the user and re-issue a fresh JWT (never stored in DB)
         var user = await _unitOfWork.Users.GetByIdAsync(authCode.UserId);
         if (user == null)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "User not found"));
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
         var userDto = new UserDto(
             user.Id,
@@ -305,12 +322,16 @@ public class AuthController : AuthenticatedControllerBase
             user.CreatedAt,
             user.UpdatedAt);
 
-        return Ok(new AuthResultDto(authCode.Token, userDto));
+        // Re-issue JWT at exchange time instead of reading stored token
+        var freshToken = _authService.GenerateJwtToken(user);
+
+        return Ok(new AuthResultDto(freshToken, userDto));
     }
 
     /// <summary>
     /// Exchanges a link code and associates the GitHub account with the authenticated user.
-    /// Requires a valid JWT session.
+    /// Requires a valid JWT session. The link code must have been initiated by the same user
+    /// (CSRF protection: code is bound to the initiating user's identity).
     /// </summary>
     [HttpPost("github/link")]
     [Authorize]
@@ -321,6 +342,8 @@ public class AuthController : AuthenticatedControllerBase
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> LinkGitHub([FromBody] LinkExchangeRequest request)
     {
+        const string genericError = "Invalid or expired link code";
+
         if (!_gitHubOAuthSettings.IsConfigured)
             return NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "GitHub OAuth is not configured"));
 
@@ -330,24 +353,21 @@ public class AuthController : AuthenticatedControllerBase
         if (string.IsNullOrWhiteSpace(request.Code))
             return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "Link code is required"));
 
-        // Look up and validate the link code
+        // Look up and validate the link code with uniform error messages
         var authCode = await _unitOfWork.OAuthAuthCodes.GetByCodeAsync(request.Code);
-        if (authCode == null)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
+        if (authCode == null || !authCode.IsLinkingCode || authCode.IsExpired || authCode.IsConsumed)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
-        if (!authCode.IsLinkingCode)
-            return BadRequest(new ApiErrorResponse(ErrorCodes.ValidationError, "This code is for login, not account linking"));
+        // CSRF protection: verify the link code was initiated by the same user who is
+        // exchanging it. This prevents an attacker from generating a link code and
+        // tricking a victim into exchanging it.
+        if (authCode.UserId != callerUserId)
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
-        if (authCode.IsExpired)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Link code has expired"));
-
-        if (authCode.IsConsumed)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
-
-        // Atomically consume the code
+        // Atomically consume the code (also checks expiry in SQL to close TOCTOU window)
         var consumed = await _unitOfWork.OAuthAuthCodes.TryConsumeAtomicAsync(request.Code);
         if (!consumed)
-            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Invalid or expired link code"));
+            return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, genericError));
 
         // Parse the provider data from the link code
         if (string.IsNullOrWhiteSpace(authCode.ProviderData))

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -181,8 +181,16 @@ public class AuthController : AuthenticatedControllerBase
         // Sign out the temporary cookie used during the OAuth handshake
         await HttpContext.SignOutAsync("GitHub");
 
+        // Determine if this is a link flow. Prefer the OAuth state (tamper-proof)
+        // over the query string parameter, but fall back to query string for compat.
+        var isLinkMode = mode == "link";
+        if (authenticateResult.Properties?.Items.TryGetValue("mode", out var stateMode) == true)
+        {
+            isLinkMode = stateMode == "link";
+        }
+
         // Account linking flow: store the GitHub identity as a link code
-        if (mode == "link")
+        if (isLinkMode)
         {
             var linkCode = GenerateAuthCode();
             var providerData = JsonSerializer.Serialize(new
@@ -242,8 +250,8 @@ public class AuthController : AuthenticatedControllerBase
         await _unitOfWork.OAuthAuthCodes.AddAsync(authCode);
         await _unitOfWork.SaveChangesAsync();
 
-        // Best-effort cleanup of expired codes
-        _ = CleanupExpiredCodesAsync();
+        // Best-effort cleanup of expired codes (runs in the same request scope)
+        await CleanupExpiredCodesAsync();
 
         var safeReturnUrl = !string.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl)
             ? returnUrl

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -116,14 +116,15 @@ public class AuthController : AuthenticatedControllerBase
     }
 
     /// <summary>
-    /// Initiates GitHub OAuth login flow. Only available when GitHub OAuth is configured.
-    /// Pass mode=link to start an account-linking flow instead of login.
-    /// When mode=link, the caller MUST be authenticated (JWT required) so the link code
-    /// is bound to their identity, preventing CSRF attacks.
+    /// Initiates GitHub OAuth login or account-linking flow. Only available when GitHub OAuth is configured.
+    /// The flow is determined entirely from server-side state: if the caller is already authenticated
+    /// (carries a valid JWT), this starts an account-linking flow bound to their identity; otherwise
+    /// it starts a normal login flow. The client must NOT supply a mode parameter -- the server
+    /// derives the intent from authentication state to prevent user-controlled bypass.
     /// </summary>
     [HttpGet("github/login")]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
-    public IActionResult GitHubLogin([FromQuery] string? returnUrl = null, [FromQuery] string? mode = null)
+    public IActionResult GitHubLogin([FromQuery] string? returnUrl = null)
     {
         if (!_gitHubOAuthSettings.IsConfigured)
             return NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "GitHub OAuth is not configured"));
@@ -138,12 +139,13 @@ public class AuthController : AuthenticatedControllerBase
             Items = { { "LoginProvider", "GitHub" } }
         };
 
-        // Account-linking mode: require authentication and bind to caller's identity
-        if (mode == "link")
+        // Derive flow from server-side authentication state only.
+        // Never use a user-supplied "mode" query parameter -- that would allow an attacker
+        // to bypass or force the sensitive account-linking branch (CWE-807 / CodeQL
+        // "user-controlled bypass of sensitive method").
+        // If the caller is already authenticated (valid JWT), treat this as a link request.
+        if (TryGetCurrentUserId(out var callerUserId, out _))
         {
-            if (!TryGetCurrentUserId(out var callerUserId, out _))
-                return Unauthorized(new ApiErrorResponse(ErrorCodes.AuthenticationFailed, "Authentication required for account linking"));
-
             properties.Items["mode"] = "link";
             properties.Items["link_user_id"] = callerUserId.ToString();
         }

--- a/backend/src/Taskdeck.Api/Extensions/AuthenticationRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/AuthenticationRegistration.cs
@@ -98,6 +98,11 @@ public static class AuthenticationRegistration
                 options.CallbackPath = "/api/auth/github/oauth-redirect";
                 options.SaveTokens = false;
 
+                // PKCE (Proof Key for Code Exchange) — defense-in-depth against
+                // authorization code interception attacks. GitHub supports PKCE
+                // and ASP.NET Core 8+ handles code_verifier/code_challenge automatically.
+                options.UsePkce = true;
+
                 options.Scope.Add("read:user");
                 options.Scope.Add("user:email");
 

--- a/backend/src/Taskdeck.Application/DTOs/UserDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/UserDtos.cs
@@ -37,3 +37,10 @@ public record ExternalLoginDto(
     string Email,
     string? DisplayName = null,
     string? AvatarUrl = null);
+
+public record LinkedAccountDto(
+    string Provider,
+    string ProviderUserId,
+    string? DisplayName,
+    string? AvatarUrl,
+    DateTimeOffset LinkedAt);

--- a/backend/src/Taskdeck.Application/Interfaces/IOAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IOAuthAuthCodeRepository.cs
@@ -1,0 +1,17 @@
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Application.Interfaces;
+
+public interface IOAuthAuthCodeRepository : IRepository<OAuthAuthCode>
+{
+    /// <summary>
+    /// Finds an auth code by its code string. Returns null if not found.
+    /// </summary>
+    Task<OAuthAuthCode?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all auth codes that have expired before the specified cutoff time.
+    /// Returns the number of codes removed.
+    /// </summary>
+    Task<int> DeleteExpiredAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Interfaces/IOAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IOAuthAuthCodeRepository.cs
@@ -10,6 +10,13 @@ public interface IOAuthAuthCodeRepository : IRepository<OAuthAuthCode>
     Task<OAuthAuthCode?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Atomically consumes an auth code by setting IsConsumed = true where IsConsumed = false.
+    /// Returns true if the code was consumed (affected 1 row), false if already consumed or not found.
+    /// This provides single-use semantics safe for concurrent requests.
+    /// </summary>
+    Task<bool> TryConsumeAtomicAsync(string code, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Deletes all auth codes that have expired before the specified cutoff time.
     /// Returns the number of codes removed.
     /// </summary>

--- a/backend/src/Taskdeck.Application/Interfaces/IUnitOfWork.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IUnitOfWork.cs
@@ -27,6 +27,7 @@ public interface IUnitOfWork
     IKnowledgeDocumentRepository KnowledgeDocuments { get; }
     IKnowledgeChunkRepository KnowledgeChunks { get; }
     IExternalLoginRepository ExternalLogins { get; }
+    IOAuthAuthCodeRepository OAuthAuthCodes { get; }
     IApiKeyRepository ApiKeys { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -209,39 +209,6 @@ public class AuthenticationService : IAuthenticationService
         }
     }
 
-    public async Task<Result<LinkedAccountDto>> LinkExternalLoginAsync(Guid userId, string provider)
-    {
-        try
-        {
-            if (userId == Guid.Empty)
-                return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError, "User ID is required");
-
-            if (string.IsNullOrWhiteSpace(provider))
-                return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError, "Provider is required");
-
-            var user = await _unitOfWork.Users.GetByIdAsync(userId);
-            if (user == null)
-                return Result.Failure<LinkedAccountDto>(ErrorCodes.NotFound, "User not found");
-
-            if (!user.IsActive)
-                return Result.Failure<LinkedAccountDto>(ErrorCodes.Forbidden, "User account is inactive");
-
-            // Check if user already has a linked account for this provider
-            var existingLogins = await _unitOfWork.ExternalLogins.GetByUserIdAsync(userId);
-            if (existingLogins.Any(l => l.Provider == provider))
-                return Result.Failure<LinkedAccountDto>(ErrorCodes.Conflict, $"Account is already linked to {provider}");
-
-            // Return a placeholder indicating the link flow should proceed via OAuth
-            // The actual linking happens in CompleteAccountLinkAsync after OAuth callback
-            return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError,
-                "Account linking requires completing the OAuth flow. Use the GitHub login redirect with mode=link.");
-        }
-        catch (DomainException ex)
-        {
-            return Result.Failure<LinkedAccountDto>(ex.ErrorCode, ex.Message);
-        }
-    }
-
     public async Task<Result<LinkedAccountDto>> CompleteAccountLinkAsync(Guid userId, string provider, string providerUserId, string? displayName, string? avatarUrl)
     {
         try

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -367,7 +367,7 @@ public class AuthenticationService : IAuthenticationService
         }
     }
 
-    private string GenerateJwtToken(User user)
+    public string GenerateJwtToken(User user)
     {
         if (!TryValidateJwtSettings(out var jwtValidationError))
             throw new DomainException(ErrorCodes.UnexpectedError, jwtValidationError);

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -209,6 +209,116 @@ public class AuthenticationService : IAuthenticationService
         }
     }
 
+    public async Task<Result<LinkedAccountDto>> LinkExternalLoginAsync(Guid userId, string provider)
+    {
+        try
+        {
+            if (userId == Guid.Empty)
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError, "User ID is required");
+
+            if (string.IsNullOrWhiteSpace(provider))
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError, "Provider is required");
+
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.NotFound, "User not found");
+
+            if (!user.IsActive)
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.Forbidden, "User account is inactive");
+
+            // Check if user already has a linked account for this provider
+            var existingLogins = await _unitOfWork.ExternalLogins.GetByUserIdAsync(userId);
+            if (existingLogins.Any(l => l.Provider == provider))
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.Conflict, $"Account is already linked to {provider}");
+
+            // Return a placeholder indicating the link flow should proceed via OAuth
+            // The actual linking happens in CompleteAccountLinkAsync after OAuth callback
+            return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError,
+                "Account linking requires completing the OAuth flow. Use the GitHub login redirect with mode=link.");
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<LinkedAccountDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<LinkedAccountDto>> CompleteAccountLinkAsync(Guid userId, string provider, string providerUserId, string? displayName, string? avatarUrl)
+    {
+        try
+        {
+            if (userId == Guid.Empty)
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.ValidationError, "User ID is required");
+
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.NotFound, "User not found");
+
+            if (!user.IsActive)
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.Forbidden, "User account is inactive");
+
+            // Check if this provider+userId combo is already linked to a different user
+            var existingLogin = await _unitOfWork.ExternalLogins.GetByProviderAsync(provider, providerUserId);
+            if (existingLogin != null)
+            {
+                if (existingLogin.UserId == userId)
+                    return Result.Failure<LinkedAccountDto>(ErrorCodes.Conflict, $"This {provider} account is already linked to your account");
+
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.Conflict, $"This {provider} account is already linked to a different user");
+            }
+
+            // Check if user already has a linked account for this provider
+            var userLogins = await _unitOfWork.ExternalLogins.GetByUserIdAsync(userId);
+            if (userLogins.Any(l => l.Provider == provider))
+                return Result.Failure<LinkedAccountDto>(ErrorCodes.Conflict, $"Your account is already linked to a {provider} account");
+
+            var newLogin = new ExternalLogin(userId, provider, providerUserId, displayName, avatarUrl);
+            await _unitOfWork.ExternalLogins.AddAsync(newLogin);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success(new LinkedAccountDto(
+                newLogin.Provider,
+                newLogin.ProviderUserId,
+                newLogin.ProviderDisplayName,
+                newLogin.AvatarUrl,
+                newLogin.CreatedAt));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<LinkedAccountDto>(ex.ErrorCode, ex.Message);
+        }
+        catch (Exception)
+        {
+            return Result.Failure<LinkedAccountDto>(ErrorCodes.UnexpectedError, "Account linking failed due to an unexpected error");
+        }
+    }
+
+    public async Task<Result> UnlinkExternalLoginAsync(Guid userId, string provider)
+    {
+        try
+        {
+            if (userId == Guid.Empty)
+                return Result.Failure(ErrorCodes.ValidationError, "User ID is required");
+
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure(ErrorCodes.NotFound, "User not found");
+
+            var logins = await _unitOfWork.ExternalLogins.GetByUserIdAsync(userId);
+            var loginToRemove = logins.FirstOrDefault(l => l.Provider == provider);
+            if (loginToRemove == null)
+                return Result.Failure(ErrorCodes.NotFound, $"No {provider} account is linked");
+
+            await _unitOfWork.ExternalLogins.DeleteAsync(loginToRemove);
+            await _unitOfWork.SaveChangesAsync();
+
+            return Result.Success();
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure(ex.ErrorCode, ex.Message);
+        }
+    }
+
     public async Task<Result> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword)
     {
         try

--- a/backend/src/Taskdeck.Application/Services/IAuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/IAuthenticationService.cs
@@ -14,7 +14,6 @@ public interface IAuthenticationService
     Task<Result> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword);
     Task<Result<UserDto>> ValidateTokenAsync(string token);
     Task<Result<AuthResultDto>> ExternalLoginAsync(ExternalLoginDto dto);
-    Task<Result<LinkedAccountDto>> LinkExternalLoginAsync(Guid userId, string provider);
     Task<Result<LinkedAccountDto>> CompleteAccountLinkAsync(Guid userId, string provider, string providerUserId, string? displayName, string? avatarUrl);
     Task<Result> UnlinkExternalLoginAsync(Guid userId, string provider);
 }

--- a/backend/src/Taskdeck.Application/Services/IAuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/IAuthenticationService.cs
@@ -14,4 +14,7 @@ public interface IAuthenticationService
     Task<Result> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword);
     Task<Result<UserDto>> ValidateTokenAsync(string token);
     Task<Result<AuthResultDto>> ExternalLoginAsync(ExternalLoginDto dto);
+    Task<Result<LinkedAccountDto>> LinkExternalLoginAsync(Guid userId, string provider);
+    Task<Result<LinkedAccountDto>> CompleteAccountLinkAsync(Guid userId, string provider, string providerUserId, string? displayName, string? avatarUrl);
+    Task<Result> UnlinkExternalLoginAsync(Guid userId, string provider);
 }

--- a/backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs
+++ b/backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs
@@ -6,6 +6,7 @@ namespace Taskdeck.Domain.Entities;
 /// <summary>
 /// A short-lived, single-use authorization code issued after OAuth callback.
 /// Stored in the database to survive restarts and support multi-instance deployments.
+/// Supports both login (Token populated) and account-linking (ProviderData populated) flows.
 /// </summary>
 public class OAuthAuthCode : Entity
 {
@@ -27,14 +28,25 @@ public class OAuthAuthCode : Entity
     }
 
     /// <summary>
-    /// The user ID this code authenticates.
+    /// The user ID this code authenticates (login flow) or Guid.Empty (link flow).
     /// </summary>
     public Guid UserId { get; private set; }
 
     /// <summary>
-    /// The pre-serialized JWT token to return on successful exchange.
+    /// The pre-serialized JWT token to return on successful exchange (login flow only).
     /// </summary>
     public string Token { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The purpose of this code: "login" or "link".
+    /// </summary>
+    public string Purpose { get; private set; } = "login";
+
+    /// <summary>
+    /// JSON-serialized provider identity data for account linking flows.
+    /// Contains provider, providerUserId, displayName, avatarUrl.
+    /// </summary>
+    public string? ProviderData { get; private set; }
 
     /// <summary>
     /// When this code expires and can no longer be exchanged.
@@ -53,6 +65,9 @@ public class OAuthAuthCode : Entity
 
     private OAuthAuthCode() : base() { }
 
+    /// <summary>
+    /// Creates an auth code for the login flow (token exchange).
+    /// </summary>
     public OAuthAuthCode(string code, Guid userId, string token, DateTimeOffset expiresAt)
         : base()
     {
@@ -68,13 +83,42 @@ public class OAuthAuthCode : Entity
         Code = code;
         UserId = userId;
         Token = token;
+        Purpose = "login";
         ExpiresAt = expiresAt;
+    }
+
+    /// <summary>
+    /// Creates an auth code for the account linking flow (provider identity exchange).
+    /// </summary>
+    public static OAuthAuthCode CreateForLinking(string code, string providerData, DateTimeOffset expiresAt)
+    {
+        if (string.IsNullOrWhiteSpace(providerData))
+            throw new DomainException(ErrorCodes.ValidationError, "Provider data cannot be empty for linking");
+
+        if (expiresAt <= DateTimeOffset.UtcNow)
+            throw new DomainException(ErrorCodes.ValidationError, "Expiry must be in the future");
+
+        var entity = new OAuthAuthCode
+        {
+            Code = code,
+            UserId = Guid.Empty,
+            Token = string.Empty,
+            Purpose = "link",
+            ProviderData = providerData,
+            ExpiresAt = expiresAt
+        };
+        return entity;
     }
 
     /// <summary>
     /// Returns true if this code has expired.
     /// </summary>
     public bool IsExpired => DateTimeOffset.UtcNow > ExpiresAt;
+
+    /// <summary>
+    /// Returns true if this is a linking code (not a login code).
+    /// </summary>
+    public bool IsLinkingCode => Purpose == "link";
 
     /// <summary>
     /// Attempts to consume this code. Returns false if already consumed or expired.

--- a/backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs
+++ b/backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs
@@ -1,0 +1,92 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// A short-lived, single-use authorization code issued after OAuth callback.
+/// Stored in the database to survive restarts and support multi-instance deployments.
+/// </summary>
+public class OAuthAuthCode : Entity
+{
+    private string _code = string.Empty;
+
+    public string Code
+    {
+        get => _code;
+        private set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new DomainException(ErrorCodes.ValidationError, "Auth code cannot be empty");
+
+            if (value.Length > 512)
+                throw new DomainException(ErrorCodes.ValidationError, "Auth code cannot exceed 512 characters");
+
+            _code = value;
+        }
+    }
+
+    /// <summary>
+    /// The user ID this code authenticates.
+    /// </summary>
+    public Guid UserId { get; private set; }
+
+    /// <summary>
+    /// The pre-serialized JWT token to return on successful exchange.
+    /// </summary>
+    public string Token { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// When this code expires and can no longer be exchanged.
+    /// </summary>
+    public DateTimeOffset ExpiresAt { get; private set; }
+
+    /// <summary>
+    /// Whether this code has been consumed (exchanged for a token).
+    /// </summary>
+    public bool IsConsumed { get; private set; }
+
+    /// <summary>
+    /// When the code was consumed, if applicable.
+    /// </summary>
+    public DateTimeOffset? ConsumedAt { get; private set; }
+
+    private OAuthAuthCode() : base() { }
+
+    public OAuthAuthCode(string code, Guid userId, string token, DateTimeOffset expiresAt)
+        : base()
+    {
+        if (userId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "User ID cannot be empty");
+
+        if (string.IsNullOrWhiteSpace(token))
+            throw new DomainException(ErrorCodes.ValidationError, "Token cannot be empty");
+
+        if (expiresAt <= DateTimeOffset.UtcNow)
+            throw new DomainException(ErrorCodes.ValidationError, "Expiry must be in the future");
+
+        Code = code;
+        UserId = userId;
+        Token = token;
+        ExpiresAt = expiresAt;
+    }
+
+    /// <summary>
+    /// Returns true if this code has expired.
+    /// </summary>
+    public bool IsExpired => DateTimeOffset.UtcNow > ExpiresAt;
+
+    /// <summary>
+    /// Attempts to consume this code. Returns false if already consumed or expired.
+    /// </summary>
+    public bool TryConsume()
+    {
+        if (IsConsumed || IsExpired)
+            return false;
+
+        IsConsumed = true;
+        ConsumedAt = DateTimeOffset.UtcNow;
+        Touch();
+        return true;
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs
+++ b/backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs
@@ -33,7 +33,8 @@ public class OAuthAuthCode : Entity
     public Guid UserId { get; private set; }
 
     /// <summary>
-    /// The pre-serialized JWT token to return on successful exchange (login flow only).
+    /// Legacy field kept for schema compatibility. No longer populated with real JWTs --
+    /// tokens are re-issued at exchange time from the stored UserId.
     /// </summary>
     public string Token { get; private set; } = string.Empty;
 
@@ -67,6 +68,8 @@ public class OAuthAuthCode : Entity
 
     /// <summary>
     /// Creates an auth code for the login flow (token exchange).
+    /// Token parameter is accepted for backward compatibility but is no longer stored;
+    /// JWTs are re-issued at exchange time from the UserId.
     /// </summary>
     public OAuthAuthCode(string code, Guid userId, string token, DateTimeOffset expiresAt)
         : base()
@@ -82,16 +85,21 @@ public class OAuthAuthCode : Entity
 
         Code = code;
         UserId = userId;
-        Token = token;
+        Token = string.Empty; // Never store actual JWT in DB — re-issue at exchange time
         Purpose = "login";
         ExpiresAt = expiresAt;
     }
 
     /// <summary>
     /// Creates an auth code for the account linking flow (provider identity exchange).
+    /// The initiatingUserId binds this code to the user who started the link flow,
+    /// preventing CSRF attacks where an attacker's GitHub is linked to a victim's account.
     /// </summary>
-    public static OAuthAuthCode CreateForLinking(string code, string providerData, DateTimeOffset expiresAt)
+    public static OAuthAuthCode CreateForLinking(string code, Guid initiatingUserId, string providerData, DateTimeOffset expiresAt)
     {
+        if (initiatingUserId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "Initiating user ID is required for linking");
+
         if (string.IsNullOrWhiteSpace(providerData))
             throw new DomainException(ErrorCodes.ValidationError, "Provider data cannot be empty for linking");
 
@@ -101,7 +109,7 @@ public class OAuthAuthCode : Entity
         var entity = new OAuthAuthCode
         {
             Code = code,
-            UserId = Guid.Empty,
+            UserId = initiatingUserId,
             Token = string.Empty,
             Purpose = "link",
             ProviderData = providerData,

--- a/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
@@ -43,6 +43,7 @@ public static class DependencyInjection
         services.AddScoped<IKnowledgeDocumentRepository, KnowledgeDocumentRepository>();
         services.AddScoped<IKnowledgeChunkRepository, KnowledgeChunkRepository>();
         services.AddScoped<IExternalLoginRepository, ExternalLoginRepository>();
+        services.AddScoped<IOAuthAuthCodeRepository, OAuthAuthCodeRepository>();
         services.AddScoped<IApiKeyRepository, ApiKeyRepository>();
         services.AddScoped<IKnowledgeSearchService, Taskdeck.Infrastructure.Services.KnowledgeFtsSearchService>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260409180437_AddOAuthAuthCodes.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260409180437_AddOAuthAuthCodes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Taskdeck.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Taskdeck.Infrastructure.Persistence;
 namespace Taskdeck.Infrastructure.Migrations
 {
     [DbContext(typeof(TaskdeckDbContext))]
-    partial class TaskdeckDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409180437_AddOAuthAuthCodes")]
+    partial class AddOAuthAuthCodes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.25");

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260409180437_AddOAuthAuthCodes.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260409180437_AddOAuthAuthCodes.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Taskdeck.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOAuthAuthCodes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OAuthAuthCodes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Code = table.Column<string>(type: "TEXT", maxLength: 512, nullable: false),
+                    UserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Token = table.Column<string>(type: "TEXT", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    IsConsumed = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),
+                    ConsumedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OAuthAuthCodes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OAuthAuthCodes_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthAuthCodes_Code",
+                table: "OAuthAuthCodes",
+                column: "Code",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthAuthCodes_ExpiresAt",
+                table: "OAuthAuthCodes",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OAuthAuthCodes_UserId",
+                table: "OAuthAuthCodes",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OAuthAuthCodes");
+        }
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260409181436_AddOAuthAuthCodes.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260409181436_AddOAuthAuthCodes.Designer.cs
@@ -11,7 +11,7 @@ using Taskdeck.Infrastructure.Persistence;
 namespace Taskdeck.Infrastructure.Migrations
 {
     [DbContext(typeof(TaskdeckDbContext))]
-    [Migration("20260409180437_AddOAuthAuthCodes")]
+    [Migration("20260409181436_AddOAuthAuthCodes")]
     partial class AddOAuthAuthCodes
     {
         /// <inheritdoc />
@@ -1328,6 +1328,17 @@ namespace Taskdeck.Infrastructure.Migrations
                         .HasColumnType("INTEGER")
                         .HasDefaultValue(false);
 
+                    b.Property<string>("ProviderData")
+                        .HasMaxLength(4096)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Purpose")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasMaxLength(20)
+                        .HasColumnType("TEXT")
+                        .HasDefaultValue("login");
+
                     b.Property<string>("Token")
                         .IsRequired()
                         .HasColumnType("TEXT");
@@ -1344,8 +1355,6 @@ namespace Taskdeck.Infrastructure.Migrations
                         .IsUnique();
 
                     b.HasIndex("ExpiresAt");
-
-                    b.HasIndex("UserId");
 
                     b.ToTable("OAuthAuthCodes", (string)null);
                 });
@@ -1813,15 +1822,6 @@ namespace Taskdeck.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("User");
-                });
-
-            modelBuilder.Entity("Taskdeck.Domain.Entities.OAuthAuthCode", b =>
-                {
-                    b.HasOne("Taskdeck.Domain.Entities.User", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("Taskdeck.Domain.Entities.OutboundWebhookDelivery", b =>

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260409181436_AddOAuthAuthCodes.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260409181436_AddOAuthAuthCodes.cs
@@ -19,6 +19,8 @@ namespace Taskdeck.Infrastructure.Migrations
                     Code = table.Column<string>(type: "TEXT", maxLength: 512, nullable: false),
                     UserId = table.Column<Guid>(type: "TEXT", nullable: false),
                     Token = table.Column<string>(type: "TEXT", nullable: false),
+                    Purpose = table.Column<string>(type: "TEXT", maxLength: 20, nullable: false, defaultValue: "login"),
+                    ProviderData = table.Column<string>(type: "TEXT", maxLength: 4096, nullable: true),
                     ExpiresAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
                     IsConsumed = table.Column<bool>(type: "INTEGER", nullable: false, defaultValue: false),
                     ConsumedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
@@ -28,12 +30,6 @@ namespace Taskdeck.Infrastructure.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_OAuthAuthCodes", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_OAuthAuthCodes_Users_UserId",
-                        column: x => x.UserId,
-                        principalTable: "Users",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(
@@ -46,11 +42,6 @@ namespace Taskdeck.Infrastructure.Migrations
                 name: "IX_OAuthAuthCodes_ExpiresAt",
                 table: "OAuthAuthCodes",
                 column: "ExpiresAt");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_OAuthAuthCodes_UserId",
-                table: "OAuthAuthCodes",
-                column: "UserId");
         }
 
         /// <inheritdoc />

--- a/backend/src/Taskdeck.Infrastructure/Migrations/TaskdeckDbContextModelSnapshot.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/TaskdeckDbContextModelSnapshot.cs
@@ -1325,6 +1325,17 @@ namespace Taskdeck.Infrastructure.Migrations
                         .HasColumnType("INTEGER")
                         .HasDefaultValue(false);
 
+                    b.Property<string>("ProviderData")
+                        .HasMaxLength(4096)
+                        .HasColumnType("TEXT");
+
+                    b.Property<string>("Purpose")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasMaxLength(20)
+                        .HasColumnType("TEXT")
+                        .HasDefaultValue("login");
+
                     b.Property<string>("Token")
                         .IsRequired()
                         .HasColumnType("TEXT");
@@ -1341,8 +1352,6 @@ namespace Taskdeck.Infrastructure.Migrations
                         .IsUnique();
 
                     b.HasIndex("ExpiresAt");
-
-                    b.HasIndex("UserId");
 
                     b.ToTable("OAuthAuthCodes", (string)null);
                 });
@@ -1810,15 +1819,6 @@ namespace Taskdeck.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("User");
-                });
-
-            modelBuilder.Entity("Taskdeck.Domain.Entities.OAuthAuthCode", b =>
-                {
-                    b.HasOne("Taskdeck.Domain.Entities.User", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("Taskdeck.Domain.Entities.OutboundWebhookDelivery", b =>

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/OAuthAuthCodeConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/OAuthAuthCodeConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Infrastructure.Persistence.Configurations;
+
+public class OAuthAuthCodeConfiguration : IEntityTypeConfiguration<OAuthAuthCode>
+{
+    public void Configure(EntityTypeBuilder<OAuthAuthCode> builder)
+    {
+        builder.ToTable("OAuthAuthCodes");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Code)
+            .IsRequired()
+            .HasMaxLength(512);
+
+        builder.Property(e => e.UserId)
+            .IsRequired();
+
+        builder.Property(e => e.Token)
+            .IsRequired();
+
+        builder.Property(e => e.ExpiresAt)
+            .IsRequired();
+
+        builder.Property(e => e.IsConsumed)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(e => e.ConsumedAt);
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.Property(e => e.UpdatedAt)
+            .IsRequired();
+
+        // Unique index on code for fast lookup
+        builder.HasIndex(e => e.Code)
+            .IsUnique();
+
+        // Index for TTL cleanup queries
+        builder.HasIndex(e => e.ExpiresAt);
+
+        // Foreign key to Users — cascade delete so deleted users
+        // don't leave orphaned codes
+        builder.HasOne<User>()
+            .WithMany()
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/OAuthAuthCodeConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/OAuthAuthCodeConfiguration.cs
@@ -22,6 +22,14 @@ public class OAuthAuthCodeConfiguration : IEntityTypeConfiguration<OAuthAuthCode
         builder.Property(e => e.Token)
             .IsRequired();
 
+        builder.Property(e => e.Purpose)
+            .IsRequired()
+            .HasMaxLength(20)
+            .HasDefaultValue("login");
+
+        builder.Property(e => e.ProviderData)
+            .HasMaxLength(4096);
+
         builder.Property(e => e.ExpiresAt)
             .IsRequired();
 
@@ -43,12 +51,5 @@ public class OAuthAuthCodeConfiguration : IEntityTypeConfiguration<OAuthAuthCode
 
         // Index for TTL cleanup queries
         builder.HasIndex(e => e.ExpiresAt);
-
-        // Foreign key to Users — cascade delete so deleted users
-        // don't leave orphaned codes
-        builder.HasOne<User>()
-            .WithMany()
-            .HasForeignKey(e => e.UserId)
-            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckDbContext.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckDbContext.cs
@@ -39,6 +39,7 @@ public class TaskdeckDbContext : DbContext
     public DbSet<KnowledgeDocument> KnowledgeDocuments => Set<KnowledgeDocument>();
     public DbSet<KnowledgeChunk> KnowledgeChunks => Set<KnowledgeChunk>();
     public DbSet<ExternalLogin> ExternalLogins => Set<ExternalLogin>();
+    public DbSet<OAuthAuthCode> OAuthAuthCodes => Set<OAuthAuthCode>();
     public DbSet<ApiKey> ApiKeys => Set<ApiKey>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Persistence;
+
+namespace Taskdeck.Infrastructure.Repositories;
+
+public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCodeRepository
+{
+    public OAuthAuthCodeRepository(TaskdeckDbContext context) : base(context)
+    {
+    }
+
+    public async Task<OAuthAuthCode?> GetByCodeAsync(string code, CancellationToken cancellationToken = default)
+    {
+        return await _context.Set<OAuthAuthCode>()
+            .FirstOrDefaultAsync(e => e.Code == code, cancellationToken);
+    }
+
+    public async Task<int> DeleteExpiredAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default)
+    {
+        return await _context.Set<OAuthAuthCode>()
+            .Where(e => e.ExpiresAt < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -31,7 +31,8 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         var nowStr = now.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00");
         var affected = await _context.Database.ExecuteSqlRawAsync(
             "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0 AND ExpiresAt > {3}",
-            nowStr, nowStr, code, nowStr);
+            [nowStr, nowStr, code, nowStr],
+            cancellationToken);
 
         return affected > 0;
     }
@@ -44,7 +45,8 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         var cutoffStr = cutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00");
         var affected = await _context.Database.ExecuteSqlRawAsync(
             "DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {0} OR IsConsumed = 1",
-            cutoffStr);
+            [cutoffStr],
+            cancellationToken);
 
         return affected;
     }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -17,10 +17,35 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
             .FirstOrDefaultAsync(e => e.Code == code, cancellationToken);
     }
 
+    public async Task<bool> TryConsumeAtomicAsync(string code, CancellationToken cancellationToken = default)
+    {
+        // Atomic UPDATE ensures only one concurrent request can consume a code.
+        // The WHERE clause filters on IsConsumed = 0 so the second requester gets 0 affected rows.
+        var now = DateTimeOffset.UtcNow;
+        var affected = await _context.Database.ExecuteSqlRawAsync(
+            "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0",
+            now.ToString("o"),
+            now.ToString("o"),
+            code);
+
+        return affected > 0;
+    }
+
     public async Task<int> DeleteExpiredAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default)
     {
-        return await _context.Set<OAuthAuthCode>()
-            .Where(e => e.ExpiresAt < cutoff)
-            .ExecuteDeleteAsync(cancellationToken);
+        // EF Core 8 with SQLite cannot translate DateTimeOffset comparisons in LINQ
+        // queries. Load all codes and filter in memory for cleanup.
+        // Auth codes are short-lived and few in number, so this is acceptable.
+        var allCodes = await _context.Set<OAuthAuthCode>()
+            .ToListAsync(cancellationToken);
+
+        var expired = allCodes.Where(e => e.ExpiresAt < cutoff).ToList();
+
+        if (expired.Count == 0)
+            return 0;
+
+        _context.Set<OAuthAuthCode>().RemoveRange(expired);
+        await _context.SaveChangesAsync(cancellationToken);
+        return expired.Count;
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -20,32 +20,32 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
     public async Task<bool> TryConsumeAtomicAsync(string code, CancellationToken cancellationToken = default)
     {
         // Atomic UPDATE ensures only one concurrent request can consume a code.
-        // The WHERE clause filters on IsConsumed = 0 so the second requester gets 0 affected rows.
+        // The WHERE clause enforces ALL invariants atomically:
+        //   - IsConsumed = 0: single-use semantics (second requester gets 0 rows)
+        //   - ExpiresAt > now: prevents TOCTOU race where expiry passes between
+        //     the application-level check and the SQL execution
+        //
+        // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm" format.
+        // We must use the same format for string comparison to work correctly.
         var now = DateTimeOffset.UtcNow;
+        var nowStr = now.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00");
         var affected = await _context.Database.ExecuteSqlRawAsync(
-            "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0",
-            now.ToString("o"),
-            now.ToString("o"),
-            code);
+            "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0 AND ExpiresAt > {3}",
+            nowStr, nowStr, code, nowStr);
 
         return affected > 0;
     }
 
     public async Task<int> DeleteExpiredAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default)
     {
-        // EF Core 8 with SQLite cannot translate DateTimeOffset comparisons in LINQ
-        // queries. Load all codes and filter in memory for cleanup.
-        // Auth codes are short-lived and few in number, so this is acceptable.
-        var allCodes = await _context.Set<OAuthAuthCode>()
-            .ToListAsync(cancellationToken);
+        // Use raw SQL to avoid loading all rows into memory (DoS risk with large tables).
+        // Deletes both expired codes AND consumed codes to prevent unbounded table growth.
+        // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm".
+        var cutoffStr = cutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00");
+        var affected = await _context.Database.ExecuteSqlRawAsync(
+            "DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {0} OR IsConsumed = 1",
+            cutoffStr);
 
-        var expired = allCodes.Where(e => e.ExpiresAt < cutoff).ToList();
-
-        if (expired.Count == 0)
-            return 0;
-
-        _context.Set<OAuthAuthCode>().RemoveRange(expired);
-        await _context.SaveChangesAsync(cancellationToken);
-        return expired.Count;
+        return affected;
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
@@ -38,6 +38,7 @@ public class UnitOfWork : IUnitOfWork
         IKnowledgeDocumentRepository knowledgeDocuments,
         IKnowledgeChunkRepository knowledgeChunks,
         IExternalLoginRepository externalLogins,
+        IOAuthAuthCodeRepository oauthAuthCodes,
         IApiKeyRepository apiKeys)
     {
         _context = context;
@@ -66,6 +67,7 @@ public class UnitOfWork : IUnitOfWork
         KnowledgeDocuments = knowledgeDocuments;
         KnowledgeChunks = knowledgeChunks;
         ExternalLogins = externalLogins;
+        OAuthAuthCodes = oauthAuthCodes;
         ApiKeys = apiKeys;
     }
 
@@ -94,6 +96,7 @@ public class UnitOfWork : IUnitOfWork
     public IKnowledgeDocumentRepository KnowledgeDocuments { get; }
     public IKnowledgeChunkRepository KnowledgeChunks { get; }
     public IExternalLoginRepository ExternalLogins { get; }
+    public IOAuthAuthCodeRepository OAuthAuthCodes { get; }
     public IApiKeyRepository ApiKeys { get; }
 
     public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/ActiveUserValidationMiddlewareTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ActiveUserValidationMiddlewareTests.cs
@@ -300,6 +300,7 @@ public class ActiveUserValidationMiddlewareTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => throw new NotImplementedException();
         public IKnowledgeChunkRepository KnowledgeChunks => throw new NotImplementedException();
         public IExternalLoginRepository ExternalLogins => throw new NotImplementedException();
+        public IOAuthAuthCodeRepository OAuthAuthCodes => throw new NotImplementedException();
         public IApiKeyRepository ApiKeys => throw new NotImplementedException();
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);

--- a/backend/tests/Taskdeck.Api.Tests/AuthControllerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuthControllerEdgeCaseTests.cs
@@ -165,6 +165,65 @@ public class AuthControllerEdgeCaseTests
     }
 
     // ─────────────────────────────────────────────────────────
+    // GitHub login — flow selection must use server-side auth state
+    // (regression for CodeQL CWE-807: user-controlled bypass)
+    // ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GitHubLogin_UnauthenticatedCaller_StartsNormalLoginFlow()
+    {
+        // Arrange — controller with an unauthenticated user context
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var userContext = CreateMockUserContext(authenticated: false);
+        var authCodeRepoMock = new Mock<IOAuthAuthCodeRepository>();
+        authCodeRepoMock.Setup(r => r.GetByCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OAuthAuthCode?)null);
+        uow.Setup(u => u.OAuthAuthCodes).Returns(authCodeRepoMock.Object);
+        var controller = new AuthController(authService.Object, CreateGitHubSettings(true), userContext.Object, uow.Object);
+
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.Setup(u => u.IsLocalUrl(It.IsAny<string>())).Returns(true);
+        urlHelper.Setup(u => u.Action(It.IsAny<Microsoft.AspNetCore.Mvc.Routing.UrlActionContext>())).Returns("/auth/callback");
+        controller.Url = urlHelper.Object;
+
+        // Act
+        var result = controller.GitHubLogin();
+
+        // Assert — a ChallengeResult is returned (not Unauthorized)
+        // and the link mode items must NOT be present (flow driven by auth state, not user input)
+        var challenge = result.Should().BeOfType<ChallengeResult>().Subject;
+        challenge.Properties!.Items.Should().NotContainKey("mode");
+        challenge.Properties.Items.Should().NotContainKey("link_user_id");
+    }
+
+    [Fact]
+    public void GitHubLogin_AuthenticatedCaller_StartsLinkFlowFromServerState()
+    {
+        // Arrange — controller with an authenticated user context (server-side state)
+        var callerId = Guid.NewGuid();
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var userContext = CreateMockUserContext(authenticated: true, userId: callerId);
+        var authCodeRepoMock = new Mock<IOAuthAuthCodeRepository>();
+        authCodeRepoMock.Setup(r => r.GetByCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OAuthAuthCode?)null);
+        uow.Setup(u => u.OAuthAuthCodes).Returns(authCodeRepoMock.Object);
+        var controller = new AuthController(authService.Object, CreateGitHubSettings(true), userContext.Object, uow.Object);
+
+        var urlHelper = new Mock<IUrlHelper>();
+        urlHelper.Setup(u => u.IsLocalUrl(It.IsAny<string>())).Returns(true);
+        urlHelper.Setup(u => u.Action(It.IsAny<Microsoft.AspNetCore.Mvc.Routing.UrlActionContext>())).Returns("/auth/callback");
+        controller.Url = urlHelper.Object;
+
+        // Act — no mode query parameter supplied; flow must be determined server-side
+        var result = controller.GitHubLogin();
+
+        // Assert — link mode must be set from the server-side JWT identity, not user input
+        var challenge = result.Should().BeOfType<ChallengeResult>().Subject;
+        challenge.Properties!.Items.Should().ContainKey("mode").WhoseValue.Should().Be("link");
+        challenge.Properties.Items.Should().ContainKey("link_user_id").WhoseValue.Should().Be(callerId.ToString());
+    }
+
+    // ─────────────────────────────────────────────────────────
     // TokenValidationMiddleware — account deletion during active session
     // ─────────────────────────────────────────────────────────
 
@@ -333,11 +392,11 @@ public class AuthControllerEdgeCaseTests
         return (unitOfWorkMock, authServiceMock);
     }
 
-    private static Mock<IUserContext> CreateMockUserContext()
+    private static Mock<IUserContext> CreateMockUserContext(bool authenticated = true, Guid? userId = null)
     {
         var mock = new Mock<IUserContext>();
-        mock.Setup(u => u.UserId).Returns(Guid.NewGuid().ToString());
-        mock.Setup(u => u.IsAuthenticated).Returns(true);
+        mock.Setup(u => u.IsAuthenticated).Returns(authenticated);
+        mock.Setup(u => u.UserId).Returns(authenticated ? (userId ?? Guid.NewGuid()).ToString() : null!);
         return mock;
     }
 

--- a/backend/tests/Taskdeck.Api.Tests/AuthControllerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuthControllerEdgeCaseTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text.Json;
 using FluentAssertions;
@@ -41,10 +39,10 @@ public class AuthControllerEdgeCaseTests
     // ─────────────────────────────────────────────────────────
 
     [Fact]
-    public void ExchangeCode_ShouldReturn400_WhenCodeIsEmpty()
+    public async Task ExchangeCode_ShouldReturn400_WhenCodeIsEmpty()
     {
-        var controller = CreateAuthController();
-        var result = controller.ExchangeCode(new ExchangeCodeRequest(string.Empty));
+        var (controller, _) = CreateAuthControllerWithUnitOfWork();
+        var result = await controller.ExchangeCode(new ExchangeCodeRequest(string.Empty));
 
         var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
         var error = badRequest.Value.Should().BeOfType<ApiErrorResponse>().Subject;
@@ -52,10 +50,10 @@ public class AuthControllerEdgeCaseTests
     }
 
     [Fact]
-    public void ExchangeCode_ShouldReturn401_WhenCodeIsInvalid()
+    public async Task ExchangeCode_ShouldReturn401_WhenCodeIsInvalid()
     {
-        var controller = CreateAuthController();
-        var result = controller.ExchangeCode(new ExchangeCodeRequest("nonexistent-code"));
+        var (controller, _) = CreateAuthControllerWithUnitOfWork();
+        var result = await controller.ExchangeCode(new ExchangeCodeRequest("nonexistent-code"));
 
         var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
         var error = unauthorized.Value.Should().BeOfType<ApiErrorResponse>().Subject;
@@ -63,44 +61,58 @@ public class AuthControllerEdgeCaseTests
     }
 
     [Fact]
-    public void ExchangeCode_ShouldPreventReplay_SecondUseOfSameCode()
+    public async Task ExchangeCode_ShouldPreventReplay_SecondUseOfSameCode()
     {
-        // Insert a code into the static dictionary via reflection
+        var (controller, uow) = CreateAuthControllerWithUnitOfWork();
+
+        // Create a valid auth code
         var code = "test-replay-code";
-        var authResult = new AuthResultDto("fake-token", new UserDto(
-            Guid.NewGuid(), "user", "user@test.com",
-            Domain.Enums.UserRole.Editor, true,
-            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+        var authCode = new OAuthAuthCode(code, Guid.NewGuid(), "fake-token", DateTimeOffset.UtcNow.AddSeconds(60));
 
-        InjectAuthCode(code, authResult, DateTimeOffset.UtcNow.AddSeconds(60));
+        var authCodeRepoMock = new Mock<IOAuthAuthCodeRepository>();
+        // First call returns the code, second call returns null (code was consumed)
+        var callCount = 0;
+        authCodeRepoMock.Setup(r => r.GetByCodeAsync(code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? authCode : null;
+            });
 
-        var controller = CreateAuthController();
+        var userRepoMock = new Mock<IUserRepository>();
+        var testUser = new User("testuser", "test@test.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(testUser, authCode.UserId);
+        userRepoMock.Setup(r => r.GetByIdAsync(authCode.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testUser);
+
+        uow.Setup(u => u.OAuthAuthCodes).Returns(authCodeRepoMock.Object);
+        uow.Setup(u => u.Users).Returns(userRepoMock.Object);
 
         // First exchange — success
-        var first = controller.ExchangeCode(new ExchangeCodeRequest(code));
+        var first = await controller.ExchangeCode(new ExchangeCodeRequest(code));
         first.Should().BeOfType<OkObjectResult>();
 
-        // Second exchange with same code — should fail (code was consumed)
-        var second = controller.ExchangeCode(new ExchangeCodeRequest(code));
+        // Second exchange with same code — should fail (code not found by mock)
+        var second = await controller.ExchangeCode(new ExchangeCodeRequest(code));
         second.Should().BeOfType<UnauthorizedObjectResult>();
     }
 
     [Fact]
-    public void ExchangeCode_ShouldReturn401_WhenCodeHasExpired()
+    public async Task ExchangeCode_ShouldReturn401_WhenCodeHasExpired()
     {
+        var (controller, uow) = CreateAuthControllerWithUnitOfWork();
+
+        // Create a code that is already expired by manipulating the entity via reflection
         var code = "test-expired-code";
-        var authResult = new AuthResultDto("fake-token", new UserDto(
-            Guid.NewGuid(), "user", "user@test.com",
-            Domain.Enums.UserRole.Editor, true,
-            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+        var authCode = CreateExpiredAuthCode(code);
 
-        // Inject code that expired 10 seconds ago
-        InjectAuthCode(code, authResult, DateTimeOffset.UtcNow.AddSeconds(-10));
+        var authCodeRepoMock = new Mock<IOAuthAuthCodeRepository>();
+        authCodeRepoMock.Setup(r => r.GetByCodeAsync(code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(authCode);
+        uow.Setup(u => u.OAuthAuthCodes).Returns(authCodeRepoMock.Object);
 
-        var controller = CreateAuthController();
-        var result = controller.ExchangeCode(new ExchangeCodeRequest(code));
+        var result = await controller.ExchangeCode(new ExchangeCodeRequest(code));
 
-        // TryRemove succeeds (code existed), then the expiry check fires — returns "Code has expired"
         var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
         var error = unauthorized.Value.Should().BeOfType<ApiErrorResponse>().Subject;
         error.Message.Should().Contain("expired");
@@ -109,7 +121,7 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public void GetProviders_ShouldReturnGitHubStatus()
     {
-        var controller = CreateAuthController(gitHubConfigured: true);
+        var (controller, _) = CreateAuthControllerWithUnitOfWork(gitHubConfigured: true);
         var result = controller.GetProviders();
 
         var ok = result.Should().BeOfType<OkObjectResult>().Subject;
@@ -123,7 +135,7 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public void GitHubLogin_ShouldReturn404_WhenNotConfigured()
     {
-        var controller = CreateAuthController(gitHubConfigured: false);
+        var (controller, _) = CreateAuthControllerWithUnitOfWork(gitHubConfigured: false);
         var result = controller.GitHubLogin();
 
         var notFound = result.Should().BeOfType<NotFoundObjectResult>().Subject;
@@ -134,10 +146,8 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public void GitHubLogin_ShouldReturn400_WhenReturnUrlIsExternal()
     {
-        var controller = CreateAuthController(gitHubConfigured: true);
+        var (controller, _) = CreateAuthControllerWithUnitOfWork(gitHubConfigured: true);
 
-        // The controller calls Url.IsLocalUrl which needs ActionContext setup.
-        // We set up a mock URL helper that rejects external URLs.
         var urlHelper = new Mock<IUrlHelper>();
         urlHelper.Setup(u => u.IsLocalUrl("https://evil.com/steal")).Returns(false);
         controller.Url = urlHelper.Object;
@@ -162,7 +172,6 @@ public class AuthControllerEdgeCaseTests
         var userRepoMock = new Mock<IUserRepository>();
         unitOfWorkMock.Setup(u => u.Users).Returns(userRepoMock.Object);
 
-        // User is deleted — returns null
         userRepoMock.Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((User?)null);
 
@@ -189,10 +198,7 @@ public class AuthControllerEdgeCaseTests
         var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("password"));
         SetUserId(user, userId);
 
-        // Token was issued 2 hours ago
         var tokenIssuedAt = DateTimeOffset.UtcNow.AddHours(-2);
-
-        // Invalidation happened 1 hour ago
         user.InvalidateTokens();
 
         var unitOfWorkMock = new Mock<IUnitOfWork>();
@@ -220,7 +226,6 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public async Task TokenValidationMiddleware_ShouldPassThrough_WhenTokenIssuedAfterReauthentication()
     {
-        // After invalidation, a freshly issued token should still work
         var userId = Guid.NewGuid();
         var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("password"));
         SetUserId(user, userId);
@@ -237,7 +242,6 @@ public class AuthControllerEdgeCaseTests
         RequestDelegate next = _ => { nextCalled = true; return Task.CompletedTask; };
         var middleware = new TokenValidationMiddleware(next, NullLogger<TokenValidationMiddleware>.Instance);
 
-        // Token issued 2 seconds after invalidation
         var tokenIssuedAt = DateTimeOffset.UtcNow.AddSeconds(2);
         var context = CreateAuthenticatedContext(userId, tokenIssuedAt);
 
@@ -249,7 +253,6 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public async Task TokenValidationMiddleware_ShouldPassThrough_WhenClaimsHaveNoUserId()
     {
-        // Token with authenticated identity but no parseable userId
         var claims = new List<Claim> { new("username", "testuser") };
         var identity = new ClaimsIdentity(claims, "Bearer");
         var principal = new ClaimsPrincipal(identity);
@@ -263,7 +266,6 @@ public class AuthControllerEdgeCaseTests
 
         await middleware.InvokeAsync(context, unitOfWorkMock.Object);
 
-        // Should pass through — let downstream handle it
         nextCalled.Should().BeTrue();
     }
 
@@ -274,8 +276,8 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public async Task Login_ShouldReturn401_WhenBodyIsNull()
     {
-        var authService = CreateMockAuthService();
-        var controller = new AuthController(authService.Object, CreateGitHubSettings(false), CreateMockUserContext().Object);
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var controller = new AuthController(authService.Object, CreateGitHubSettings(false), CreateMockUserContext().Object, uow.Object);
 
         var result = await controller.Login(null);
 
@@ -287,8 +289,8 @@ public class AuthControllerEdgeCaseTests
     [Fact]
     public async Task Login_ShouldReturn401_WhenFieldsEmpty()
     {
-        var authService = CreateMockAuthService();
-        var controller = new AuthController(authService.Object, CreateGitHubSettings(false), CreateMockUserContext().Object);
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var controller = new AuthController(authService.Object, CreateGitHubSettings(false), CreateMockUserContext().Object, uow.Object);
 
         var result = await controller.Login(new LoginDto("", ""));
 
@@ -301,22 +303,30 @@ public class AuthControllerEdgeCaseTests
     // Helpers
     // ─────────────────────────────────────────────────────────
 
-    private static AuthController CreateAuthController(bool gitHubConfigured = false)
+    private static (AuthController Controller, Mock<IUnitOfWork> UnitOfWork) CreateAuthControllerWithUnitOfWork(bool gitHubConfigured = false)
     {
-        var authServiceMock = CreateMockAuthService();
+        var (unitOfWorkMock, authServiceMock) = CreateMockAuthServiceWithUow();
         var gitHubSettings = CreateGitHubSettings(gitHubConfigured);
-        return new AuthController(authServiceMock.Object, gitHubSettings, CreateMockUserContext().Object);
+
+        // Set up default OAuthAuthCodes repo that returns null (code not found)
+        var authCodeRepoMock = new Mock<IOAuthAuthCodeRepository>();
+        authCodeRepoMock.Setup(r => r.GetByCodeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OAuthAuthCode?)null);
+        unitOfWorkMock.Setup(u => u.OAuthAuthCodes).Returns(authCodeRepoMock.Object);
+
+        var controller = new AuthController(authServiceMock.Object, gitHubSettings, CreateMockUserContext().Object, unitOfWorkMock.Object);
+        return (controller, unitOfWorkMock);
     }
 
-    private static Mock<AuthenticationService> CreateMockAuthService()
+    private static (Mock<IUnitOfWork> UnitOfWork, Mock<AuthenticationService> AuthService) CreateMockAuthServiceWithUow()
     {
         var unitOfWorkMock = new Mock<IUnitOfWork>();
         var userRepoMock = new Mock<IUserRepository>();
         unitOfWorkMock.Setup(u => u.Users).Returns(userRepoMock.Object);
         unitOfWorkMock.Setup(u => u.ExternalLogins).Returns(new Mock<IExternalLoginRepository>().Object);
 
-        // AuthenticationService is not sealed, but its constructor requires specific params
-        return new Mock<AuthenticationService>(unitOfWorkMock.Object, DefaultJwtSettings) { CallBase = true };
+        var authServiceMock = new Mock<AuthenticationService>(unitOfWorkMock.Object, DefaultJwtSettings) { CallBase = true };
+        return (unitOfWorkMock, authServiceMock);
     }
 
     private static Mock<IUserContext> CreateMockUserContext()
@@ -334,13 +344,13 @@ public class AuthControllerEdgeCaseTests
             : new GitHubOAuthSettings();
     }
 
-    private static void InjectAuthCode(string code, AuthResultDto result, DateTimeOffset expiry)
+    private static OAuthAuthCode CreateExpiredAuthCode(string code)
     {
-        // Access the static _authCodes field via reflection
-        var field = typeof(AuthController).GetField("_authCodes",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = (ConcurrentDictionary<string, (AuthResultDto Result, DateTimeOffset Expiry)>)field!.GetValue(null)!;
-        dict[code] = (result, expiry);
+        // Create a valid code first, then set ExpiresAt to the past via reflection
+        var authCode = new OAuthAuthCode(code, Guid.NewGuid(), "fake-token", DateTimeOffset.UtcNow.AddSeconds(60));
+        var expiresAtProp = typeof(OAuthAuthCode).GetProperty("ExpiresAt");
+        expiresAtProp!.SetValue(authCode, DateTimeOffset.UtcNow.AddSeconds(-10));
+        return authCode;
     }
 
     private static DefaultHttpContext CreateAuthenticatedContext(Guid userId, DateTimeOffset? iat)

--- a/backend/tests/Taskdeck.Api.Tests/AuthControllerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuthControllerEdgeCaseTests.cs
@@ -67,22 +67,26 @@ public class AuthControllerEdgeCaseTests
 
         // Create a valid auth code
         var code = "test-replay-code";
-        var authCode = new OAuthAuthCode(code, Guid.NewGuid(), "fake-token", DateTimeOffset.UtcNow.AddSeconds(60));
+        var userId = Guid.NewGuid();
+        var authCode = new OAuthAuthCode(code, userId, "fake-token", DateTimeOffset.UtcNow.AddSeconds(60));
 
         var authCodeRepoMock = new Mock<IOAuthAuthCodeRepository>();
-        // First call returns the code, second call returns null (code was consumed)
-        var callCount = 0;
         authCodeRepoMock.Setup(r => r.GetByCodeAsync(code, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(authCode);
+
+        // First TryConsumeAtomicAsync returns true (consumed), second returns false (already consumed)
+        var consumeCallCount = 0;
+        authCodeRepoMock.Setup(r => r.TryConsumeAtomicAsync(code, It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
-                callCount++;
-                return callCount == 1 ? authCode : null;
+                consumeCallCount++;
+                return consumeCallCount == 1;
             });
 
         var userRepoMock = new Mock<IUserRepository>();
         var testUser = new User("testuser", "test@test.com", BCrypt.Net.BCrypt.HashPassword("pass"));
-        SetUserId(testUser, authCode.UserId);
-        userRepoMock.Setup(r => r.GetByIdAsync(authCode.UserId, It.IsAny<CancellationToken>()))
+        SetUserId(testUser, userId);
+        userRepoMock.Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(testUser);
 
         uow.Setup(u => u.OAuthAuthCodes).Returns(authCodeRepoMock.Object);
@@ -92,7 +96,7 @@ public class AuthControllerEdgeCaseTests
         var first = await controller.ExchangeCode(new ExchangeCodeRequest(code));
         first.Should().BeOfType<OkObjectResult>();
 
-        // Second exchange with same code — should fail (code not found by mock)
+        // Second exchange with same code — should fail (atomic consume returns false)
         var second = await controller.ExchangeCode(new ExchangeCodeRequest(code));
         second.Should().BeOfType<UnauthorizedObjectResult>();
     }

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -843,6 +843,7 @@ public class LlmQueueToProposalWorkerTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/OAuthTokenLifecycleTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OAuthTokenLifecycleTests.cs
@@ -146,25 +146,33 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "oauth-cleanup");
 
-        // Insert expired codes directly into the database
-        using var scope = _factory.Services.CreateScope();
-        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-
         var expiredCode1 = $"cleanup-expired-1-{Guid.NewGuid():N}";
         var expiredCode2 = $"cleanup-expired-2-{Guid.NewGuid():N}";
         var validCode = $"cleanup-valid-{Guid.NewGuid():N}";
 
-        await InsertAuthCodeDirectly(scope, expiredCode1, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(-30));
-        await InsertAuthCodeDirectly(scope, expiredCode2, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(-5));
-        await InsertAuthCodeDirectly(scope, validCode, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(60));
+        // Insert codes in one scope
+        using (var insertScope = _factory.Services.CreateScope())
+        {
+            await InsertAuthCodeDirectly(insertScope, expiredCode1, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(-30));
+            await InsertAuthCodeDirectly(insertScope, expiredCode2, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(-5));
+            await InsertAuthCodeDirectly(insertScope, validCode, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(60));
+        }
 
-        // Run cleanup
-        var deleted = await uow.OAuthAuthCodes.DeleteExpiredAsync(DateTimeOffset.UtcNow);
-        deleted.Should().BeGreaterThanOrEqualTo(2, "at least the two expired codes should be deleted");
+        // Run cleanup in a separate scope (fresh DbContext)
+        using (var cleanupScope = _factory.Services.CreateScope())
+        {
+            var uow = cleanupScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var deleted = await uow.OAuthAuthCodes.DeleteExpiredAsync(DateTimeOffset.UtcNow);
+            deleted.Should().BeGreaterThanOrEqualTo(2, "at least the two expired codes should be deleted");
+        }
 
-        // The valid code should still be retrievable
-        var remainingCode = await uow.OAuthAuthCodes.GetByCodeAsync(validCode);
-        remainingCode.Should().NotBeNull("valid code should survive cleanup");
+        // Verify in yet another scope
+        using (var verifyScope = _factory.Services.CreateScope())
+        {
+            var uow = verifyScope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var remainingCode = await uow.OAuthAuthCodes.GetByCodeAsync(validCode);
+            remainingCode.Should().NotBeNull("valid code should survive cleanup");
+        }
     }
 
     // ─────────────────────────────────────────────────────────
@@ -431,21 +439,17 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
     {
         var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
 
-        // Use raw SQL to bypass the domain entity validation (which rejects past expiry dates)
-        await db.Database.ExecuteSqlRawAsync(
-            "INSERT INTO OAuthAuthCodes (Id, Code, UserId, Token, Purpose, ProviderData, ExpiresAt, IsConsumed, ConsumedAt, CreatedAt, UpdatedAt) " +
-            "VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10})",
-            Guid.NewGuid().ToString(),
-            code,
-            userId.ToString(),
-            token,
-            "login",
-            (string?)null!,
-            expiresAt.ToString("o"),
-            false,
-            (string?)null!,
-            DateTimeOffset.UtcNow.ToString("o"),
-            DateTimeOffset.UtcNow.ToString("o"));
+        // Create a valid auth code first, then adjust ExpiresAt via reflection
+        // for testing expired codes (constructor rejects past dates).
+        var futureExpiry = DateTimeOffset.UtcNow.AddSeconds(600);
+        var authCode = new OAuthAuthCode(code, userId, token, futureExpiry);
+
+        // Override ExpiresAt to the desired value (may be in the past for testing)
+        var expiresAtProp = typeof(OAuthAuthCode).GetProperty("ExpiresAt");
+        expiresAtProp!.SetValue(authCode, expiresAt);
+
+        db.OAuthAuthCodes.Add(authCode);
+        await db.SaveChangesAsync();
     }
 
     private static string CreateCustomJwt(

--- a/backend/tests/Taskdeck.Api.Tests/OAuthTokenLifecycleTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OAuthTokenLifecycleTests.cs
@@ -1,27 +1,30 @@
-using System.Collections.Concurrent;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Reflection;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
-using Taskdeck.Api.Controllers;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Persistence;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
 
 /// <summary>
 /// Integration tests for OAuth auth code store behavior and JWT token lifecycle.
-/// Covers scenarios from #723 (TST-55): static auth code store, token issuance,
+/// Covers scenarios from #723 (TST-55): DB-backed auth code store, token issuance,
 /// validation, expiration, wrong-key rejection, deactivated user, SignalR query-string auth,
 /// and code cleanup semantics.
+/// Updated for #676: auth codes now stored in SQLite via OAuthAuthCode entity.
 /// </summary>
 public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
 {
@@ -42,7 +45,7 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "oauth-valid");
 
-        var code = InjectAuthCodeForUser(user, TimeSpan.FromSeconds(60));
+        var code = await InjectAuthCodeForUser(user, TimeSpan.FromSeconds(60));
 
         // Exchange code via the HTTP endpoint
         using var anonClient = _factory.CreateClient();
@@ -67,7 +70,7 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         var user = await ApiTestHarness.AuthenticateAsync(client, "oauth-expired");
 
         // Inject code that expired 10 seconds ago
-        var code = InjectAuthCodeForUser(user, TimeSpan.FromSeconds(-10));
+        var code = await InjectAuthCodeForUser(user, TimeSpan.FromSeconds(-10));
 
         using var anonClient = _factory.CreateClient();
         var response = await anonClient.PostAsJsonAsync("/api/auth/github/exchange", new { Code = code });
@@ -102,7 +105,7 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "oauth-replay");
 
-        var code = InjectAuthCodeForUser(user, TimeSpan.FromSeconds(60));
+        var code = await InjectAuthCodeForUser(user, TimeSpan.FromSeconds(60));
 
         using var anonClient = _factory.CreateClient();
 
@@ -120,10 +123,9 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "oauth-concurrent");
 
-        var code = InjectAuthCodeForUser(user, TimeSpan.FromSeconds(60));
+        var code = await InjectAuthCodeForUser(user, TimeSpan.FromSeconds(60));
 
         // Fire multiple concurrent exchange requests for the same code.
-        // HttpClient is thread-safe, so reuse a single instance to avoid handler leaks.
         using var exchangeClient = _factory.CreateClient();
         var tasks = Enumerable.Range(0, 5)
             .Select(_ => exchangeClient.PostAsJsonAsync("/api/auth/github/exchange", new { Code = code }))
@@ -139,50 +141,30 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
-    public void AuthCodeStore_CleanupRemovesExpiredCodes()
+    public async Task AuthCodeStore_ExpiredCodesCanBeCleanedUp()
     {
-        // Insert several codes: some expired, some valid
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "oauth-cleanup");
+
+        // Insert expired codes directly into the database
+        using var scope = _factory.Services.CreateScope();
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
         var expiredCode1 = $"cleanup-expired-1-{Guid.NewGuid():N}";
         var expiredCode2 = $"cleanup-expired-2-{Guid.NewGuid():N}";
         var validCode = $"cleanup-valid-{Guid.NewGuid():N}";
 
-        var dummyResult = CreateDummyAuthResult();
+        await InsertAuthCodeDirectly(scope, expiredCode1, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(-30));
+        await InsertAuthCodeDirectly(scope, expiredCode2, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(-5));
+        await InsertAuthCodeDirectly(scope, validCode, user.UserId, user.Token, DateTimeOffset.UtcNow.AddSeconds(60));
 
-        var dict = GetAuthCodesDict();
-        dict[expiredCode1] = (dummyResult, DateTimeOffset.UtcNow.AddSeconds(-30));
-        dict[expiredCode2] = (dummyResult, DateTimeOffset.UtcNow.AddSeconds(-5));
-        dict[validCode] = (dummyResult, DateTimeOffset.UtcNow.AddSeconds(60));
+        // Run cleanup
+        var deleted = await uow.OAuthAuthCodes.DeleteExpiredAsync(DateTimeOffset.UtcNow);
+        deleted.Should().BeGreaterThanOrEqualTo(2, "at least the two expired codes should be deleted");
 
-        // Trigger cleanup by calling CleanupExpiredCodes via reflection
-        var cleanupMethod = typeof(AuthController).GetMethod("CleanupExpiredCodes",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        cleanupMethod!.Invoke(null, null);
-
-        dict.ContainsKey(expiredCode1).Should().BeFalse("expired code should be cleaned up");
-        dict.ContainsKey(expiredCode2).Should().BeFalse("expired code should be cleaned up");
-        dict.ContainsKey(validCode).Should().BeTrue("valid code should survive cleanup");
-
-        // Clean up the valid code to avoid cross-test interference
-        dict.TryRemove(validCode, out _);
-    }
-
-    [Fact]
-    public void AuthCodeStore_CleanupOnlyTriggeredDuringExchange_ExpiredCodesAccumulate()
-    {
-        // Document the current behavior: expired codes persist until CleanupExpiredCodes is called.
-        // This test validates the behavior described in the issue: cleanup is not on a timer.
-        // The static ConcurrentDictionary also does not work with horizontal scaling — see #676.
-        var code = $"accumulate-{Guid.NewGuid():N}";
-        var dict = GetAuthCodesDict();
-        var dummyResult = CreateDummyAuthResult();
-
-        dict[code] = (dummyResult, DateTimeOffset.UtcNow.AddSeconds(-60));
-
-        // Without an exchange attempt, the expired code remains in the dictionary
-        dict.ContainsKey(code).Should().BeTrue("expired codes accumulate until cleanup is triggered");
-
-        // Clean up
-        dict.TryRemove(code, out _);
+        // The valid code should still be retrievable
+        var remainingCode = await uow.OAuthAuthCodes.GetByCodeAsync(validCode);
+        remainingCode.Should().NotBeNull("valid code should survive cleanup");
     }
 
     // ─────────────────────────────────────────────────────────
@@ -195,7 +177,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "tok-expired");
 
-        // Create an already-expired JWT
         var expiredToken = CreateCustomJwt(
             userId: user.UserId,
             username: user.Username,
@@ -211,7 +192,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         var response = await expiredClient.GetAsync("/api/boards");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-        // Verify the response is JSON ApiErrorResponse, not HTML
         await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.Unauthorized);
     }
 
@@ -221,7 +201,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "tok-wrongkey");
 
-        // Sign with a completely different secret key
         var wrongKeyToken = CreateCustomJwt(
             userId: user.UserId,
             username: user.Username,
@@ -269,14 +248,9 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "tok-deactivated");
 
-        // Deactivate the user account via the self-scope endpoint.
-        // After deactivation, the TokenValidationMiddleware should reject
-        // the original token because user.IsActive is false.
         var deactivateResponse = await client.PostAsync($"/api/users/{user.UserId}/deactivate", null);
         deactivateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        // The original token is still structurally valid (not expired, correct key),
-        // but the middleware rejects it because the user is inactive.
         var response = await client.GetAsync("/api/boards");
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -289,7 +263,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "tok-reissue");
 
-        // Change password
         var changePwdResponse = await client.PostAsJsonAsync("/api/auth/change-password", new
         {
             CurrentPassword = "password123",
@@ -297,7 +270,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         });
         changePwdResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        // Login with the new password to get a fresh token
         using var freshClient = _factory.CreateClient();
         var loginResponse = await freshClient.PostAsJsonAsync("/api/auth/login", new
         {
@@ -308,7 +280,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
         var freshAuth = await loginResponse.Content.ReadFromJsonAsync<AuthResultDto>();
         freshClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", freshAuth!.Token);
 
-        // Fresh token should work
         var response = await freshClient.GetAsync("/api/boards");
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -316,12 +287,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
     // ─────────────────────────────────────────────────────────
     // 3. SignalR auth
     // ─────────────────────────────────────────────────────────
-    // Note: The .NET SignalR client with HttpMessageHandlerFactory (in-process
-    // test transport) sends tokens via the Authorization header, not via the
-    // ?access_token= query string. These tests verify SignalR endpoint auth
-    // generally but do NOT exercise the OnMessageReceived query-string
-    // extraction path in AuthenticationRegistration.cs. True query-string
-    // auth testing would require WebSocket transport or manual URL construction.
 
     [Fact]
     public async Task SignalR_AcceptsValidJwt()
@@ -386,7 +351,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
     [Fact]
     public async Task GitHubLogin_WhenNotConfigured_Returns404()
     {
-        // The test factory does not configure GitHub OAuth secrets
         using var client = _factory.CreateClient();
 
         var response = await client.GetAsync("/api/auth/github/login");
@@ -410,35 +374,78 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
     }
 
     // ─────────────────────────────────────────────────────────
+    // 5. Account linking endpoints
+    // ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LinkedAccounts_ReturnsEmptyListForNewUser()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "link-empty");
+
+        var response = await client.GetAsync("/api/auth/linked-accounts");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var accounts = await response.Content.ReadFromJsonAsync<LinkedAccountDto[]>();
+        accounts.Should().NotBeNull();
+        accounts!.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UnlinkGitHub_Returns404_WhenNotLinked()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "unlink-none");
+
+        var response = await client.DeleteAsync("/api/auth/github/link");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task LinkGitHub_Returns401_WhenNotAuthenticated()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/auth/github/link", new { Code = "test" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ─────────────────────────────────────────────────────────
     // Helpers
     // ─────────────────────────────────────────────────────────
 
-    private static string InjectAuthCodeForUser(TestUserContext user, TimeSpan validFor)
+    private async Task<string> InjectAuthCodeForUser(TestUserContext user, TimeSpan validFor)
     {
         var code = $"test-code-{Guid.NewGuid():N}";
-        var authResult = new AuthResultDto(user.Token, new UserDto(
-            user.UserId, user.Username, user.Email,
-            Domain.Enums.UserRole.Editor, true,
-            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+        var expiresAt = DateTimeOffset.UtcNow.Add(validFor);
 
-        var dict = GetAuthCodesDict();
-        dict[code] = (authResult, DateTimeOffset.UtcNow.Add(validFor));
+        using var scope = _factory.Services.CreateScope();
+        await InsertAuthCodeDirectly(scope, code, user.UserId, user.Token, expiresAt);
+
         return code;
     }
 
-    private static ConcurrentDictionary<string, (AuthResultDto Result, DateTimeOffset Expiry)> GetAuthCodesDict()
+    private static async Task InsertAuthCodeDirectly(IServiceScope scope, string code, Guid userId, string token, DateTimeOffset expiresAt)
     {
-        var field = typeof(AuthController).GetField("_authCodes",
-            BindingFlags.NonPublic | BindingFlags.Static);
-        return (ConcurrentDictionary<string, (AuthResultDto Result, DateTimeOffset Expiry)>)field!.GetValue(null)!;
-    }
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
 
-    private static AuthResultDto CreateDummyAuthResult()
-    {
-        return new AuthResultDto("dummy-token", new UserDto(
-            Guid.NewGuid(), "dummy", "dummy@test.com",
-            Domain.Enums.UserRole.Editor, true,
-            DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+        // Use raw SQL to bypass the domain entity validation (which rejects past expiry dates)
+        await db.Database.ExecuteSqlRawAsync(
+            "INSERT INTO OAuthAuthCodes (Id, Code, UserId, Token, Purpose, ProviderData, ExpiresAt, IsConsumed, ConsumedAt, CreatedAt, UpdatedAt) " +
+            "VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10})",
+            Guid.NewGuid().ToString(),
+            code,
+            userId.ToString(),
+            token,
+            "login",
+            (string?)null!,
+            expiresAt.ToString("o"),
+            false,
+            (string?)null!,
+            DateTimeOffset.UtcNow.ToString("o"),
+            DateTimeOffset.UtcNow.ToString("o"));
     }
 
     private static string CreateCustomJwt(
@@ -465,8 +472,6 @@ public class OAuthTokenLifecycleTests : IClassFixture<TestWebApplicationFactory>
                 ClaimValueTypes.Integer64)
         };
 
-        // For expired tokens: set notBefore far in the past and expires in the past.
-        // For valid tokens: notBefore = now, expires = now + expiresIn.
         var notBefore = expiresIn < TimeSpan.Zero
             ? now.AddMinutes(-60)
             : now;

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerReliabilityTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerReliabilityTests.cs
@@ -642,6 +642,7 @@ public class OutboundWebhookDeliveryWorkerReliabilityTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
@@ -548,6 +548,7 @@ public class OutboundWebhookDeliveryWorkerTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookHmacDeliveryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookHmacDeliveryTests.cs
@@ -535,6 +535,7 @@ public class OutboundWebhookHmacDeliveryTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
@@ -341,6 +341,7 @@ public class ProposalHousekeepingWorkerEdgeCaseTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
@@ -219,6 +219,7 @@ public class ProposalHousekeepingWorkerTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -595,6 +595,7 @@ public class WorkerResilienceTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -630,6 +631,7 @@ public class WorkerResilienceTests
         public IKnowledgeDocumentRepository KnowledgeDocuments => null!;
         public IKnowledgeChunkRepository KnowledgeChunks => null!;
         public IExternalLoginRepository ExternalLogins => null!;
+        public IOAuthAuthCodeRepository OAuthAuthCodes => null!;
         public IApiKeyRepository ApiKeys => null!;
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/backend/tests/Taskdeck.Application.Tests/Services/AccountLinkingTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AccountLinkingTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+/// <summary>
+/// Tests for account linking and unlinking functionality in AuthenticationService.
+/// Linked to #676.
+/// </summary>
+public class AccountLinkingTests
+{
+    private static readonly JwtSettings DefaultJwtSettings = new()
+    {
+        SecretKey = "TestKeyMustBeAtLeast32CharactersLong!",
+        Issuer = "TestIssuer",
+        Audience = "TestAudience",
+        ExpirationMinutes = 60
+    };
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_ValidNewLink_CreatesExternalLogin()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        uow.Setup(u => u.ExternalLogins.GetByProviderAsync("GitHub", "gh-123", It.IsAny<CancellationToken>())).ReturnsAsync((ExternalLogin?)null);
+        uow.Setup(u => u.ExternalLogins.GetByUserIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(Enumerable.Empty<ExternalLogin>());
+        uow.Setup(u => u.ExternalLogins.AddAsync(It.IsAny<ExternalLogin>(), It.IsAny<CancellationToken>())).ReturnsAsync((ExternalLogin e, CancellationToken _) => e);
+
+        var result = await service.CompleteAccountLinkAsync(userId, "GitHub", "gh-123", "Test User", "https://avatar.url/img.png");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Provider.Should().Be("GitHub");
+        result.Value.ProviderUserId.Should().Be("gh-123");
+        result.Value.DisplayName.Should().Be("Test User");
+        uow.Verify(u => u.ExternalLogins.AddAsync(It.IsAny<ExternalLogin>(), It.IsAny<CancellationToken>()), Times.Once);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_AlreadyLinkedToSameUser_ReturnsConflict()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+
+        var existingLogin = new ExternalLogin(userId, "GitHub", "gh-123");
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        uow.Setup(u => u.ExternalLogins.GetByProviderAsync("GitHub", "gh-123", It.IsAny<CancellationToken>())).ReturnsAsync(existingLogin);
+
+        var result = await service.CompleteAccountLinkAsync(userId, "GitHub", "gh-123", null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("already linked to your account");
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_AlreadyLinkedToDifferentUser_ReturnsConflict()
+    {
+        var userId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+
+        var existingLogin = new ExternalLogin(otherUserId, "GitHub", "gh-123");
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        uow.Setup(u => u.ExternalLogins.GetByProviderAsync("GitHub", "gh-123", It.IsAny<CancellationToken>())).ReturnsAsync(existingLogin);
+
+        var result = await service.CompleteAccountLinkAsync(userId, "GitHub", "gh-123", null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("different user");
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_UserAlreadyHasProviderLinked_ReturnsConflict()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+
+        var existingUserLogin = new ExternalLogin(userId, "GitHub", "gh-existing");
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        uow.Setup(u => u.ExternalLogins.GetByProviderAsync("GitHub", "gh-new", It.IsAny<CancellationToken>())).ReturnsAsync((ExternalLogin?)null);
+        uow.Setup(u => u.ExternalLogins.GetByUserIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(new[] { existingUserLogin });
+
+        var result = await service.CompleteAccountLinkAsync(userId, "GitHub", "gh-new", null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("already linked");
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_UserNotFound_ReturnsNotFound()
+    {
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((User?)null);
+
+        var result = await service.CompleteAccountLinkAsync(Guid.NewGuid(), "GitHub", "gh-123", null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task CompleteAccountLinkAsync_InactiveUser_ReturnsForbidden()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+        user.Deactivate();
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+
+        var result = await service.CompleteAccountLinkAsync(userId, "GitHub", "gh-123", null, null);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+    }
+
+    [Fact]
+    public async Task UnlinkExternalLoginAsync_ExistingLink_RemovesIt()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+
+        var login = new ExternalLogin(userId, "GitHub", "gh-123");
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        uow.Setup(u => u.ExternalLogins.GetByUserIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(new[] { login });
+
+        var result = await service.UnlinkExternalLoginAsync(userId, "GitHub");
+
+        result.IsSuccess.Should().BeTrue();
+        uow.Verify(u => u.ExternalLogins.DeleteAsync(login, It.IsAny<CancellationToken>()), Times.Once);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UnlinkExternalLoginAsync_NoExistingLink_ReturnsNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(user, userId);
+
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        uow.Setup(u => u.ExternalLogins.GetByUserIdAsync(userId, It.IsAny<CancellationToken>())).ReturnsAsync(Enumerable.Empty<ExternalLogin>());
+
+        var result = await service.UnlinkExternalLoginAsync(userId, "GitHub");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task UnlinkExternalLoginAsync_UserNotFound_ReturnsNotFound()
+    {
+        var (service, uow) = CreateService();
+        uow.Setup(u => u.Users.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((User?)null);
+
+        var result = await service.UnlinkExternalLoginAsync(Guid.NewGuid(), "GitHub");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────
+
+    private static (AuthenticationService Service, Mock<IUnitOfWork> UnitOfWork) CreateService()
+    {
+        var uow = new Mock<IUnitOfWork>();
+        var service = new AuthenticationService(uow.Object, DefaultJwtSettings);
+        return (service, uow);
+    }
+
+    private static void SetUserId(User user, Guid userId)
+    {
+        var idProperty = typeof(Domain.Common.Entity).GetProperty("Id");
+        idProperty!.SetValue(user, userId);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/OAuthAuthCodeTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/OAuthAuthCodeTests.cs
@@ -19,7 +19,7 @@ public class OAuthAuthCodeTests
 
         authCode.Code.Should().Be(code);
         authCode.UserId.Should().Be(userId);
-        authCode.Token.Should().Be(token);
+        authCode.Token.Should().BeEmpty("JWT is never stored in DB — re-issued at exchange time");
         authCode.ExpiresAt.Should().Be(expiresAt);
         authCode.IsConsumed.Should().BeFalse();
         authCode.ConsumedAt.Should().BeNull();
@@ -122,37 +122,45 @@ public class OAuthAuthCodeTests
     [Fact]
     public void CreateForLinking_ValidParameters_CreatesEntity()
     {
+        var initiatingUserId = Guid.NewGuid();
         var providerData = "{\"provider\":\"GitHub\",\"providerUserId\":\"12345\"}";
         var expiresAt = DateTimeOffset.UtcNow.AddSeconds(60);
 
-        var linkCode = OAuthAuthCode.CreateForLinking("link-code", providerData, expiresAt);
+        var linkCode = OAuthAuthCode.CreateForLinking("link-code", initiatingUserId, providerData, expiresAt);
 
         linkCode.Code.Should().Be("link-code");
         linkCode.Purpose.Should().Be("link");
         linkCode.IsLinkingCode.Should().BeTrue();
         linkCode.ProviderData.Should().Be(providerData);
-        linkCode.UserId.Should().Be(Guid.Empty);
+        linkCode.UserId.Should().Be(initiatingUserId);
         linkCode.Token.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateForLinking_EmptyUserId_Throws()
+    {
+        var act = () => OAuthAuthCode.CreateForLinking("code", Guid.Empty, "{}", DateTimeOffset.UtcNow.AddSeconds(60));
+        act.Should().Throw<DomainException>().WithMessage("*Initiating user ID is required*");
     }
 
     [Fact]
     public void CreateForLinking_EmptyProviderData_Throws()
     {
-        var act = () => OAuthAuthCode.CreateForLinking("code", "", DateTimeOffset.UtcNow.AddSeconds(60));
+        var act = () => OAuthAuthCode.CreateForLinking("code", Guid.NewGuid(), "", DateTimeOffset.UtcNow.AddSeconds(60));
         act.Should().Throw<DomainException>().WithMessage("*Provider data cannot be empty*");
     }
 
     [Fact]
     public void CreateForLinking_PastExpiry_Throws()
     {
-        var act = () => OAuthAuthCode.CreateForLinking("code", "{}", DateTimeOffset.UtcNow.AddSeconds(-10));
+        var act = () => OAuthAuthCode.CreateForLinking("code", Guid.NewGuid(), "{}", DateTimeOffset.UtcNow.AddSeconds(-10));
         act.Should().Throw<DomainException>().WithMessage("*Expiry must be in the future*");
     }
 
     [Fact]
     public void CreateForLinking_TryConsume_WorksCorrectly()
     {
-        var linkCode = OAuthAuthCode.CreateForLinking("link-code", "{}", DateTimeOffset.UtcNow.AddSeconds(60));
+        var linkCode = OAuthAuthCode.CreateForLinking("link-code", Guid.NewGuid(), "{}", DateTimeOffset.UtcNow.AddSeconds(60));
 
         var consumed = linkCode.TryConsume();
 

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/OAuthAuthCodeTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/OAuthAuthCodeTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class OAuthAuthCodeTests
+{
+    [Fact]
+    public void Constructor_ValidParameters_CreatesEntity()
+    {
+        var userId = Guid.NewGuid();
+        var code = "test-code-abc123";
+        var token = "jwt-token-value";
+        var expiresAt = DateTimeOffset.UtcNow.AddSeconds(60);
+
+        var authCode = new OAuthAuthCode(code, userId, token, expiresAt);
+
+        authCode.Code.Should().Be(code);
+        authCode.UserId.Should().Be(userId);
+        authCode.Token.Should().Be(token);
+        authCode.ExpiresAt.Should().Be(expiresAt);
+        authCode.IsConsumed.Should().BeFalse();
+        authCode.ConsumedAt.Should().BeNull();
+        authCode.Purpose.Should().Be("login");
+        authCode.IsLinkingCode.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_EmptyCode_Throws()
+    {
+        var act = () => new OAuthAuthCode("", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+        act.Should().Throw<DomainException>().WithMessage("*Auth code cannot be empty*");
+    }
+
+    [Fact]
+    public void Constructor_EmptyUserId_Throws()
+    {
+        var act = () => new OAuthAuthCode("code", Guid.Empty, "token", DateTimeOffset.UtcNow.AddSeconds(60));
+        act.Should().Throw<DomainException>().WithMessage("*User ID cannot be empty*");
+    }
+
+    [Fact]
+    public void Constructor_EmptyToken_Throws()
+    {
+        var act = () => new OAuthAuthCode("code", Guid.NewGuid(), "", DateTimeOffset.UtcNow.AddSeconds(60));
+        act.Should().Throw<DomainException>().WithMessage("*Token cannot be empty*");
+    }
+
+    [Fact]
+    public void Constructor_PastExpiry_Throws()
+    {
+        var act = () => new OAuthAuthCode("code", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(-10));
+        act.Should().Throw<DomainException>().WithMessage("*Expiry must be in the future*");
+    }
+
+    [Fact]
+    public void Constructor_CodeTooLong_Throws()
+    {
+        var longCode = new string('x', 513);
+        var act = () => new OAuthAuthCode(longCode, Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+        act.Should().Throw<DomainException>().WithMessage("*Auth code cannot exceed 512 characters*");
+    }
+
+    [Fact]
+    public void TryConsume_ValidCode_ReturnsTrue()
+    {
+        var authCode = new OAuthAuthCode("code", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+
+        var consumed = authCode.TryConsume();
+
+        consumed.Should().BeTrue();
+        authCode.IsConsumed.Should().BeTrue();
+        authCode.ConsumedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void TryConsume_AlreadyConsumed_ReturnsFalse()
+    {
+        var authCode = new OAuthAuthCode("code", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+        authCode.TryConsume();
+
+        var secondConsume = authCode.TryConsume();
+
+        secondConsume.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryConsume_Expired_ReturnsFalse()
+    {
+        var authCode = new OAuthAuthCode("code", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+
+        // Force expiry via reflection
+        var expiresAtProp = typeof(OAuthAuthCode).GetProperty("ExpiresAt");
+        expiresAtProp!.SetValue(authCode, DateTimeOffset.UtcNow.AddSeconds(-10));
+
+        var consumed = authCode.TryConsume();
+
+        consumed.Should().BeFalse();
+        authCode.IsConsumed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_FutureExpiry_ReturnsFalse()
+    {
+        var authCode = new OAuthAuthCode("code", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+        authCode.IsExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_PastExpiry_ReturnsTrue()
+    {
+        var authCode = new OAuthAuthCode("code", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddSeconds(60));
+
+        var expiresAtProp = typeof(OAuthAuthCode).GetProperty("ExpiresAt");
+        expiresAtProp!.SetValue(authCode, DateTimeOffset.UtcNow.AddSeconds(-10));
+
+        authCode.IsExpired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateForLinking_ValidParameters_CreatesEntity()
+    {
+        var providerData = "{\"provider\":\"GitHub\",\"providerUserId\":\"12345\"}";
+        var expiresAt = DateTimeOffset.UtcNow.AddSeconds(60);
+
+        var linkCode = OAuthAuthCode.CreateForLinking("link-code", providerData, expiresAt);
+
+        linkCode.Code.Should().Be("link-code");
+        linkCode.Purpose.Should().Be("link");
+        linkCode.IsLinkingCode.Should().BeTrue();
+        linkCode.ProviderData.Should().Be(providerData);
+        linkCode.UserId.Should().Be(Guid.Empty);
+        linkCode.Token.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateForLinking_EmptyProviderData_Throws()
+    {
+        var act = () => OAuthAuthCode.CreateForLinking("code", "", DateTimeOffset.UtcNow.AddSeconds(60));
+        act.Should().Throw<DomainException>().WithMessage("*Provider data cannot be empty*");
+    }
+
+    [Fact]
+    public void CreateForLinking_PastExpiry_Throws()
+    {
+        var act = () => OAuthAuthCode.CreateForLinking("code", "{}", DateTimeOffset.UtcNow.AddSeconds(-10));
+        act.Should().Throw<DomainException>().WithMessage("*Expiry must be in the future*");
+    }
+
+    [Fact]
+    public void CreateForLinking_TryConsume_WorksCorrectly()
+    {
+        var linkCode = OAuthAuthCode.CreateForLinking("link-code", "{}", DateTimeOffset.UtcNow.AddSeconds(60));
+
+        var consumed = linkCode.TryConsume();
+
+        consumed.Should().BeTrue();
+        linkCode.IsConsumed.Should().BeTrue();
+
+        // Second consume should fail
+        linkCode.TryConsume().Should().BeFalse();
+    }
+}

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.13.1-alpine AS build
+FROM node:24.13.1-bookworm-slim AS build
 WORKDIR /app
 
 COPY frontend/taskdeck-web/package.json frontend/taskdeck-web/package-lock.json ./

--- a/frontend/taskdeck-web/src/api/authApi.ts
+++ b/frontend/taskdeck-web/src/api/authApi.ts
@@ -1,5 +1,5 @@
 import http from './http'
-import type { LoginRequest, RegisterRequest, ChangePasswordRequest, AuthResponse, AuthProviders } from '../types/auth'
+import type { LoginRequest, RegisterRequest, ChangePasswordRequest, AuthResponse, AuthProviders, LinkedAccount } from '../types/auth'
 
 export const authApi = {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
@@ -24,5 +24,19 @@ export const authApi = {
   async exchangeOAuthCode(code: string): Promise<AuthResponse> {
     const { data } = await http.post<AuthResponse>('/auth/github/exchange', { code })
     return data
+  },
+
+  async getLinkedAccounts(): Promise<LinkedAccount[]> {
+    const { data } = await http.get<LinkedAccount[]>('/auth/linked-accounts')
+    return data
+  },
+
+  async linkGitHub(code: string): Promise<LinkedAccount> {
+    const { data } = await http.post<LinkedAccount>('/auth/github/link', { code })
+    return data
+  },
+
+  async unlinkGitHub(): Promise<void> {
+    await http.delete('/auth/github/link')
   },
 }

--- a/frontend/taskdeck-web/src/tests/views/ProfileSettingsView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ProfileSettingsView.spec.ts
@@ -40,6 +40,30 @@ vi.mock('../../store/featureFlagStore', () => ({
   }),
 }))
 
+vi.mock('../../api/authApi', () => ({
+  authApi: {
+    getProviders: vi.fn().mockResolvedValue({ gitHub: false }),
+    getLinkedAccounts: vi.fn().mockResolvedValue([]),
+    linkGitHub: vi.fn(),
+    unlinkGitHub: vi.fn(),
+  },
+}))
+
+vi.mock('../../utils/demoMode', () => ({
+  isDemoMode: false,
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    replace: vi.fn(),
+    push: vi.fn(),
+  }),
+  useRoute: () => ({
+    query: {},
+    path: '/workspace/settings',
+  }),
+}))
+
 describe('ProfileSettingsView', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/frontend/taskdeck-web/src/types/auth.ts
+++ b/frontend/taskdeck-web/src/types/auth.ts
@@ -42,3 +42,11 @@ export interface SessionState {
 export interface AuthProviders {
   gitHub: boolean
 }
+
+export interface LinkedAccount {
+  provider: string
+  providerUserId: string
+  displayName: string | null
+  avatarUrl: string | null
+  linkedAt: string
+}

--- a/frontend/taskdeck-web/src/views/ProfileSettingsView.vue
+++ b/frontend/taskdeck-web/src/views/ProfileSettingsView.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { useSessionStore } from '../store/sessionStore'
 import { useFeatureFlagStore } from '../store/featureFlagStore'
+import { authApi } from '../api/authApi'
 import type { FeatureFlags } from '../types/feature-flags'
+import type { LinkedAccount } from '../types/auth'
 import { getErrorDisplay } from '../composables/useErrorMapper'
 import { normalizeBoardRole } from '../utils/roles'
+import { isDemoMode } from '../utils/demoMode'
 
+const router = useRouter()
+const route = useRoute()
 const session = useSessionStore()
 const featureFlags = useFeatureFlagStore()
 
@@ -15,6 +21,14 @@ const confirmNewPassword = ref('')
 const passwordError = ref<string | null>(null)
 const passwordSuccess = ref(false)
 const submitting = ref(false)
+
+// Account linking state
+const githubAvailable = ref(false)
+const linkedAccounts = ref<LinkedAccount[]>([])
+const linkingGitHub = ref(false)
+const linkError = ref<string | null>(null)
+const linkSuccess = ref<string | null>(null)
+const unlinking = ref(false)
 
 const roleLabel = computed(() => (
   session.defaultRole === null ? 'Unknown' : normalizeBoardRole(session.defaultRole)
@@ -31,6 +45,14 @@ const opsCapabilitySummary = computed(() => {
       return 'Ops CLI template access is limited; request elevated access for admin templates.'
   }
 })
+
+const isGitHubLinked = computed(() =>
+  linkedAccounts.value.some(a => a.provider === 'GitHub')
+)
+
+const gitHubAccount = computed(() =>
+  linkedAccounts.value.find(a => a.provider === 'GitHub')
+)
 
 async function handleChangePassword() {
   passwordError.value = null
@@ -64,6 +86,73 @@ async function handleChangePassword() {
     submitting.value = false
   }
 }
+
+function startGitHubLink() {
+  const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
+  const returnUrl = '/workspace/settings'
+  window.location.href = `${apiBase}/auth/github/login?mode=link&returnUrl=${encodeURIComponent(returnUrl)}`
+}
+
+async function handleLinkCode(code: string) {
+  linkingGitHub.value = true
+  linkError.value = null
+  linkSuccess.value = null
+  try {
+    const linked = await authApi.linkGitHub(code)
+    linkedAccounts.value.push(linked)
+    linkSuccess.value = `GitHub account linked successfully (${linked.displayName || linked.providerUserId})`
+  } catch (e: unknown) {
+    linkError.value = getErrorDisplay(e, 'Failed to link GitHub account.').message
+  } finally {
+    linkingGitHub.value = false
+  }
+}
+
+async function handleUnlinkGitHub() {
+  unlinking.value = true
+  linkError.value = null
+  linkSuccess.value = null
+  try {
+    await authApi.unlinkGitHub()
+    linkedAccounts.value = linkedAccounts.value.filter(a => a.provider !== 'GitHub')
+    linkSuccess.value = 'GitHub account unlinked successfully'
+  } catch (e: unknown) {
+    linkError.value = getErrorDisplay(e, 'Failed to unlink GitHub account.').message
+  } finally {
+    unlinking.value = false
+  }
+}
+
+async function loadLinkedAccounts() {
+  if (isDemoMode) return
+  try {
+    linkedAccounts.value = await authApi.getLinkedAccounts()
+  } catch {
+    // Non-blocking — just won't show linked accounts
+  }
+}
+
+async function loadProviders() {
+  if (isDemoMode) return
+  try {
+    const providers = await authApi.getProviders()
+    githubAvailable.value = providers.gitHub === true
+  } catch {
+    // Silently ignore
+  }
+}
+
+onMounted(async () => {
+  // Check for OAuth link code in query params
+  const linkCode = [route.query.oauth_link_code].flat()[0]
+  if (linkCode) {
+    await router.replace({ path: route.path, query: { ...route.query, oauth_link_code: undefined } })
+    await handleLinkCode(linkCode)
+  }
+
+  // Load linked accounts and provider availability in parallel
+  await Promise.all([loadLinkedAccounts(), loadProviders()])
+})
 
 const flagLabels: Record<keyof FeatureFlags, string> = {
   newShell: 'New Shell Layout',
@@ -105,6 +194,52 @@ const flagLabels: Record<keyof FeatureFlags, string> = {
           <span class="td-info-label">Ops Access</span>
           <span class="td-info-value">{{ opsCapabilitySummary }}</span>
         </div>
+      </div>
+    </section>
+
+    <!-- Linked Accounts Section -->
+    <section v-if="githubAvailable && !isDemoMode" class="td-settings__section">
+      <h2 class="td-section-title">Linked Accounts</h2>
+      <p class="td-section-desc">Connect your GitHub account to sign in with GitHub.</p>
+
+      <div v-if="linkError" class="td-alert td-alert--error" role="alert">{{ linkError }}</div>
+      <div v-if="linkSuccess" class="td-alert td-alert--success" role="status">{{ linkSuccess }}</div>
+      <div v-if="linkingGitHub" class="td-link-loading">Linking GitHub account...</div>
+
+      <div v-if="isGitHubLinked && gitHubAccount" class="td-linked-account">
+        <div class="td-linked-account__info">
+          <img
+            v-if="gitHubAccount.avatarUrl"
+            :src="gitHubAccount.avatarUrl"
+            alt="GitHub avatar"
+            class="td-linked-account__avatar"
+          />
+          <div class="td-linked-account__details">
+            <span class="td-linked-account__provider">GitHub</span>
+            <span class="td-linked-account__name">{{ gitHubAccount.displayName || gitHubAccount.providerUserId }}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="td-btn td-btn--danger-outline"
+          :disabled="unlinking"
+          @click="handleUnlinkGitHub"
+        >
+          {{ unlinking ? 'Unlinking...' : 'Unlink' }}
+        </button>
+      </div>
+
+      <div v-else-if="!linkingGitHub" class="td-link-action">
+        <button
+          type="button"
+          class="td-btn td-btn--github"
+          @click="startGitHubLink"
+        >
+          <svg class="td-github-icon" viewBox="0 0 16 16" width="20" height="20" aria-hidden="true">
+            <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+          </svg>
+          Link GitHub Account
+        </button>
       </div>
     </section>
 
@@ -184,4 +319,58 @@ const flagLabels: Record<keyof FeatureFlags, string> = {
 .td-flag-row { display: flex; justify-content: space-between; align-items: center; padding: var(--td-space-2) 0; }
 .td-flag-label { font-size: var(--td-font-sm); color: var(--td-text-primary); }
 .td-checkbox { width: 18px; height: 18px; cursor: pointer; }
+
+/* GitHub button styling */
+.td-btn--github {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--td-space-2);
+  width: 100%;
+  padding: var(--td-space-2) var(--td-space-4);
+  background: #24292f;
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--td-radius-md);
+  font-size: var(--td-font-base);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--td-transition-fast);
+}
+.td-btn--github:hover:not(:disabled) { background: #2f363d; }
+.td-btn--github:disabled { opacity: 0.4; cursor: not-allowed; }
+.td-github-icon { flex-shrink: 0; }
+
+/* Danger outline button for unlinking */
+.td-btn--danger-outline {
+  background: transparent;
+  color: var(--td-color-error);
+  border: 1px solid var(--td-color-error);
+  padding: var(--td-space-1) var(--td-space-3);
+  border-radius: var(--td-radius-md);
+  font-size: var(--td-font-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--td-transition-fast);
+}
+.td-btn--danger-outline:hover:not(:disabled) { background: var(--td-color-error-light); }
+.td-btn--danger-outline:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* Linked account display */
+.td-linked-account {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--td-space-3);
+  border: 1px solid var(--td-border-default);
+  border-radius: var(--td-radius-md);
+  background: var(--td-surface-container);
+}
+.td-linked-account__info { display: flex; align-items: center; gap: var(--td-space-3); }
+.td-linked-account__avatar { width: 32px; height: 32px; border-radius: 50%; }
+.td-linked-account__details { display: flex; flex-direction: column; }
+.td-linked-account__provider { font-size: var(--td-font-xs); color: var(--td-text-tertiary); text-transform: uppercase; letter-spacing: 0.05em; }
+.td-linked-account__name { font-size: var(--td-font-sm); font-weight: 500; color: var(--td-text-primary); }
+.td-link-action { margin-top: var(--td-space-2); }
+.td-link-loading { padding: var(--td-space-3); text-align: center; color: var(--td-text-secondary); font-size: var(--td-font-sm); }
 </style>

--- a/frontend/taskdeck-web/src/views/ProfileSettingsView.vue
+++ b/frontend/taskdeck-web/src/views/ProfileSettingsView.vue
@@ -89,8 +89,11 @@ async function handleChangePassword() {
 
 function startGitHubLink() {
   const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api'
-  const returnUrl = '/workspace/settings'
-  window.location.href = `${apiBase}/auth/github/login?mode=link&returnUrl=${encodeURIComponent(returnUrl)}`
+  // Return to the profile settings page after OAuth completes.
+  // Note: mode=link is NOT passed — the backend derives link/login mode from
+  // server-side auth state (JWT presence) to prevent user-controlled bypass.
+  const returnUrl = '/workspace/settings/profile'
+  window.location.href = `${apiBase}/auth/github/login?returnUrl=${encodeURIComponent(returnUrl)}`
 }
 
 async function handleLinkCode(code: string) {


### PR DESCRIPTION
## Summary

Implements #676 — three concrete improvements to the GitHub OAuth integration:

- **In-memory auth code store replaced with SQLite/EF Core**: Auth codes now persist across restarts and work in multi-instance deployments. Uses `OAuthAuthCode` entity with atomic `TryConsumeAtomicAsync` for race-safe single-use semantics via raw SQL `UPDATE WHERE IsConsumed = 0`.

- **PKCE enabled**: Sets `UsePkce = true` on the GitHub OAuth handler. ASP.NET Core 8 automatically generates code_verifier/code_challenge — defense-in-depth against authorization code interception.

- **Account linking**: Authenticated users can link/unlink GitHub accounts from the Settings page. Uses a dedicated link flow: `GET /api/auth/github/login?mode=link` stores GitHub identity in a link code, then `POST /api/auth/github/link` exchanges the code while requiring JWT auth. Prevents linking already-linked accounts with proper conflict detection.

### Key files changed

**Backend:**
- `backend/src/Taskdeck.Domain/Entities/OAuthAuthCode.cs` — New entity with Purpose (login/link), TryConsume, CreateForLinking
- `backend/src/Taskdeck.Api/Controllers/AuthController.cs` — DB-backed exchange, link/unlink/linked-accounts endpoints
- `backend/src/Taskdeck.Api/Extensions/AuthenticationRegistration.cs` — PKCE enabled
- `backend/src/Taskdeck.Application/Services/AuthenticationService.cs` — CompleteAccountLinkAsync, UnlinkExternalLoginAsync

**Frontend:**
- `frontend/taskdeck-web/src/views/ProfileSettingsView.vue` — Linked Accounts section with Link/Unlink GitHub
- `frontend/taskdeck-web/src/api/authApi.ts` — linkGitHub, unlinkGitHub, getLinkedAccounts
- `frontend/taskdeck-web/src/types/auth.ts` — LinkedAccount type

**Tests:**
- 15 domain tests for OAuthAuthCode entity
- 9 application tests for account linking/unlinking
- Updated OAuthTokenLifecycleTests for DB-backed store (concurrent exchange, cleanup, replay)
- Updated AuthControllerEdgeCaseTests for atomic consume
- Updated ProfileSettingsView test for router/auth mocks

## Test plan

- [x] Backend: `dotnet test backend/Taskdeck.sln -c Release -m:1` — all 1181 tests pass
- [x] Frontend: `npm run typecheck && npx vitest --run` — all 1898 tests pass, no errors
- [ ] Manual: Verify GitHub OAuth login still works end-to-end
- [ ] Manual: Test account linking from Settings page
- [ ] Manual: Verify PKCE parameters in GitHub authorization URL

Closes #676