### PR TITLE
feat(frontend): FE-15 HTTP retry with exponential backoff (#854)

### DIFF
--- a/frontend/taskdeck-web/src/api/http.ts
+++ b/frontend/taskdeck-web/src/api/http.ts
@@ -92,6 +92,10 @@ http.interceptors.response.use(
     const config = error.config as (RetryableRequestConfig & InternalAxiosRequestConfig) | undefined
     if (!config) return Promise.reject(error)
 
+    // Short-circuit: caller opted out explicitly. Keeps the interceptor
+    // transparent for tests and for fail-fast background polls.
+    if (config.skipRetry) return Promise.reject(error)
+
     if (!isRetryableError(error)) return Promise.reject(error)
 
     const attempt = (config.__retryCount ?? 0) + 1
@@ -107,9 +111,34 @@ http.interceptors.response.use(
       )
     }
 
-    await new Promise<void>((resolve) => setTimeout(resolve, delay))
-    // Bail out if the caller cancelled the request while we were waiting.
-    if (config.signal?.aborted) return Promise.reject(error)
+    // Race the backoff wait against the request's AbortSignal so we don't
+    // hold the promise open for up to 60s on a cancelled request. Reject
+    // with axios.CanceledError so callers can discriminate via
+    // axios.isCancel(err) instead of treating a stale 5xx as user error.
+    const signal = config.signal as AbortSignal | undefined
+    if (signal?.aborted) {
+      return Promise.reject(new axios.CanceledError('Request aborted before retry'))
+    }
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, delay)
+        if (signal) {
+          const onAbort = () => {
+            clearTimeout(timer)
+            signal.removeEventListener('abort', onAbort)
+            reject(new axios.CanceledError('Request aborted while waiting to retry'))
+          }
+          signal.addEventListener('abort', onAbort, { once: true })
+        }
+      })
+    } catch (abortErr) {
+      return Promise.reject(abortErr)
+    }
+    // Double-check (defensive): some adapters may fire abort synchronously
+    // right at the edge of the timer resolving.
+    if (signal?.aborted) {
+      return Promise.reject(new axios.CanceledError('Request aborted while waiting to retry'))
+    }
     return http.request(config)
   },
 )

--- a/frontend/taskdeck-web/src/api/http.ts
+++ b/frontend/taskdeck-web/src/api/http.ts
@@ -1,9 +1,15 @@
-import axios, { AxiosHeaders, type InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosHeaders, type AxiosError, type InternalAxiosRequestConfig } from 'axios'
 import { isTokenExpired } from '../utils/jwt'
 import { createRequestId } from '../utils/requestId'
 import { isAuthRoutePath } from '../utils/navigation'
 import { isDemoMode } from '../utils/demoMode'
 import * as tokenStorage from '../utils/tokenStorage'
+import {
+  MAX_RETRIES,
+  computeRetryDelay,
+  isRetryableError,
+  type RetryableRequestConfig,
+} from './httpRetry'
 
 const REQUEST_ID_HEADER = 'X-Request-Id'
 
@@ -63,6 +69,49 @@ http.interceptors.response.use(
     }
     return Promise.reject(error)
   }
+)
+
+/**
+ * Retry interceptor (issue #854 / FE-15).
+ *
+ * Response rejection handlers fire in registration order, so this handler
+ * runs AFTER the 401/error-logging handler above — the 401 handler sees the
+ * original transient failure first (harmless logging, no-op since it is not
+ * a 401), then we decide whether to retry. On a retryable transient failure
+ * (5xx, 429, network/timeout) against an idempotent method, we wait with
+ * exponential backoff (honouring Retry-After for 429) and re-issue the
+ * request via `http.request(config)`. Non-retryable errors (4xx other than
+ * 429, non-idempotent methods, exhausted retries, cancellations) reject,
+ * so the caller sees the terminal error. 401 handling is preserved because
+ * 401 is never retryable, so the first handler's redirect logic runs
+ * normally before we pass the rejection through.
+ */
+http.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const config = error.config as (RetryableRequestConfig & InternalAxiosRequestConfig) | undefined
+    if (!config) return Promise.reject(error)
+
+    if (!isRetryableError(error)) return Promise.reject(error)
+
+    const attempt = (config.__retryCount ?? 0) + 1
+    if (attempt > MAX_RETRIES) return Promise.reject(error)
+    config.__retryCount = attempt
+
+    const delay = computeRetryDelay(error, attempt)
+    if (import.meta.env.DEV) {
+      const status = error.response?.status ?? 'network'
+      console.warn(
+        `[http] retry ${attempt}/${MAX_RETRIES} for ${config.method?.toUpperCase()} ${config.url} ` +
+          `after ${delay}ms (status=${status})`,
+      )
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, delay))
+    // Bail out if the caller cancelled the request while we were waiting.
+    if (config.signal?.aborted) return Promise.reject(error)
+    return http.request(config)
+  },
 )
 
 export default http

--- a/frontend/taskdeck-web/src/api/httpRetry.ts
+++ b/frontend/taskdeck-web/src/api/httpRetry.ts
@@ -8,7 +8,7 @@
  *
  * Kept framework-free so it is trivially unit-testable.
  */
-import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
+import axios, { type AxiosError, type AxiosRequestConfig } from 'axios'
 
 /** Maximum number of retry attempts per request (not counting the original). */
 export const MAX_RETRIES = 3
@@ -25,9 +25,22 @@ export const MAX_DELAY_MS = 60_000
 /** Idempotent HTTP methods safe to retry without risking duplicate side effects. */
 const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'])
 
+/**
+ * Non-transient 5xx codes. 501 Not Implemented and 505 HTTP Version Not
+ * Supported indicate a permanent server/protocol-level mismatch — retrying
+ * will not change the outcome and only wastes time and quota.
+ */
+const NON_TRANSIENT_5XX = new Set([501, 505])
+
 /** Extended config type that tracks retry attempt count on the request. */
 export interface RetryableRequestConfig extends AxiosRequestConfig {
   __retryCount?: number
+  /**
+   * Opt out of the retry interceptor for this specific request. Useful for
+   * tests that deliberately mock terminal failures and for callers that want
+   * fail-fast semantics (e.g. background polls that have their own cadence).
+   */
+  skipRetry?: boolean
 }
 
 /** Decide whether a method may be safely retried. Case-insensitive. */
@@ -56,6 +69,12 @@ export function parseRetryAfter(
     if (!Number.isFinite(seconds) || seconds < 0) return null
     return Math.min(seconds * 1000, MAX_DELAY_MS)
   }
+
+  // Reject obvious numeric forms that the regex above did not match
+  // (e.g. negative numbers, "+5", "1e3"). Real HTTP-dates always contain
+  // day/month names, so require at least one ASCII letter for the
+  // HTTP-date branch.
+  if (!/[A-Za-z]/.test(trimmed)) return null
 
   // HTTP-date form.
   const parsed = Date.parse(trimmed)
@@ -95,6 +114,9 @@ export function isRetryableError(error: AxiosError): boolean {
   const config = error.config as RetryableRequestConfig | undefined
   if (!config || !isIdempotent(config.method)) return false
 
+  // Caller-requested opt-out (e.g. tests mocking terminal failures).
+  if (config.skipRetry) return false
+
   // Network / timeout errors: no response object.
   if (!error.response) {
     // Axios sets code === 'ECONNABORTED' for timeouts; both should retry.
@@ -102,9 +124,32 @@ export function isRetryableError(error: AxiosError): boolean {
   }
 
   const status = error.response.status
-  if (status === 429) return true
-  if (status >= 500 && status < 600) return true
+  if (status === 429 || status === 408) return true
+  if (status >= 500 && status < 600 && !NON_TRANSIENT_5XX.has(status)) return true
   return false
+}
+
+/**
+ * Extract a header value in a case-insensitive way, handling both Axios 1.x
+ * `AxiosHeaders` instances (which expose `.get()` with case-insensitive
+ * lookup) and plain header objects (as used by `axios-mock-adapter` and some
+ * non-conforming adapters, where arbitrary casing can leak through).
+ */
+function getHeader(headers: unknown, name: string): string | undefined {
+  if (!headers || typeof headers !== 'object') return undefined
+  if (headers instanceof axios.AxiosHeaders) {
+    const value = headers.get(name)
+    return typeof value === 'string' ? value : undefined
+  }
+  const lower = name.toLowerCase()
+  const record = headers as Record<string, unknown>
+  for (const key of Object.keys(record)) {
+    if (key.toLowerCase() === lower) {
+      const value = record[key]
+      if (typeof value === 'string') return value
+    }
+  }
+  return undefined
 }
 
 /** Compute delay for a given error/attempt, honouring Retry-After on 429. */
@@ -116,10 +161,8 @@ export function computeRetryDelay(
   const now = options.now ?? Date.now()
   const random = options.random ?? Math.random
   const status = error.response?.status
-  if (status === 429) {
-    const header =
-      (error.response?.headers?.['retry-after'] as string | undefined) ??
-      (error.response?.headers?.['Retry-After'] as string | undefined)
+  if (status === 429 || status === 503) {
+    const header = getHeader(error.response?.headers, 'retry-after')
     const parsed = parseRetryAfter(header, now)
     if (parsed !== null) return parsed
   }

--- a/frontend/taskdeck-web/src/api/httpRetry.ts
+++ b/frontend/taskdeck-web/src/api/httpRetry.ts
@@ -1,0 +1,127 @@
+/**
+ * HTTP retry helpers for the shared Axios client (issue #854 / FE-15).
+ *
+ * Retries transient failures (5xx, 429, network errors) on idempotent
+ * methods with exponential backoff and jitter. 429 responses honour the
+ * `Retry-After` header (numeric seconds or RFC 1123 HTTP-date) up to a
+ * safe upper bound.
+ *
+ * Kept framework-free so it is trivially unit-testable.
+ */
+import axios, { AxiosError, type AxiosRequestConfig } from 'axios'
+
+/** Maximum number of retry attempts per request (not counting the original). */
+export const MAX_RETRIES = 3
+
+/** Base delay in ms before the first retry; doubled each subsequent attempt. */
+export const BASE_DELAY_MS = 1000
+
+/**
+ * Upper bound on any single wait, including a server-supplied `Retry-After`.
+ * Prevents a hostile or malformed header from hanging the UI for minutes.
+ */
+export const MAX_DELAY_MS = 60_000
+
+/** Idempotent HTTP methods safe to retry without risking duplicate side effects. */
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'])
+
+/** Extended config type that tracks retry attempt count on the request. */
+export interface RetryableRequestConfig extends AxiosRequestConfig {
+  __retryCount?: number
+}
+
+/** Decide whether a method may be safely retried. Case-insensitive. */
+export function isIdempotent(method: string | undefined): boolean {
+  if (!method) return false
+  return IDEMPOTENT_METHODS.has(method.toUpperCase())
+}
+
+/**
+ * Parse a Retry-After header value. Accepts either a non-negative integer
+ * seconds value or an RFC 1123 HTTP-date. Returns the delay in milliseconds,
+ * clamped to [0, MAX_DELAY_MS]. Returns null on any malformed input so the
+ * caller can fall back to default backoff.
+ */
+export function parseRetryAfter(
+  value: string | null | undefined,
+  now: number = Date.now(),
+): number | null {
+  if (value == null) return null
+  const trimmed = String(value).trim()
+  if (trimmed === '') return null
+
+  // Numeric seconds form.
+  if (/^\d+(?:\.\d+)?$/.test(trimmed)) {
+    const seconds = Number(trimmed)
+    if (!Number.isFinite(seconds) || seconds < 0) return null
+    return Math.min(seconds * 1000, MAX_DELAY_MS)
+  }
+
+  // HTTP-date form.
+  const parsed = Date.parse(trimmed)
+  if (Number.isNaN(parsed)) return null
+  const delta = parsed - now
+  if (delta <= 0) return 0
+  return Math.min(delta, MAX_DELAY_MS)
+}
+
+/**
+ * Exponential backoff with +/-25% jitter to avoid thundering-herd
+ * synchronisation when many clients recover from the same outage.
+ * `attempt` is 1-indexed: first retry uses BASE_DELAY_MS, second uses 2x, etc.
+ */
+export function computeBackoff(
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const exponential = BASE_DELAY_MS * Math.pow(2, Math.max(0, attempt - 1))
+  const capped = Math.min(exponential, MAX_DELAY_MS)
+  // Jitter in [-0.25, +0.25]; avoid going below 0.
+  const jitter = (random() - 0.5) * 0.5
+  const jittered = Math.max(0, Math.round(capped * (1 + jitter)))
+  return Math.min(jittered, MAX_DELAY_MS)
+}
+
+/**
+ * Whether an Axios error is a transient failure eligible for retry, given
+ * the request method and current attempt count. Does NOT treat 401/403/4xx
+ * (except 429) as retryable — those should flow through the existing
+ * session/error handling.
+ */
+export function isRetryableError(error: AxiosError): boolean {
+  // Cancellation (user navigation, AbortController) must never retry.
+  if (axios.isCancel(error)) return false
+
+  const config = error.config as RetryableRequestConfig | undefined
+  if (!config || !isIdempotent(config.method)) return false
+
+  // Network / timeout errors: no response object.
+  if (!error.response) {
+    // Axios sets code === 'ECONNABORTED' for timeouts; both should retry.
+    return true
+  }
+
+  const status = error.response.status
+  if (status === 429) return true
+  if (status >= 500 && status < 600) return true
+  return false
+}
+
+/** Compute delay for a given error/attempt, honouring Retry-After on 429. */
+export function computeRetryDelay(
+  error: AxiosError,
+  attempt: number,
+  options: { now?: number; random?: () => number } = {},
+): number {
+  const now = options.now ?? Date.now()
+  const random = options.random ?? Math.random
+  const status = error.response?.status
+  if (status === 429) {
+    const header =
+      (error.response?.headers?.['retry-after'] as string | undefined) ??
+      (error.response?.headers?.['Retry-After'] as string | undefined)
+    const parsed = parseRetryAfter(header, now)
+    if (parsed !== null) return parsed
+  }
+  return computeBackoff(attempt, random)
+}

--- a/frontend/taskdeck-web/src/tests/api/http.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/http.spec.ts
@@ -333,4 +333,188 @@ describe('http interceptors (#725)', () => {
       expect(response.data).toEqual({ id: 'new-1' })
     })
   })
+
+  // ── Retry interceptor (#854) ───────────────────────────────────────────
+
+  describe('retry interceptor (#854)', () => {
+    // Use fake timers so the 1s/2s/4s backoffs don't actually wait.
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.spyOn(tokenStorage, 'getToken').mockReturnValue(null)
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    // Drive the retry loop: advance fake timers until axios-mock-adapter has
+    // seen `expectedRequests` total requests (or until we time out). Works
+    // whether delays are 1s, 2s, 4s, Retry-After, etc.
+    async function drainRetries(expectedRequests: number, options: { maxTicks?: number; tickMs?: number } = {}) {
+      const maxTicks = options.maxTicks ?? 200
+      const tickMs = options.tickMs ?? 100
+      for (let i = 0; i < maxTicks; i++) {
+        if (mock.history.get.length >= expectedRequests) return
+        await vi.advanceTimersByTimeAsync(tickMs)
+      }
+    }
+
+    it('retries GET 500 three times then fails (4 total requests)', async () => {
+      mock.onGet('/flaky').reply(500, { error: 'boom' })
+
+      const pending = http.get('/flaky')
+      const expectation = expect(pending).rejects.toMatchObject({
+        response: { status: 500 },
+      })
+      await drainRetries(4, { tickMs: 1000, maxTicks: 30 })
+      await expectation
+
+      expect(mock.history.get.length).toBe(4)
+    })
+
+    it('succeeds on retry when GET 500 then 200', async () => {
+      let call = 0
+      mock.onGet('/eventually').reply(() => {
+        call++
+        return call === 1 ? [500, { error: 'temp' }] : [200, { ok: true }]
+      })
+
+      const pending = http.get('/eventually')
+      await drainRetries(2, { tickMs: 1000, maxTicks: 10 })
+      const response = await pending
+
+      expect(response.status).toBe(200)
+      expect(response.data).toEqual({ ok: true })
+      expect(mock.history.get.length).toBe(2)
+    })
+
+    it('does not retry POST on 500 (single request)', async () => {
+      mock.onPost('/write').reply(500, { error: 'boom' })
+
+      await expect(http.post('/write', { k: 'v' })).rejects.toMatchObject({
+        response: { status: 500 },
+      })
+      expect(mock.history.post.length).toBe(1)
+    })
+
+    it('does not retry PATCH on 500 (single request)', async () => {
+      mock.onPatch('/update').reply(500, { error: 'boom' })
+
+      await expect(http.patch('/update', { k: 'v' })).rejects.toMatchObject({
+        response: { status: 500 },
+      })
+      expect(mock.history.patch.length).toBe(1)
+    })
+
+    it('retries PUT on 500', async () => {
+      mock.onPut('/put').reply(500, { error: 'boom' })
+
+      const pending = http.put('/put', { k: 'v' })
+      const expectation = expect(pending).rejects.toMatchObject({
+        response: { status: 500 },
+      })
+      await drainRetries(4, { tickMs: 1000, maxTicks: 30 })
+      // drainRetries tracks only GET; use history.put instead for this case
+      for (let i = 0; i < 30 && mock.history.put.length < 4; i++) {
+        await vi.advanceTimersByTimeAsync(1000)
+      }
+      await expectation
+
+      expect(mock.history.put.length).toBe(4)
+    })
+
+    it('does not retry GET 404 (4xx client error)', async () => {
+      mock.onGet('/missing').reply(404, { error: 'nope' })
+
+      await expect(http.get('/missing')).rejects.toMatchObject({
+        response: { status: 404 },
+      })
+      expect(mock.history.get.length).toBe(1)
+    })
+
+    it('does not retry GET 401 (preserves session redirect flow)', async () => {
+      Object.defineProperty(window, 'location', {
+        value: { pathname: '/workspace/home', search: '', href: '' },
+        writable: true,
+        configurable: true,
+      })
+      const clearSpy = vi.spyOn(tokenStorage, 'clearAll')
+      mock.onGet('/auth').reply(401, { error: 'nope' })
+
+      await expect(http.get('/auth')).rejects.toMatchObject({
+        response: { status: 401 },
+      })
+      expect(mock.history.get.length).toBe(1)
+      // Existing 401 handler must still fire.
+      expect(clearSpy).toHaveBeenCalled()
+    })
+
+    it('retries GET on network error', async () => {
+      mock.onGet('/offline').networkError()
+
+      const pending = http.get('/offline')
+      const expectation = expect(pending).rejects.toThrow()
+      await drainRetries(4, { tickMs: 1000, maxTicks: 30 })
+      await expectation
+
+      expect(mock.history.get.length).toBe(4)
+    })
+
+    it('honours numeric Retry-After on 429', async () => {
+      // First call: 429 with Retry-After: 2 (seconds). Second call: 200.
+      let call = 0
+      mock.onGet('/throttled').reply(() => {
+        call++
+        if (call === 1) return [429, { error: 'slow down' }, { 'retry-after': '2' }]
+        return [200, { ok: true }]
+      })
+
+      const pending = http.get('/throttled')
+      // Advance 1.9s — retry should NOT have fired yet.
+      await vi.advanceTimersByTimeAsync(1900)
+      expect(mock.history.get.length).toBe(1)
+      // Advance past the 2s mark.
+      await vi.advanceTimersByTimeAsync(200)
+      const response = await pending
+
+      expect(response.status).toBe(200)
+      expect(mock.history.get.length).toBe(2)
+    })
+
+    it('honours HTTP-date Retry-After on 429', async () => {
+      const fixedNow = Date.parse('2026-04-16T12:00:00Z')
+      vi.setSystemTime(fixedNow)
+      const target = new Date(fixedNow + 3000).toUTCString() // 3s in the future
+
+      let call = 0
+      mock.onGet('/throttled-date').reply(() => {
+        call++
+        if (call === 1) return [429, { error: 'slow down' }, { 'retry-after': target }]
+        return [200, { ok: true }]
+      })
+
+      const pending = http.get('/throttled-date')
+      await drainRetries(2, { tickMs: 500, maxTicks: 20 })
+      const response = await pending
+
+      expect(response.status).toBe(200)
+      expect(mock.history.get.length).toBe(2)
+    })
+
+    it('aborts retry loop when request is cancelled mid-wait', async () => {
+      mock.onGet('/slow').reply(500, { error: 'boom' })
+      const controller = new AbortController()
+      const pending = http.get('/slow', { signal: controller.signal })
+
+      // Let first attempt fail and enter the retry wait.
+      await vi.advanceTimersByTimeAsync(1)
+      expect(mock.history.get.length).toBe(1)
+
+      controller.abort()
+      // Advance past the backoff; should NOT re-issue.
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      await expect(pending).rejects.toBeDefined()
+      expect(mock.history.get.length).toBe(1)
+    })
+  })
 })

--- a/frontend/taskdeck-web/src/tests/api/http.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/http.spec.ts
@@ -12,6 +12,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import MockAdapter from 'axios-mock-adapter'
+import axios from 'axios'
 
 // ─── JWT helpers ────────────────────────────────────────────────────────────
 
@@ -245,7 +246,11 @@ describe('http interceptors (#725)', () => {
       })
       mock.onGet('/test').reply(500, { message: 'Internal Server Error' })
 
-      await expect(http.get('/test')).rejects.toThrow()
+      // `skipRetry: true` opts out of the retry interceptor (#854). Without
+      // it a 500 would trigger 3 retries with 1s/2s/4s backoffs and blow past
+      // the default 5s vitest timeout. Retry behaviour is covered by the
+      // dedicated `retry interceptor (#854)` suite below.
+      await expect(http.get('/test', { skipRetry: true })).rejects.toThrow()
 
       expect(clearSpy).not.toHaveBeenCalled()
       expect(window.location.href).toBe('')
@@ -279,7 +284,8 @@ describe('http interceptors (#725)', () => {
       vi.spyOn(tokenStorage, 'getToken').mockReturnValue(null)
       mock.onGet('/test').networkError()
 
-      await expect(http.get('/test')).rejects.toThrow('Network Error')
+      // skipRetry avoids the 1s+2s+4s retry path (see 500 test above).
+      await expect(http.get('/test', { skipRetry: true })).rejects.toThrow('Network Error')
     })
 
     it('does not clear storage or redirect on network error', async () => {
@@ -292,7 +298,7 @@ describe('http interceptors (#725)', () => {
       })
       mock.onGet('/test').networkError()
 
-      await expect(http.get('/test')).rejects.toThrow()
+      await expect(http.get('/test', { skipRetry: true })).rejects.toThrow()
 
       expect(clearSpy).not.toHaveBeenCalled()
       expect(window.location.href).toBe('')
@@ -306,7 +312,7 @@ describe('http interceptors (#725)', () => {
       vi.spyOn(tokenStorage, 'getToken').mockReturnValue(null)
       mock.onGet('/test').timeout()
 
-      await expect(http.get('/test')).rejects.toThrow()
+      await expect(http.get('/test', { skipRetry: true })).rejects.toThrow()
     })
   })
 
@@ -347,15 +353,27 @@ describe('http interceptors (#725)', () => {
     })
 
     // Drive the retry loop: advance fake timers until axios-mock-adapter has
-    // seen `expectedRequests` total requests (or until we time out). Works
-    // whether delays are 1s, 2s, 4s, Retry-After, etc.
-    async function drainRetries(expectedRequests: number, options: { maxTicks?: number; tickMs?: number } = {}) {
+    // seen `expectedRequests` of the given method (default GET), or throw an
+    // explicit error if not reached within the budget. Throwing prevents
+    // silent hangs (Copilot feedback on PR #890) — a stalled retry loop now
+    // fails fast at drainRetries rather than waiting for the outer test
+    // timeout.
+    async function drainRetries(
+      expectedRequests: number,
+      options: { maxTicks?: number; tickMs?: number; method?: keyof typeof mock.history } = {},
+    ) {
       const maxTicks = options.maxTicks ?? 200
       const tickMs = options.tickMs ?? 100
+      const method = options.method ?? 'get'
+      const seen = () => mock.history[method].length
       for (let i = 0; i < maxTicks; i++) {
-        if (mock.history.get.length >= expectedRequests) return
+        if (seen() >= expectedRequests) return
         await vi.advanceTimersByTimeAsync(tickMs)
       }
+      throw new Error(
+        `drainRetries: expected ${expectedRequests} ${method.toUpperCase()} request(s) within ` +
+          `${maxTicks * tickMs}ms, observed ${seen()}`,
+      )
     }
 
     it('retries GET 500 three times then fails (4 total requests)', async () => {
@@ -412,11 +430,7 @@ describe('http interceptors (#725)', () => {
       const expectation = expect(pending).rejects.toMatchObject({
         response: { status: 500 },
       })
-      await drainRetries(4, { tickMs: 1000, maxTicks: 30 })
-      // drainRetries tracks only GET; use history.put instead for this case
-      for (let i = 0; i < 30 && mock.history.put.length < 4; i++) {
-        await vi.advanceTimersByTimeAsync(1000)
-      }
+      await drainRetries(4, { tickMs: 1000, maxTicks: 30, method: 'put' })
       await expectation
 
       expect(mock.history.put.length).toBe(4)
@@ -500,10 +514,48 @@ describe('http interceptors (#725)', () => {
       expect(mock.history.get.length).toBe(2)
     })
 
+    it('skipRetry opt-out disables the retry loop for a single request', async () => {
+      // Verifies the opt-out path used by the baseline tests above — a 500
+      // with skipRetry must reject immediately after one request, NOT after
+      // the 1s/2s/4s retry schedule.
+      mock.onGet('/once').reply(500, { error: 'boom' })
+      await expect(http.get('/once', { skipRetry: true })).rejects.toMatchObject({
+        response: { status: 500 },
+      })
+      expect(mock.history.get.length).toBe(1)
+    })
+
+    it('does not retry non-transient 5xx (501 Not Implemented)', async () => {
+      mock.onGet('/not-implemented').reply(501, { error: 'nope' })
+      await expect(http.get('/not-implemented')).rejects.toMatchObject({
+        response: { status: 501 },
+      })
+      expect(mock.history.get.length).toBe(1)
+    })
+
+    it('retries GET 408 Request Timeout', async () => {
+      mock.onGet('/timeout-status').reply(408, { error: 'timeout' })
+      const pending = http.get('/timeout-status')
+      const expectation = expect(pending).rejects.toMatchObject({
+        response: { status: 408 },
+      })
+      await drainRetries(4, { tickMs: 1000, maxTicks: 30 })
+      await expectation
+      expect(mock.history.get.length).toBe(4)
+    })
+
     it('aborts retry loop when request is cancelled mid-wait', async () => {
       mock.onGet('/slow').reply(500, { error: 'boom' })
       const controller = new AbortController()
       const pending = http.get('/slow', { signal: controller.signal })
+      // Attach the rejection expectation BEFORE we drive timers forward so
+      // the promise is already being awaited when it settles. Previously the
+      // raw `pending` sat unobserved and Vitest flagged the rejection as
+      // unhandled (PR #890 self-review finding).
+      const expectation = expect(pending).rejects.toSatisfy((err: unknown) => {
+        // Cancellation should surface via axios.isCancel, NOT the original 500.
+        return axios.isCancel(err)
+      })
 
       // Let first attempt fail and enter the retry wait.
       await vi.advanceTimersByTimeAsync(1)
@@ -513,7 +565,7 @@ describe('http interceptors (#725)', () => {
       // Advance past the backoff; should NOT re-issue.
       await vi.advanceTimersByTimeAsync(10_000)
 
-      await expect(pending).rejects.toBeDefined()
+      await expectation
       expect(mock.history.get.length).toBe(1)
     })
   })

--- a/frontend/taskdeck-web/src/tests/api/httpRetry.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/httpRetry.spec.ts
@@ -79,6 +79,22 @@ describe('httpRetry — parseRetryAfter', () => {
 
   it('rejects negative numeric values', () => {
     expect(parseRetryAfter('-5')).toBeNull()
+    expect(parseRetryAfter('-1')).toBeNull()
+    expect(parseRetryAfter('-0.1')).toBeNull()
+  })
+
+  it('rejects numeric-ish forms that the strict numeric regex rejects', () => {
+    // Date.parse accepts several pseudo-numeric forms ("-5", "+5", "1e3")
+    // as valid dates, which we must NOT treat as Retry-After values. Real
+    // HTTP-dates always include day/month names, so require at least one
+    // ASCII letter before falling through to Date.parse.
+    expect(parseRetryAfter('+5')).toBeNull()
+    expect(parseRetryAfter('1e3')).toBeNull()
+    expect(parseRetryAfter('.5')).toBeNull()
+    // Pure positive integers like '2026' are legal numeric seconds per the
+    // HTTP Retry-After spec and are NOT rejected — they're capped at
+    // MAX_DELAY_MS by the numeric branch.
+    expect(parseRetryAfter('2026')).toBe(MAX_DELAY_MS)
   })
 
   it('parses RFC 1123 HTTP-date relative to now', () => {
@@ -145,6 +161,23 @@ describe('httpRetry — isRetryableError', () => {
     }
   })
 
+  it('retries GET 408 (request timeout — classic transient)', () => {
+    expect(isRetryableError(makeError({ status: 408, method: 'get' }))).toBe(true)
+  })
+
+  it('does not retry GET 501 or 505 (non-transient server errors)', () => {
+    // 501 Not Implemented and 505 HTTP Version Not Supported indicate a
+    // permanent server/protocol capability mismatch — no point retrying.
+    expect(isRetryableError(makeError({ status: 501, method: 'get' }))).toBe(false)
+    expect(isRetryableError(makeError({ status: 505, method: 'get' }))).toBe(false)
+  })
+
+  it('does not retry when config.skipRetry is set', () => {
+    const err = makeError({ status: 500, method: 'get' })
+    ;(err.config as { skipRetry?: boolean }).skipRetry = true
+    expect(isRetryableError(err)).toBe(false)
+  })
+
   it('does not retry POST even on 500', () => {
     expect(isRetryableError(makeError({ status: 500, method: 'post' }))).toBe(false)
   })
@@ -184,6 +217,30 @@ describe('httpRetry — computeRetryDelay', () => {
   it('uses exponential backoff on 5xx (no Retry-After)', () => {
     const err = makeError({ status: 500, method: 'get' })
     expect(computeRetryDelay(err, 2, { random: () => 0.5 })).toBe(BASE_DELAY_MS * 2)
+  })
+
+  it('honours Retry-After on 503 (Service Unavailable)', () => {
+    // 503 is the other standard status for Retry-After, often seen during
+    // rolling deploys or maintenance windows.
+    const err = makeError({ status: 503, headers: { 'retry-after': '5' }, method: 'get' })
+    expect(computeRetryDelay(err, 1, { random: () => 0.5 })).toBe(5000)
+  })
+
+  it('reads Retry-After case-insensitively via AxiosHeaders instance', async () => {
+    const { AxiosHeaders } = await import('axios')
+    const headers = new AxiosHeaders()
+    headers.set('Retry-After', '3')
+    const err = makeError({ status: 429, method: 'get' })
+    // Replace the plain-object headers with an AxiosHeaders instance.
+    ;(err.response as { headers: unknown }).headers = headers
+    expect(computeRetryDelay(err, 1, { random: () => 0.5 })).toBe(3000)
+  })
+
+  it('reads Retry-After from mixed-case plain-object headers', () => {
+    // Some adapters (axios-mock-adapter) hand the interceptor a plain object
+    // with whatever case the test used. We must still find the value.
+    const err = makeError({ status: 429, headers: { 'Retry-After': '2' }, method: 'get' })
+    expect(computeRetryDelay(err, 1, { random: () => 0.5 })).toBe(2000)
   })
 })
 

--- a/frontend/taskdeck-web/src/tests/api/httpRetry.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/httpRetry.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the retry helpers in api/httpRetry.ts (issue #854 / FE-15).
+ *
+ * These tests exercise the pure helpers directly so we can assert delay
+ * shapes and edge cases without going through the Axios pipeline.
+ */
+import { describe, it, expect } from 'vitest'
+import type { AxiosError } from 'axios'
+import axios from 'axios'
+import {
+  BASE_DELAY_MS,
+  MAX_DELAY_MS,
+  MAX_RETRIES,
+  computeBackoff,
+  computeRetryDelay,
+  isIdempotent,
+  isRetryableError,
+  parseRetryAfter,
+} from '../../api/httpRetry'
+
+function makeError(overrides: Partial<AxiosError> & { status?: number; headers?: Record<string, string>; method?: string }): AxiosError {
+  const { status, headers, method, ...rest } = overrides
+  return {
+    isAxiosError: true,
+    name: 'AxiosError',
+    message: 'test',
+    config: { method: method ?? 'get', url: '/x' },
+    response: status !== undefined
+      ? { status, statusText: '', data: {}, headers: headers ?? {}, config: {} as never }
+      : undefined,
+    ...rest,
+  } as AxiosError
+}
+
+describe('httpRetry — isIdempotent', () => {
+  it('treats GET / HEAD / OPTIONS / PUT / DELETE as idempotent', () => {
+    expect(isIdempotent('GET')).toBe(true)
+    expect(isIdempotent('HEAD')).toBe(true)
+    expect(isIdempotent('OPTIONS')).toBe(true)
+    expect(isIdempotent('PUT')).toBe(true)
+    expect(isIdempotent('DELETE')).toBe(true)
+  })
+
+  it('is case-insensitive', () => {
+    expect(isIdempotent('get')).toBe(true)
+    expect(isIdempotent('Put')).toBe(true)
+    expect(isIdempotent('dElEtE')).toBe(true)
+  })
+
+  it('treats POST / PATCH as non-idempotent', () => {
+    expect(isIdempotent('POST')).toBe(false)
+    expect(isIdempotent('post')).toBe(false)
+    expect(isIdempotent('PATCH')).toBe(false)
+  })
+
+  it('returns false for undefined / empty method', () => {
+    expect(isIdempotent(undefined)).toBe(false)
+    expect(isIdempotent('')).toBe(false)
+  })
+})
+
+describe('httpRetry — parseRetryAfter', () => {
+  it('returns null for null / undefined / empty input', () => {
+    expect(parseRetryAfter(null)).toBeNull()
+    expect(parseRetryAfter(undefined)).toBeNull()
+    expect(parseRetryAfter('')).toBeNull()
+    expect(parseRetryAfter('   ')).toBeNull()
+  })
+
+  it('parses numeric seconds into milliseconds', () => {
+    expect(parseRetryAfter('0')).toBe(0)
+    expect(parseRetryAfter('2')).toBe(2000)
+    expect(parseRetryAfter('30')).toBe(30_000)
+  })
+
+  it('caps numeric seconds at MAX_DELAY_MS', () => {
+    expect(parseRetryAfter('9999999')).toBe(MAX_DELAY_MS)
+  })
+
+  it('rejects negative numeric values', () => {
+    expect(parseRetryAfter('-5')).toBeNull()
+  })
+
+  it('parses RFC 1123 HTTP-date relative to now', () => {
+    const now = Date.parse('2026-04-16T12:00:00Z')
+    const target = new Date(now + 5000).toUTCString() // 5 seconds in the future
+    const parsed = parseRetryAfter(target, now)
+    expect(parsed).toBe(5000)
+  })
+
+  it('clamps past HTTP-date to 0', () => {
+    const now = Date.parse('2026-04-16T12:00:00Z')
+    const past = new Date(now - 10_000).toUTCString()
+    expect(parseRetryAfter(past, now)).toBe(0)
+  })
+
+  it('caps future HTTP-date at MAX_DELAY_MS', () => {
+    const now = Date.parse('2026-04-16T12:00:00Z')
+    const farFuture = new Date(now + 10 * 60 * 1000).toUTCString() // 10 min
+    expect(parseRetryAfter(farFuture, now)).toBe(MAX_DELAY_MS)
+  })
+
+  it('returns null for malformed input', () => {
+    expect(parseRetryAfter('not-a-date')).toBeNull()
+    expect(parseRetryAfter('abc123')).toBeNull()
+  })
+})
+
+describe('httpRetry — computeBackoff', () => {
+  it('doubles per attempt at the midpoint (random=0.5 → no jitter)', () => {
+    const r = () => 0.5
+    expect(computeBackoff(1, r)).toBe(BASE_DELAY_MS)
+    expect(computeBackoff(2, r)).toBe(BASE_DELAY_MS * 2)
+    expect(computeBackoff(3, r)).toBe(BASE_DELAY_MS * 4)
+  })
+
+  it('applies at most +/-25% jitter', () => {
+    const delays = [0, 0.25, 0.5, 0.75, 1].map((v) => computeBackoff(2, () => v))
+    const base = BASE_DELAY_MS * 2
+    for (const d of delays) {
+      expect(d).toBeGreaterThanOrEqual(Math.floor(base * 0.75))
+      expect(d).toBeLessThanOrEqual(Math.ceil(base * 1.25))
+    }
+  })
+
+  it('caps at MAX_DELAY_MS even for very high attempts', () => {
+    expect(computeBackoff(100, () => 0.5)).toBeLessThanOrEqual(MAX_DELAY_MS)
+  })
+})
+
+describe('httpRetry — isRetryableError', () => {
+  it('retries GET 500/502/503/504', () => {
+    for (const s of [500, 502, 503, 504]) {
+      expect(isRetryableError(makeError({ status: s, method: 'get' }))).toBe(true)
+    }
+  })
+
+  it('retries GET 429', () => {
+    expect(isRetryableError(makeError({ status: 429, method: 'get' }))).toBe(true)
+  })
+
+  it('does not retry 4xx (401/403/404/409/422)', () => {
+    for (const s of [400, 401, 403, 404, 409, 422]) {
+      expect(isRetryableError(makeError({ status: s, method: 'get' }))).toBe(false)
+    }
+  })
+
+  it('does not retry POST even on 500', () => {
+    expect(isRetryableError(makeError({ status: 500, method: 'post' }))).toBe(false)
+  })
+
+  it('does not retry PATCH even on 500', () => {
+    expect(isRetryableError(makeError({ status: 500, method: 'patch' }))).toBe(false)
+  })
+
+  it('retries GET network error (no response)', () => {
+    expect(isRetryableError(makeError({ method: 'get' }))).toBe(true)
+  })
+
+  it('does not retry a cancelled request', () => {
+    const cancelled = new axios.Cancel('user aborted') as unknown as AxiosError
+    expect(isRetryableError(cancelled)).toBe(false)
+  })
+})
+
+describe('httpRetry — computeRetryDelay', () => {
+  it('honours Retry-After on 429 (seconds)', () => {
+    const err = makeError({ status: 429, headers: { 'retry-after': '3' }, method: 'get' })
+    expect(computeRetryDelay(err, 1, { random: () => 0.5 })).toBe(3000)
+  })
+
+  it('honours Retry-After on 429 (HTTP-date)', () => {
+    const now = Date.parse('2026-04-16T12:00:00Z')
+    const target = new Date(now + 4000).toUTCString()
+    const err = makeError({ status: 429, headers: { 'retry-after': target }, method: 'get' })
+    expect(computeRetryDelay(err, 1, { now, random: () => 0.5 })).toBe(4000)
+  })
+
+  it('falls back to exponential backoff on malformed Retry-After', () => {
+    const err = makeError({ status: 429, headers: { 'retry-after': 'garbage' }, method: 'get' })
+    expect(computeRetryDelay(err, 1, { random: () => 0.5 })).toBe(BASE_DELAY_MS)
+  })
+
+  it('uses exponential backoff on 5xx (no Retry-After)', () => {
+    const err = makeError({ status: 500, method: 'get' })
+    expect(computeRetryDelay(err, 2, { random: () => 0.5 })).toBe(BASE_DELAY_MS * 2)
+  })
+})
+
+describe('httpRetry — exported constants', () => {
+  it('defaults to 3 retries', () => {
+    expect(MAX_RETRIES).toBe(3)
+  })
+
+  it('base delay is 1s', () => {
+    expect(BASE_DELAY_MS).toBe(1000)
+  })
+
+  it('max delay cap is 60s', () => {
+    expect(MAX_DELAY_MS).toBe(60_000)
+  })
+})

--- a/frontend/taskdeck-web/tests/e2e/error-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/error-recovery.spec.ts
@@ -28,7 +28,9 @@ test.beforeEach(async ({ page, request }) => {
 // ─── Scenario 1: Board load failure → error state shown → retry succeeds ─────
 
 test('board load failure should display error state and allow retry', async ({ page }) => {
-  let callCount = 0
+  let failedLoads = 0
+  const MAX_FAILED_LOADS = 4 // 1 initial + 3 retries from httpRetry.ts MAX_RETRIES
+  let firstGotoDone = false
 
   await page.route('**/api/boards/**', async (route) => {
     // Only intercept GET requests for board details (not cards, not list)
@@ -39,8 +41,13 @@ test('board load failure should display error state and allow retry', async ({ p
       return
     }
 
-    callCount += 1
-    if (callCount === 1) {
+    // The FE-15 retry interceptor retries idempotent 5xx up to 3 times, so we
+    // must fail the initial load AND all retries to actually surface the
+    // error state. After the first `page.goto` has settled on that error
+    // state, `firstGotoDone` flips and we let subsequent loads (post-reload)
+    // succeed to prove the retry button / reload recovers.
+    if (!firstGotoDone && failedLoads < MAX_FAILED_LOADS) {
+      failedLoads += 1
       await route.fulfill({
         status: 503,
         contentType: 'application/json',
@@ -62,14 +69,18 @@ test('board load failure should display error state and allow retry', async ({ p
     columnNamePrefix: 'Backlog',
   })
 
-  // First visit: 503 should be served
+  // First visit: 503 should be served on every attempt (initial + 3 retries)
+  // so the terminal error state surfaces.
   await page.goto(`/workspace/boards/${boardId}`)
 
-  // Expect the error state to be visible — any role=alert or error-related text
+  // Expect the error state to be visible — any role=alert or error-related text.
+  // Timeout is generous because the retry interceptor waits 1s+2s+4s
+  // between attempts before surfacing the terminal rejection.
   const errorState = page.getByRole('alert').first()
-  await expect(errorState).toBeVisible({ timeout: 10_000 })
+  await expect(errorState).toBeVisible({ timeout: 20_000 })
+  firstGotoDone = true
 
-  // After a reload the route continues normally (callCount > 1)
+  // After a reload the route continues normally
   await page.reload()
 
   // Board heading should now be visible

--- a/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
@@ -172,14 +172,21 @@ test('first-run path should guide home to capture to review to execute to board'
 
 test('home should recover from loading and error states on first-run summary refresh', async ({ page }) => {
   let requestCount = 0
+  // The FE-15 retry interceptor retries idempotent 5xx up to 3 times, so the
+  // initial load plus its 3 retries (4 total) must fail to surface the error
+  // state. Only the first request is gated — subsequent retries fail
+  // immediately so backoff is the only delay.
+  const MAX_FAILED_REQUESTS = 4 // 1 initial + 3 retries (MAX_RETRIES)
   let releaseFirstRequest: (() => void) | null = null
   const firstRequestGate = new Promise<void>((resolve) => { releaseFirstRequest = resolve })
 
   await page.route('**/api/workspace/home', async (route) => {
     requestCount += 1
 
-    if (requestCount === 1) {
-      await firstRequestGate
+    if (requestCount <= MAX_FAILED_REQUESTS) {
+      if (requestCount === 1) {
+        await firstRequestGate
+      }
       await route.fulfill({
         status: 500,
         contentType: 'application/json',
@@ -197,7 +204,9 @@ test('home should recover from loading and error states on first-run summary ref
   await page.goto('/workspace/home')
   await expect(page.getByText('Loading your workspace summary...')).toBeVisible()
   releaseFirstRequest!()
-  await expect(page.getByRole('alert')).toContainText('Temporary home summary failure')
+  // Generous timeout because the retry interceptor waits 1s+2s+4s between
+  // attempts before surfacing the terminal rejection.
+  await expect(page.getByRole('alert')).toContainText('Temporary home summary failure', { timeout: 20_000 })
 
   await page.reload()
   await expect(page.getByRole('heading', { name: 'Home', exact: true })).toBeVisible()


### PR DESCRIPTION
## Summary

Adds an Axios retry interceptor to the frontend HTTP client:
- Retries on 5xx and network errors, max 3 attempts
- Exponential backoff (1s, 2s, 4s) with ±25% jitter
- Idempotent methods only (GET, HEAD, OPTIONS, PUT, DELETE) — POST/PATCH are never retried
- 429 responses honour `Retry-After` (seconds or HTTP-date), capped at a sane upper bound
- No retry on 4xx client errors (401, 403, 404, 409, 422)
- Respects `axios.isCancel` to abort on navigation
- Logging gated behind `import.meta.env.DEV`

Closes #854

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npx vitest --run -t retry` passes
- [ ] `npm run lint` passes
- [ ] No regression on existing 401 session-expiry flow