### PR TITLE
perf: PERF-10 add composite indexes for AuditLog, LlmRequest, Card (#846)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260416161303_AddPerfIndexes.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260416161303_AddPerfIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Taskdeck.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Taskdeck.Infrastructure.Persistence;
 namespace Taskdeck.Infrastructure.Migrations
 {
     [DbContext(typeof(TaskdeckDbContext))]
-    partial class TaskdeckDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260416161303_AddPerfIndexes")]
+    partial class AddPerfIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.25");

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260416161303_AddPerfIndexes.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260416161303_AddPerfIndexes.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Taskdeck.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPerfIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Cards_BoardId",
+                table: "Cards");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cards_BoardId_ColumnId",
+                table: "Cards",
+                columns: new[] { "BoardId", "ColumnId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_EntityId_Timestamp",
+                table: "AuditLogs",
+                columns: new[] { "EntityId", "Timestamp" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditLogs_UserId_Timestamp",
+                table: "AuditLogs",
+                columns: new[] { "UserId", "Timestamp" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Cards_BoardId_ColumnId",
+                table: "Cards");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLogs_EntityId_Timestamp",
+                table: "AuditLogs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AuditLogs_UserId_Timestamp",
+                table: "AuditLogs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cards_BoardId",
+                table: "Cards",
+                column: "BoardId");
+        }
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/AuditLogConfiguration.cs
@@ -47,5 +47,18 @@ public class AuditLogConfiguration : IEntityTypeConfiguration<AuditLog>
         builder.HasIndex(al => new { al.EntityType, al.EntityId });
         builder.HasIndex(al => al.Timestamp);
         builder.HasIndex(al => al.UserId);
+
+        // PERF-10: composite indexes for common history/audit queries.
+        // (UserId, Timestamp) accelerates per-user audit reads ordered by recency
+        // (AuditLogRepository.GetByUserAsync).
+        builder.HasIndex(al => new { al.UserId, al.Timestamp })
+            .HasDatabaseName("IX_AuditLogs_UserId_Timestamp");
+
+        // Note: AuditLog has no BoardId column; board scope is resolved via
+        // EntityId (see AuditLogRepository.GetByBoardAsync). A composite on
+        // (EntityId, Timestamp) accelerates that ORDER BY Timestamp DESC pattern
+        // and serves as the board-scoped analogue named for in PERF-10.
+        builder.HasIndex(al => new { al.EntityId, al.Timestamp })
+            .HasDatabaseName("IX_AuditLogs_EntityId_Timestamp");
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/CardConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/CardConfiguration.cs
@@ -44,5 +44,13 @@ public class CardConfiguration : IEntityTypeConfiguration<Card>
             .WithOne(cl => cl.Card)
             .HasForeignKey(cl => cl.CardId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        // PERF-10: composite index for board+column lookups (the default board
+        // load path filters by BoardId and then groups by ColumnId). SQLite can
+        // satisfy single-column filters on BoardId from this composite too, but
+        // we retain the existing IX_Cards_BoardId / IX_Cards_ColumnId indexes to
+        // avoid changing FK index conventions.
+        builder.HasIndex(c => new { c.BoardId, c.ColumnId })
+            .HasDatabaseName("IX_Cards_BoardId_ColumnId");
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/CardConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/CardConfiguration.cs
@@ -47,9 +47,11 @@ public class CardConfiguration : IEntityTypeConfiguration<Card>
 
         // PERF-10: composite index for board+column lookups (the default board
         // load path filters by BoardId and then groups by ColumnId). SQLite can
-        // satisfy single-column filters on BoardId from this composite too, but
-        // we retain the existing IX_Cards_BoardId / IX_Cards_ColumnId indexes to
-        // avoid changing FK index conventions.
+        // also satisfy single-column filters on BoardId from the leftmost prefix
+        // of this composite index, so the redundant single-column IX_Cards_BoardId
+        // is dropped by the AddPerfIndexes migration. The FK on Cards.BoardId is
+        // still enforced by SQLite via the FOREIGN KEY constraint itself (not the
+        // index), and IX_Cards_ColumnId remains unchanged as an FK convention index.
         builder.HasIndex(c => new { c.BoardId, c.ColumnId })
             .HasDatabaseName("IX_Cards_BoardId_ColumnId");
     }


### PR DESCRIPTION
## Summary

Adds composite indexes via EF Core migration (`20260416161303_AddPerfIndexes`):

- `IX_Cards_BoardId_ColumnId` on `Cards (BoardId, ColumnId)` — replaces the single-column `IX_Cards_BoardId`, which SQLite can satisfy via the leftmost prefix of the composite. The `FK_Cards_Boards_BoardId` constraint remains enforced by the FOREIGN KEY schema itself (not the index). `IX_Cards_ColumnId` is retained.
- `IX_AuditLogs_UserId_Timestamp` on `AuditLogs (UserId, Timestamp)` — accelerates `AuditLogRepository.GetByUserAsync` (filters by `UserId` and orders by `Timestamp DESC`).
- `IX_AuditLogs_EntityId_Timestamp` on `AuditLogs (EntityId, Timestamp)` — accelerates `AuditLogRepository.GetByBoardAsync`.

## Deviations from the issue AC

- **AuditLog `(BoardId, Timestamp)` → `(EntityId, Timestamp)`**: `AuditLog` has no `BoardId` column; board scope is resolved polymorphically via `EntityId`. The composite on `(EntityId, Timestamp)` is the functional analogue and serves the same query path. Adding a literal `BoardId` column was out of scope for PERF-10.
- **`IX_LlmRequests_UserId_Status` not created**: Already present pre-PR (see `LlmRequestConfiguration.cs:59`, `builder.HasIndex(lr => new { lr.UserId, lr.Status })`). Re-declaring would create a duplicate `IX_LlmRequests_UserId_Status1`.

## Ordering semantics (SQLite + EF Core 8)

Descending-timestamp ordering on an index requires EF Core 9 (`IsDescending()`), which the repo does not use. The indexes are declared unordered; SQLite's query planner performs a backward range scan for `ORDER BY Timestamp DESC` over the composite, which is acceptable for local-first SQLite workloads.

## Snapshot drift picked up

The regenerated snapshot also records `IsConcurrencyToken()` on `AutomationProposal.UpdatedAt`, which was already declared in the entity configuration (main commit `9f7dc936`) but absent from the previous snapshot. This is a model-only annotation (no schema change on SQLite); no `AlterColumn` is required.

Closes #846

## Test plan

- [x] Backend unit + integration suites pass (Integration: 20/20, Architecture: 8/8, Api migration subset: 14/14)
- [x] Migration applies cleanly to a fresh SQLite DB (covered by Integration tests)
- [x] Snapshot stays in sync with entity configurations