### PR TITLE
docs: SEC-28 SECURITY.md vulnerability disclosure policy (#853)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ We are looking for developers and small-team leads who manage their own boards a
 - Keep PRs scoped and include verification evidence.
 - For contribution guidance and repo rules, see `AGENTS.md`.
 
+## Security
+
+Found a vulnerability? Please report it privately — see [SECURITY.md](SECURITY.md) for our responsible-disclosure policy, supported-version scope, and response timeline. Do not open a public issue or discussion for suspected security issues.
+
 ## License
 
 Taskdeck is released under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,13 +4,13 @@ Taskdeck is a local-first execution workspace in active pre-1.0 development. We 
 
 ## Supported Versions
 
-Taskdeck has not yet shipped a stable release. The only supported version for security fixes is the latest commit on the `main` branch. Forks, archived branches, and prerelease builds are not supported.
+Taskdeck has not yet shipped a stable release. The latest commit on the `main` branch is the only version guaranteed to receive security fixes. The latest tagged pre-1.0 release may be reviewed on a best-effort basis, but support for that tag is not guaranteed. Older tags, forks, archived branches, and other prerelease builds are not supported.
 
 | Version | Supported |
 |---------|-----------|
-| Latest `main`           | Yes |
-| Tagged pre-1.0 releases | Best-effort (latest tag only) |
-| Older tags or forks     | No  |
+| Latest `main`                 | Yes (guaranteed) |
+| Latest tagged pre-1.0 release | Best-effort only (not guaranteed) |
+| Older tags, forks, archived branches, other prerelease builds | No |
 
 Once a 1.0 release ships, this table will be updated to reflect a formal supported-version window.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ Out of scope:
 
 - We do **not** currently run a paid bug bounty program.
 - We cannot guarantee 24/7 response times. Taskdeck is maintained by a small team.
-- We do not provide CVE assignment directly; we will coordinate with GitHub Security Advisories and, where appropriate, MITRE.
+- We do not assign CVEs directly. Where appropriate, we will request a CVE through GitHub Security Advisories (GitHub is a CVE Numbering Authority).
 
 ## Safe Harbor
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security Policy
+
+Taskdeck is a local-first execution workspace in active pre-1.0 development. We take security reports seriously and appreciate responsible disclosure from the community.
+
+## Supported Versions
+
+Taskdeck has not yet shipped a stable release. The only supported version for security fixes is the latest commit on the `main` branch. Forks, archived branches, and prerelease builds are not supported.
+
+| Version | Supported |
+|---------|-----------|
+| Latest `main`           | Yes |
+| Tagged pre-1.0 releases | Best-effort (latest tag only) |
+| Older tags or forks     | No  |
+
+Once a 1.0 release ships, this table will be updated to reflect a formal supported-version window.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately. Do **not** open a public GitHub issue, discussion, or pull request that describes the vulnerability.
+
+Preferred channels, in order:
+
+1. **GitHub private vulnerability reporting** — use the [Report a vulnerability](https://github.com/Chris0Jeky/Taskdeck/security/advisories/new) button on the repository Security tab. This is the fastest path and is monitored by the maintainers.
+2. **Email** — `security@taskdeck.dev` (placeholder address; see note below). If you do not receive an acknowledgment within the timeline below, please fall back to the GitHub private advisory channel above.
+
+> Note: `security@taskdeck.dev` is a placeholder while the `taskdeck.dev` domain is being secured. Until this note is removed, GitHub private vulnerability reporting is the authoritative channel.
+
+When reporting, please include:
+
+- A description of the issue and its potential impact
+- Steps to reproduce (proof-of-concept code, affected endpoint, request payload, etc.)
+- The commit SHA or build you tested against
+- Any suggested mitigation, if known
+
+## Response Timeline
+
+These targets are best-effort for a pre-1.0 project maintained by a small team.
+
+| Stage              | Target                                 |
+|--------------------|----------------------------------------|
+| Acknowledgment     | Within 48 hours of receipt             |
+| Initial assessment | Within 7 calendar days of acknowledgment |
+| Fix or mitigation  | Prioritized by severity; no fixed SLA  |
+| Public disclosure  | Coordinated with the reporter once a fix or mitigation is available |
+
+We will keep the reporter informed of progress and credit you in the advisory unless you prefer to remain anonymous.
+
+## Scope
+
+In scope:
+
+- Source code under this repository (backend, frontend, CLI, scripts)
+- Official container images built from `deploy/`
+- Default configuration and documented deployment guidance
+
+Out of scope:
+
+- Social engineering of maintainers, contributors, or users
+- Physical attacks against developer hardware
+- Denial-of-service findings that require sustained traffic or resource exhaustion without a novel amplification vector
+- Vulnerabilities in third-party services Taskdeck integrates with (report those to the upstream vendor)
+- Issues that require an already-compromised host, root access, or a malicious OS-level user
+- Missing security-hardening best practices without a demonstrated exploit (for example, lack of a specific header on a non-sensitive endpoint)
+- Automated scanner output without a working proof-of-concept
+
+## What We Do Not Offer
+
+- We do **not** currently run a paid bug bounty program.
+- We cannot guarantee 24/7 response times. Taskdeck is maintained by a small team.
+- We do not provide CVE assignment directly; we will coordinate with GitHub Security Advisories and, where appropriate, MITRE.
+
+## Safe Harbor
+
+We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to avoid privacy violations, data destruction, and service disruption
+- Only interact with systems and accounts they own or have explicit permission to test
+- Give us reasonable time to respond before any public disclosure
+- Do not exploit findings beyond what is necessary to demonstrate the vulnerability
+
+## Related Documents
+
+- [`docs/security/SECURITY_OWASP_BASELINE.md`](docs/security/SECURITY_OWASP_BASELINE.md) — baseline hardening posture
+- [`docs/security/SECURITY_DEPENDENCY_VULNERABILITY_POLICY.md`](docs/security/SECURITY_DEPENDENCY_VULNERABILITY_POLICY.md) — dependency vulnerability management policy
+- [`docs/security/SECRETS_MANAGEMENT_BASELINE.md`](docs/security/SECRETS_MANAGEMENT_BASELINE.md) — secrets handling

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,11 +22,9 @@ Preferred channel:
 
 - **GitHub private vulnerability reporting** — use the [Report a vulnerability](https://github.com/Chris0Jeky/Taskdeck/security/advisories/new) button on the repository Security tab. This is the authoritative channel, is encrypted in transit and at rest, and is the only path we actively monitor today.
 
-Fallback channel (best-effort):
+Fallback channel (not yet active):
 
-- **Email** — `security@taskdeck.dev` (placeholder address; see note below).
-
-> Note: `security@taskdeck.dev` is a placeholder while the `taskdeck.dev` domain is being secured, and this inbox may not be actively monitored. Please prefer the GitHub private advisory channel above. This note will be removed once a monitored email address is available.
+- **Email** — `security@taskdeck.dev` is reserved for future use but **is not yet monitored**. Do not use it for time-sensitive reports. Until this address is announced as live in this document, please use GitHub private vulnerability reporting instead. This section will be updated when the mailbox is active.
 
 We do not currently publish a PGP key. If your report includes sensitive payloads, GitHub's private advisory channel is sufficient (TLS in transit, encrypted at rest); use pseudonymized data if you are uncomfortable sharing raw captures.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,12 +18,17 @@ Once a 1.0 release ships, this table will be updated to reflect a formal support
 
 Please report suspected vulnerabilities privately. Do **not** open a public GitHub issue, discussion, or pull request that describes the vulnerability.
 
-Preferred channels, in order:
+Preferred channel:
 
-1. **GitHub private vulnerability reporting** — use the [Report a vulnerability](https://github.com/Chris0Jeky/Taskdeck/security/advisories/new) button on the repository Security tab. This is the fastest path and is monitored by the maintainers.
-2. **Email** — `security@taskdeck.dev` (placeholder address; see note below). If you do not receive an acknowledgment within the timeline below, please fall back to the GitHub private advisory channel above.
+- **GitHub private vulnerability reporting** — use the [Report a vulnerability](https://github.com/Chris0Jeky/Taskdeck/security/advisories/new) button on the repository Security tab. This is the authoritative channel, is encrypted in transit and at rest, and is the only path we actively monitor today.
 
-> Note: `security@taskdeck.dev` is a placeholder while the `taskdeck.dev` domain is being secured. Until this note is removed, GitHub private vulnerability reporting is the authoritative channel.
+Fallback channel (best-effort):
+
+- **Email** — `security@taskdeck.dev` (placeholder address; see note below).
+
+> Note: `security@taskdeck.dev` is a placeholder while the `taskdeck.dev` domain is being secured, and this inbox may not be actively monitored. Please prefer the GitHub private advisory channel above. This note will be removed once a monitored email address is available.
+
+We do not currently publish a PGP key. If your report includes sensitive payloads, GitHub's private advisory channel is sufficient (TLS in transit, encrypted at rest); use pseudonymized data if you are uncomfortable sharing raw captures.
 
 When reporting, please include:
 


### PR DESCRIPTION
## Summary
- Add SECURITY.md at repo root with responsible-disclosure contact (GitHub private advisory + placeholder email), 48h acknowledgment target, supported-version scope (pre-1.0: latest main), in-scope/out-of-scope items, and safe-harbor language
- Cross-link from README.md with a concise Security section

Closes #853

## Test plan
- [ ] SECURITY.md renders correctly on GitHub
- [ ] README link resolves
- [ ] GitHub surfaces the "Report a vulnerability" private advisory path (via repository Security tab)