### PR TITLE
ops: OPS-29 Docker container hardening (#866)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -44,8 +44,8 @@ services:
     expose:
       - "8080"
     init: true
-    mem_limit: 512m
-    mem_reservation: 256m
+    mem_limit: 512M
+    mem_reservation: 256M
     cpus: 1.0
     security_opt:
       - no-new-privileges:true
@@ -70,8 +70,8 @@ services:
     expose:
       - "8080"
     init: true
-    mem_limit: 128m
-    mem_reservation: 64m
+    mem_limit: 128M
+    mem_reservation: 64M
     cpus: 0.5
     security_opt:
       - no-new-privileges:true
@@ -87,7 +87,10 @@ services:
 
   proxy:
     profiles: ["baseline"]
-    image: nginx:1.27-alpine
+    # Unprivileged base: runs as UID 101, listens on 8080 natively. This keeps
+    # the reverse proxy out of the last-root-container bucket so the whole
+    # baseline stack runs non-root end to end.
+    image: nginxinc/nginx-unprivileged:1.27-alpine
     depends_on:
       - api
       - web
@@ -96,8 +99,8 @@ services:
     volumes:
       - ./nginx/reverse-proxy.conf:/etc/nginx/conf.d/default.conf:ro
     init: true
-    mem_limit: 128m
-    mem_reservation: 64m
+    mem_limit: 128M
+    mem_reservation: 64M
     cpus: 0.5
     security_opt:
       - no-new-privileges:true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,23 @@
 name: taskdeck
 
+# Hardening notes (OPS-29):
+#   - `mem_limit` / `cpus` are applied by `docker compose up` in non-swarm mode.
+#   - `deploy.resources.limits` is honoured by swarm and by `docker compose
+#     --compatibility`. We keep both so limits apply regardless of how the
+#     stack is launched.
+#   - `logging` caps per-container log disk usage. Without this, json-file logs
+#     grow without bound on long-running hosts.
+#   - `init: true` runs `tini` as PID 1 so SIGTERM/SIGINT are forwarded to the
+#     app process even when the entrypoint is not a shell.
+#   - `security_opt: no-new-privileges` is defence-in-depth; it blocks the
+#     process (and children) from gaining privileges via setuid binaries.
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   api:
     profiles: ["baseline"]
@@ -25,6 +43,20 @@ services:
       - taskdeck-db:/app/data
     expose:
       - "8080"
+    init: true
+    mem_limit: 512m
+    mem_reservation: 256m
+    cpus: 1.0
+    security_opt:
+      - no-new-privileges:true
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+        reservations:
+          memory: 256M
     restart: unless-stopped
 
   web:
@@ -37,6 +69,20 @@ services:
         VITE_API_BASE_URL: ${TASKDECK_VITE_API_BASE_URL:-/api}
     expose:
       - "8080"
+    init: true
+    mem_limit: 128m
+    mem_reservation: 64m
+    cpus: 0.5
+    security_opt:
+      - no-new-privileges:true
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 128M
+        reservations:
+          memory: 64M
     restart: unless-stopped
 
   proxy:
@@ -49,6 +95,20 @@ services:
       - "${TASKDECK_PROXY_PORT:-8080}:8080"
     volumes:
       - ./nginx/reverse-proxy.conf:/etc/nginx/conf.d/default.conf:ro
+    init: true
+    mem_limit: 128m
+    mem_reservation: 64m
+    cpus: 0.5
+    security_opt:
+      - no-new-privileges:true
+    logging: *default-logging
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 128M
+        reservations:
+          memory: 64M
     restart: unless-stopped
 
 volumes:

--- a/deploy/docker/.gitattributes
+++ b/deploy/docker/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/deploy/docker/backend-entrypoint.sh
+++ b/deploy/docker/backend-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Backend container entrypoint.
+#
+# Why this script exists:
+#   - We want the API to run as non-root (appuser UID/GID 10001) for defence in
+#     depth. Dockerfile USER alone is not enough when an existing named volume
+#     was created by a prior image that ran as root: the on-disk files inside
+#     the volume retain root ownership and the new non-root process cannot
+#     write them. That would leave /health/ready permanently failing after an
+#     upgrade.
+#   - To make upgrades safe, we briefly start as root, chown the mounted data
+#     directory to appuser, then drop privileges via setpriv before execing
+#     the .NET app. setpriv is part of util-linux which is already present in
+#     mcr.microsoft.com/dotnet/aspnet:8.0 (Debian 12).
+#
+# If the container is launched with --user appuser (or via some other mechanism
+# that strips CAP_CHOWN), the chown is best-effort and the script still execs
+# the app under the current uid so we never fail closed on a misconfiguration
+# that is merely restrictive.
+
+set -eu
+
+DATA_DIR="${TASKDECK_DATA_DIR:-/app/data}"
+APP_UID="${TASKDECK_APP_UID:-10001}"
+APP_GID="${TASKDECK_APP_GID:-10001}"
+
+if [ "$(id -u)" = "0" ]; then
+    # Ensure the data directory exists and is writable by the app user. This
+    # covers fresh volumes and upgrades from previous root-owned volumes.
+    mkdir -p "$DATA_DIR"
+    chown -R "$APP_UID:$APP_GID" "$DATA_DIR" || echo "warning: chown $DATA_DIR failed; continuing" >&2
+    exec setpriv --reuid="$APP_UID" --regid="$APP_GID" --clear-groups -- "$@"
+fi
+
+# Already running as non-root (e.g. operator passed --user). Just exec.
+exec "$@"

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -11,26 +11,36 @@ WORKDIR /app
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
 
-# Install curl for HEALTHCHECK probes. aspnet:8.0 is Debian-based and has no HTTP client by default.
-# Keep the layer lean: update, install, clean apt cache in one RUN.
+# Install curl for HEALTHCHECK probes. aspnet:8.0 is Debian-based and has no
+# HTTP client by default. util-linux (for setpriv) is already in the base
+# image so we do not install it. Keep the layer lean: update, install, clean
+# apt cache in one RUN.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /app/publish ./
-
-# Non-root user (UID/GID > 10000 per hardening guidance). Owns /app so the
-# runtime can read published assets and write to the /app/data SQLite volume.
+# Non-root user (UID/GID > 10000 per hardening guidance). Created before COPY
+# so we can write published assets with correct ownership in a single layer
+# instead of chown-ing them post-copy (which duplicates the files across
+# image layers and inflates the image size).
 RUN groupadd --system --gid 10001 appuser \
     && useradd --system --uid 10001 --gid 10001 --home-dir /app --shell /usr/sbin/nologin appuser \
     && mkdir -p /app/data \
-    && chown -R appuser:appuser /app
+    && chown appuser:appuser /app /app/data
+
+COPY --from=build --chown=appuser:appuser /app/publish ./
+
+# Entrypoint handles upgrade-time volume ownership and drops to appuser via
+# setpriv. We keep the container starting as root so the entrypoint can chown
+# /app/data on upgrade from images that ran as root; the app itself still runs
+# unprivileged. security_opt: no-new-privileges (set in compose) prevents any
+# later escalation.
+COPY deploy/docker/backend-entrypoint.sh /usr/local/bin/taskdeck-entrypoint
+RUN chmod +x /usr/local/bin/taskdeck-entrypoint
 
 EXPOSE 8080
-
-USER appuser
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD curl -fsS http://localhost:8080/health/ready || exit 1
 
-ENTRYPOINT ["dotnet", "Taskdeck.Api.dll"]
+ENTRYPOINT ["/usr/local/bin/taskdeck-entrypoint", "dotnet", "Taskdeck.Api.dll"]

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -11,8 +11,26 @@ WORKDIR /app
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
 
+# Install curl for HEALTHCHECK probes. aspnet:8.0 is Debian-based and has no HTTP client by default.
+# Keep the layer lean: update, install, clean apt cache in one RUN.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/publish ./
 
+# Non-root user (UID/GID > 10000 per hardening guidance). Owns /app so the
+# runtime can read published assets and write to the /app/data SQLite volume.
+RUN groupadd --system --gid 10001 appuser \
+    && useradd --system --uid 10001 --gid 10001 --home-dir /app --shell /usr/sbin/nologin appuser \
+    && mkdir -p /app/data \
+    && chown -R appuser:appuser /app
+
 EXPOSE 8080
+
+USER appuser
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:8080/health/ready || exit 1
 
 ENTRYPOINT ["dotnet", "Taskdeck.Api.dll"]

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -11,10 +11,19 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 RUN npm run build
 
-FROM nginx:1.27-alpine AS runtime
+# nginx-unprivileged runs as UID 101 (nginx) and listens on 8080 by default,
+# so we avoid needing root to bind port 80 or CAP_NET_BIND_SERVICE. This
+# matches our frontend.conf which already declares `listen 8080;`.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 WORKDIR /usr/share/nginx/html
 
-COPY deploy/nginx/frontend.conf /etc/nginx/conf.d/default.conf
-COPY --from=build /app/dist ./
+# The base image installs wget via busybox, so the HEALTHCHECK below has a
+# lightweight HTTP client without extra apk installs. We only need the
+# config file override and the built static assets.
+COPY --chown=nginx:nginx deploy/nginx/frontend.conf /etc/nginx/conf.d/default.conf
+COPY --from=build --chown=nginx:nginx /app/dist ./
 
 EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget --spider -q http://localhost:8080/healthz || exit 1

--- a/deploy/docker/frontend.Dockerfile
+++ b/deploy/docker/frontend.Dockerfile
@@ -25,5 +25,9 @@ COPY --from=build --chown=nginx:nginx /app/dist ./
 
 EXPOSE 8080
 
+# NOTE: use 127.0.0.1 rather than `localhost`. Inside this alpine-based image,
+# `localhost` resolves to [::1] first and our nginx only binds 0.0.0.0:8080,
+# so a `localhost` probe fails with Connection refused and the container is
+# reported permanently unhealthy. IPv4 literal avoids the resolver path.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget --spider -q http://localhost:8080/healthz || exit 1
+    CMD wget --spider -q http://127.0.0.1:8080/healthz || exit 1


### PR DESCRIPTION
## Summary

Hardens backend and frontend container images:
- **Backend Dockerfile**: non-root runtime via entrypoint that chowns `/app/data` and drops to `appuser` (UID 10001) with `setpriv`; HEALTHCHECK against `/health/ready`
- **Frontend Dockerfile**: non-root USER (nginx unprivileged base), HEALTHCHECK against `/healthz` (dedicated location in `nginx/frontend.conf`)
- **docker-compose.yml**: `mem_limit` / `cpus` (classic compose compatible), `logging` driver with `max-size: 10m` / `max-file: 3`, `init: true`, `no-new-privileges`, proxy on `nginxinc/nginx-unprivileged`

Closes #866

## Test plan
- [x] `docker compose -f deploy/docker-compose.yml config` validates
- [x] Backend container starts and healthcheck transitions to healthy (verified `Status: healthy` via `docker inspect`)
- [x] Frontend container starts and healthcheck transitions to healthy (verified `Status: healthy` via `docker inspect`)
- [x] Simulated upgrade from root-owned volume: entrypoint chowns `/app/data` and app runs as `appuser` without permission errors
- [x] No regression to baseline profile (stack runs end to end; `/`, `/health/live`, `/health/ready`, `/healthz` all respond via proxy)