### PR TITLE
test: TST-11 manual validation slice E -- starter packs, archive recovery, activity traceability (#134)

### DIFF
--- a/docs/testing/MANUAL_REHEARSAL_RUNBOOK_SLICE_E.md
+++ b/docs/testing/MANUAL_REHEARSAL_RUNBOOK_SLICE_E.md
@@ -1,0 +1,417 @@
+# Manual Rehearsal Runbook: Slice E -- Starter Packs, Archive Recovery, Activity Traceability
+
+Last Updated: 2026-04-15
+
+Companion scenarios: `docs/testing/MANUAL_VALIDATION_SLICE_E_SCENARIOS.md`
+Automated tests: `frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts`, `validation-archive-recovery.spec.ts`, `validation-activity-traceability.spec.ts`
+
+## Purpose
+
+Step-by-step rehearsal guide for a human operator to execute manual validation of starter packs, archive/recovery, and activity/audit surfaces. Each section includes evidence capture instructions and expected timing.
+
+## Pre-Rehearsal Setup
+
+### Environment
+
+1. Remove `backend/src/Taskdeck.Api/taskdeck.db` for a clean baseline.
+2. Start backend:
+   ```bash
+   dotnet run --project backend/src/Taskdeck.Api/Taskdeck.Api.csproj
+   ```
+3. Start frontend:
+   ```bash
+   cd frontend/taskdeck-web
+   npm run dev
+   ```
+4. Open `http://localhost:5173` (or fallback port).
+5. Prepare a screenshots folder: `evidence/slice-e-{date}/`.
+
+### Accounts
+
+| Alias | Username | Email | Password | Purpose |
+|---|---|---|---|---|
+| **Operator** | `slice-e-user` | `slice-e@test.local` | `TestPass1!` | Primary test user |
+| **Isolator** | `slice-e-iso` | `slice-e-iso@test.local` | `TestPass2!` | Cross-user isolation checks |
+
+Register both accounts via `POST /api/auth/register` and save bearer tokens.
+
+```bash
+# Register operator
+curl -s -X POST http://localhost:5000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"slice-e-user","email":"slice-e@test.local","password":"TestPass1!"}' \
+  | tee /dev/stderr | jq -r '.token' > /tmp/token_op.txt
+
+# Register isolator
+curl -s -X POST http://localhost:5000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"username":"slice-e-iso","email":"slice-e-iso@test.local","password":"TestPass2!"}' \
+  | tee /dev/stderr | jq -r '.token' > /tmp/token_iso.txt
+
+TOKEN_OP=$(cat /tmp/token_op.txt)
+TOKEN_ISO=$(cat /tmp/token_iso.txt)
+```
+
+### Run Metadata (Record Before Starting)
+
+| Field | Value |
+|---|---|
+| Date/time (UTC) | |
+| Commit SHA | |
+| Browser and version | |
+| OS | |
+| DB baseline | `fresh` |
+| Env flags changed | |
+| Estimated duration | 45-60 minutes |
+
+---
+
+## Phase 1: Starter Packs (est. 15-20 min)
+
+### 1.1 Browse Catalog (TST11-SC-001)
+
+```bash
+# Create a board
+BOARD_ID=$(curl -s -X POST http://localhost:5000/api/boards \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"name":"Starter Pack Test Board"}' | jq -r '.id')
+
+# Get catalog
+curl -s http://localhost:5000/api/boards/$BOARD_ID/starter-packs/catalog \
+  -H "Authorization: Bearer $TOKEN_OP" | jq .
+```
+
+**Evidence:** Save catalog response JSON. Note pack count and IDs.
+
+**Pass criteria:** 200 response, array of catalog entries.
+
+### 1.2 Dry-Run Preview (TST11-SC-002)
+
+```bash
+curl -s -X POST http://localhost:5000/api/boards/$BOARD_ID/starter-packs/apply \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{
+    "manifest": {
+      "schemaVersion": "1.0",
+      "packId": "rehearsal-small",
+      "displayName": "Rehearsal Small",
+      "description": "Test pack",
+      "compatibility": {"minTaskdeckVersion":"1.0.0","requiredFeatures":["boards"]},
+      "tags": ["test"],
+      "labels": [{"name":"urgent","color":"#DC2626","description":"Urgent"}],
+      "columns": [{"name":"Backlog","position":0},{"name":"Done","position":1}],
+      "templates": [],
+      "seedCards": [{"title":"Test Card","description":"Seed","columnName":"Backlog","labels":["urgent"]}]
+    },
+    "dryRun": true
+  }' | jq .
+```
+
+**Evidence:** Save dry-run response. Verify `dryRun: true`, `applied: false`, `actions` non-empty.
+
+Then confirm board is unchanged:
+```bash
+curl -s http://localhost:5000/api/boards/$BOARD_ID/columns \
+  -H "Authorization: Bearer $TOKEN_OP" | jq .
+# Should return empty array
+```
+
+**Pass criteria:** Board has no columns after dry-run.
+
+### 1.3 Apply to Empty Board (TST11-SC-003)
+
+```bash
+# Same manifest, dryRun: false
+curl -s -X POST http://localhost:5000/api/boards/$BOARD_ID/starter-packs/apply \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{
+    "manifest": {
+      "schemaVersion": "1.0",
+      "packId": "rehearsal-small",
+      "displayName": "Rehearsal Small",
+      "description": "Test pack",
+      "compatibility": {"minTaskdeckVersion":"1.0.0","requiredFeatures":["boards"]},
+      "tags": ["test"],
+      "labels": [{"name":"urgent","color":"#DC2626","description":"Urgent"}],
+      "columns": [{"name":"Backlog","position":0},{"name":"Done","position":1}],
+      "templates": [],
+      "seedCards": [{"title":"Test Card","description":"Seed","columnName":"Backlog","labels":["urgent"]}]
+    },
+    "dryRun": false
+  }' | jq .
+```
+
+**Evidence:** Save apply response. Verify `applied: true`.
+
+```bash
+# Verify board state
+curl -s http://localhost:5000/api/boards/$BOARD_ID/columns \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[].name'
+
+curl -s http://localhost:5000/api/boards/$BOARD_ID/labels \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[].name'
+
+curl -s http://localhost:5000/api/boards/$BOARD_ID/cards \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[].title'
+```
+
+**Pass criteria:** Columns: Backlog, Done. Labels: urgent. Cards: Test Card.
+
+### 1.4 Re-apply Idempotency (TST11-SC-004)
+
+Re-run the same apply call from 1.3 with `dryRun: true`.
+
+**Pass criteria:** Conflicts array non-empty, board state unchanged.
+
+### 1.5 Conflict with Existing Content (TST11-SC-005)
+
+```bash
+# Create a new board with a pre-existing column
+CONFLICT_BOARD=$(curl -s -X POST http://localhost:5000/api/boards \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"name":"Conflict Test Board"}' | jq -r '.id')
+
+curl -s -X POST http://localhost:5000/api/boards/$CONFLICT_BOARD/columns \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d "{\"boardId\":\"$CONFLICT_BOARD\",\"name\":\"Occupied Lane\",\"position\":0,\"wipLimit\":null}"
+```
+
+Apply the same manifest with `dryRun: true`.
+
+**Pass criteria:** Response includes `ColumnPositionConflict` in conflicts array.
+
+---
+
+## Phase 2: Archive and Recovery (est. 15-20 min)
+
+### 2.1 Archive a Board (TST11-SC-010)
+
+```bash
+# Create a board with content
+ARCH_BOARD=$(curl -s -X POST http://localhost:5000/api/boards \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"name":"Archive Test Board"}' | jq -r '.id')
+
+# Archive it
+curl -s -X PUT http://localhost:5000/api/boards/$ARCH_BOARD \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"isArchived": true}' | jq '.isArchived'
+# Should print: true
+
+# Verify absent from default list
+curl -s http://localhost:5000/api/boards \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[].name'
+
+# Verify present with includeArchived
+curl -s "http://localhost:5000/api/boards?includeArchived=true" \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[] | select(.name=="Archive Test Board")'
+```
+
+**Evidence:** Default list without board, includeArchived list with board.
+
+**Pass criteria:** Board absent from default, present with includeArchived=true.
+
+### 2.2 Archive View in UI (TST11-SC-011)
+
+1. Log in as Operator in the browser.
+2. Navigate to `/workspace/archive`.
+3. Verify "Archived Boards" section shows the archived board.
+4. Screenshot the view.
+
+**Evidence:** Screenshot showing archived board with Restore button.
+
+### 2.3 Restore Archived Board (TST11-SC-012)
+
+1. In the archive view, click "Restore Board" on the archived board.
+2. Accept the confirmation dialog.
+3. Verify success toast appears.
+4. Navigate to `/workspace/boards`.
+5. Verify the board reappears.
+
+**Evidence:** Screenshot of boards list after restore.
+
+### 2.4 State Preservation (TST11-SC-013)
+
+```bash
+# Create a rich board, add columns, cards, then archive and restore
+RICH_BOARD=$(curl -s -X POST http://localhost:5000/api/boards \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"name":"Rich Board"}' | jq -r '.id')
+
+# Add columns
+for col in '{"name":"Todo","position":0}' '{"name":"Doing","position":1}' '{"name":"Done","position":2}'; do
+  curl -s -X POST http://localhost:5000/api/boards/$RICH_BOARD/columns \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN_OP" \
+    -d "{\"boardId\":\"$RICH_BOARD\",$col,\"wipLimit\":null}"
+done
+
+# Get Todo column ID
+TODO_COL=$(curl -s http://localhost:5000/api/boards/$RICH_BOARD/columns \
+  -H "Authorization: Bearer $TOKEN_OP" | jq -r '.[] | select(.name=="Todo") | .id')
+
+# Add card
+curl -s -X POST http://localhost:5000/api/boards/$RICH_BOARD/cards \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d "{\"boardId\":\"$RICH_BOARD\",\"columnId\":\"$TODO_COL\",\"title\":\"Preserved Card\",\"description\":\"Survives cycle\",\"position\":0}"
+
+# Capture baseline
+curl -s http://localhost:5000/api/boards/$RICH_BOARD/cards \
+  -H "Authorization: Bearer $TOKEN_OP" | jq . > /tmp/baseline_cards.json
+
+# Archive
+curl -s -X PUT http://localhost:5000/api/boards/$RICH_BOARD \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"isArchived": true}'
+
+# Restore
+curl -s -X PUT http://localhost:5000/api/boards/$RICH_BOARD \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN_OP" \
+  -d '{"isArchived": false}'
+
+# Compare
+curl -s http://localhost:5000/api/boards/$RICH_BOARD/cards \
+  -H "Authorization: Bearer $TOKEN_OP" | jq . > /tmp/restored_cards.json
+
+diff /tmp/baseline_cards.json /tmp/restored_cards.json
+```
+
+**Pass criteria:** `diff` produces no output (identical state).
+
+### 2.5 Cross-User Isolation (TST11-SC-016)
+
+```bash
+# Isolator should not see Operator's archived boards
+curl -s "http://localhost:5000/api/boards?includeArchived=true" \
+  -H "Authorization: Bearer $TOKEN_ISO" | jq '.[].name'
+
+curl -s http://localhost:5000/api/archive/items \
+  -H "Authorization: Bearer $TOKEN_ISO" | jq '.[].name'
+```
+
+**Pass criteria:** Operator's boards not visible to Isolator.
+
+### 2.6 Unauthorized Access (TST11-SC-017)
+
+```bash
+# No bearer token
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/api/archive/items
+# Should print 401
+```
+
+**Pass criteria:** 401 response.
+
+---
+
+## Phase 3: Activity and Traceability (est. 15-20 min)
+
+### 3.1 Board-Scoped Audit (TST11-SC-018)
+
+```bash
+# Use an existing board that has had mutations
+curl -s http://localhost:5000/api/audit/boards/$BOARD_ID \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[0:5]'
+```
+
+**Evidence:** Save first 5 audit entries. Note action types and timestamps.
+
+**Pass criteria:** Non-empty timeline with action and timestamp fields.
+
+### 3.2 Entity-Scoped Audit (TST11-SC-019)
+
+```bash
+# Get a card ID from the test board
+CARD_ID=$(curl -s http://localhost:5000/api/boards/$BOARD_ID/cards \
+  -H "Authorization: Bearer $TOKEN_OP" | jq -r '.[0].id')
+
+curl -s http://localhost:5000/api/audit/entities/card/$CARD_ID \
+  -H "Authorization: Bearer $TOKEN_OP" | jq .
+```
+
+**Evidence:** Card-level audit entries.
+
+**Pass criteria:** At least one entry (creation event).
+
+### 3.3 User-Scoped Audit (TST11-SC-020)
+
+```bash
+curl -s http://localhost:5000/api/audit/users/me \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[0:10]'
+```
+
+**Evidence:** First 10 user-scoped audit entries.
+
+**Pass criteria:** Non-empty timeline spanning actions from all phases.
+
+### 3.4 Board Mutation Audit Trail (TST11-SC-021)
+
+Verify the archive test board's audit trail includes create, rename (if performed), archive, and restore entries:
+
+```bash
+curl -s http://localhost:5000/api/audit/boards/$ARCH_BOARD \
+  -H "Authorization: Bearer $TOKEN_OP" | jq '.[].action'
+```
+
+**Pass criteria:** Multiple distinct action types in the timeline.
+
+### 3.5 Activity View UI (TST11-SC-023, TST11-SC-024)
+
+1. Navigate to `/workspace/activity`.
+2. Verify page loads with heading "Activity".
+3. Verify help callout "Why do these selectors matter?" is visible.
+4. Verify "Open Review" and "Open Boards" buttons are present.
+5. Select board mode, pick a board, click Fetch.
+6. Verify timeline entries appear.
+7. Screenshot the populated activity view.
+
+**Evidence:** Screenshots of activity view in each mode.
+
+### 3.6 Unauthorized Audit Access (TST11-SC-025)
+
+```bash
+# No bearer token
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/api/audit/boards/$BOARD_ID
+# Should print 401
+
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/api/audit/users/me
+# Should print 401
+
+# Cross-user check
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5000/api/audit/boards/$BOARD_ID \
+  -H "Authorization: Bearer $TOKEN_ISO"
+# Should print 403 or 404
+```
+
+**Pass criteria:** 401 without token, 403/404 for cross-user access.
+
+---
+
+## Post-Rehearsal Checklist
+
+| Item | Status |
+|---|---|
+| All Phase 1 scenarios executed | |
+| All Phase 2 scenarios executed | |
+| All Phase 3 scenarios executed | |
+| Evidence screenshots collected | |
+| API response JSONs saved | |
+| Cross-user isolation verified | |
+| Unauthorized access verified | |
+| Run metadata recorded at top | |
+
+## Known Limitations
+
+- Starter pack catalog may be empty if no built-in packs are registered in the application layer. The apply endpoint works with any valid manifest regardless.
+- Archive recovery inventory (`/api/archive/items`) tracks items archived through the archive recovery service. Board archival via `PUT /api/boards/{id}` uses a simpler `isArchived` flag and may not always create a recovery inventory entry.
+- Activity audit granularity depends on which mutations trigger audit logging. Not all property-level changes may generate individual entries.

--- a/docs/testing/MANUAL_VALIDATION_SLICE_E_SCENARIOS.md
+++ b/docs/testing/MANUAL_VALIDATION_SLICE_E_SCENARIOS.md
@@ -1,0 +1,459 @@
+# Manual Validation Slice E: Starter Packs, Archive Recovery, and Activity Traceability
+
+Last Updated: 2026-04-15
+
+Companion references:
+- `docs/MANUAL_TEST_CHECKLIST.md` (parent checklist, sections B.5-6, G, O)
+- `docs/STATUS.md` (current implementation snapshot)
+- `docs/TESTING_GUIDE.md` (test operations reference)
+- `docs/testing/manual-validation-a-workspace-board-ux.md` (Slice A)
+- `docs/testing/manual-validation-b-authz-contracts.md` (Slice B)
+
+## Purpose
+
+Validate starter pack catalog and application lifecycle, archive/recovery flows, and activity/audit traceability. This slice covers three related but distinct surfaces that share a theme: structured board seeding, soft-delete recovery, and mutation observability.
+
+## Environment Setup
+
+### Prerequisites
+
+1. Clean backend database (remove `backend/src/Taskdeck.Api/taskdeck.db` if present).
+2. Start backend:
+   ```bash
+   dotnet run --project backend/src/Taskdeck.Api/Taskdeck.Api.csproj
+   ```
+3. Start frontend:
+   ```bash
+   cd frontend/taskdeck-web
+   npm run dev
+   ```
+4. Open `http://localhost:5173` (or fallback port printed by Vite).
+5. Register a test user and obtain a bearer token for API-level scenarios.
+
+### Run Metadata (Record Before and After Each Run)
+
+| Field | Value |
+|---|---|
+| Date/time (UTC) | |
+| Commit SHA | |
+| Browser and version | |
+| OS | |
+| DB baseline | `fresh` / `existing` |
+| Env flags changed | |
+| Artifacts collected | |
+
+---
+
+## Category 1: Starter Packs
+
+### TST11-SC-001: Browse Starter Pack Catalog
+
+**Goal:** Verify the catalog endpoint returns available packs.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board via `POST /api/boards` | 201 with board ID |
+| 2 | `GET /api/boards/{boardId}/starter-packs/catalog` | 200 with array of catalog entries, each containing `packId`, `displayName`, `description`, `tags` |
+| 3 | Verify at least one built-in pack exists | Catalog is non-empty |
+
+**Evidence:** Response JSON showing catalog entries.
+
+---
+
+### TST11-SC-002: Preview Pack Contents via Dry Run
+
+**Goal:** Verify dry-run mode previews changes without applying them.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a fresh board | 201 with board ID |
+| 2 | `POST /api/boards/{boardId}/starter-packs/apply` with `dryRun: true` and a valid manifest | 200 with `dryRun: true`, `applied: false`, `actions` array listing intended changes |
+| 3 | `GET /api/boards/{boardId}/columns` | Board has no new columns (dry-run did not mutate) |
+| 4 | `GET /api/boards/{boardId}/labels` | Board has no new labels |
+
+**Evidence:** Dry-run response JSON and empty board state verification.
+
+---
+
+### TST11-SC-003: Apply Pack to Empty Board
+
+**Goal:** Verify a starter pack applies successfully to a board with no existing content.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a fresh board | 201 with board ID |
+| 2 | `POST /api/boards/{boardId}/starter-packs/apply` with `dryRun: false` and a manifest containing columns, labels, and seed cards | 200 with `applied: true`, `dryRun: false`, no blocking conflicts |
+| 3 | `GET /api/boards/{boardId}/columns` | Columns match manifest (names and positions) |
+| 4 | `GET /api/boards/{boardId}/labels` | Labels match manifest (names and colors) |
+| 5 | `GET /api/boards/{boardId}/cards` | Seed cards present with correct titles, column assignments, and label bindings |
+
+**Evidence:** Screenshots or JSON responses confirming board matches manifest.
+
+---
+
+### TST11-SC-004: Re-apply Same Pack (Idempotency)
+
+**Goal:** Verify re-applying the same pack does not create duplicates.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Use the board from TST11-SC-003 (pack already applied) | Board has columns, labels, cards from first apply |
+| 2 | `POST /api/boards/{boardId}/starter-packs/apply` with same manifest and `dryRun: true` | Response includes conflicts for existing columns/labels (position or name collisions) |
+| 3 | Verify `hasBlockingConflicts` is `true` or conflicts array is non-empty | Dry-run correctly detects collisions |
+| 4 | `GET /api/boards/{boardId}/columns` | Column count unchanged from step 1 |
+
+**Evidence:** Dry-run conflict response and unchanged board state.
+
+---
+
+### TST11-SC-005: Apply Pack to Board with Existing Content (Conflict Detection)
+
+**Goal:** Verify conflict detection when board already has content at overlapping positions.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board and add a column at position 0 named "Occupied Lane" | Column created at position 0 |
+| 2 | `POST /api/boards/{boardId}/starter-packs/apply` with `dryRun: true` and a manifest requesting a column at position 0 | 200 with `dryRun: true`, `conflicts` array containing `ColumnPositionConflict` |
+| 3 | Verify conflict entry includes `code`, `path`, `message`, `existingValue`, `incomingValue` | All conflict fields populated |
+| 4 | `POST /api/boards/{boardId}/starter-packs/apply` with `dryRun: false` and same manifest | Response has `hasBlockingConflicts: true`, `applied: false` |
+
+**Evidence:** Conflict response JSON with detailed conflict entries.
+
+---
+
+### TST11-SC-006: Dry-Run Preview with Conflict Highlighting
+
+**Goal:** Verify the dry-run response distinguishes blocking vs. warning conflicts.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board with a column at position 0 | Board has one column |
+| 2 | `POST /api/boards/{boardId}/starter-packs/apply` with `dryRun: true` and manifest with a column at same position | 200 response |
+| 3 | Inspect each conflict entry for `severity` field | Severity is either `"blocking"` or `"warning"` |
+| 4 | Verify `hasBlockingConflicts` matches presence of blocking-severity conflicts | Boolean correctly computed |
+
+**Evidence:** Conflict entries with severity annotations.
+
+---
+
+### TST11-SC-007: Pack with Labels, Columns, and Blueprint Cards
+
+**Goal:** Verify a complex manifest with all entity types applies correctly.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a fresh board | Board created |
+| 2 | Apply manifest with 3+ labels, 4 columns (one with WIP limit), 1 template, 3 seed cards spanning multiple columns and labels | 200 with `applied: true` |
+| 3 | Verify columns have correct WIP limits | `GET /api/boards/{boardId}/columns` shows `wipLimit` values |
+| 4 | Verify cards are placed in correct columns | Card `columnId` matches expected column |
+| 5 | Verify card-label bindings | Cards have expected label associations |
+
+**Evidence:** Full board state JSON after apply.
+
+---
+
+### TST11-SC-008: Apply Multiple Packs to Same Board
+
+**Goal:** Verify sequential pack applications accumulate content without corruption.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a fresh board and apply "small" fixture pack | Board has 2 columns, 1 label, 1 card |
+| 2 | Apply a second manifest with non-overlapping columns (positions 2, 3) and different labels | 200 with `applied: true`, no blocking conflicts |
+| 3 | `GET /api/boards/{boardId}/columns` | Board now has 4 columns (original 2 + new 2) |
+| 4 | `GET /api/boards/{boardId}/labels` | Board has combined labels from both packs |
+
+**Evidence:** Board state after each apply showing accumulation.
+
+---
+
+### TST11-SC-009: Validate Manifest JSON Endpoint
+
+**Goal:** Verify the manifest validation endpoint checks structural correctness.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | `POST /api/boards/{boardId}/starter-packs/validate-manifest` with valid manifest JSON | 200 with `isValid: true`, empty errors |
+| 2 | `POST /api/boards/{boardId}/starter-packs/validate-manifest` with invalid JSON (missing required fields) | 200 with `isValid: false`, errors array with path and message |
+| 3 | `POST /api/boards/{boardId}/starter-packs/validate-manifest` with empty body | 400 validation error |
+
+**Evidence:** Validation responses for valid, invalid, and empty inputs.
+
+---
+
+## Category 2: Archive and Recovery
+
+### TST11-SC-010: Archive a Board
+
+**Goal:** Verify archiving a board removes it from the default board list.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board with at least one column and one card | Board visible in `GET /api/boards` |
+| 2 | `PUT /api/boards/{boardId}` with `isArchived: true` | 200 with updated board showing `isArchived: true` |
+| 3 | `GET /api/boards` (default, no `includeArchived`) | Archived board absent from list |
+| 4 | `GET /api/boards?includeArchived=true` | Archived board present with `isArchived: true` |
+
+**Evidence:** Board list before and after archival.
+
+---
+
+### TST11-SC-011: View Archived Boards in Archive Workspace
+
+**Goal:** Verify `/workspace/archive` displays archived boards.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Archive a board (per TST11-SC-010) | Board is archived |
+| 2 | Navigate to `/workspace/archive` | View loads with "Archived Boards" section |
+| 3 | Verify archived board appears in the list | Board name visible with "board" badge and "Restore Board" button |
+| 4 | Verify entity type filter select is present | Dropdown with "All types", "Boards", "Columns", "Cards" options |
+
+**Evidence:** Screenshot of archive view showing archived board.
+
+---
+
+### TST11-SC-012: Restore Archived Board
+
+**Goal:** Verify restoring an archived board returns it to the default board list.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Archive a board | Board archived |
+| 2 | Navigate to `/workspace/archive` | Archived board visible |
+| 3 | Click "Restore Board" on the archived board (accept confirmation) | Success toast, board removed from archive list |
+| 4 | Navigate to `/workspace/boards` | Restored board appears in board list |
+| 5 | Open restored board | Board state (columns, cards, labels) preserved |
+
+**Evidence:** Screenshots before restore, after restore, and board detail showing preserved state.
+
+---
+
+### TST11-SC-013: Archive Board with Active Cards (State Preservation)
+
+**Goal:** Verify card state is fully preserved through archive/restore cycle.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board with 3 columns, 5 cards across columns, 2 labels applied to cards | Board has rich state |
+| 2 | Record card positions, column assignments, and label bindings | Baseline captured |
+| 3 | Archive the board | Board archived |
+| 4 | Restore the board | Board restored |
+| 5 | `GET /api/boards/{boardId}/cards` | Card positions, column IDs, titles, descriptions, and label bindings match baseline |
+| 6 | `GET /api/boards/{boardId}/columns` | Column names, positions, WIP limits match baseline |
+
+**Evidence:** Before/after JSON comparison of board state.
+
+---
+
+### TST11-SC-014: Archive Recovery via Archive API
+
+**Goal:** Verify the archive recovery endpoint restores entities by type.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | `GET /api/archive/items` | Returns list of archive items (may be empty on fresh DB) |
+| 2 | `GET /api/archive/items?entityType=board` | Filters to board-type archive items only |
+| 3 | If available items exist, `POST /api/archive/{entityType}/{entityId}/restore` with valid body | 200 with restore result showing `success: true` |
+| 4 | Verify restored item no longer appears in `GET /api/archive/items` | Item removed from archive |
+
+**Evidence:** Archive items list and restore response.
+
+---
+
+### TST11-SC-015: Restore Conflict Detection (Name Collision)
+
+**Goal:** Verify archive restore handles name collisions gracefully.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create and archive a board named "Project Alpha" | Board archived |
+| 2 | Create a new board also named "Project Alpha" | Second board exists with same name |
+| 3 | Attempt to restore the archived board | Restore succeeds with name resolution or reports conflict clearly |
+| 4 | Verify no data corruption on either board | Both boards accessible with correct state |
+
+**Evidence:** Restore response and both boards' state.
+
+---
+
+### TST11-SC-016: Cross-User Archive Isolation
+
+**Goal:** Verify users cannot see or restore other users' archived items.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | UserA creates and archives a board | Board archived for UserA |
+| 2 | UserB calls `GET /api/archive/items` | UserA's archived items not visible to UserB |
+| 3 | UserB calls `GET /api/boards?includeArchived=true` | UserA's archived board not in UserB's list |
+| 4 | UserA calls `GET /api/archive/items` | UserA's archived items visible |
+
+**Evidence:** Archive item lists for both users showing isolation.
+
+---
+
+### TST11-SC-017: Archive Unauthorized Access
+
+**Goal:** Verify archive endpoints require authentication.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | `GET /api/archive/items` without bearer token | 401 with `errorCode` and `message` |
+| 2 | `POST /api/archive/board/{entityId}/restore` without bearer token | 401 |
+| 3 | `GET /api/archive/items/{id}` without bearer token | 401 |
+
+**Evidence:** Error response payloads.
+
+---
+
+## Category 3: Activity and Traceability
+
+### TST11-SC-018: View Board-Scoped Activity Timeline
+
+**Goal:** Verify board history shows all mutations within a board.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board, add columns, cards, and labels | Board has mutation history |
+| 2 | `GET /api/audit/boards/{boardId}` | 200 with timeline entries including board creation, column additions, card additions, label additions |
+| 3 | Verify entries have timestamps and action descriptions | Each entry has meaningful `action`, `timestamp`, and `entityType` |
+
+**Evidence:** Audit timeline JSON for the board.
+
+---
+
+### TST11-SC-019: View Entity-Scoped Activity (Card Level)
+
+**Goal:** Verify entity-level audit returns history for a specific card.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a card on a board | Card exists |
+| 2 | Move the card to a different column | Card moved |
+| 3 | `GET /api/audit/entities/card/{cardId}` | Timeline shows card creation and move events |
+| 4 | Verify each entry references the correct entity | `entityType` is "Card", entity ID matches |
+
+**Evidence:** Card-level audit entries showing create and move.
+
+---
+
+### TST11-SC-020: View User-Scoped Activity
+
+**Goal:** Verify user activity timeline shows the current user's actions.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Perform several board mutations (create board, add card, move card) | Actions recorded |
+| 2 | `GET /api/audit/users/me` | 200 with entries for all actions performed by the current user |
+| 3 | Verify entries span multiple boards if applicable | Cross-board user timeline |
+
+**Evidence:** User audit timeline JSON.
+
+---
+
+### TST11-SC-021: Verify Audit Entries for Board Mutations
+
+**Goal:** Verify create, rename, archive, and restore actions all generate audit entries.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a board | Audit entry for board creation |
+| 2 | Rename the board via `PUT /api/boards/{boardId}` | Audit entry for rename |
+| 3 | Archive the board (`PUT` with `isArchived: true`) | Audit entry for archive |
+| 4 | Restore the board (`PUT` with `isArchived: false`) | Audit entry for restore/unarchive |
+| 5 | `GET /api/audit/boards/{boardId}` | All four mutation types present in timeline |
+
+**Evidence:** Audit timeline showing create, rename, archive, restore entries.
+
+---
+
+### TST11-SC-022: Verify Audit Entries for Proposal Operations
+
+**Goal:** Verify approve, reject, and execute actions on proposals generate audit entries.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Create a capture item and triage it to produce a proposal | Proposal created |
+| 2 | Approve the proposal | Audit entry recorded |
+| 3 | Execute (apply) the proposal | Audit entry recorded |
+| 4 | `GET /api/audit/users/me` | Timeline includes proposal approval and execution entries |
+
+**Evidence:** Audit entries for proposal lifecycle.
+
+---
+
+### TST11-SC-023: Activity View Mode Switching
+
+**Goal:** Verify the Activity view supports mode selection between board, entity, and user.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Navigate to `/workspace/activity` | View loads with mode selector (board, entity, user) |
+| 2 | Select "board" mode | Board selector appears; entity fields hidden |
+| 3 | Select a board and click Fetch | Board history timeline displayed |
+| 4 | Switch to "entity" mode | Entity type selector and entity selector appear |
+| 5 | Switch to "user" mode | Selectors simplified to user history fetch |
+
+**Evidence:** Screenshots of each mode state.
+
+---
+
+### TST11-SC-024: Activity Selector Discoverability
+
+**Goal:** Verify activity selectors are discoverable without manual ID entry.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | Navigate to `/workspace/activity` | Activity view loads |
+| 2 | In "board" mode, verify board selector shows board names (not raw IDs) | Dropdown contains readable board names |
+| 3 | In "entity" mode, verify entity type selector lists Board, Column, Card, Label | All entity types available |
+| 4 | After selecting entity type and board context, verify entity selector populates with named options | Entities listed by name, not raw ID |
+| 5 | Verify help callout is visible | "Why do these selectors matter?" callout present |
+
+**Evidence:** Screenshot showing populated selectors and help callout.
+
+---
+
+### TST11-SC-025: Audit Unauthorized Access
+
+**Goal:** Verify audit endpoints require authentication and authorization.
+
+| Step | Action | Expected Outcome |
+|---|---|---|
+| 1 | `GET /api/audit/boards/{boardId}` without bearer token | 401 |
+| 2 | `GET /api/audit/entities/card/{cardId}` without bearer token | 401 |
+| 3 | `GET /api/audit/users/me` without bearer token | 401 |
+| 4 | UserB calls `GET /api/audit/boards/{userA-boardId}` | 403 (no read access to UserA's board) |
+
+**Evidence:** Error response payloads.
+
+---
+
+## Traceability Matrix
+
+| Scenario ID | Manual Checklist Section | API Route | Surface |
+|---|---|---|---|
+| TST11-SC-001 | B.5 | `GET /api/boards/{id}/starter-packs/catalog` | Starter Packs |
+| TST11-SC-002 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-003 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-004 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-005 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-006 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-007 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-008 | B.5 | `POST /api/boards/{id}/starter-packs/apply` | Starter Packs |
+| TST11-SC-009 | B.5 | `POST /api/boards/{id}/starter-packs/validate-manifest` | Starter Packs |
+| TST11-SC-010 | B.3, G | `PUT /api/boards/{id}` | Archive |
+| TST11-SC-011 | G.1 | `/workspace/archive` | Archive |
+| TST11-SC-012 | G.3-4 | `/workspace/archive`, `PUT /api/boards/{id}` | Archive |
+| TST11-SC-013 | G.3-4 | Archive/restore cycle | Archive |
+| TST11-SC-014 | G.1-3 | `GET/POST /api/archive/*` | Archive |
+| TST11-SC-015 | P2.5 | `POST /api/archive/{type}/{id}/restore` | Archive |
+| TST11-SC-016 | P.4, K4 | `GET /api/archive/items` | Archive |
+| TST11-SC-017 | P.4 | `GET /api/archive/items` | Archive |
+| TST11-SC-018 | O.2 | `GET /api/audit/boards/{id}` | Activity |
+| TST11-SC-019 | O.3 | `GET /api/audit/entities/{type}/{id}` | Activity |
+| TST11-SC-020 | O.4 | `GET /api/audit/users/me` | Activity |
+| TST11-SC-021 | O.2 | `GET /api/audit/boards/{id}` | Activity |
+| TST11-SC-022 | O.2-4 | `GET /api/audit/users/me` | Activity |
+| TST11-SC-023 | O.1 | `/workspace/activity` | Activity |
+| TST11-SC-024 | O.1-3 | `/workspace/activity` | Activity |
+| TST11-SC-025 | P (API spot checks) | `GET /api/audit/*` | Activity |

--- a/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
@@ -34,12 +34,27 @@ interface CardDto {
 
 interface AuditEntryDto {
   id: string
-  action: string
+  action: number
   entityType: string
   entityId: string
   timestamp: string
-  [key: string]: unknown
+  userName?: string | null
+  changes?: string | null
+  userId?: string | null
 }
+
+/**
+ * AuditAction enum values from backend Domain/Enums/AuditAction.cs.
+ * The API serializes these as integers (System.Text.Json default).
+ */
+const AuditAction = {
+  Created: 0,
+  Updated: 1,
+  Deleted: 2,
+  Archived: 3,
+  Unarchived: 4,
+  Moved: 5,
+} as const
 
 let auth: AuthResult
 
@@ -146,13 +161,19 @@ test.describe('TST11-SC-018: Board-scoped activity timeline', () => {
     await addCard(request, boardId, colId, 'Audit Card 1')
 
     const history = await getBoardHistory(request, boardId)
-    expect(history.length).toBeGreaterThan(0)
+    // Board creation + column creation + card creation = at least 3 entries
+    expect(history.length).toBeGreaterThanOrEqual(3)
 
     // Entries should have required fields
     for (const entry of history) {
-      expect(entry.action).toBeTruthy()
+      expect(typeof entry.action).toBe('number')
+      expect(entry.action).toBeGreaterThanOrEqual(0)
       expect(entry.timestamp).toBeTruthy()
+      expect(entry.entityType).toBeTruthy()
     }
+
+    // Verify a Created action exists
+    expect(history.some((e) => e.action === AuditAction.Created)).toBeTruthy()
   })
 })
 
@@ -165,10 +186,8 @@ test.describe('TST11-SC-019: Entity-scoped activity (card level)', () => {
     const history = await getEntityHistory(request, 'card', cardId)
     expect(history.length).toBeGreaterThan(0)
 
-    // Should include a creation event
-    const hasCreateAction = history.some((e) =>
-      e.action.toLowerCase().includes('creat') || e.action.toLowerCase().includes('add'),
-    )
+    // Should include a creation event (action === 0 is AuditAction.Created)
+    const hasCreateAction = history.some((e) => e.action === AuditAction.Created)
     expect(hasCreateAction).toBeTruthy()
   })
 })
@@ -208,7 +227,17 @@ test.describe('TST11-SC-021: Audit entries for board mutations', () => {
 
     const history = await getBoardHistory(request, boardId)
     // Should have at least entries for create + rename + archive + restore
-    expect(history.length).toBeGreaterThanOrEqual(1)
+    expect(history.length).toBeGreaterThanOrEqual(4)
+
+    const actionTypes = new Set(history.map((e) => e.action))
+    // Created (0) should be present from board creation
+    expect(actionTypes.has(AuditAction.Created)).toBeTruthy()
+    // Updated (1) should be present from rename
+    expect(actionTypes.has(AuditAction.Updated)).toBeTruthy()
+    // Archived (3) should be present from archive
+    expect(actionTypes.has(AuditAction.Archived)).toBeTruthy()
+    // Unarchived (4) should be present from restore
+    expect(actionTypes.has(AuditAction.Unarchived)).toBeTruthy()
   })
 })
 
@@ -220,12 +249,40 @@ test.describe('TST11-SC-023: Activity view mode switching', () => {
     await page.goto('/workspace/activity')
     await expect(page.getByRole('heading', { name: 'Activity' })).toBeVisible()
 
-    // Verify the view loads with content
-    await expect(page.getByText('Activity')).toBeVisible()
-
     // Verify the hero actions are present
     await expect(page.getByRole('button', { name: 'Open Review' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Open Boards' })).toBeVisible()
+
+    // Locate the mode selector dropdown
+    const modeSelector = page.locator('select[aria-label="Activity view mode"]')
+    await expect(modeSelector).toBeVisible()
+
+    // Verify all three options exist
+    const options = modeSelector.locator('option')
+    await expect(options).toHaveCount(3)
+    await expect(options.nth(0)).toHaveText('Board History')
+    await expect(options.nth(1)).toHaveText('Entity History')
+    await expect(options.nth(2)).toHaveText('User History')
+
+    // Default mode should be 'board'
+    await expect(modeSelector).toHaveValue('board')
+
+    // Switch to 'entity' mode and verify entity-specific controls appear
+    await modeSelector.selectOption('entity')
+    await expect(modeSelector).toHaveValue('entity')
+    const entityTypeSelector = page.locator('select[aria-label="Select entity type"]')
+    await expect(entityTypeSelector).toBeVisible()
+
+    // Switch to 'user' mode and verify user-specific content appears
+    await modeSelector.selectOption('user')
+    await expect(modeSelector).toHaveValue('user')
+    await expect(page.getByText('Current user:')).toBeVisible()
+
+    // Switch back to 'board' mode and verify board selector reappears
+    await modeSelector.selectOption('board')
+    await expect(modeSelector).toHaveValue('board')
+    const boardSelector = page.locator('select[aria-label="Select board"]')
+    await expect(boardSelector).toBeVisible()
   })
 })
 

--- a/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
@@ -249,9 +249,10 @@ test.describe('TST11-SC-023: Activity view mode switching', () => {
     await page.goto('/workspace/activity')
     await expect(page.getByRole('heading', { name: 'Activity' })).toBeVisible()
 
-    // Verify the hero actions are present
-    await expect(page.getByRole('button', { name: 'Open Review' })).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Open Boards' })).toBeVisible()
+    // Verify the hero actions are present (use .first() since the button also
+    // appears inside the WorkspaceHelpCallout actions slot)
+    await expect(page.getByRole('button', { name: 'Open Review' }).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Open Boards' }).first()).toBeVisible()
 
     // Locate the mode selector dropdown
     const modeSelector = page.locator('select[aria-label="Activity view mode"]')

--- a/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
@@ -220,13 +220,6 @@ test.describe('TST11-SC-023: Activity view mode switching', () => {
     await page.goto('/workspace/activity')
     await expect(page.getByRole('heading', { name: 'Activity' })).toBeVisible()
 
-    // Mode selector should exist with board/entity/user options
-    const modeSelector = page.locator('[data-testid="activity-mode-selector"]').or(
-      page.getByRole('combobox').first(),
-    ).or(
-      page.locator('select').first(),
-    )
-
     // Verify the view loads with content
     await expect(page.getByText('Activity')).toBeVisible()
 

--- a/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-activity-traceability.spec.ts
@@ -1,0 +1,287 @@
+/**
+ * TST-11 Slice E: Activity timeline and audit traceability validation.
+ *
+ * Covers board-scoped audit, entity-scoped audit (card level),
+ * user-scoped audit, audit entries for board mutations (create, archive, restore),
+ * activity view mode switching and selector discoverability,
+ * and unauthorized access checks.
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  API_BASE_URL,
+  registerAndAttachSession,
+  registerUserSession,
+  type AuthResult,
+} from './support/authSession'
+
+interface BoardDto {
+  id: string
+  name: string
+}
+
+interface ColumnDto {
+  id: string
+  name: string
+  position: number
+}
+
+interface CardDto {
+  id: string
+  title: string
+  columnId: string
+}
+
+interface AuditEntryDto {
+  id: string
+  action: string
+  entityType: string
+  entityId: string
+  timestamp: string
+  [key: string]: unknown
+}
+
+let auth: AuthResult
+
+test.beforeEach(async ({ page, request }) => {
+  auth = await registerAndAttachSession(page, request, 'activity-val')
+})
+
+async function createBoard(
+  request: import('@playwright/test').APIRequestContext,
+  name: string,
+): Promise<string> {
+  const response = await request.post(`${API_BASE_URL}/boards`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+    data: { name, description: 'Activity validation board' },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const board = (await response.json()) as BoardDto
+  return board.id
+}
+
+async function addColumn(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+  name: string,
+  position: number,
+): Promise<string> {
+  const response = await request.post(
+    `${API_BASE_URL}/boards/${boardId}/columns`,
+    {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { boardId, name, position, wipLimit: null },
+    },
+  )
+
+  expect(response.status()).toBe(201)
+  const column = (await response.json()) as ColumnDto
+  return column.id
+}
+
+async function addCard(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+  columnId: string,
+  title: string,
+): Promise<string> {
+  const response = await request.post(
+    `${API_BASE_URL}/boards/${boardId}/cards`,
+    {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { boardId, columnId, title, description: 'Audit test card', position: 0 },
+    },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  const card = (await response.json()) as CardDto
+  return card.id
+}
+
+async function getBoardHistory(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+  token?: string,
+): Promise<AuditEntryDto[]> {
+  const response = await request.get(
+    `${API_BASE_URL}/audit/boards/${boardId}`,
+    { headers: { Authorization: `Bearer ${token ?? auth.token}` } },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as AuditEntryDto[]
+}
+
+async function getEntityHistory(
+  request: import('@playwright/test').APIRequestContext,
+  entityType: string,
+  entityId: string,
+): Promise<AuditEntryDto[]> {
+  const response = await request.get(
+    `${API_BASE_URL}/audit/entities/${entityType}/${entityId}`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as AuditEntryDto[]
+}
+
+async function getUserHistory(
+  request: import('@playwright/test').APIRequestContext,
+): Promise<AuditEntryDto[]> {
+  const response = await request.get(
+    `${API_BASE_URL}/audit/users/me`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as AuditEntryDto[]
+}
+
+test.describe('TST11-SC-018: Board-scoped activity timeline', () => {
+  test('board history includes creation and child entity mutations', async ({ request }) => {
+    const boardId = await createBoard(request, `Audit Board ${Date.now()}`)
+    const colId = await addColumn(request, boardId, 'Todo', 0)
+    await addCard(request, boardId, colId, 'Audit Card 1')
+
+    const history = await getBoardHistory(request, boardId)
+    expect(history.length).toBeGreaterThan(0)
+
+    // Entries should have required fields
+    for (const entry of history) {
+      expect(entry.action).toBeTruthy()
+      expect(entry.timestamp).toBeTruthy()
+    }
+  })
+})
+
+test.describe('TST11-SC-019: Entity-scoped activity (card level)', () => {
+  test('card history shows creation event', async ({ request }) => {
+    const boardId = await createBoard(request, `Card Audit ${Date.now()}`)
+    const colId = await addColumn(request, boardId, 'Backlog', 0)
+    const cardId = await addCard(request, boardId, colId, 'Traced Card')
+
+    const history = await getEntityHistory(request, 'card', cardId)
+    expect(history.length).toBeGreaterThan(0)
+
+    // Should include a creation event
+    const hasCreateAction = history.some((e) =>
+      e.action.toLowerCase().includes('creat') || e.action.toLowerCase().includes('add'),
+    )
+    expect(hasCreateAction).toBeTruthy()
+  })
+})
+
+test.describe('TST11-SC-020: User-scoped activity', () => {
+  test('user history contains actions from the current session', async ({ request }) => {
+    const boardId = await createBoard(request, `User Audit ${Date.now()}`)
+    await addColumn(request, boardId, 'Backlog', 0)
+
+    const history = await getUserHistory(request)
+    expect(history.length).toBeGreaterThan(0)
+  })
+})
+
+test.describe('TST11-SC-021: Audit entries for board mutations', () => {
+  test('create, rename, archive, and restore all generate audit entries', async ({ request }) => {
+    // Create
+    const boardId = await createBoard(request, `Mutation Audit ${Date.now()}`)
+
+    // Rename
+    await request.put(`${API_BASE_URL}/boards/${boardId}`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { name: `Renamed Mutation Audit ${Date.now()}` },
+    })
+
+    // Archive
+    await request.put(`${API_BASE_URL}/boards/${boardId}`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { isArchived: true },
+    })
+
+    // Restore (unarchive)
+    await request.put(`${API_BASE_URL}/boards/${boardId}`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { isArchived: false },
+    })
+
+    const history = await getBoardHistory(request, boardId)
+    // Should have at least entries for create + rename + archive + restore
+    expect(history.length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+test.describe('TST11-SC-023: Activity view mode switching', () => {
+  test('activity view supports board, entity, and user mode selection', async ({ page, request }) => {
+    // Create a board so there is data to work with
+    await createBoard(request, `Activity Mode ${Date.now()}`)
+
+    await page.goto('/workspace/activity')
+    await expect(page.getByRole('heading', { name: 'Activity' })).toBeVisible()
+
+    // Mode selector should exist with board/entity/user options
+    const modeSelector = page.locator('[data-testid="activity-mode-selector"]').or(
+      page.getByRole('combobox').first(),
+    ).or(
+      page.locator('select').first(),
+    )
+
+    // Verify the view loads with content
+    await expect(page.getByText('Activity')).toBeVisible()
+
+    // Verify the hero actions are present
+    await expect(page.getByRole('button', { name: 'Open Review' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Open Boards' })).toBeVisible()
+  })
+})
+
+test.describe('TST11-SC-024: Activity selector discoverability', () => {
+  test('activity view shows help callout and navigation buttons', async ({ page, request }) => {
+    await createBoard(request, `Activity Discover ${Date.now()}`)
+
+    await page.goto('/workspace/activity')
+    await expect(page.getByRole('heading', { name: 'Activity' })).toBeVisible()
+
+    // Help callout should be visible
+    await expect(page.getByText('Why do these selectors matter?')).toBeVisible()
+
+    // Navigation links
+    await expect(page.getByRole('button', { name: 'Open Review' }).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Open Boards' }).first()).toBeVisible()
+  })
+})
+
+test.describe('TST11-SC-025: Audit unauthorized access', () => {
+  test('audit endpoints return 401 without authentication', async ({ request }) => {
+    const boardResponse = await request.get(
+      `${API_BASE_URL}/audit/boards/00000000-0000-0000-0000-000000000000`,
+    )
+    expect(boardResponse.status()).toBe(401)
+
+    const entityResponse = await request.get(
+      `${API_BASE_URL}/audit/entities/card/00000000-0000-0000-0000-000000000000`,
+    )
+    expect(entityResponse.status()).toBe(401)
+
+    const userResponse = await request.get(`${API_BASE_URL}/audit/users/me`)
+    expect(userResponse.status()).toBe(401)
+  })
+
+  test('cross-user board audit returns 403', async ({ request }) => {
+    // UserA creates a board
+    const boardId = await createBoard(request, `Cross Audit ${Date.now()}`)
+
+    // Register UserB
+    const userB = await registerUserSession(request, 'audit-cross-b')
+
+    // UserB tries to access UserA's board audit
+    const response = await request.get(
+      `${API_BASE_URL}/audit/boards/${boardId}`,
+      { headers: { Authorization: `Bearer ${userB.token}` } },
+    )
+
+    // Should be 403 (forbidden) or 404 (board not found for this user)
+    expect([403, 404]).toContain(response.status())
+  })
+})

--- a/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
@@ -181,6 +181,16 @@ test.describe('TST11-SC-012: Restore archived board', () => {
     // Board should reappear in boards list
     const boards = await listBoards(request)
     expect(boards.some((b) => b.id === boardId)).toBeTruthy()
+
+    // Verify seeded column still exists after restore
+    const columnsResponse = await request.get(
+      `${API_BASE_URL}/boards/${boardId}/columns`,
+      { headers: { Authorization: `Bearer ${auth.token}` } },
+    )
+    expect(columnsResponse.ok()).toBeTruthy()
+    const columns = (await columnsResponse.json()) as Array<{ id: string; name: string }>
+    expect(columns.length).toBeGreaterThanOrEqual(1)
+    expect(columns.some((c) => c.name.startsWith('Todo'))).toBeTruthy()
   })
 })
 
@@ -200,6 +210,14 @@ test.describe('TST11-SC-013: State preservation through archive/restore', () => 
       })
     }
 
+    // Add a label
+    const labelResponse = await request.post(`${API_BASE_URL}/boards/${boardId}/labels`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { boardId, name: 'preserve-test', colorHex: '#10B981' },
+    })
+    expect(labelResponse.ok()).toBeTruthy()
+    const createdLabel = (await labelResponse.json()) as { id: string; name: string }
+
     // Get columns to find IDs
     const columnsResponse = await request.get(`${API_BASE_URL}/boards/${boardId}/columns`, {
       headers: { Authorization: `Bearer ${auth.token}` },
@@ -207,7 +225,7 @@ test.describe('TST11-SC-013: State preservation through archive/restore', () => 
     const columns = (await columnsResponse.json()) as Array<{ id: string; name: string; position: number }>
     const todoCol = columns.find((c) => c.name === 'Todo')!
 
-    // Add a card
+    // Add a card with label
     const cardResponse = await request.post(`${API_BASE_URL}/boards/${boardId}/cards`, {
       headers: { Authorization: `Bearer ${auth.token}` },
       data: {
@@ -216,30 +234,36 @@ test.describe('TST11-SC-013: State preservation through archive/restore', () => 
         title: 'Preserved Card',
         description: 'This card should survive archive/restore.',
         position: 0,
+        labelIds: [createdLabel.id],
       },
     })
     expect(cardResponse.ok()).toBeTruthy()
+    const createdCard = (await cardResponse.json()) as { id: string; title: string; columnId: string; position: number }
 
     // Capture baseline
     const baselineCards = await request.get(`${API_BASE_URL}/boards/${boardId}/cards`, {
       headers: { Authorization: `Bearer ${auth.token}` },
     })
-    const cardsBefore = (await baselineCards.json()) as Array<{ id: string; title: string; columnId: string }>
+    const cardsBefore = (await baselineCards.json()) as Array<{ id: string; title: string; columnId: string; position: number }>
 
     // Archive and restore
     await archiveBoard(request, boardId)
     await unarchiveBoard(request, boardId)
 
-    // Verify state
+    // Verify cards state -- find by ID, not by array index
     const restoredCards = await request.get(`${API_BASE_URL}/boards/${boardId}/cards`, {
       headers: { Authorization: `Bearer ${auth.token}` },
     })
-    const cardsAfter = (await restoredCards.json()) as Array<{ id: string; title: string; columnId: string }>
+    const cardsAfter = (await restoredCards.json()) as Array<{ id: string; title: string; columnId: string; position: number }>
 
     expect(cardsAfter).toHaveLength(cardsBefore.length)
-    expect(cardsAfter[0].title).toBe('Preserved Card')
-    expect(cardsAfter[0].columnId).toBe(cardsBefore[0].columnId)
+    const restoredCard = cardsAfter.find((c) => c.id === createdCard.id)
+    expect(restoredCard).toBeTruthy()
+    expect(restoredCard!.title).toBe('Preserved Card')
+    expect(restoredCard!.columnId).toBe(todoCol.id)
+    expect(restoredCard!.position).toBe(createdCard.position)
 
+    // Verify columns state
     const restoredCols = await request.get(`${API_BASE_URL}/boards/${boardId}/columns`, {
       headers: { Authorization: `Bearer ${auth.token}` },
     })
@@ -248,6 +272,13 @@ test.describe('TST11-SC-013: State preservation through archive/restore', () => 
     expect(columnsAfter.map((c) => `${c.position}:${c.name}`).sort()).toEqual(
       columns.map((c) => `${c.position}:${c.name}`).sort(),
     )
+
+    // Verify labels survived
+    const restoredLabels = await request.get(`${API_BASE_URL}/boards/${boardId}/labels`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    })
+    const labelsAfter = (await restoredLabels.json()) as Array<{ id: string; name: string }>
+    expect(labelsAfter.some((l) => l.name === 'preserve-test')).toBeTruthy()
   })
 })
 

--- a/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
@@ -1,0 +1,309 @@
+/**
+ * TST-11 Slice E: Archive and recovery flow validation.
+ *
+ * Covers board archival, archive workspace viewing, board restoration,
+ * state preservation through archive/restore cycle, archive API endpoint
+ * behavior, cross-user isolation, and unauthorized access checks.
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  API_BASE_URL,
+  registerAndAttachSession,
+  registerUserSession,
+  type AuthResult,
+} from './support/authSession'
+import { createBoardWithColumn } from './support/boardHelpers'
+
+interface BoardDto {
+  id: string
+  name: string
+  isArchived: boolean
+  updatedAt: string
+}
+
+interface ArchiveItemDto {
+  id: string
+  entityType: string
+  entityId: string
+  name: string
+  boardId: string
+  restoreStatus: number | string
+  archivedAt: string
+}
+
+let auth: AuthResult
+
+test.beforeEach(async ({ page, request }) => {
+  auth = await registerAndAttachSession(page, request, 'archive-val')
+})
+
+async function createBoard(
+  request: import('@playwright/test').APIRequestContext,
+  name: string,
+): Promise<string> {
+  const response = await request.post(`${API_BASE_URL}/boards`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+    data: { name, description: 'Archive validation board' },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const board = (await response.json()) as BoardDto
+  return board.id
+}
+
+async function archiveBoard(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+): Promise<void> {
+  const response = await request.put(`${API_BASE_URL}/boards/${boardId}`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+    data: { isArchived: true },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const board = (await response.json()) as BoardDto
+  expect(board.isArchived).toBeTruthy()
+}
+
+async function unarchiveBoard(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+): Promise<void> {
+  const response = await request.put(`${API_BASE_URL}/boards/${boardId}`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+    data: { isArchived: false },
+  })
+
+  expect(response.ok()).toBeTruthy()
+}
+
+async function listBoards(
+  request: import('@playwright/test').APIRequestContext,
+  includeArchived = false,
+): Promise<BoardDto[]> {
+  const url = includeArchived
+    ? `${API_BASE_URL}/boards?includeArchived=true`
+    : `${API_BASE_URL}/boards`
+
+  const response = await request.get(url, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as BoardDto[]
+}
+
+async function getArchiveItems(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  entityType?: string,
+): Promise<ArchiveItemDto[]> {
+  const params = entityType ? `?entityType=${entityType}` : ''
+  const response = await request.get(`${API_BASE_URL}/archive/items${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as ArchiveItemDto[]
+}
+
+test.describe('TST11-SC-010: Archive a board', () => {
+  test('archived board disappears from default board list', async ({ request }) => {
+    const boardName = `Archive Test ${Date.now()}`
+    const boardId = await createBoard(request, boardName)
+
+    // Verify board is in default list
+    const boardsBefore = await listBoards(request)
+    expect(boardsBefore.some((b) => b.id === boardId)).toBeTruthy()
+
+    // Archive the board
+    await archiveBoard(request, boardId)
+
+    // Board should be absent from default list
+    const boardsAfter = await listBoards(request)
+    expect(boardsAfter.some((b) => b.id === boardId)).toBeFalsy()
+
+    // Board should be present when includeArchived=true
+    const boardsWithArchived = await listBoards(request, true)
+    const archivedBoard = boardsWithArchived.find((b) => b.id === boardId)
+    expect(archivedBoard).toBeTruthy()
+    expect(archivedBoard!.isArchived).toBeTruthy()
+  })
+})
+
+test.describe('TST11-SC-011: View archived boards in archive workspace', () => {
+  test('archive view shows archived boards', async ({ page, request }) => {
+    const boardName = `Archive View ${Date.now()}`
+    const boardId = await createBoard(request, boardName)
+    await archiveBoard(request, boardId)
+
+    await page.goto('/workspace/archive')
+    await expect(page.getByRole('heading', { name: 'Archive' })).toBeVisible()
+    await expect(page.getByText('Archived Boards')).toBeVisible()
+
+    // Archived board should appear in the list
+    await expect(page.getByText(boardName)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Restore Board' }).first()).toBeVisible()
+
+    // Entity type filter should be present
+    await expect(page.getByRole('combobox', { name: 'Filter by entity type' })).toBeVisible()
+  })
+})
+
+test.describe('TST11-SC-012: Restore archived board', () => {
+  test('restored board reappears in board list with preserved state', async ({ page, request }) => {
+    const seed = `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
+    const boardId = await createBoardWithColumn(request, auth, seed, {
+      boardNamePrefix: 'Restore Test',
+      description: 'board for restore validation',
+      columnNamePrefix: 'Todo',
+    })
+
+    // Archive the board
+    await archiveBoard(request, boardId)
+
+    // Navigate to archive and restore
+    await page.goto('/workspace/archive')
+    await expect(page.getByRole('heading', { name: 'Archive' })).toBeVisible()
+
+    // Find and click restore for this board
+    const boardRow = page.locator('.td-archive-row').filter({ hasText: `Restore Test ${seed}` })
+    await expect(boardRow).toBeVisible()
+
+    // Accept the confirmation dialog
+    page.once('dialog', (dialog) => dialog.accept())
+    await boardRow.getByRole('button', { name: 'Restore Board' }).click()
+
+    // Verify success toast
+    await expect(page.getByText('Restored board')).toBeVisible()
+
+    // Board should reappear in boards list
+    const boards = await listBoards(request)
+    expect(boards.some((b) => b.id === boardId)).toBeTruthy()
+  })
+})
+
+test.describe('TST11-SC-013: State preservation through archive/restore', () => {
+  test('card positions and labels survive archive/restore cycle', async ({ request }) => {
+    const boardId = await createBoard(request, `State Preserve ${Date.now()}`)
+
+    // Add columns
+    for (const col of [
+      { name: 'Todo', position: 0 },
+      { name: 'Doing', position: 1 },
+      { name: 'Done', position: 2 },
+    ]) {
+      await request.post(`${API_BASE_URL}/boards/${boardId}/columns`, {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { boardId, ...col, wipLimit: null },
+      })
+    }
+
+    // Get columns to find IDs
+    const columnsResponse = await request.get(`${API_BASE_URL}/boards/${boardId}/columns`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    })
+    const columns = (await columnsResponse.json()) as Array<{ id: string; name: string; position: number }>
+    const todoCol = columns.find((c) => c.name === 'Todo')!
+
+    // Add a card
+    const cardResponse = await request.post(`${API_BASE_URL}/boards/${boardId}/cards`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: {
+        boardId,
+        columnId: todoCol.id,
+        title: 'Preserved Card',
+        description: 'This card should survive archive/restore.',
+        position: 0,
+      },
+    })
+    expect(cardResponse.ok()).toBeTruthy()
+
+    // Capture baseline
+    const baselineCards = await request.get(`${API_BASE_URL}/boards/${boardId}/cards`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    })
+    const cardsBefore = (await baselineCards.json()) as Array<{ id: string; title: string; columnId: string }>
+
+    // Archive and restore
+    await archiveBoard(request, boardId)
+    await unarchiveBoard(request, boardId)
+
+    // Verify state
+    const restoredCards = await request.get(`${API_BASE_URL}/boards/${boardId}/cards`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    })
+    const cardsAfter = (await restoredCards.json()) as Array<{ id: string; title: string; columnId: string }>
+
+    expect(cardsAfter).toHaveLength(cardsBefore.length)
+    expect(cardsAfter[0].title).toBe('Preserved Card')
+    expect(cardsAfter[0].columnId).toBe(cardsBefore[0].columnId)
+
+    const restoredCols = await request.get(`${API_BASE_URL}/boards/${boardId}/columns`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    })
+    const columnsAfter = (await restoredCols.json()) as Array<{ name: string; position: number }>
+    expect(columnsAfter).toHaveLength(3)
+    expect(columnsAfter.map((c) => `${c.position}:${c.name}`).sort()).toEqual(
+      columns.map((c) => `${c.position}:${c.name}`).sort(),
+    )
+  })
+})
+
+test.describe('TST11-SC-014: Archive recovery API', () => {
+  test('archive items endpoint returns list and supports entity type filter', async ({ request }) => {
+    // Get all archive items
+    const allItems = await getArchiveItems(request, auth.token)
+    expect(Array.isArray(allItems)).toBeTruthy()
+
+    // Filter by entity type
+    const boardItems = await getArchiveItems(request, auth.token, 'board')
+    expect(Array.isArray(boardItems)).toBeTruthy()
+
+    // All returned items should be board type
+    for (const item of boardItems) {
+      expect(item.entityType.toLowerCase()).toBe('board')
+    }
+  })
+})
+
+test.describe('TST11-SC-016: Cross-user archive isolation', () => {
+  test('users cannot see each other archived boards', async ({ request }) => {
+    // UserA creates and archives a board
+    const boardName = `UserA Private ${Date.now()}`
+    const boardId = await createBoard(request, boardName)
+    await archiveBoard(request, boardId)
+
+    // Register UserB
+    const userB = await registerUserSession(request, 'archive-iso-b')
+
+    // UserB checks archived boards
+    const userBBoards = await request.get(`${API_BASE_URL}/boards?includeArchived=true`, {
+      headers: { Authorization: `Bearer ${userB.token}` },
+    })
+    expect(userBBoards.ok()).toBeTruthy()
+    const userBBoardList = (await userBBoards.json()) as BoardDto[]
+
+    // UserA's archived board should not be visible to UserB
+    expect(userBBoardList.some((b) => b.id === boardId)).toBeFalsy()
+
+    // UserB checks archive items
+    const userBItems = await getArchiveItems(request, userB.token)
+    expect(userBItems.some((i) => i.entityId === boardId)).toBeFalsy()
+  })
+})
+
+test.describe('TST11-SC-017: Archive unauthorized access', () => {
+  test('archive endpoints return 401 without authentication', async ({ request }) => {
+    const itemsResponse = await request.get(`${API_BASE_URL}/archive/items`)
+    expect(itemsResponse.status()).toBe(401)
+
+    // Restore endpoint also requires auth
+    const restoreResponse = await request.post(
+      `${API_BASE_URL}/archive/board/00000000-0000-0000-0000-000000000000/restore`,
+      { data: { targetBoardId: null, restoreMode: 0, conflictStrategy: 0 } },
+    )
+    expect(restoreResponse.status()).toBe(401)
+  })
+})

--- a/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
@@ -140,7 +140,7 @@ test.describe('TST11-SC-011: View archived boards in archive workspace', () => {
 
     await page.goto('/workspace/archive')
     await expect(page.getByRole('heading', { name: 'Archive', exact: true })).toBeVisible()
-    await expect(page.getByText('Archived Boards')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Archived Boards' })).toBeVisible()
 
     // Archived board should appear in the list
     await expect(page.getByText(boardName)).toBeVisible()

--- a/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
@@ -139,7 +139,7 @@ test.describe('TST11-SC-011: View archived boards in archive workspace', () => {
     await archiveBoard(request, boardId)
 
     await page.goto('/workspace/archive')
-    await expect(page.getByRole('heading', { name: 'Archive' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Archive', exact: true })).toBeVisible()
     await expect(page.getByText('Archived Boards')).toBeVisible()
 
     // Archived board should appear in the list
@@ -165,7 +165,7 @@ test.describe('TST11-SC-012: Restore archived board', () => {
 
     // Navigate to archive and restore
     await page.goto('/workspace/archive')
-    await expect(page.getByRole('heading', { name: 'Archive' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Archive', exact: true })).toBeVisible()
 
     // Find and click restore for this board
     const boardRow = page.locator('.td-archive-row').filter({ hasText: `Restore Test ${seed}` })

--- a/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
@@ -195,12 +195,15 @@ test.describe('TST11-SC-002: Dry-run preview without mutation', () => {
     expect(Array.isArray(result.actions)).toBeTruthy()
     expect(result.actions.length).toBeGreaterThan(0)
 
-    // Board should be unchanged
+    // Board should be unchanged -- no columns, labels, or cards created
     const columns = await getColumns(request, boardId)
     expect(columns).toHaveLength(0)
 
     const labels = await getLabels(request, boardId)
     expect(labels).toHaveLength(0)
+
+    const cards = await getCards(request, boardId)
+    expect(cards).toHaveLength(0)
   })
 })
 
@@ -313,9 +316,20 @@ test.describe('TST11-SC-005: Conflict detection with existing content', () => {
       },
     )
 
-    // 409 Conflict or 200 with hasBlockingConflicts
+    // Controller returns 409 Conflict when non-dry-run has blocking conflicts
+    const applyStatus = applyResponse.status()
+    expect([200, 409]).toContain(applyStatus)
+
     const applyResult = await applyResponse.json()
-    expect(applyResult.applied).toBeFalsy()
+    expect(applyResult.applied).toBe(false)
+
+    if (applyStatus === 200) {
+      // If 200, the result must explicitly flag blocking conflicts
+      expect(applyResult.hasBlockingConflicts).toBe(true)
+    }
+    // Either way, conflicts array must be populated
+    expect(Array.isArray(applyResult.conflicts)).toBe(true)
+    expect(applyResult.conflicts.length).toBeGreaterThan(0)
   })
 })
 
@@ -340,13 +354,14 @@ test.describe('TST11-SC-006: Dry-run conflict severity', () => {
     expect(response.ok()).toBeTruthy()
     const result = await response.json()
 
+    expect(result.conflicts.length).toBeGreaterThan(0)
+
     for (const conflict of result.conflicts) {
       expect(conflict.code).toBeTruthy()
       expect(conflict.message).toBeTruthy()
-      // Severity should be present (blocking or warning)
-      if (conflict.severity) {
-        expect(['blocking', 'warning']).toContain(conflict.severity.toLowerCase())
-      }
+      // Severity MUST be present on every conflict (blocking or warning)
+      expect(conflict.severity).toBeTruthy()
+      expect(['blocking', 'warning']).toContain(conflict.severity.toLowerCase())
     }
   })
 })

--- a/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
@@ -435,12 +435,15 @@ test.describe('TST11-SC-008: Multiple packs on same board', () => {
     expect(firstResponse.ok()).toBeTruthy()
     expect((await firstResponse.json()).applied).toBeTruthy()
 
-    // Second manifest with non-overlapping positions
+    // Second manifest adds only labels (no columns) to avoid position
+    // conflicts. Column positions must be contiguous starting at 0 per
+    // schema validation, so a second pack cannot define non-overlapping
+    // column positions. Labels accumulate without conflict.
     const secondManifest = {
       schemaVersion: '1.0',
       packId: 'val-second',
       displayName: 'Validation Second',
-      description: 'Non-overlapping second pack.',
+      description: 'Label-only second pack.',
       compatibility: {
         minTaskdeckVersion: '1.0.0',
         requiredFeatures: ['boards'],
@@ -449,10 +452,7 @@ test.describe('TST11-SC-008: Multiple packs on same board', () => {
       labels: [
         { name: 'feature', color: '#10B981', description: 'Feature work' },
       ],
-      columns: [
-        { name: 'In Progress', position: 2 },
-        { name: 'Review', position: 3 },
-      ],
+      columns: [],
       templates: [],
       seedCards: [],
     }
@@ -468,9 +468,11 @@ test.describe('TST11-SC-008: Multiple packs on same board', () => {
     expect(secondResponse.ok()).toBeTruthy()
     expect((await secondResponse.json()).applied).toBeTruthy()
 
+    // First pack's columns are preserved
     const columns = await getColumns(request, boardId)
-    expect(columns).toHaveLength(4)
+    expect(columns).toHaveLength(2)
 
+    // Labels from both packs accumulated
     const labels = await getLabels(request, boardId)
     expect(labels.map((l) => l.name).sort()).toEqual(['feature', 'urgent'])
   })

--- a/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
@@ -273,9 +273,15 @@ test.describe('TST11-SC-004: Re-apply same pack (idempotency)', () => {
     // Should detect conflicts (columns at same positions already exist)
     expect(dryRunResult.conflicts.length).toBeGreaterThan(0)
 
-    // Board state unchanged
+    // Board state unchanged — verify columns, labels, and cards
     const columnsAfterDryRun = await getColumns(request, boardId)
     expect(columnsAfterDryRun).toHaveLength(columnsAfterFirst.length)
+
+    const labelsAfterDryRun = await getLabels(request, boardId)
+    expect(labelsAfterDryRun).toHaveLength(1) // only 'urgent' from first apply
+
+    const cardsAfterDryRun = await getCards(request, boardId)
+    expect(cardsAfterDryRun).toHaveLength(1) // only seed card from first apply
   })
 })
 
@@ -506,6 +512,6 @@ test.describe('TST11-SC-009: Manifest validation endpoint', () => {
       },
     )
 
-    expect(response.status()).toBeGreaterThanOrEqual(400)
+    expect(response.status()).toBe(400)
   })
 })

--- a/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-starter-packs.spec.ts
@@ -1,0 +1,494 @@
+/**
+ * TST-11 Slice E: Starter pack lifecycle validation.
+ *
+ * Covers catalog browsing, dry-run preview, apply to empty board,
+ * re-apply idempotency (conflict detection), conflict highlighting,
+ * complex manifests with labels/columns/cards, multiple pack application,
+ * and manifest validation.
+ *
+ * All scenarios use the API directly (no UI starter-pack surface yet).
+ */
+
+import { expect, test } from '@playwright/test'
+import {
+  API_BASE_URL,
+  registerUserSession,
+  type AuthResult,
+} from './support/authSession'
+import type { ColumnDto, LabelDto, CardDto } from './support/starterPackFixtures'
+
+interface BoardDto {
+  id: string
+  name: string
+}
+
+let auth: AuthResult
+
+test.beforeEach(async ({ request }) => {
+  auth = await registerUserSession(request, 'starter-pack-val')
+})
+
+async function createBoard(
+  request: import('@playwright/test').APIRequestContext,
+  name: string,
+): Promise<string> {
+  const response = await request.post(`${API_BASE_URL}/boards`, {
+    headers: { Authorization: `Bearer ${auth.token}` },
+    data: { name, description: 'Starter pack validation board' },
+  })
+
+  expect(response.ok()).toBeTruthy()
+  const board = (await response.json()) as BoardDto
+  return board.id
+}
+
+async function getColumns(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+): Promise<ColumnDto[]> {
+  const response = await request.get(
+    `${API_BASE_URL}/boards/${boardId}/columns`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as ColumnDto[]
+}
+
+async function getLabels(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+): Promise<LabelDto[]> {
+  const response = await request.get(
+    `${API_BASE_URL}/boards/${boardId}/labels`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as LabelDto[]
+}
+
+async function getCards(
+  request: import('@playwright/test').APIRequestContext,
+  boardId: string,
+): Promise<CardDto[]> {
+  const response = await request.get(
+    `${API_BASE_URL}/boards/${boardId}/cards`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+
+  expect(response.ok()).toBeTruthy()
+  return (await response.json()) as CardDto[]
+}
+
+const SMALL_MANIFEST = {
+  schemaVersion: '1.0',
+  packId: 'val-small',
+  displayName: 'Validation Small',
+  description: 'Small pack for validation tests.',
+  compatibility: {
+    minTaskdeckVersion: '1.0.0',
+    requiredFeatures: ['boards', 'labels', 'cards'],
+  },
+  tags: ['validation'],
+  labels: [
+    { name: 'urgent', color: '#DC2626', description: 'Urgent items' },
+  ],
+  columns: [
+    { name: 'Backlog', position: 0 },
+    { name: 'Done', position: 1 },
+  ],
+  templates: [],
+  seedCards: [
+    {
+      title: 'Validate: first task',
+      description: 'Seed card for validation.',
+      columnName: 'Backlog',
+      labels: ['urgent'],
+    },
+  ],
+}
+
+const COMPLEX_MANIFEST = {
+  schemaVersion: '1.0',
+  packId: 'val-complex',
+  displayName: 'Validation Complex',
+  description: 'Complex pack for multi-entity validation.',
+  compatibility: {
+    minTaskdeckVersion: '1.0.0',
+    requiredFeatures: ['boards', 'labels', 'cards'],
+  },
+  tags: ['validation', 'complex'],
+  labels: [
+    { name: 'priority-high', color: '#E85D5D', description: 'High priority' },
+    { name: 'bug', color: '#DC2626', description: 'Bug tracking' },
+    { name: 'needs-review', color: '#2563EB', description: 'Review needed' },
+  ],
+  columns: [
+    { name: 'Backlog', position: 0 },
+    { name: 'In Progress', position: 1, wipLimit: 4 },
+    { name: 'Review', position: 2, wipLimit: 2 },
+    { name: 'Done', position: 3 },
+  ],
+  templates: [
+    {
+      templateId: 'bug-template',
+      title: 'Bug Report',
+      description: 'Template for bug reports.',
+      checklist: ['Reproduce', 'Root cause', 'Fix'],
+    },
+  ],
+  seedCards: [
+    {
+      title: 'Val: investigate flaky test',
+      description: 'Flaky test investigation.',
+      columnName: 'Backlog',
+      templateId: 'bug-template',
+      labels: ['bug', 'priority-high'],
+    },
+    {
+      title: 'Val: review release notes',
+      description: 'Pre-release review.',
+      columnName: 'Review',
+      labels: ['needs-review'],
+    },
+    {
+      title: 'Val: harden auth',
+      description: 'Auth hardening task.',
+      columnName: 'In Progress',
+      labels: ['priority-high'],
+    },
+  ],
+}
+
+test.describe('TST11-SC-001: Browse starter pack catalog', () => {
+  test('catalog returns available packs', async ({ request }) => {
+    const boardId = await createBoard(request, `Catalog Browse ${Date.now()}`)
+
+    const response = await request.get(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/catalog`,
+      { headers: { Authorization: `Bearer ${auth.token}` } },
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const catalog = await response.json()
+    expect(Array.isArray(catalog)).toBeTruthy()
+  })
+})
+
+test.describe('TST11-SC-002: Dry-run preview without mutation', () => {
+  test('dry-run previews actions but does not apply', async ({ request }) => {
+    const boardId = await createBoard(request, `DryRun Preview ${Date.now()}`)
+
+    const response = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: true },
+      },
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const result = await response.json()
+    expect(result.dryRun).toBeTruthy()
+    expect(result.applied).toBeFalsy()
+    expect(Array.isArray(result.actions)).toBeTruthy()
+    expect(result.actions.length).toBeGreaterThan(0)
+
+    // Board should be unchanged
+    const columns = await getColumns(request, boardId)
+    expect(columns).toHaveLength(0)
+
+    const labels = await getLabels(request, boardId)
+    expect(labels).toHaveLength(0)
+  })
+})
+
+test.describe('TST11-SC-003: Apply pack to empty board', () => {
+  test('pack applies successfully with columns, labels, and seed cards', async ({ request }) => {
+    const boardId = await createBoard(request, `Apply Empty ${Date.now()}`)
+
+    const response = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: false },
+      },
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const result = await response.json()
+    expect(result.applied).toBeTruthy()
+    expect(result.dryRun).toBeFalsy()
+
+    const columns = await getColumns(request, boardId)
+    expect(columns.map((c) => `${c.position}:${c.name}`)).toEqual([
+      '0:Backlog',
+      '1:Done',
+    ])
+
+    const labels = await getLabels(request, boardId)
+    expect(labels.map((l) => l.name)).toEqual(['urgent'])
+
+    const cards = await getCards(request, boardId)
+    expect(cards.map((c) => c.title)).toEqual(['Validate: first task'])
+    expect(cards[0].labels.map((l) => l.name)).toEqual(['urgent'])
+  })
+})
+
+test.describe('TST11-SC-004: Re-apply same pack (idempotency)', () => {
+  test('re-apply detects conflicts without creating duplicates', async ({ request }) => {
+    const boardId = await createBoard(request, `Reapply ${Date.now()}`)
+
+    // First apply
+    const firstResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: false },
+      },
+    )
+
+    expect(firstResponse.ok()).toBeTruthy()
+    const firstResult = await firstResponse.json()
+    expect(firstResult.applied).toBeTruthy()
+
+    const columnsAfterFirst = await getColumns(request, boardId)
+
+    // Dry-run second apply
+    const dryRunResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: true },
+      },
+    )
+
+    expect(dryRunResponse.ok()).toBeTruthy()
+    const dryRunResult = await dryRunResponse.json()
+    expect(dryRunResult.dryRun).toBeTruthy()
+    // Should detect conflicts (columns at same positions already exist)
+    expect(dryRunResult.conflicts.length).toBeGreaterThan(0)
+
+    // Board state unchanged
+    const columnsAfterDryRun = await getColumns(request, boardId)
+    expect(columnsAfterDryRun).toHaveLength(columnsAfterFirst.length)
+  })
+})
+
+test.describe('TST11-SC-005: Conflict detection with existing content', () => {
+  test('detects column position conflicts on occupied board', async ({ request }) => {
+    const boardId = await createBoard(request, `Conflict ${Date.now()}`)
+
+    // Pre-seed a column at position 0
+    const colResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/columns`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { boardId, name: 'Occupied Lane', position: 0, wipLimit: null },
+      },
+    )
+
+    expect(colResponse.status()).toBe(201)
+
+    // Dry-run with manifest that wants position 0
+    const dryRunResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: true },
+      },
+    )
+
+    expect(dryRunResponse.ok()).toBeTruthy()
+    const dryRunResult = await dryRunResponse.json()
+    expect(dryRunResult.conflicts.some((c: { code: string }) => c.code === 'ColumnPositionConflict')).toBeTruthy()
+
+    // Non-dry-run should not apply due to blocking conflicts
+    const applyResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: false },
+      },
+    )
+
+    // 409 Conflict or 200 with hasBlockingConflicts
+    const applyResult = await applyResponse.json()
+    expect(applyResult.applied).toBeFalsy()
+  })
+})
+
+test.describe('TST11-SC-006: Dry-run conflict severity', () => {
+  test('conflict entries include severity annotation', async ({ request }) => {
+    const boardId = await createBoard(request, `Severity ${Date.now()}`)
+
+    // Pre-seed column at position 0
+    await request.post(`${API_BASE_URL}/boards/${boardId}/columns`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { boardId, name: 'Existing', position: 0, wipLimit: null },
+    })
+
+    const response = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: true },
+      },
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const result = await response.json()
+
+    for (const conflict of result.conflicts) {
+      expect(conflict.code).toBeTruthy()
+      expect(conflict.message).toBeTruthy()
+      // Severity should be present (blocking or warning)
+      if (conflict.severity) {
+        expect(['blocking', 'warning']).toContain(conflict.severity.toLowerCase())
+      }
+    }
+  })
+})
+
+test.describe('TST11-SC-007: Complex manifest with all entity types', () => {
+  test('applies labels, columns with WIP limits, templates, and seed cards', async ({ request }) => {
+    const boardId = await createBoard(request, `Complex ${Date.now()}`)
+
+    const response = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: COMPLEX_MANIFEST, dryRun: false },
+      },
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const result = await response.json()
+    expect(result.applied).toBeTruthy()
+
+    const columns = await getColumns(request, boardId)
+    expect(columns.map((c) => `${c.position}:${c.name}`)).toEqual([
+      '0:Backlog',
+      '1:In Progress',
+      '2:Review',
+      '3:Done',
+    ])
+
+    // Verify WIP limits
+    const inProgressCol = columns.find((c) => c.name === 'In Progress')
+    expect(inProgressCol?.wipLimit).toBe(4)
+    const reviewCol = columns.find((c) => c.name === 'Review')
+    expect(reviewCol?.wipLimit).toBe(2)
+
+    const labels = await getLabels(request, boardId)
+    expect(labels.map((l) => l.name).sort()).toEqual([
+      'bug',
+      'needs-review',
+      'priority-high',
+    ])
+
+    const cards = await getCards(request, boardId)
+    expect(cards).toHaveLength(3)
+
+    const columnNameById = new Map(columns.map((c) => [c.id, c.name]))
+    const cardPlacements = cards
+      .map((c) => `${c.title}@${columnNameById.get(c.columnId)}`)
+      .sort()
+
+    expect(cardPlacements).toEqual([
+      'Val: harden auth@In Progress',
+      'Val: investigate flaky test@Backlog',
+      'Val: review release notes@Review',
+    ])
+  })
+})
+
+test.describe('TST11-SC-008: Multiple packs on same board', () => {
+  test('sequential non-overlapping packs accumulate content', async ({ request }) => {
+    const boardId = await createBoard(request, `MultiPack ${Date.now()}`)
+
+    // Apply small manifest (positions 0, 1)
+    const firstResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: SMALL_MANIFEST, dryRun: false },
+      },
+    )
+
+    expect(firstResponse.ok()).toBeTruthy()
+    expect((await firstResponse.json()).applied).toBeTruthy()
+
+    // Second manifest with non-overlapping positions
+    const secondManifest = {
+      schemaVersion: '1.0',
+      packId: 'val-second',
+      displayName: 'Validation Second',
+      description: 'Non-overlapping second pack.',
+      compatibility: {
+        minTaskdeckVersion: '1.0.0',
+        requiredFeatures: ['boards'],
+      },
+      tags: ['validation'],
+      labels: [
+        { name: 'feature', color: '#10B981', description: 'Feature work' },
+      ],
+      columns: [
+        { name: 'In Progress', position: 2 },
+        { name: 'Review', position: 3 },
+      ],
+      templates: [],
+      seedCards: [],
+    }
+
+    const secondResponse = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/apply`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifest: secondManifest, dryRun: false },
+      },
+    )
+
+    expect(secondResponse.ok()).toBeTruthy()
+    expect((await secondResponse.json()).applied).toBeTruthy()
+
+    const columns = await getColumns(request, boardId)
+    expect(columns).toHaveLength(4)
+
+    const labels = await getLabels(request, boardId)
+    expect(labels.map((l) => l.name).sort()).toEqual(['feature', 'urgent'])
+  })
+})
+
+test.describe('TST11-SC-009: Manifest validation endpoint', () => {
+  test('validates correct manifest as valid', async ({ request }) => {
+    const boardId = await createBoard(request, `ManifestVal ${Date.now()}`)
+
+    const response = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/validate-manifest`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: { manifestJson: JSON.stringify(SMALL_MANIFEST) },
+      },
+    )
+
+    expect(response.ok()).toBeTruthy()
+    const result = await response.json()
+    expect(result.isValid).toBeTruthy()
+  })
+
+  test('rejects empty body with validation error', async ({ request }) => {
+    const boardId = await createBoard(request, `ManifestEmpty ${Date.now()}`)
+
+    const response = await request.post(
+      `${API_BASE_URL}/boards/${boardId}/starter-packs/validate-manifest`,
+      {
+        headers: { Authorization: `Bearer ${auth.token}` },
+        data: {},
+      },
+    )
+
+    expect(response.status()).toBeGreaterThanOrEqual(400)
+  })
+})


### PR DESCRIPTION
## Summary
- Add scripted scenario catalog for starter pack lifecycle, archive/restore flows, and activity audit traceability (25 numbered scenarios TST11-SC-001 through TST11-SC-025)
- Add Playwright E2E tests for starter packs, archive recovery, and activity timeline
- Add manual rehearsal runbook with curl-based evidence capture instructions

Closes #134

## Test plan
- [ ] Playwright E2E tests pass
- [ ] Scenario catalog covers starter packs, archive, and activity categories
- [ ] Rehearsal runbook is actionable with step-by-step curl commands