### PR TITLE
TST-50: Property-based and adversarial input tests

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/CaptureAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureAdversarialTests.cs
@@ -1,0 +1,232 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Extended adversarial tests for capture/inbox endpoint.
+/// Exercises binary data, null bytes, very long strings, nested JSON,
+/// and random binary content — verifying NO 500 responses.
+/// </summary>
+public class CaptureAdversarialTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private bool _isAuthenticated;
+
+    public CaptureAdversarialTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task EnsureAuthenticatedAsync()
+    {
+        if (_isAuthenticated) return;
+        await ApiTestHarness.AuthenticateAsync(_client, "capture-adversarial");
+        _isAuthenticated = true;
+    }
+
+    // ─────────────────────── Very long strings ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(1000)]
+    [InlineData(20_000)]     // at limit
+    [InlineData(20_001)]     // just over limit
+    [InlineData(100_000)]    // far over limit
+    public async Task CaptureItem_WithVariousTextLengths_NeverReturns500(int length)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var text = length == 0 ? "" : new string('c', length);
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Capture returned 500 for text of {length} chars");
+    }
+
+    // ─────────────────────── Null bytes and control characters ───────────────────────
+
+    [Theory]
+    [InlineData("\u0000")]
+    [InlineData("text\u0000with\u0000null\u0000bytes")]
+    [InlineData("\u0001\u0002\u0003\u0004\u0005\u0006\u0007")]
+    [InlineData("\u0008\u000B\u000C\u000E\u000F\u0010")]
+    [InlineData("\x1B[31mcolored\x1B[0m")]
+    [InlineData("\r\n\r\n\r\n")]
+    [InlineData("\t\t\t\t\t")]
+    [InlineData("before\u0000after")]
+    public async Task CaptureItem_WithControlChars_NeverReturns500(string text)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Capture returned 500 for text with control chars");
+    }
+
+    // ─────────────────────── Unicode edge cases ───────────────────────
+
+    [Theory]
+    [InlineData("\uFEFF")]                        // BOM
+    [InlineData("\uFFFD")]                        // replacement character
+    [InlineData("\u200B")]                        // zero-width space
+    [InlineData("\u200E")]                        // LTR mark
+    [InlineData("\u202E")]                        // RTL override
+    [InlineData("\u0301")]                        // combining accent
+    [InlineData("e\u0301")]                       // decomposed e-acute
+    [InlineData("\u00E9")]                        // precomposed e-acute
+    [InlineData("👨‍👩‍👧‍👦")]                   // family emoji
+    [InlineData("𝕋𝕖𝕤𝕥")]                        // math bold
+    [InlineData("田中太郎")]                       // CJK
+    [InlineData("مرحبا")]                         // Arabic RTL
+    [InlineData("\u0E01\u0E38")]                  // Thai combining
+    [InlineData("\uDBFF\uDFFF")]                  // max surrogate pair
+    public async Task CaptureItem_WithUnicodeEdgeCases_NeverReturns500(string text)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Capture returned 500 for unicode edge case");
+    }
+
+    // ─────────────────────── Nested JSON as text content ───────────────────────
+
+    [Theory]
+    [InlineData("{\"nested\": true}")]
+    [InlineData("[1, 2, 3]")]
+    [InlineData("{\"__proto__\": {\"admin\": true}}")]
+    [InlineData("{\"constructor\": {\"prototype\": {\"isAdmin\": true}}}")]
+    [InlineData("{\"action\": \"delete\", \"target\": \"all_boards\"}")]
+    [InlineData("{{7*7}}")]
+    [InlineData("${7*7}")]
+    [InlineData("#{7*7}")]
+    public async Task CaptureItem_WithNestedJsonAndTemplates_NeverReturns500(string text)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Capture returned 500 for nested JSON/template content");
+
+        if (response.IsSuccessStatusCode)
+        {
+            var item = await response.Content.ReadFromJsonAsync<CaptureItemDto>();
+            item.Should().NotBeNull();
+            item!.RawText.Should().Contain(text,
+                "nested JSON should be stored as literal text, not interpreted");
+        }
+    }
+
+    // ─────────────────────── XSS/injection payloads ───────────────────────
+
+    [Theory]
+    [InlineData("<script>alert(document.cookie)</script>")]
+    [InlineData("<img src=x onerror=alert(1)>")]
+    [InlineData("<svg onload=alert(1)>")]
+    [InlineData("'; DROP TABLE capture_items; --")]
+    [InlineData("\" OR 1=1 --")]
+    [InlineData("Robert'); DROP TABLE students;--")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public async Task CaptureItem_WithInjectionPayloads_StoredVerbatim(string text)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Capture returned 500 for injection payload");
+
+        if (response.IsSuccessStatusCode)
+        {
+            var item = await response.Content.ReadFromJsonAsync<CaptureItemDto>();
+            item.Should().NotBeNull();
+            // Injection payloads should be stored verbatim, not sanitized
+            item!.RawText.Should().Contain(text);
+        }
+    }
+
+    // ─────────────────────── Optional field adversarial ───────────────────────
+
+    [Theory]
+    [InlineData("<script>", null, null)]
+    [InlineData("test", "<script>alert(1)</script>", null)]
+    [InlineData("test", null, "<script>")]
+    [InlineData("test", "'; DROP TABLE capture_items; --", "'; DROP TABLE capture_items; --")]
+    public async Task CaptureItem_WithAdversarialOptionalFields_NeverReturns500(
+        string text, string? titleHint, string? externalRef)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text, TitleHint: titleHint, ExternalRef: externalRef));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Capture returned 500 for adversarial optional fields");
+    }
+
+    // ─────────────────────── Malformed JSON bodies ───────────────────────
+
+    [Theory]
+    [InlineData("{")]
+    [InlineData("[")]
+    [InlineData("null")]
+    [InlineData("\"just a string\"")]
+    [InlineData("12345")]
+    [InlineData("{\"text\": null}")]
+    [InlineData("{\"boardId\": \"not-a-guid\", \"text\": \"test\"}")]
+    [InlineData("{\"text\": 12345}")]
+    public async Task CaptureItem_WithMalformedJson_NeverReturns500(string body)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/api/capture/items", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Capture returned 500 for malformed JSON: {body}");
+    }
+
+    // ─────────────────────── Board ID adversarial ───────────────────────
+
+    [Fact]
+    public async Task CaptureItem_WithEmptyGuidBoardId_NeverReturns500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(Guid.Empty, "test text"));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Capture returned 500 for Guid.Empty board ID");
+    }
+
+    [Fact]
+    public async Task CaptureItem_WithNonexistentBoardId_NeverReturns500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(Guid.NewGuid(), "test text"));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Capture returned 500 for nonexistent board ID");
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/No500sMetaTest.cs
+++ b/backend/tests/Taskdeck.Api.Tests/No500sMetaTest.cs
@@ -34,24 +34,27 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
 
     // ─────────────────────── Random content generators ───────────────────────
 
-    private static readonly Random Rng = new(42); // deterministic seed for reproducibility
+    // Use a per-test Random instance for deterministic reproducibility.
+    // Static Random is not thread-safe; per-method instantiation avoids races.
+    private static Random CreateRng() => new(42);
 
-    private static string RandomString(int minLen, int maxLen)
+    private static string RandomString(Random rng, int minLen, int maxLen)
     {
-        var length = Rng.Next(minLen, maxLen + 1);
+        var length = rng.Next(minLen, maxLen + 1);
         var chars = new char[length];
         for (int i = 0; i < length; i++)
         {
-            // Mix of ASCII, unicode, and control chars
-            var category = Rng.Next(10);
+            // Mix of ASCII, unicode, control chars, and null bytes
+            var category = rng.Next(11);
             chars[i] = category switch
             {
-                0 => (char)Rng.Next(1, 32),               // control chars (skip null)
-                1 => (char)Rng.Next(0x4E00, 0x4F00),      // CJK
-                2 => (char)Rng.Next(0x0600, 0x0700),      // Arabic
-                3 => (char)Rng.Next(0x0300, 0x0370),      // combining diacriticals
-                4 => (char)Rng.Next(0x2000, 0x2070),      // general punctuation / special
-                _ => (char)Rng.Next(0x20, 0x7F),          // printable ASCII
+                0 => '\0',                                 // null byte
+                1 => (char)rng.Next(1, 32),                // control chars (skip null)
+                2 => (char)rng.Next(0x4E00, 0x4F00),       // CJK
+                3 => (char)rng.Next(0x0600, 0x0700),       // Arabic
+                4 => (char)rng.Next(0x0300, 0x0370),       // combining diacriticals
+                5 => (char)rng.Next(0x2000, 0x2070),       // general punctuation / special
+                _ => (char)rng.Next(0x20, 0x7F),           // printable ASCII
             };
         }
         return new string(chars);
@@ -63,25 +66,18 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
     public async Task BoardCreation_100RandomPayloads_Never500()
     {
         await EnsureAuthenticatedAsync();
+        var rng = CreateRng();
 
         for (int i = 0; i < 100; i++)
         {
-            var name = RandomString(0, 200);
-            var description = Rng.Next(2) == 0 ? null : RandomString(0, 2000);
+            var name = RandomString(rng, 0, 200);
+            var description = rng.Next(2) == 0 ? null : RandomString(rng, 0, 2000);
 
             var response = await _client.PostAsJsonAsync("/api/boards",
                 new CreateBoardDto(name, description));
 
             ((int)response.StatusCode).Should().BeLessThan(500,
                 $"Board creation returned 500 on iteration {i} for name [{name.Length} chars]");
-
-            // Verify no stack trace in response body
-            if ((int)response.StatusCode >= 500)
-            {
-                var body = await response.Content.ReadAsStringAsync();
-                body.Should().NotContain("System.", "500 response should not contain stack traces");
-                body.Should().NotContain("at Taskdeck.", "500 response should not contain stack traces");
-            }
         }
     }
 
@@ -91,23 +87,18 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
     public async Task CaptureCreation_100RandomPayloads_Never500()
     {
         await EnsureAuthenticatedAsync();
+        var rng = CreateRng();
 
         for (int i = 0; i < 100; i++)
         {
-            var text = RandomString(0, 25_000);
-            var boardId = Rng.Next(3) == 0 ? (Guid?)Guid.NewGuid() : null;
+            var text = RandomString(rng, 0, 25_000);
+            var boardId = rng.Next(3) == 0 ? (Guid?)Guid.NewGuid() : null;
 
             var response = await _client.PostAsJsonAsync("/api/capture/items",
                 new CreateCaptureItemDto(boardId, text));
 
             ((int)response.StatusCode).Should().BeLessThan(500,
                 $"Capture creation returned 500 on iteration {i} for text [{text.Length} chars]");
-
-            if ((int)response.StatusCode >= 500)
-            {
-                var body = await response.Content.ReadAsStringAsync();
-                body.Should().NotContain("System.", "500 response should not contain stack traces");
-            }
         }
     }
 
@@ -117,6 +108,7 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
     public async Task CardCreation_RandomPayloads_Never500()
     {
         await EnsureAuthenticatedAsync();
+        var rng = CreateRng();
 
         // Create a board and column for card tests
         var boardResponse = await _client.PostAsJsonAsync("/api/boards",
@@ -132,8 +124,8 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
 
         for (int i = 0; i < 50; i++)
         {
-            var title = RandomString(0, 300);
-            var description = Rng.Next(2) == 0 ? null : RandomString(0, 3000);
+            var title = RandomString(rng, 0, 300);
+            var description = rng.Next(2) == 0 ? null : RandomString(rng, 0, 3000);
 
             var response = await _client.PostAsJsonAsync(
                 $"/api/boards/{board.Id}/cards",
@@ -150,10 +142,11 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
     public async Task Search_50RandomQueries_Never500()
     {
         await EnsureAuthenticatedAsync();
+        var rng = CreateRng();
 
         for (int i = 0; i < 50; i++)
         {
-            var query = RandomString(0, 500);
+            var query = RandomString(rng, 0, 500);
 
             var response = await _client.GetAsync(
                 $"/api/search?q={Uri.EscapeDataString(query)}");
@@ -175,15 +168,17 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
         boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
 
+        var rng = CreateRng();
+
         for (int i = 0; i < 50; i++)
         {
-            var name = RandomString(0, 100);
-            var wipLimit = Rng.Next(4) switch
+            var name = RandomString(rng, 0, 100);
+            var wipLimit = rng.Next(4) switch
             {
                 0 => (int?)null,
                 1 => 0,
                 2 => -1,
-                _ => Rng.Next(1, 1000)
+                _ => rng.Next(1, 1000)
             };
 
             var response = await _client.PostAsJsonAsync(
@@ -207,13 +202,15 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
         boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
         var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
 
+        var rng = CreateRng();
+
         for (int i = 0; i < 50; i++)
         {
-            var name = RandomString(0, 50);
-            var color = Rng.Next(3) switch
+            var name = RandomString(rng, 0, 50);
+            var color = rng.Next(3) switch
             {
-                0 => RandomString(0, 10),       // random string, not a valid hex
-                1 => $"#{Rng.Next(0xFFFFFF):X6}", // valid hex
+                0 => RandomString(rng, 0, 10),     // random string, not a valid hex
+                1 => $"#{rng.Next(0xFFFFFF):X6}",   // valid hex
                 _ => ""
             };
 
@@ -234,7 +231,7 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
     [InlineData("GET", "/api/capture/items")]
     [InlineData("GET", "/api/automation/proposals")]
     [InlineData("GET", "/api/notifications")]
-    public async Task AuthenticatedEndpoints_NeverReturn500WithStackTrace(string method, string path)
+    public async Task AuthenticatedEndpoints_NeverReturn500(string method, string path)
     {
         await EnsureAuthenticatedAsync();
 
@@ -249,13 +246,8 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
                 new StringContent("{}", Encoding.UTF8, "application/json"));
         }
 
-        if ((int)response.StatusCode >= 500)
-        {
-            var body = await response.Content.ReadAsStringAsync();
-            body.Should().NotContain("StackTrace",
-                $"{method} {path} returned 500 with stack trace exposed");
-            body.Should().NotContain("at Taskdeck.",
-                $"{method} {path} returned 500 with internal exception details exposed");
-        }
+        // Fail the test when any 500 is returned -- this is the core "no 500s" assertion.
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"{method} {path} returned {(int)response.StatusCode}");
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/No500sMetaTest.cs
+++ b/backend/tests/Taskdeck.Api.Tests/No500sMetaTest.cs
@@ -57,11 +57,6 @@ public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
         return new string(chars);
     }
 
-    private static string RandomGuidString()
-    {
-        return Guid.NewGuid().ToString();
-    }
-
     // ─────────────────────── Board creation sweep ───────────────────────
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/No500sMetaTest.cs
+++ b/backend/tests/Taskdeck.Api.Tests/No500sMetaTest.cs
@@ -1,0 +1,266 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Meta-test: for any well-formed request with random content, the API never returns
+/// 500 Internal Server Error with a stack trace. This is a comprehensive sweep across
+/// multiple endpoints with randomized but structurally valid payloads.
+/// </summary>
+public class No500sMetaTest : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private bool _isAuthenticated;
+
+    public No500sMetaTest(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task EnsureAuthenticatedAsync()
+    {
+        if (_isAuthenticated) return;
+        await ApiTestHarness.AuthenticateAsync(_client, "no500s-meta");
+        _isAuthenticated = true;
+    }
+
+    // ─────────────────────── Random content generators ───────────────────────
+
+    private static readonly Random Rng = new(42); // deterministic seed for reproducibility
+
+    private static string RandomString(int minLen, int maxLen)
+    {
+        var length = Rng.Next(minLen, maxLen + 1);
+        var chars = new char[length];
+        for (int i = 0; i < length; i++)
+        {
+            // Mix of ASCII, unicode, and control chars
+            var category = Rng.Next(10);
+            chars[i] = category switch
+            {
+                0 => (char)Rng.Next(1, 32),               // control chars (skip null)
+                1 => (char)Rng.Next(0x4E00, 0x4F00),      // CJK
+                2 => (char)Rng.Next(0x0600, 0x0700),      // Arabic
+                3 => (char)Rng.Next(0x0300, 0x0370),      // combining diacriticals
+                4 => (char)Rng.Next(0x2000, 0x2070),      // general punctuation / special
+                _ => (char)Rng.Next(0x20, 0x7F),          // printable ASCII
+            };
+        }
+        return new string(chars);
+    }
+
+    private static string RandomGuidString()
+    {
+        return Guid.NewGuid().ToString();
+    }
+
+    // ─────────────────────── Board creation sweep ───────────────────────
+
+    [Fact]
+    public async Task BoardCreation_100RandomPayloads_Never500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        for (int i = 0; i < 100; i++)
+        {
+            var name = RandomString(0, 200);
+            var description = Rng.Next(2) == 0 ? null : RandomString(0, 2000);
+
+            var response = await _client.PostAsJsonAsync("/api/boards",
+                new CreateBoardDto(name, description));
+
+            ((int)response.StatusCode).Should().BeLessThan(500,
+                $"Board creation returned 500 on iteration {i} for name [{name.Length} chars]");
+
+            // Verify no stack trace in response body
+            if ((int)response.StatusCode >= 500)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                body.Should().NotContain("System.", "500 response should not contain stack traces");
+                body.Should().NotContain("at Taskdeck.", "500 response should not contain stack traces");
+            }
+        }
+    }
+
+    // ─────────────────────── Capture creation sweep ───────────────────────
+
+    [Fact]
+    public async Task CaptureCreation_100RandomPayloads_Never500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        for (int i = 0; i < 100; i++)
+        {
+            var text = RandomString(0, 25_000);
+            var boardId = Rng.Next(3) == 0 ? (Guid?)Guid.NewGuid() : null;
+
+            var response = await _client.PostAsJsonAsync("/api/capture/items",
+                new CreateCaptureItemDto(boardId, text));
+
+            ((int)response.StatusCode).Should().BeLessThan(500,
+                $"Capture creation returned 500 on iteration {i} for text [{text.Length} chars]");
+
+            if ((int)response.StatusCode >= 500)
+            {
+                var body = await response.Content.ReadAsStringAsync();
+                body.Should().NotContain("System.", "500 response should not contain stack traces");
+            }
+        }
+    }
+
+    // ─────────────────────── Card creation sweep ───────────────────────
+
+    [Fact]
+    public async Task CardCreation_RandomPayloads_Never500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        // Create a board and column for card tests
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"no500s-cards-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        var colResponse = await _client.PostAsJsonAsync(
+            $"/api/boards/{board!.Id}/columns",
+            new CreateColumnDto(board.Id, "TestCol", null, null));
+        colResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var col = await colResponse.Content.ReadFromJsonAsync<ColumnDto>();
+
+        for (int i = 0; i < 50; i++)
+        {
+            var title = RandomString(0, 300);
+            var description = Rng.Next(2) == 0 ? null : RandomString(0, 3000);
+
+            var response = await _client.PostAsJsonAsync(
+                $"/api/boards/{board.Id}/cards",
+                new CreateCardDto(board.Id, col!.Id, title, description, null, null));
+
+            ((int)response.StatusCode).Should().BeLessThan(500,
+                $"Card creation returned 500 on iteration {i} for title [{title.Length} chars]");
+        }
+    }
+
+    // ─────────────────────── Search sweep ───────────────────────
+
+    [Fact]
+    public async Task Search_50RandomQueries_Never500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        for (int i = 0; i < 50; i++)
+        {
+            var query = RandomString(0, 500);
+
+            var response = await _client.GetAsync(
+                $"/api/search?q={Uri.EscapeDataString(query)}");
+
+            ((int)response.StatusCode).Should().BeLessThan(500,
+                $"Search returned 500 on iteration {i} for query [{query.Length} chars]");
+        }
+    }
+
+    // ─────────────────────── Column creation sweep ───────────────────────
+
+    [Fact]
+    public async Task ColumnCreation_RandomPayloads_Never500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"no500s-cols-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        for (int i = 0; i < 50; i++)
+        {
+            var name = RandomString(0, 100);
+            var wipLimit = Rng.Next(4) switch
+            {
+                0 => (int?)null,
+                1 => 0,
+                2 => -1,
+                _ => Rng.Next(1, 1000)
+            };
+
+            var response = await _client.PostAsJsonAsync(
+                $"/api/boards/{board!.Id}/columns",
+                new CreateColumnDto(board.Id, name, null, wipLimit));
+
+            ((int)response.StatusCode).Should().BeLessThan(500,
+                $"Column creation returned 500 on iteration {i} for name [{name.Length} chars]");
+        }
+    }
+
+    // ─────────────────────── Label creation sweep ───────────────────────
+
+    [Fact]
+    public async Task LabelCreation_RandomPayloads_Never500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"no500s-labels-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        for (int i = 0; i < 50; i++)
+        {
+            var name = RandomString(0, 50);
+            var color = Rng.Next(3) switch
+            {
+                0 => RandomString(0, 10),       // random string, not a valid hex
+                1 => $"#{Rng.Next(0xFFFFFF):X6}", // valid hex
+                _ => ""
+            };
+
+            var response = await _client.PostAsJsonAsync(
+                $"/api/boards/{board!.Id}/labels",
+                new { name, colorHex = color });
+
+            ((int)response.StatusCode).Should().BeLessThan(500,
+                $"Label creation returned 500 on iteration {i}");
+        }
+    }
+
+    // ─────────────────────── Cross-endpoint: 500 response body check ───────────────────────
+
+    [Theory]
+    [InlineData("GET", "/api/boards")]
+    [InlineData("GET", "/api/search?q=test")]
+    [InlineData("GET", "/api/capture/items")]
+    [InlineData("GET", "/api/automation/proposals")]
+    [InlineData("GET", "/api/notifications")]
+    public async Task AuthenticatedEndpoints_NeverReturn500WithStackTrace(string method, string path)
+    {
+        await EnsureAuthenticatedAsync();
+
+        HttpResponseMessage response;
+        if (method == "GET")
+        {
+            response = await _client.GetAsync(path);
+        }
+        else
+        {
+            response = await _client.PostAsync(path,
+                new StringContent("{}", Encoding.UTF8, "application/json"));
+        }
+
+        if ((int)response.StatusCode >= 500)
+        {
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().NotContain("StackTrace",
+                $"{method} {path} returned 500 with stack trace exposed");
+            body.Should().NotContain("at Taskdeck.",
+                $"{method} {path} returned 500 with internal exception details exposed");
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
@@ -1,0 +1,234 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Adversarial tests for automation proposal creation with malformed operation payloads.
+/// Verifies that malformed types, missing fields, extra unknown fields, and adversarial
+/// parameter content never cause 500 errors.
+/// </summary>
+public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private bool _isAuthenticated;
+
+    public ProposalOperationsAdversarialTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task EnsureAuthenticatedAsync()
+    {
+        if (_isAuthenticated) return;
+        await ApiTestHarness.AuthenticateAsync(_client, "proposal-adversarial");
+        _isAuthenticated = true;
+    }
+
+    // ─────────────────────── Malformed proposal JSON ───────────────────────
+
+    public static IEnumerable<object[]> MalformedProposalBodies()
+    {
+        // Missing required fields
+        yield return new object[] { "{}" };
+        yield return new object[] { "{\"summary\": \"test\"}" };
+        yield return new object[] { "{\"sourceType\": 0}" };
+
+        // Wrong types for fields
+        yield return new object[] { "{\"sourceType\": \"not-a-number\", \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\"}" };
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": 12345, \"riskLevel\": 0, \"correlationId\": \"abc\"}" };
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": \"high\", \"correlationId\": \"abc\"}" };
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": 12345}" };
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", \"expiryMinutes\": \"sixty\"}" };
+
+        // Extra unknown fields
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", \"__proto__\": {\"admin\": true}}" };
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", \"constructor\": {\"prototype\": {}}}" };
+        yield return new object[] { "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", \"extraField\": \"ignored\"}" };
+
+        // Operations with malformed data
+        yield return new object[]
+        {
+            "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+            "\"operations\": [{\"sequence\": \"not-int\", \"actionType\": \"create\", \"targetType\": \"card\", " +
+            "\"parameters\": \"{}\", \"idempotencyKey\": \"key1\"}]}"
+        };
+        yield return new object[]
+        {
+            "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+            "\"operations\": [{\"sequence\": 0, \"actionType\": null, \"targetType\": \"card\", " +
+            "\"parameters\": \"{}\", \"idempotencyKey\": \"key1\"}]}"
+        };
+        yield return new object[]
+        {
+            "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+            "\"operations\": \"not-an-array\"}"
+        };
+
+        // NOTE: Deeply nested JSON parameters and XSS in actionType cause 500s.
+        // These are documented as known bugs in separate skip-annotated tests below.
+
+        // Null/empty operations
+        yield return new object[]
+        {
+            "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+            "\"operations\": null}"
+        };
+        yield return new object[]
+        {
+            "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+            "\"operations\": []}"
+        };
+
+        // NOTE: XSS in actionType causes 500 — documented in a separate skip-annotated test below.
+
+        // SQL injection in parameters
+        yield return new object[]
+        {
+            "{\"sourceType\": 0, \"summary\": \"'; DROP TABLE proposals; --\", \"riskLevel\": 0, " +
+            "\"correlationId\": \"abc\", \"operations\": [{\"sequence\": 0, \"actionType\": \"create\", " +
+            "\"targetType\": \"card\", \"parameters\": \"'; DROP TABLE cards; --\", \"idempotencyKey\": \"key1\"}]}"
+        };
+
+        // Enum out of range
+        yield return new object[] { "{\"sourceType\": 999, \"summary\": \"test\", \"riskLevel\": 999, \"correlationId\": \"abc\"}" };
+        yield return new object[] { "{\"sourceType\": -1, \"summary\": \"test\", \"riskLevel\": -1, \"correlationId\": \"abc\"}" };
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedProposalBodies))]
+    public async Task CreateProposal_WithMalformedBody_NeverReturns500(string body)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/api/automation/proposals", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Proposal creation returned 500 for body: {body}");
+    }
+
+    // ─────────────────────── Adversarial summary strings ───────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\u0000")]
+    [InlineData("<script>alert('xss')</script>")]
+    [InlineData("'; DROP TABLE proposals; --")]
+    public async Task CreateProposal_WithAdversarialSummary_NeverReturns500(string summary)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/automation/proposals",
+            new CreateProposalDto(
+                ProposalSourceType.Manual,
+                Guid.NewGuid(),
+                summary,
+                RiskLevel.Low,
+                Guid.NewGuid().ToString()));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Proposal creation returned 500 for summary: [{summary.Length} chars]");
+    }
+
+    // ─────────────────────── Boundary length summary ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(500)]
+    [InlineData(501)]
+    [InlineData(10_000)]
+    [InlineData(100_000)]
+    public async Task CreateProposal_WithVariousSummaryLengths_NeverReturns500(int length)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var summary = length == 0 ? "" : new string('s', length);
+        var response = await _client.PostAsJsonAsync("/api/automation/proposals",
+            new CreateProposalDto(
+                ProposalSourceType.Manual,
+                Guid.NewGuid(),
+                summary,
+                RiskLevel.Low,
+                Guid.NewGuid().ToString()));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Proposal creation returned 500 for summary of {length} chars");
+    }
+
+    // ─────────────────────── Expiry minutes boundary ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    [InlineData(int.MaxValue)]
+    public async Task CreateProposal_WithBoundaryExpiryMinutes_NeverReturns500(int expiryMinutes)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var response = await _client.PostAsJsonAsync("/api/automation/proposals",
+            new CreateProposalDto(
+                ProposalSourceType.Manual,
+                Guid.NewGuid(),
+                "Valid summary",
+                RiskLevel.Low,
+                Guid.NewGuid().ToString(),
+                ExpiryMinutes: expiryMinutes));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Proposal creation returned 500 for expiryMinutes={expiryMinutes}");
+    }
+
+    // ─────────────────────── Known 500 bugs (skip-annotated) ───────────────────────
+    // These tests document real API bugs discovered by adversarial testing.
+    // When operations contain unexpected actionType values or nested parameter JSON,
+    // the proposal creation endpoint returns 500 instead of 4xx.
+
+    [Fact(Skip = "Known bug: proposal endpoint returns 500 when operations contain XSS in actionType")]
+    public async Task KnownBug_XssInActionType_Causes500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+                   "\"operations\": [{\"sequence\": 0, \"actionType\": \"<script>alert(1)</script>\", " +
+                   "\"targetType\": \"card\", \"parameters\": \"{}\", \"idempotencyKey\": \"key1\"}]}";
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/api/automation/proposals", content);
+
+        // BUG: This returns 500 instead of 400/422.
+        // Expected: ((int)response.StatusCode).Should().BeLessThan(500);
+        ((int)response.StatusCode).Should().Be(500,
+            "Documenting known bug: XSS in actionType causes 500");
+    }
+
+    [Fact(Skip = "Known bug: proposal endpoint returns 500 when operations contain deeply nested parameter JSON")]
+    public async Task KnownBug_DeepNestedParameters_Causes500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+                   "\"operations\": [{\"sequence\": 0, \"actionType\": \"create\", \"targetType\": \"card\", " +
+                   "\"parameters\": \"{\\\"nested\\\": {\\\"deep\\\": {\\\"deeper\\\": true}}}\", \"idempotencyKey\": \"key1\"}]}";
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/api/automation/proposals", content);
+
+        // BUG: This returns 500 instead of 400/422 or 201.
+        // Expected: ((int)response.StatusCode).Should().BeLessThan(500);
+        ((int)response.StatusCode).Should().Be(500,
+            "Documenting known bug: nested parameter JSON causes 500");
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/WebhookUrlAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WebhookUrlAdversarialTests.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Adversarial tests for webhook endpoint URL validation.
+/// Verifies that dangerous, malformed, and RFC 3986 edge-case URLs
+/// are rejected with 4xx — never 5xx.
+/// </summary>
+public class WebhookUrlAdversarialTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private bool _isAuthenticated;
+    private Guid? _boardId;
+
+    public WebhookUrlAdversarialTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task EnsureAuthenticatedAsync()
+    {
+        if (_isAuthenticated) return;
+        await ApiTestHarness.AuthenticateAsync(_client, "webhook-adversarial");
+        _isAuthenticated = true;
+    }
+
+    private async Task<Guid> EnsureBoardAsync()
+    {
+        if (_boardId.HasValue) return _boardId.Value;
+        await EnsureAuthenticatedAsync();
+        var board = await ApiTestHarness.CreateBoardAsync(_client, "webhook-test");
+        _boardId = board.Id;
+        return board.Id;
+    }
+
+    // ─────────────────────── RFC 3986 edge-case URLs ───────────────────────
+
+    public static IEnumerable<object[]> AdversarialWebhookUrls()
+    {
+        // Dangerous URL schemes
+        yield return new object[] { "javascript:alert(1)" };
+        yield return new object[] { "data:text/html,<script>alert(1)</script>" };
+        yield return new object[] { "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==" };
+        yield return new object[] { "vbscript:MsgBox(1)" };
+        yield return new object[] { "file:///etc/passwd" };
+        yield return new object[] { "ftp://evil.com/payload" };
+
+        // URLs with credentials (userinfo component)
+        yield return new object[] { "https://admin:password@evil.com/webhook" };
+        yield return new object[] { "http://user:pass@127.0.0.1/callback" };
+
+        // Internal/localhost URLs (SSRF vectors)
+        yield return new object[] { "http://localhost/webhook" };
+        yield return new object[] { "http://127.0.0.1/webhook" };
+        yield return new object[] { "http://[::1]/webhook" };
+        yield return new object[] { "http://0.0.0.0/webhook" };
+        yield return new object[] { "http://169.254.169.254/latest/meta-data/" };
+        yield return new object[] { "http://metadata.google.internal/" };
+
+        // Malformed URLs
+        yield return new object[] { "" };
+        yield return new object[] { " " };
+        yield return new object[] { "not-a-url" };
+        yield return new object[] { "://missing-scheme" };
+        yield return new object[] { "http://" };
+        yield return new object[] { "http:///no-host" };
+
+        // URLs with injection payloads
+        yield return new object[] { "https://evil.com/webhook?q='; DROP TABLE webhooks; --" };
+        yield return new object[] { "https://evil.com/webhook#<script>alert(1)</script>" };
+        yield return new object[] { "https://evil.com/\u0000null-byte" };
+        yield return new object[] { "https://evil.com/\r\nHeader-Injection: true" };
+
+        // URLs with unicode
+        yield return new object[] { "https://evil.com/\u200Bhidden" };
+        yield return new object[] { "https://evil.com/\u202Efdp.exe" };
+        yield return new object[] { "https://xn--n3h.com/webhook" }; // punycode emoji domain
+
+        // Extremely long URL
+        yield return new object[] { "https://example.com/" + new string('a', 10_000) };
+
+        // URL with port boundaries
+        yield return new object[] { "https://example.com:0/webhook" };
+        yield return new object[] { "https://example.com:99999/webhook" };
+        yield return new object[] { "https://example.com:-1/webhook" };
+    }
+
+    [Theory]
+    [MemberData(nameof(AdversarialWebhookUrls))]
+    public async Task CreateWebhook_WithAdversarialUrl_NeverReturns500(string endpointUrl)
+    {
+        var boardId = await EnsureBoardAsync();
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/boards/{boardId}/webhooks",
+            new CreateOutboundWebhookSubscriptionDto(endpointUrl));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Webhook creation returned 500 for URL: {endpointUrl}");
+    }
+
+    [Theory]
+    [InlineData("https://example.com/webhook")]
+    [InlineData("https://hooks.slack.com/services/T00/B00/xxxx")]
+    [InlineData("https://example.com:8443/api/webhook")]
+    public async Task CreateWebhook_WithValidUrl_Succeeds(string endpointUrl)
+    {
+        var boardId = await EnsureBoardAsync();
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/boards/{boardId}/webhooks",
+            new CreateOutboundWebhookSubscriptionDto(endpointUrl));
+
+        // Valid HTTPS URLs should either succeed or be accepted
+        ((int)response.StatusCode).Should().BeLessThan(500);
+    }
+
+    // ─────────────────────── Event filter adversarial ───────────────────────
+
+    [Theory]
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("'; DROP TABLE events; --")]
+    [InlineData("")]
+    [InlineData("\u0000")]
+    public async Task CreateWebhook_WithAdversarialEventFilter_NeverReturns500(string eventFilter)
+    {
+        var boardId = await EnsureBoardAsync();
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/boards/{boardId}/webhooks",
+            new CreateOutboundWebhookSubscriptionDto(
+                "https://example.com/webhook",
+                new List<string> { eventFilter }));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Webhook creation returned 500 for event filter: {eventFilter}");
+    }
+
+    // ─────────────────────── Null/missing body ───────────────────────
+
+    [Fact]
+    public async Task CreateWebhook_WithNullBody_NeverReturns500()
+    {
+        var boardId = await EnsureBoardAsync();
+
+        var content = new StringContent("null", System.Text.Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"/api/boards/{boardId}/webhooks", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Webhook creation returned 500 for null body");
+    }
+
+    [Fact]
+    public async Task CreateWebhook_WithEmptyBody_NeverReturns500()
+    {
+        var boardId = await EnsureBoardAsync();
+
+        var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"/api/boards/{boardId}/webhooks", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Webhook creation returned 500 for empty object body");
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/WebhookUrlAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WebhookUrlAdversarialTests.cs
@@ -119,8 +119,9 @@ public class WebhookUrlAdversarialTests : IClassFixture<TestWebApplicationFactor
             $"/api/boards/{boardId}/webhooks",
             new CreateOutboundWebhookSubscriptionDto(endpointUrl));
 
-        // Valid HTTPS URLs should either succeed or be accepted
-        ((int)response.StatusCode).Should().BeLessThan(500);
+        // Valid HTTPS URLs should be accepted (201 Created)
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            $"Valid webhook URL '{endpointUrl}' should be accepted");
     }
 
     // ─────────────────────── Event filter adversarial ───────────────────────

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
@@ -250,6 +250,11 @@ public class CaptureProvenanceRoundTripFuzzTests
 
     private static Arbitrary<CaptureProvenanceV1> CaptureProvenanceArb()
     {
+        var promptVersionGen = Gen.Elements("v1.0", "v2.1", "v0.99-beta", "prompt-edge-case");
+        var providerGen = Gen.Elements("mock", "openai", "gemini", "anthropic");
+        var modelGen = Gen.Elements("mock-model", "gpt-4", "gemini-pro", "claude-3");
+        var surfaceGen = Gen.Elements("inbox", "chat", "api", "cli", "import");
+
         var gen = Gen.OneOf(
             Gen.Constant(true),
             Gen.Constant(false)
@@ -257,23 +262,26 @@ public class CaptureProvenanceRoundTripFuzzTests
         {
             if (!hasOptionals)
             {
-                return Gen.Constant(new CaptureProvenanceV1(Guid.NewGuid()));
+                return Gen.Fresh(() => new CaptureProvenanceV1(Guid.NewGuid()));
             }
 
-            return Gen.Fresh(() =>
-                new CaptureProvenanceV1(
-                    Guid.NewGuid(),
-                    TriageRunId: Guid.NewGuid(),
-                    ProposalId: Guid.NewGuid(),
-                    PromptVersion: "v1.0",
-                    Provider: "mock",
-                    Model: "mock-model",
-                    RequestedByUserId: Guid.NewGuid(),
-                    CorrelationId: Guid.NewGuid().ToString(),
-                    SourceSurface: "inbox",
-                    BoardId: Guid.NewGuid(),
-                    SessionId: Guid.NewGuid(),
-                    ConvertedAt: DateTimeOffset.UtcNow));
+            return promptVersionGen.SelectMany(pv =>
+                providerGen.SelectMany(provider =>
+                modelGen.SelectMany(model =>
+                surfaceGen.Select(surface =>
+                    new CaptureProvenanceV1(
+                        Guid.NewGuid(),
+                        TriageRunId: Guid.NewGuid(),
+                        ProposalId: Guid.NewGuid(),
+                        PromptVersion: pv,
+                        Provider: provider,
+                        Model: model,
+                        RequestedByUserId: Guid.NewGuid(),
+                        CorrelationId: Guid.NewGuid().ToString(),
+                        SourceSurface: surface,
+                        BoardId: Guid.NewGuid(),
+                        SessionId: Guid.NewGuid(),
+                        ConvertedAt: DateTimeOffset.UtcNow)))));
         });
 
         return Arb.From(gen);

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
@@ -282,7 +282,7 @@ public class CaptureProvenanceRoundTripFuzzTests
                         BoardId: Guid.NewGuid(),
                         SessionId: Guid.NewGuid(),
                         // Use a fixed timestamp for deterministic reproduction with FsCheck seeds
-                        ConvertedAt: new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero)))));
+                        ConvertedAt: new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero))))));
         });
 
         return Arb.From(gen);

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
@@ -281,7 +281,8 @@ public class CaptureProvenanceRoundTripFuzzTests
                         SourceSurface: surface,
                         BoardId: Guid.NewGuid(),
                         SessionId: Guid.NewGuid(),
-                        ConvertedAt: DateTimeOffset.UtcNow)))));
+                        // Use a fixed timestamp for deterministic reproduction with FsCheck seeds
+                        ConvertedAt: new DateTimeOffset(2026, 4, 10, 12, 0, 0, TimeSpan.Zero)))));
         });
 
         return Arb.From(gen);

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/CaptureProvenanceRoundTripFuzzTests.cs
@@ -1,0 +1,308 @@
+using System.Text.Json;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Fuzz;
+
+/// <summary>
+/// Property-based tests for capture payload and provenance serialization round-trips.
+/// Key properties:
+/// - CapturePayloadV1 survives JSON serialize/deserialize with identity
+/// - CaptureProvenanceV1 fields are always recoverable after round-trip
+/// - CaptureItemDto provenance is preserved through serialization
+/// </summary>
+public class CaptureProvenanceRoundTripFuzzTests
+{
+    private const int MaxTests = 200;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false
+    };
+
+    // ─────────────────────── Adversarial string generators ───────────────────────
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE capture_items; --"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant("emoji 👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("back\\slash"),
+        Gen.Constant("new\nline\ttab"),
+        Gen.Constant(""),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<string?> NullableStringGen() => Gen.OneOf(
+        Gen.Constant((string?)null),
+        AdversarialStringGen().Select(s => (string?)s)
+    );
+
+    // ─────────────────────── CaptureProvenanceV1 round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property CaptureProvenanceV1_RoundTrip_AllFieldsPreserved()
+    {
+        return Prop.ForAll(
+            CaptureProvenanceArb(),
+            provenance =>
+            {
+                var json = JsonSerializer.Serialize(provenance, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CaptureProvenanceV1>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.CaptureItemId.Should().Be(provenance.CaptureItemId);
+                deserialized.TriageRunId.Should().Be(provenance.TriageRunId);
+                deserialized.ProposalId.Should().Be(provenance.ProposalId);
+                deserialized.PromptVersion.Should().Be(provenance.PromptVersion);
+                deserialized.Provider.Should().Be(provenance.Provider);
+                deserialized.Model.Should().Be(provenance.Model);
+                deserialized.RequestedByUserId.Should().Be(provenance.RequestedByUserId);
+                deserialized.CorrelationId.Should().Be(provenance.CorrelationId);
+                deserialized.SourceSurface.Should().Be(provenance.SourceSurface);
+                deserialized.BoardId.Should().Be(provenance.BoardId);
+                deserialized.SessionId.Should().Be(provenance.SessionId);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property CaptureProvenanceV1_WithAdversarialStrings_RoundTrips()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(AdversarialStringGen()),
+            Arb.From(AdversarialStringGen()),
+            (promptVersion, provider, model) =>
+            {
+                var provenance = new CaptureProvenanceV1(
+                    Guid.NewGuid(),
+                    PromptVersion: promptVersion,
+                    Provider: provider,
+                    Model: model);
+
+                var json = JsonSerializer.Serialize(provenance, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CaptureProvenanceV1>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.PromptVersion.Should().Be(promptVersion);
+                deserialized.Provider.Should().Be(provider);
+                deserialized.Model.Should().Be(model);
+            });
+    }
+
+    // ─────────────────────── CapturePayloadV1 round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property CapturePayloadV1_RoundTrip_PreservesAllFields()
+    {
+        return Prop.ForAll(
+            CapturePayloadArb(),
+            payload =>
+            {
+                var json = JsonSerializer.Serialize(payload, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CapturePayloadV1>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Version.Should().Be(payload.Version);
+                deserialized.Source.Should().Be(payload.Source);
+                deserialized.Text.Should().Be(payload.Text);
+                deserialized.TitleHint.Should().Be(payload.TitleHint);
+                deserialized.ExternalRef.Should().Be(payload.ExternalRef);
+
+                if (payload.Provenance is not null)
+                {
+                    deserialized.Provenance.Should().NotBeNull();
+                    deserialized.Provenance!.CaptureItemId.Should().Be(payload.Provenance.CaptureItemId);
+                }
+                else
+                {
+                    deserialized.Provenance.Should().BeNull();
+                }
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property CapturePayloadV1_WithAdversarialText_RoundTrips()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            text =>
+            {
+                var payload = new CapturePayloadV1(
+                    1,
+                    CaptureSource.Typed,
+                    text);
+
+                var json = JsonSerializer.Serialize(payload, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CapturePayloadV1>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Text.Should().Be(text);
+            });
+    }
+
+    // ─────────────────────── CreateCaptureItemDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property CreateCaptureItemDto_RoundTrip_Identity()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(NullableStringGen()),
+            Arb.From(NullableStringGen()),
+            (text, titleHint, externalRef) =>
+            {
+                var dto = new CreateCaptureItemDto(null, text,
+                    TitleHint: titleHint, ExternalRef: externalRef);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CreateCaptureItemDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Text.Should().Be(text);
+                deserialized.TitleHint.Should().Be(titleHint);
+                deserialized.ExternalRef.Should().Be(externalRef);
+                deserialized.BoardId.Should().BeNull();
+            });
+    }
+
+    // ─────────────────────── Deserialization safety ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property CapturePayloadV1_ArbitraryJson_NeverThrowsUnhandled()
+    {
+        return Prop.ForAll(
+            ArbMap.Default.ArbFor<string>(),
+            json =>
+            {
+                try
+                {
+                    JsonSerializer.Deserialize<CapturePayloadV1>(json ?? "null", JsonOptions);
+                }
+                catch (JsonException)
+                {
+                    // Expected for malformed JSON
+                }
+                catch (Exception ex)
+                {
+                    ex.Should().BeNull(
+                        $"Unexpected exception type {ex.GetType()}: {ex.Message}");
+                }
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property CaptureProvenanceV1_ArbitraryJson_NeverThrowsUnhandled()
+    {
+        return Prop.ForAll(
+            ArbMap.Default.ArbFor<string>(),
+            json =>
+            {
+                try
+                {
+                    JsonSerializer.Deserialize<CaptureProvenanceV1>(json ?? "null", JsonOptions);
+                }
+                catch (JsonException)
+                {
+                    // Expected
+                }
+                catch (Exception ex)
+                {
+                    ex.Should().BeNull(
+                        $"Unexpected exception type {ex.GetType()}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── DateTimeOffset edge cases in provenance ───────────────────────
+
+    [Theory]
+    [InlineData("0001-01-01T00:00:00+00:00")]
+    [InlineData("9999-12-31T23:59:59.9999999+00:00")]
+    [InlineData("2026-04-10T00:00:00+00:00")]
+    [InlineData("1970-01-01T00:00:00+00:00")]      // Unix epoch
+    public void CaptureProvenance_WithDateTimeBoundaries_RoundTrips(string dateStr)
+    {
+        var date = DateTimeOffset.Parse(dateStr);
+        var provenance = new CaptureProvenanceV1(
+            Guid.NewGuid(),
+            ConvertedAt: date);
+
+        var json = JsonSerializer.Serialize(provenance, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<CaptureProvenanceV1>(json, JsonOptions);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.ConvertedAt.Should().Be(date);
+    }
+
+    // ─────────────────────── Arbitrary generators ───────────────────────
+
+    private static Arbitrary<CaptureProvenanceV1> CaptureProvenanceArb()
+    {
+        var gen = Gen.OneOf(
+            Gen.Constant(true),
+            Gen.Constant(false)
+        ).SelectMany(hasOptionals =>
+        {
+            if (!hasOptionals)
+            {
+                return Gen.Constant(new CaptureProvenanceV1(Guid.NewGuid()));
+            }
+
+            return Gen.Fresh(() =>
+                new CaptureProvenanceV1(
+                    Guid.NewGuid(),
+                    TriageRunId: Guid.NewGuid(),
+                    ProposalId: Guid.NewGuid(),
+                    PromptVersion: "v1.0",
+                    Provider: "mock",
+                    Model: "mock-model",
+                    RequestedByUserId: Guid.NewGuid(),
+                    CorrelationId: Guid.NewGuid().ToString(),
+                    SourceSurface: "inbox",
+                    BoardId: Guid.NewGuid(),
+                    SessionId: Guid.NewGuid(),
+                    ConvertedAt: DateTimeOffset.UtcNow));
+        });
+
+        return Arb.From(gen);
+    }
+
+    private static Arbitrary<CapturePayloadV1> CapturePayloadArb()
+    {
+        var gen = Gen.OneOf(
+            Gen.Elements(CaptureSource.Typed, CaptureSource.Paste, CaptureSource.Import)
+        ).SelectMany(source =>
+            AdversarialStringGen().SelectMany(text =>
+            Gen.OneOf(
+                Gen.Constant(true),
+                Gen.Constant(false)
+            ).Select(hasProvenance =>
+            {
+                var provenance = hasProvenance
+                    ? new CaptureProvenanceV1(Guid.NewGuid())
+                    : null;
+
+                return new CapturePayloadV1(
+                    1,
+                    source,
+                    text,
+                    TitleHint: text.Length > 5 ? text[..5] : null,
+                    ExternalRef: null,
+                    Provenance: provenance);
+            })));
+
+        return Arb.From(gen);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/QueryBoundaryValueTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/QueryBoundaryValueTests.cs
@@ -132,11 +132,14 @@ public class QueryBoundaryValueTests
     }
 
     [Fact]
-    public void Card_DueDate_AcceptsNull()
+    public void Card_DueDate_NullDoesNotOverwrite()
     {
+        // Passing null for dueDate is a no-op (preserves existing value)
         var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
-        card.Update(dueDate: null);
-        card.DueDate.Should().BeNull();
+        var existingDue = DateTimeOffset.UtcNow.AddDays(7);
+        card.Update(dueDate: existingDue);
+        card.Update(dueDate: null); // should not clear the due date
+        card.DueDate.Should().Be(existingDue);
     }
 
     // ─────────────────────── String: empty vs null vs whitespace vs max-length ───────────────────────

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/QueryBoundaryValueTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/QueryBoundaryValueTests.cs
@@ -338,51 +338,48 @@ public class QueryBoundaryValueTests
 
     // ─────────────────────── Entity Touch property ───────────────────────
 
-    [Property(MaxTest = MaxTests)]
-    public Property AnyValidEntity_Touch_AdvancesUpdatedAt()
+    // Verifies that entity mutations always set UpdatedAt.
+    // Uses individual [Fact] tests instead of a property-based test to avoid
+    // Thread.Sleep(1) * 200 iterations performance cost and timestamp resolution issues.
+
+    [Fact]
+    public void Board_Update_SetsUpdatedAt()
     {
-        return Prop.ForAll(
-            Arb.From(Gen.Elements("board", "card", "column", "label")),
-            entityType =>
-            {
-                DateTimeOffset initialUpdatedAt;
-                DateTimeOffset afterUpdatedAt;
+        var board = new Board("Test");
+        var initialUpdatedAt = board.UpdatedAt;
+        // Ensure clock advances past timer resolution
+        Thread.Sleep(16);
+        board.Update(name: "Updated");
+        board.UpdatedAt.Should().BeAfter(initialUpdatedAt);
+    }
 
-                switch (entityType)
-                {
-                    case "board":
-                        var board = new Board("Test");
-                        initialUpdatedAt = board.UpdatedAt;
-                        Thread.Sleep(1);
-                        board.Update(name: "Updated");
-                        afterUpdatedAt = board.UpdatedAt;
-                        break;
-                    case "card":
-                        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
-                        initialUpdatedAt = card.UpdatedAt;
-                        Thread.Sleep(1);
-                        card.Update(description: "Updated");
-                        afterUpdatedAt = card.UpdatedAt;
-                        break;
-                    case "column":
-                        var col = new Column(Guid.NewGuid(), "Col", 0);
-                        initialUpdatedAt = col.UpdatedAt;
-                        Thread.Sleep(1);
-                        col.SetPosition(1);
-                        afterUpdatedAt = col.UpdatedAt;
-                        break;
-                    case "label":
-                        var label = new Label(Guid.NewGuid(), "Label", "#FF0000");
-                        initialUpdatedAt = label.UpdatedAt;
-                        Thread.Sleep(1);
-                        label.Update(name: "Updated");
-                        afterUpdatedAt = label.UpdatedAt;
-                        break;
-                    default:
-                        throw new InvalidOperationException($"Unknown entity type: {entityType}");
-                }
+    [Fact]
+    public void Card_Update_SetsUpdatedAt()
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        var initialUpdatedAt = card.UpdatedAt;
+        Thread.Sleep(16);
+        card.Update(description: "Updated");
+        card.UpdatedAt.Should().BeAfter(initialUpdatedAt);
+    }
 
-                afterUpdatedAt.Should().BeOnOrAfter(initialUpdatedAt);
-            });
+    [Fact]
+    public void Column_SetPosition_SetsUpdatedAt()
+    {
+        var col = new Column(Guid.NewGuid(), "Col", 0);
+        var initialUpdatedAt = col.UpdatedAt;
+        Thread.Sleep(16);
+        col.SetPosition(1);
+        col.UpdatedAt.Should().BeAfter(initialUpdatedAt);
+    }
+
+    [Fact]
+    public void Label_Update_SetsUpdatedAt()
+    {
+        var label = new Label(Guid.NewGuid(), "Label", "#FF0000");
+        var initialUpdatedAt = label.UpdatedAt;
+        Thread.Sleep(16);
+        label.Update(name: "Updated");
+        label.UpdatedAt.Should().BeAfter(initialUpdatedAt);
     }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/QueryBoundaryValueTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/QueryBoundaryValueTests.cs
@@ -1,0 +1,388 @@
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Boundary-value tests for inputs that exercise SQLite query edge cases.
+/// Covers GUID format variations, DateTime boundaries, and string
+/// edge cases (empty vs null vs whitespace vs max-length).
+/// Key property: domain entities handle all these values correctly
+/// without silently corrupting data or throwing unhandled exceptions.
+/// </summary>
+public class QueryBoundaryValueTests
+{
+    private const int MaxTests = 200;
+
+    // ─────────────────────── GUID format variations ───────────────────────
+
+    [Theory]
+    [InlineData("00000000-0000-0000-0000-000000000000")]  // Guid.Empty
+    [InlineData("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")]  // uppercase max
+    [InlineData("ffffffff-ffff-ffff-ffff-ffffffffffff")]  // lowercase max
+    [InlineData("aAbBcCdD-eEfF-1234-5678-9aBcDeFfAaBb")]  // mixed case
+    [InlineData("12345678-1234-1234-1234-123456789abc")]  // typical
+    public void GuidFormat_RoundTrips_ThroughToString(string guidStr)
+    {
+        var guid = Guid.Parse(guidStr);
+        // .NET normalizes GUID to lowercase with hyphens
+        var roundTripped = Guid.Parse(guid.ToString());
+        roundTripped.Should().Be(guid);
+    }
+
+    [Fact]
+    public void GuidEmpty_RejectedForEntityId()
+    {
+        var act = () => new Card(Guid.Empty, Guid.NewGuid(), Guid.NewGuid(), "Title");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void GuidEmpty_RejectedForBoardOwnerId()
+    {
+        var act = () => new Board("Test", ownerId: Guid.Empty);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property RandomGuid_AlwaysAccepted_AsCardBoardId()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Fresh(() => Guid.NewGuid())),
+            guid =>
+            {
+                var card = new Card(guid, Guid.NewGuid(), "Title");
+                card.BoardId.Should().Be(guid);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property RandomGuid_AlwaysAccepted_AsColumnBoardId()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Fresh(() => Guid.NewGuid())),
+            guid =>
+            {
+                var column = new Column(guid, "Col", 0);
+                column.BoardId.Should().Be(guid);
+            });
+    }
+
+    // ─────────────────────── DateTime boundary values ───────────────────────
+
+    [Fact]
+    public void Board_CreatedAt_IsRecentUtc()
+    {
+        var board = new Board("Test");
+        board.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Card_CreatedAt_IsRecentUtc()
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        card.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Column_CreatedAt_IsRecentUtc()
+    {
+        var column = new Column(Guid.NewGuid(), "Col", 0);
+        column.CreatedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Theory]
+    [InlineData("0001-01-01T00:00:00+00:00")]      // DateTimeOffset.MinValue
+    [InlineData("9999-12-31T23:59:59.9999999+00:00")] // DateTimeOffset.MaxValue
+    [InlineData("1970-01-01T00:00:00+00:00")]        // Unix epoch
+    [InlineData("2038-01-19T03:14:07+00:00")]        // Y2038 problem boundary
+    [InlineData("1999-12-31T23:59:59+00:00")]        // Y2K edge
+    [InlineData("2000-01-01T00:00:00+00:00")]        // Y2K
+    public void DateTimeOffset_Parse_AcceptsBoundaryValues(string dateStr)
+    {
+        var dto = DateTimeOffset.Parse(dateStr);
+        // Round-trip through ISO 8601 string
+        var roundTripped = DateTimeOffset.Parse(dto.ToString("O"));
+        roundTripped.Should().Be(dto);
+    }
+
+    [Fact]
+    public void Card_DueDate_AcceptsDistantFuture()
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        var farFuture = new DateTimeOffset(9999, 12, 31, 23, 59, 59, TimeSpan.Zero);
+        card.Update(dueDate: farFuture);
+        card.DueDate.Should().Be(farFuture);
+    }
+
+    [Fact]
+    public void Card_DueDate_AcceptsDistantPast()
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        var farPast = new DateTimeOffset(1, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        card.Update(dueDate: farPast);
+        card.DueDate.Should().Be(farPast);
+    }
+
+    [Fact]
+    public void Card_DueDate_AcceptsNull()
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        card.Update(dueDate: null);
+        card.DueDate.Should().BeNull();
+    }
+
+    // ─────────────────────── String: empty vs null vs whitespace vs max-length ───────────────────────
+
+    [Theory]
+    [InlineData("", false)]        // empty - invalid
+    [InlineData(" ", false)]       // single space - invalid
+    [InlineData("  ", false)]      // multiple spaces - invalid
+    [InlineData("\t", false)]      // tab - invalid
+    [InlineData("\n", false)]      // newline - invalid
+    [InlineData(" \t\n ", false)]  // mixed whitespace - invalid
+    [InlineData("a", true)]        // single char - valid
+    [InlineData(" a ", true)]      // leading/trailing whitespace with content - valid (not trimmed by domain)
+    public void Board_Name_EmptyVsWhitespace_Boundaries(string name, bool shouldSucceed)
+    {
+        if (shouldSucceed)
+        {
+            var board = new Board(name);
+            board.Name.Should().NotBeNullOrEmpty();
+        }
+        else
+        {
+            var act = () => new Board(name);
+            act.Should().Throw<DomainException>()
+                .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        }
+    }
+
+    [Fact]
+    public void Board_Name_AtMaxLength_Accepted()
+    {
+        var name = new string('x', 100);
+        var board = new Board(name);
+        board.Name.Length.Should().Be(100);
+    }
+
+    [Fact]
+    public void Board_Name_OverMaxLength_Rejected()
+    {
+        var name = new string('x', 101);
+        var act = () => new Board(name);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Card_Title_AtMaxLength_Accepted()
+    {
+        var title = new string('x', 200);
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), title);
+        card.Title.Length.Should().Be(200);
+    }
+
+    [Fact]
+    public void Card_Title_OverMaxLength_Rejected()
+    {
+        var title = new string('x', 201);
+        var act = () => new Card(Guid.NewGuid(), Guid.NewGuid(), title);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Card_Description_AtMaxLength_Accepted()
+    {
+        var desc = new string('d', 2000);
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        card.Update(description: desc);
+        card.Description.Length.Should().Be(2000);
+    }
+
+    [Fact]
+    public void Card_Description_OverMaxLength_Rejected()
+    {
+        var desc = new string('d', 2001);
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        var act = () => card.Update(description: desc);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Card_Description_EmptyString_Accepted()
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        card.Update(description: "");
+        card.Description.Should().Be("");
+    }
+
+    [Fact]
+    public void Column_Name_AtMaxLength_Accepted()
+    {
+        var name = new string('c', 50);
+        var col = new Column(Guid.NewGuid(), name, 0);
+        col.Name.Length.Should().Be(50);
+    }
+
+    [Fact]
+    public void Column_Name_OverMaxLength_Rejected()
+    {
+        var name = new string('c', 51);
+        var act = () => new Column(Guid.NewGuid(), name, 0);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Label_Name_AtMaxLength_Accepted()
+    {
+        var name = new string('l', 30);
+        var label = new Label(Guid.NewGuid(), name, "#FF0000");
+        label.Name.Length.Should().Be(30);
+    }
+
+    [Fact]
+    public void Label_Name_OverMaxLength_Rejected()
+    {
+        var name = new string('l', 31);
+        var act = () => new Label(Guid.NewGuid(), name, "#FF0000");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    // ─────────────────────── Position boundary values ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void Card_Position_NonNegative_Accepted(int position)
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        card.SetPosition(position);
+        card.Position.Should().Be(position);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    [InlineData(int.MinValue)]
+    public void Card_Position_Negative_Rejected(int position)
+    {
+        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+        var act = () => card.SetPosition(position);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void Column_Position_NonNegative_Accepted(int position)
+    {
+        var col = new Column(Guid.NewGuid(), "Col", 0);
+        col.SetPosition(position);
+        col.Position.Should().Be(position);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Column_Position_Negative_Rejected(int position)
+    {
+        var col = new Column(Guid.NewGuid(), "Col", 0);
+        var act = () => col.SetPosition(position);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    // ─────────────────────── WipLimit boundary values ───────────────────────
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(int.MaxValue)]
+    public void Column_WipLimit_Positive_Accepted(int wipLimit)
+    {
+        var col = new Column(Guid.NewGuid(), "Col", 0, wipLimit);
+        col.WipLimit.Should().Be(wipLimit);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(int.MinValue)]
+    public void Column_WipLimit_ZeroOrNegative_Rejected(int wipLimit)
+    {
+        var act = () => new Column(Guid.NewGuid(), "Col", 0, wipLimit);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Column_WipLimit_Null_Accepted()
+    {
+        var col = new Column(Guid.NewGuid(), "Col", 0, null);
+        col.WipLimit.Should().BeNull();
+    }
+
+    // ─────────────────────── Entity Touch property ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property AnyValidEntity_Touch_AdvancesUpdatedAt()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Elements("board", "card", "column", "label")),
+            entityType =>
+            {
+                DateTimeOffset initialUpdatedAt;
+                DateTimeOffset afterUpdatedAt;
+
+                switch (entityType)
+                {
+                    case "board":
+                        var board = new Board("Test");
+                        initialUpdatedAt = board.UpdatedAt;
+                        Thread.Sleep(1);
+                        board.Update(name: "Updated");
+                        afterUpdatedAt = board.UpdatedAt;
+                        break;
+                    case "card":
+                        var card = new Card(Guid.NewGuid(), Guid.NewGuid(), "Title");
+                        initialUpdatedAt = card.UpdatedAt;
+                        Thread.Sleep(1);
+                        card.Update(description: "Updated");
+                        afterUpdatedAt = card.UpdatedAt;
+                        break;
+                    case "column":
+                        var col = new Column(Guid.NewGuid(), "Col", 0);
+                        initialUpdatedAt = col.UpdatedAt;
+                        Thread.Sleep(1);
+                        col.SetPosition(1);
+                        afterUpdatedAt = col.UpdatedAt;
+                        break;
+                    case "label":
+                        var label = new Label(Guid.NewGuid(), "Label", "#FF0000");
+                        initialUpdatedAt = label.UpdatedAt;
+                        Thread.Sleep(1);
+                        label.Update(name: "Updated");
+                        afterUpdatedAt = label.UpdatedAt;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown entity type: {entityType}");
+                }
+
+                afterUpdatedAt.Should().BeOnOrAfter(initialUpdatedAt);
+            });
+    }
+}

--- a/frontend/taskdeck-web/src/tests/property/adversarialData.spec.ts
+++ b/frontend/taskdeck-web/src/tests/property/adversarialData.spec.ts
@@ -23,7 +23,7 @@ const adversarialString = fc.oneof(
   fc.constant('\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}'),
   fc.constant('田中太郎'),
   fc.constant('مرحبا'),
-  fc.constant('{\"nested\": true}'),
+  fc.constant('{"nested": true}'),
   fc.constant('back\\slash'),
   fc.constant('\x1B[31mRed\x1B[0m'),
   fc.string(),
@@ -68,26 +68,24 @@ describe('Adversarial Data: Proposal Operation Parameters', () => {
     )
   })
 
-  it('malformed operation parameters string does not throw when parsed cautiously', () => {
+  it('malformed operation parameters produce parse errors or non-object results', () => {
     const malformedParams = [
-      '',
-      'not json',
-      '{',
-      '[',
-      '{"unclosed": ',
-      'null',
-      '12345',
-      '<xml>data</xml>',
+      { input: '', shouldThrow: true },
+      { input: 'not json', shouldThrow: true },
+      { input: '{', shouldThrow: true },
+      { input: '[', shouldThrow: true },
+      { input: '{"unclosed": ', shouldThrow: true },
+      { input: 'null', shouldThrow: false, expectedValue: null },
+      { input: '12345', shouldThrow: false, expectedValue: 12345 },
+      { input: '<xml>data</xml>', shouldThrow: true },
     ]
 
-    for (const param of malformedParams) {
-      expect(() => {
-        try {
-          JSON.parse(param)
-        } catch {
-          // Expected - the frontend should handle this gracefully
-        }
-      }).not.toThrow()
+    for (const { input, shouldThrow, expectedValue } of malformedParams) {
+      if (shouldThrow) {
+        expect(() => JSON.parse(input)).toThrow()
+      } else {
+        expect(JSON.parse(input)).toBe(expectedValue)
+      }
     }
   })
 })
@@ -217,36 +215,34 @@ describe('Adversarial Data: Numeric Boundary Values', () => {
 })
 
 describe('Adversarial Data: Capture Text Edge Cases', () => {
-  it('capture text with binary-like data should serialize', () => {
-    // Simulate various binary-like string patterns
-    const binaryPatterns = [
+  it('capture text with binary-like data should serialize or throw JsonError', () => {
+    // Patterns that survive JSON round-trip
+    const safePatterns = [
       '\x00\x01\x02\x03\x04\x05',
       String.fromCharCode(...Array.from({ length: 256 }, (_, i) => i)),
       '\uFFFE\uFFFF', // non-characters
-      '\uD800', // lone surrogate (will be replaced in JSON)
     ]
 
-    for (const pattern of binaryPatterns) {
-      expect(() => {
-        try {
-          const json = JSON.stringify({ text: pattern })
-          JSON.parse(json)
-        } catch {
-          // Some patterns may fail JSON serialization, which is expected
-        }
-      }).not.toThrow()
+    for (const pattern of safePatterns) {
+      const json = JSON.stringify({ text: pattern })
+      const parsed = JSON.parse(json)
+      expect(parsed.text).toBe(pattern)
     }
+
+    // Lone surrogates are replaced by JSON.stringify, verify no crash
+    const loneSurrogate = '\uD800'
+    const json = JSON.stringify({ text: loneSurrogate })
+    const parsed = JSON.parse(json)
+    expect(typeof parsed.text).toBe('string')
   })
 
   it('very long capture text (50K chars) should not freeze', () => {
     const longText = 'x'.repeat(50_000)
-    const start = performance.now()
 
     const json = JSON.stringify({ text: longText })
-    JSON.parse(json)
+    const parsed = JSON.parse(json)
 
-    const elapsed = performance.now() - start
-    // Should complete well under 1 second
-    expect(elapsed).toBeLessThan(1000)
+    // Functional correctness: text survives round-trip
+    expect(parsed.text).toBe(longText)
   })
 })

--- a/frontend/taskdeck-web/src/tests/property/adversarialData.spec.ts
+++ b/frontend/taskdeck-web/src/tests/property/adversarialData.spec.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest'
+import * as fc from 'fast-check'
+
+/**
+ * Additional adversarial data tests for frontend input handling.
+ * Extends inputSanitization.spec.ts with:
+ * - Proposal operation parameter handling
+ * - Capture provenance round-trip
+ * - Webhook URL display safety
+ * - Extreme numeric boundary values
+ */
+
+// Adversarial string arbitrary reused across tests
+const adversarialString = fc.oneof(
+  fc.constant("<script>alert('xss')</script>"),
+  fc.constant('<img src=x onerror=alert(1)>'),
+  fc.constant("'; DROP TABLE boards; --"),
+  fc.constant('" OR 1=1 --'),
+  fc.constant('\u0000'),
+  fc.constant('\uFEFF'),
+  fc.constant('\u200B'),
+  fc.constant('\u202E'),
+  fc.constant('\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}'),
+  fc.constant('田中太郎'),
+  fc.constant('مرحبا'),
+  fc.constant('{\"nested\": true}'),
+  fc.constant('back\\slash'),
+  fc.constant('\x1B[31mRed\x1B[0m'),
+  fc.string(),
+)
+
+describe('Adversarial Data: Proposal Operation Parameters', () => {
+  it('any string serialized as operation parameter survives JSON round-trip', () => {
+    fc.assert(
+      fc.property(adversarialString, (input) => {
+        const operation = {
+          sequence: 0,
+          actionType: 'create',
+          targetType: 'card',
+          parameters: JSON.stringify({ title: input }),
+          idempotencyKey: crypto.randomUUID(),
+        }
+        const json = JSON.stringify(operation)
+        const parsed = JSON.parse(json)
+        const innerParams = JSON.parse(parsed.parameters)
+        expect(innerParams.title).toBe(input)
+      }),
+      { numRuns: 500 },
+    )
+  })
+
+  it('proposal with adversarial summary should serialize safely', () => {
+    fc.assert(
+      fc.property(adversarialString, (summary) => {
+        const proposal = {
+          id: crypto.randomUUID(),
+          sourceType: 0,
+          summary,
+          riskLevel: 0,
+          status: 'PendingReview',
+          operations: [],
+        }
+        const json = JSON.stringify(proposal)
+        const parsed = JSON.parse(json)
+        expect(parsed.summary).toBe(summary)
+      }),
+      { numRuns: 500 },
+    )
+  })
+
+  it('malformed operation parameters string does not throw when parsed cautiously', () => {
+    const malformedParams = [
+      '',
+      'not json',
+      '{',
+      '[',
+      '{"unclosed": ',
+      'null',
+      '12345',
+      '<xml>data</xml>',
+    ]
+
+    for (const param of malformedParams) {
+      expect(() => {
+        try {
+          JSON.parse(param)
+        } catch {
+          // Expected - the frontend should handle this gracefully
+        }
+      }).not.toThrow()
+    }
+  })
+})
+
+describe('Adversarial Data: Capture Provenance Round-Trip', () => {
+  it('provenance with all optional fields survives JSON round-trip', () => {
+    const provenanceArb = fc.record({
+      captureItemId: fc.uuid(),
+      triageRunId: fc.option(fc.uuid(), { nil: null }),
+      proposalId: fc.option(fc.uuid(), { nil: null }),
+      promptVersion: fc.option(fc.string({ maxLength: 50 }), { nil: null }),
+      provider: fc.option(fc.string({ maxLength: 50 }), { nil: null }),
+      model: fc.option(fc.string({ maxLength: 50 }), { nil: null }),
+      requestedByUserId: fc.option(fc.uuid(), { nil: null }),
+      correlationId: fc.option(fc.uuid(), { nil: null }),
+      sourceSurface: fc.option(fc.string({ maxLength: 50 }), { nil: null }),
+      boardId: fc.option(fc.uuid(), { nil: null }),
+      sessionId: fc.option(fc.uuid(), { nil: null }),
+    })
+
+    fc.assert(
+      fc.property(provenanceArb, (provenance) => {
+        const json = JSON.stringify(provenance)
+        const parsed = JSON.parse(json)
+        expect(parsed.captureItemId).toBe(provenance.captureItemId)
+        expect(parsed.triageRunId).toBe(provenance.triageRunId)
+        expect(parsed.proposalId).toBe(provenance.proposalId)
+        expect(parsed.promptVersion).toBe(provenance.promptVersion)
+        expect(parsed.provider).toBe(provenance.provider)
+        expect(parsed.model).toBe(provenance.model)
+      }),
+      { numRuns: 200 },
+    )
+  })
+
+  it('provenance with adversarial string fields round-trips', () => {
+    fc.assert(
+      fc.property(adversarialString, adversarialString, (promptVersion, provider) => {
+        const provenance = {
+          captureItemId: crypto.randomUUID(),
+          promptVersion,
+          provider,
+        }
+        const json = JSON.stringify(provenance)
+        const parsed = JSON.parse(json)
+        expect(parsed.promptVersion).toBe(promptVersion)
+        expect(parsed.provider).toBe(provider)
+      }),
+      { numRuns: 500 },
+    )
+  })
+})
+
+describe('Adversarial Data: Webhook URL Display Safety', () => {
+  it('dangerous URLs should be displayable as text without execution', () => {
+    const dangerousUrls = [
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      'vbscript:MsgBox(1)',
+      'file:///etc/passwd',
+      'https://admin:password@evil.com/webhook',
+      'http://169.254.169.254/latest/meta-data/',
+    ]
+
+    for (const url of dangerousUrls) {
+      // When displayed as text content, the URL string should be preserved exactly
+      expect(typeof url).toBe('string')
+      // URL encoding should work without throwing
+      expect(() => encodeURIComponent(url)).not.toThrow()
+      // JSON round-trip should preserve the URL
+      const json = JSON.stringify({ url })
+      const parsed = JSON.parse(json)
+      expect(parsed.url).toBe(url)
+    }
+  })
+
+  it('extremely long URLs should not cause OOM', () => {
+    const longUrl = 'https://example.com/' + 'a'.repeat(100_000)
+    expect(() => {
+      JSON.stringify({ url: longUrl })
+    }).not.toThrow()
+    expect(longUrl.length).toBe(100_020)
+  })
+})
+
+describe('Adversarial Data: Numeric Boundary Values', () => {
+  it('card position with extreme values should serialize correctly', () => {
+    const extremePositions = [
+      0,
+      1,
+      -1,
+      Number.MAX_SAFE_INTEGER,
+      Number.MIN_SAFE_INTEGER,
+      Number.MAX_VALUE,
+      Number.MIN_VALUE,
+      Infinity,
+      -Infinity,
+      NaN,
+    ]
+
+    for (const pos of extremePositions) {
+      const card = { id: crypto.randomUUID(), position: pos }
+      const json = JSON.stringify(card)
+      const parsed = JSON.parse(json)
+
+      if (Number.isFinite(pos)) {
+        expect(parsed.position).toBe(pos)
+      } else if (Number.isNaN(pos)) {
+        // JSON.stringify converts NaN to null
+        expect(parsed.position).toBeNull()
+      } else {
+        // JSON.stringify converts Infinity to null
+        expect(parsed.position).toBeNull()
+      }
+    }
+  })
+
+  it('wipLimit boundary values should be handled', () => {
+    const wipLimits = [0, 1, -1, null, undefined, Number.MAX_SAFE_INTEGER]
+
+    for (const wipLimit of wipLimits) {
+      const col = { name: 'Col', wipLimit }
+      expect(() => JSON.stringify(col)).not.toThrow()
+    }
+  })
+})
+
+describe('Adversarial Data: Capture Text Edge Cases', () => {
+  it('capture text with binary-like data should serialize', () => {
+    // Simulate various binary-like string patterns
+    const binaryPatterns = [
+      '\x00\x01\x02\x03\x04\x05',
+      String.fromCharCode(...Array.from({ length: 256 }, (_, i) => i)),
+      '\uFFFE\uFFFF', // non-characters
+      '\uD800', // lone surrogate (will be replaced in JSON)
+    ]
+
+    for (const pattern of binaryPatterns) {
+      expect(() => {
+        try {
+          const json = JSON.stringify({ text: pattern })
+          JSON.parse(json)
+        } catch {
+          // Some patterns may fail JSON serialization, which is expected
+        }
+      }).not.toThrow()
+    }
+  })
+
+  it('very long capture text (50K chars) should not freeze', () => {
+    const longText = 'x'.repeat(50_000)
+    const start = performance.now()
+
+    const json = JSON.stringify({ text: longText })
+    JSON.parse(json)
+
+    const elapsed = performance.now() - start
+    // Should complete well under 1 second
+    expect(elapsed).toBeLessThan(1000)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds webhook URL adversarial tests (RFC 3986 edge cases, SSRF vectors, dangerous schemes, credentials in URLs)
- Adds proposal operations adversarial tests (malformed types, missing fields, extra unknown fields, boundary values)
- Adds capture endpoint adversarial tests (binary data, null bytes, very long strings, nested JSON, injection payloads)
- Adds no-500s meta-test sweeping boards, capture, cards, search, columns, labels with randomized content
- Adds capture provenance serialization round-trip property tests (CaptureProvenanceV1, CapturePayloadV1)
- Adds SQLite query boundary value tests (GUID formats, DateTime boundaries, string edge cases, position/WipLimit boundaries)
- Adds frontend adversarial data tests (proposal parameters, provenance round-trip, webhook URL safety, numeric boundaries)
- Documents two known API bugs: proposal endpoint returns 500 for XSS in actionType and nested parameter JSON (skip-annotated)

Closes #717

## Test plan
- [x] All new property/fuzz tests pass (58 domain, 11 application, 144 API, frontend)
- [x] No existing tests broken (4010 backend, 1927 frontend all pass)
- [x] No new NuGet packages added (uses existing FsCheck and fast-check)
- [x] 2 known bugs documented as skip-annotated tests