### PR TITLE
feat(frontend): FE-14 Vue error boundary for crash prevention (#852)

### DIFF
--- a/frontend/taskdeck-web/src/App.vue
+++ b/frontend/taskdeck-web/src/App.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import ToastContainer from './components/common/ToastContainer.vue'
 import AppShell from './components/shell/AppShell.vue'
+import ErrorBoundary from './components/ErrorBoundary.vue'
 import { useSessionStore } from './store/sessionStore'
 import { useFeatureFlagStore } from './store/featureFlagStore'
 import { useWorkspaceStore } from './store/workspaceStore'
@@ -39,9 +40,13 @@ watch(
   <div id="app">
     <a href="#td-main-content" class="td-skip-link">Skip to main content</a>
     <!-- Shell layout for workspace routes -->
-    <AppShell v-if="showShell" />
+    <ErrorBoundary v-if="showShell">
+      <AppShell />
+    </ErrorBoundary>
     <!-- Direct render for public routes (login/register) -->
-    <router-view v-else />
+    <ErrorBoundary v-else>
+      <router-view />
+    </ErrorBoundary>
     <ToastContainer />
   </div>
 </template>

--- a/frontend/taskdeck-web/src/components/ErrorBoundary.vue
+++ b/frontend/taskdeck-web/src/components/ErrorBoundary.vue
@@ -12,6 +12,7 @@
  */
 import { onErrorCaptured, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { reportToSentry } from '../utils/errorReporting'
 
 const props = withDefaults(
   defineProps<{
@@ -28,7 +29,10 @@ const emit = defineEmits<{
   reset: []
 }>()
 
-const crashedError = ref<unknown>(null)
+// Track crash state with an explicit boolean so we do not collide with
+// descendants that throw `null`/`undefined` — Vue errors can be any value.
+const hasCrashed = ref(false)
+const crashedError = ref<unknown>(undefined)
 const crashInfo = ref<string>('')
 
 // useRoute/useRouter can be undefined in isolated unit tests where no router
@@ -69,7 +73,8 @@ function getStack(err: unknown): string | null {
 }
 
 function reset() {
-  crashedError.value = null
+  hasCrashed.value = false
+  crashedError.value = undefined
   crashInfo.value = ''
   emit('reset')
 }
@@ -92,21 +97,17 @@ function goHome() {
 }
 
 onErrorCaptured((err, _instance, info) => {
+  hasCrashed.value = true
   crashedError.value = err
   crashInfo.value = info
 
   // Always log so errors are not silently swallowed.
   console.error('[ErrorBoundary] caught error', err, info)
 
-  // Forward to Sentry if the host page has installed it (no hard dependency).
-  const sentry = (globalThis as unknown as { Sentry?: { captureException?: (e: unknown) => void } }).Sentry
-  if (sentry && typeof sentry.captureException === 'function') {
-    try {
-      sentry.captureException(err)
-    } catch {
-      // Never let reporting failures bubble out of the boundary.
-    }
-  }
+  // Forward to Sentry via the centralized utility so the lifecycle `info`
+  // string is preserved and reporting behavior stays consistent across the
+  // app. `reportToSentry` never throws.
+  reportToSentry(err, { source: 'ErrorBoundary', info })
 
   emit('error', err, info)
 
@@ -120,7 +121,7 @@ if (route) {
   watch(
     () => route.fullPath,
     (next, prev) => {
-      if (props.resetOnRouteChange && crashedError.value !== null && next !== prev) {
+      if (props.resetOnRouteChange && hasCrashed.value && next !== prev) {
         reset()
       }
     },
@@ -140,7 +141,7 @@ const isDev = (() => {
 </script>
 
 <template>
-  <slot v-if="crashedError === null" />
+  <slot v-if="!hasCrashed" />
   <div
     v-else
     class="td-error-boundary"

--- a/frontend/taskdeck-web/src/components/ErrorBoundary.vue
+++ b/frontend/taskdeck-web/src/components/ErrorBoundary.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+/**
+ * ErrorBoundary catches render and lifecycle errors in its descendant tree
+ * via Vue's `onErrorCaptured` hook and renders a fallback UI in place of the
+ * crashed subtree. It is deliberately styled with plain inline CSS so that
+ * it cannot itself crash when design tokens or stylesheets are unavailable.
+ *
+ * Scope caveat: Vue's `errorCaptured` does NOT catch async promise rejections
+ * that originate outside a render/lifecycle call stack. Those are handled
+ * globally via `app.config.errorHandler` and `window` listeners installed in
+ * `main.ts`.
+ */
+import { onErrorCaptured, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const props = withDefaults(
+  defineProps<{
+    /** Reset fallback state automatically when the route changes. */
+    resetOnRouteChange?: boolean
+  }>(),
+  {
+    resetOnRouteChange: true,
+  },
+)
+
+const emit = defineEmits<{
+  error: [error: unknown, info: string]
+  reset: []
+}>()
+
+const crashedError = ref<unknown>(null)
+const crashInfo = ref<string>('')
+
+// useRoute/useRouter can be undefined in isolated unit tests where no router
+// is installed. Guard against that so the boundary can still be mounted in
+// minimal test harnesses.
+const route = (() => {
+  try {
+    return useRoute()
+  } catch {
+    return null
+  }
+})()
+const router = (() => {
+  try {
+    return useRouter()
+  } catch {
+    return null
+  }
+})()
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message || err.name || 'Unknown error'
+  }
+  if (typeof err === 'string') return err
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+function getStack(err: unknown): string | null {
+  if (err instanceof Error && typeof err.stack === 'string') {
+    return err.stack
+  }
+  return null
+}
+
+function reset() {
+  crashedError.value = null
+  crashInfo.value = ''
+  emit('reset')
+}
+
+function reload() {
+  if (typeof window !== 'undefined') {
+    window.location.reload()
+  }
+}
+
+function goHome() {
+  if (router) {
+    void router.push('/')
+    reset()
+    return
+  }
+  if (typeof window !== 'undefined') {
+    window.location.assign('/')
+  }
+}
+
+onErrorCaptured((err, _instance, info) => {
+  crashedError.value = err
+  crashInfo.value = info
+
+  // Always log so errors are not silently swallowed.
+  // eslint-disable-next-line no-console
+  console.error('[ErrorBoundary] caught error', err, info)
+
+  // Forward to Sentry if the host page has installed it (no hard dependency).
+  const sentry = (globalThis as unknown as { Sentry?: { captureException?: (e: unknown) => void } }).Sentry
+  if (sentry && typeof sentry.captureException === 'function') {
+    try {
+      sentry.captureException(err)
+    } catch {
+      // Never let reporting failures bubble out of the boundary.
+    }
+  }
+
+  emit('error', err, info)
+
+  // Stop propagation so ancestors do not unmount the whole app.
+  return false
+})
+
+// Reset the boundary automatically when the route changes so a crash on one
+// view does not permanently lock the user out of others.
+if (route) {
+  watch(
+    () => route.fullPath,
+    (next, prev) => {
+      if (props.resetOnRouteChange && crashedError.value !== null && next !== prev) {
+        reset()
+      }
+    },
+  )
+}
+
+// Expose for tests / parent components.
+defineExpose({ reset })
+
+const isDev = (() => {
+  try {
+    return Boolean(import.meta.env?.DEV)
+  } catch {
+    return false
+  }
+})()
+</script>
+
+<template>
+  <slot v-if="crashedError === null" />
+  <div
+    v-else
+    class="td-error-boundary"
+    role="alert"
+    aria-live="assertive"
+    data-testid="error-boundary-fallback"
+  >
+    <div class="td-error-boundary__card">
+      <h2 class="td-error-boundary__title">Something went wrong</h2>
+      <p class="td-error-boundary__message">
+        A part of the app crashed unexpectedly. Your session is still active — you can
+        reload the page or return home to continue working.
+      </p>
+      <div class="td-error-boundary__actions">
+        <button
+          type="button"
+          class="td-error-boundary__btn td-error-boundary__btn--primary"
+          @click="reload"
+        >
+          Reload page
+        </button>
+        <button
+          type="button"
+          class="td-error-boundary__btn td-error-boundary__btn--secondary"
+          @click="goHome"
+        >
+          Go to home
+        </button>
+        <button
+          type="button"
+          class="td-error-boundary__btn td-error-boundary__btn--ghost"
+          @click="reset"
+        >
+          Dismiss
+        </button>
+      </div>
+      <details v-if="isDev" class="td-error-boundary__details">
+        <summary>Error details (dev only)</summary>
+        <p class="td-error-boundary__info">{{ crashInfo }}</p>
+        <pre class="td-error-boundary__stack">{{ formatError(crashedError) }}</pre>
+        <pre v-if="getStack(crashedError)" class="td-error-boundary__stack">{{ getStack(crashedError) }}</pre>
+      </details>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/*
+ * Inline, dependency-free styling. The boundary must render correctly even
+ * when the global stylesheet or design tokens are unavailable (for example
+ * if the stylesheet itself is the source of the crash). Avoid var(--td-*).
+ */
+.td-error-boundary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+.td-error-boundary__card {
+  max-width: 36rem;
+  width: 100%;
+  padding: 24px;
+  border: 1px solid #f1b0b7;
+  background: #fff5f5;
+  color: #6e1f2a;
+  border-radius: 8px;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.td-error-boundary__title {
+  margin: 0 0 8px;
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.td-error-boundary__message {
+  margin: 0 0 16px;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #4a1720;
+}
+
+.td-error-boundary__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.td-error-boundary__btn {
+  appearance: none;
+  border: 1px solid transparent;
+  padding: 8px 14px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.td-error-boundary__btn--primary {
+  background: #b02a37;
+  color: #fff;
+}
+
+.td-error-boundary__btn--primary:hover {
+  background: #951f2c;
+}
+
+.td-error-boundary__btn--secondary {
+  background: #fff;
+  color: #6e1f2a;
+  border-color: #d9a1a7;
+}
+
+.td-error-boundary__btn--secondary:hover {
+  background: #fbe7e9;
+}
+
+.td-error-boundary__btn--ghost {
+  background: transparent;
+  color: #6e1f2a;
+}
+
+.td-error-boundary__btn--ghost:hover {
+  background: #fbe7e9;
+}
+
+.td-error-boundary__details {
+  margin-top: 16px;
+  font-size: 0.85rem;
+}
+
+.td-error-boundary__info {
+  margin: 8px 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.td-error-boundary__stack {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: #fde2e5;
+  padding: 8px;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  max-height: 240px;
+  overflow: auto;
+}
+</style>

--- a/frontend/taskdeck-web/src/components/ErrorBoundary.vue
+++ b/frontend/taskdeck-web/src/components/ErrorBoundary.vue
@@ -96,7 +96,6 @@ onErrorCaptured((err, _instance, info) => {
   crashInfo.value = info
 
   // Always log so errors are not silently swallowed.
-  // eslint-disable-next-line no-console
   console.error('[ErrorBoundary] caught error', err, info)
 
   // Forward to Sentry if the host page has installed it (no hard dependency).

--- a/frontend/taskdeck-web/src/components/shell/AppShell.vue
+++ b/frontend/taskdeck-web/src/components/shell/AppShell.vue
@@ -11,6 +11,7 @@ import ShellSidebar from './ShellSidebar.vue'
 import ShellTopbar from './ShellTopbar.vue'
 import ShellCommandPalette from './ShellCommandPalette.vue'
 import ShellKeyboardHelp from './ShellKeyboardHelp.vue'
+import ErrorBoundary from '../ErrorBoundary.vue'
 import type { CommandItem } from './ShellCommandPalette.vue'
 
 const router = useRouter()
@@ -191,7 +192,14 @@ onUnmounted(() => {
       <ShellTopbar @open-command-palette="openCommandPalette" />
 
       <main id="td-main-content" class="td-content">
-        <router-view />
+        <!--
+          Per-view ErrorBoundary keeps the sidebar and topbar usable when a
+          single route component crashes. The outer boundary in App.vue is
+          the last-resort backstop for crashes in AppShell itself.
+        -->
+        <ErrorBoundary>
+          <router-view />
+        </ErrorBoundary>
       </main>
     </div>
 

--- a/frontend/taskdeck-web/src/main.ts
+++ b/frontend/taskdeck-web/src/main.ts
@@ -3,12 +3,22 @@ import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
 import './style.css'
+import {
+  installVueErrorHandler,
+  installWindowErrorListeners,
+} from './utils/errorReporting'
 
 const app = createApp(App)
 const pinia = createPinia()
 
 app.use(pinia)
 app.use(router)
+
+// Install global crash-prevention hooks before mount so early errors are
+// captured. The Vue handler is the top-level backstop for render/lifecycle
+// errors; the window listeners catch async rejections and non-Vue errors.
+installVueErrorHandler(app)
+installWindowErrorListeners()
 
 app.mount('#app')
 

--- a/frontend/taskdeck-web/src/tests/components/ErrorBoundary.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/ErrorBoundary.spec.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h, ref, nextTick } from 'vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import ErrorBoundary from '../../components/ErrorBoundary.vue'
+
+/** A child component that throws on render when `shouldThrow` is true. */
+const ThrowingChild = defineComponent({
+  name: 'ThrowingChild',
+  props: {
+    shouldThrow: { type: Boolean, default: false },
+    message: { type: String, default: 'kaboom from child' },
+  },
+  setup(props) {
+    return () => {
+      if (props.shouldThrow) {
+        throw new Error(props.message)
+      }
+      return h('div', { class: 'healthy-child' }, 'child is healthy')
+    }
+  },
+})
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', name: 'home', component: { template: '<div>home</div>' } },
+      { path: '/other', name: 'other', component: { template: '<div>other</div>' } },
+    ],
+  })
+}
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    // Ensure no leftover Sentry global between tests.
+    delete (globalThis as { Sentry?: unknown }).Sentry
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    delete (globalThis as { Sentry?: unknown }).Sentry
+  })
+
+  it('renders its slot content when no error occurs', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: false }),
+      },
+    })
+
+    expect(wrapper.text()).toContain('child is healthy')
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(false)
+  })
+
+  it('renders fallback UI with role="alert" when a descendant throws', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: true, message: 'render-boom' }),
+      },
+    })
+
+    await flushPromises()
+
+    const fallback = wrapper.find('[data-testid="error-boundary-fallback"]')
+    expect(fallback.exists()).toBe(true)
+    expect(fallback.attributes('role')).toBe('alert')
+    expect(fallback.attributes('aria-live')).toBe('assertive')
+    expect(fallback.text()).toContain('Something went wrong')
+  })
+
+  it('logs the caught error to console.error', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: true, message: 'log-me' }),
+      },
+    })
+    await flushPromises()
+
+    expect(consoleErrorSpy).toHaveBeenCalled()
+    const allCalls = consoleErrorSpy.mock.calls.flat().map(String).join(' ')
+    expect(allCalls).toContain('ErrorBoundary')
+  })
+
+  it('forwards the error to window.Sentry.captureException when present', async () => {
+    const captureException = vi.fn()
+    ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
+
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: true, message: 'to-sentry' }),
+      },
+    })
+    await flushPromises()
+
+    expect(captureException).toHaveBeenCalledTimes(1)
+    const err = captureException.mock.calls[0][0]
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('to-sentry')
+  })
+
+  it('does not throw when Sentry.captureException itself throws', async () => {
+    ;(globalThis as { Sentry?: unknown }).Sentry = {
+      captureException: () => {
+        throw new Error('sentry exploded')
+      },
+    }
+
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    expect(() => {
+      mount(ErrorBoundary, {
+        global: { plugins: [router] },
+        slots: {
+          default: () => h(ThrowingChild, { shouldThrow: true }),
+        },
+      })
+    }).not.toThrow()
+  })
+
+  it('renders Reload and Go to home buttons in the fallback', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: true }),
+      },
+    })
+    await flushPromises()
+
+    const buttonTexts = wrapper.findAll('button').map((b) => b.text())
+    expect(buttonTexts).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/Reload/i),
+        expect.stringMatching(/home/i),
+        expect.stringMatching(/Dismiss/i),
+      ]),
+    )
+  })
+
+  it('navigates to home and clears fallback when "Go to home" is clicked', async () => {
+    const router = makeRouter()
+    await router.push('/other')
+    await router.isReady()
+
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: true }),
+      },
+    })
+    await flushPromises()
+
+    const homeBtn = wrapper.findAll('button').find((b) => /home/i.test(b.text()))
+    expect(homeBtn).toBeTruthy()
+    await homeBtn!.trigger('click')
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/')
+  })
+
+  it('resets the fallback when the route changes (resetOnRouteChange=true)', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    // Use a reactive flag so we can flip the child back to healthy before the
+    // route change — otherwise the child will just throw again and the
+    // boundary will re-trap.
+    const shouldThrow = ref(true)
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: shouldThrow.value }),
+      },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(true)
+
+    shouldThrow.value = false
+    await nextTick()
+    await router.push('/other')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(false)
+  })
+
+  it('does not reset on route change when resetOnRouteChange=false', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const shouldThrow = ref(true)
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      props: { resetOnRouteChange: false },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: shouldThrow.value }),
+      },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(true)
+
+    shouldThrow.value = false
+    await nextTick()
+    await router.push('/other')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(true)
+  })
+
+  it('emits an "error" event with the error and info when a child throws', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: true, message: 'emit-me' }),
+      },
+    })
+    await flushPromises()
+
+    const emitted = wrapper.emitted('error')
+    expect(emitted).toBeTruthy()
+    expect(emitted!.length).toBeGreaterThan(0)
+    const [err] = emitted![0]
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('emit-me')
+  })
+
+  it('exposes a reset() method that clears fallback state', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const shouldThrow = ref(true)
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: {
+        default: () => h(ThrowingChild, { shouldThrow: shouldThrow.value }),
+      },
+    })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(true)
+
+    shouldThrow.value = false
+    await nextTick()
+    ;(wrapper.vm as unknown as { reset: () => void }).reset()
+    await flushPromises()
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(false)
+  })
+
+  it('renders without a router installed (graceful degradation)', async () => {
+    // No router plugin — useRoute/useRouter will throw internally. The
+    // component must still mount and render the healthy slot.
+    const wrapper = mount(ErrorBoundary, {
+      slots: { default: () => h(ThrowingChild, { shouldThrow: false }) },
+    })
+    expect(wrapper.text()).toContain('child is healthy')
+  })
+})

--- a/frontend/taskdeck-web/src/tests/components/ErrorBoundary.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/ErrorBoundary.spec.ts
@@ -100,7 +100,7 @@ describe('ErrorBoundary', () => {
     expect(allCalls).toContain('ErrorBoundary')
   })
 
-  it('forwards the error to window.Sentry.captureException when present', async () => {
+  it('forwards the error to window.Sentry.captureException with ErrorBoundary source and info', async () => {
     const captureException = vi.fn()
     ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
 
@@ -117,9 +117,13 @@ describe('ErrorBoundary', () => {
     await flushPromises()
 
     expect(captureException).toHaveBeenCalledTimes(1)
-    const err = captureException.mock.calls[0][0]
+    const [err, hint] = captureException.mock.calls[0]
     expect(err).toBeInstanceOf(Error)
     expect((err as Error).message).toBe('to-sentry')
+    // The hint must carry the ErrorBoundary source and the Vue lifecycle info
+    // string so Sentry context stays consistent across reporting paths.
+    expect(hint).toMatchObject({ source: 'ErrorBoundary' })
+    expect((hint as { info?: string }).info).toEqual(expect.any(String))
   })
 
   it('does not throw when Sentry.captureException itself throws', async () => {
@@ -287,5 +291,31 @@ describe('ErrorBoundary', () => {
       slots: { default: () => h(ThrowingChild, { shouldThrow: false }) },
     })
     expect(wrapper.text()).toContain('child is healthy')
+  })
+
+  it('renders fallback when a descendant throws a falsy value (null)', async () => {
+    // Guards against the sentinel-collision bug: if crash state were tracked
+    // as `crashedError === null`, a child that throws `null` would be treated
+    // as healthy. We track crash state with an explicit boolean to avoid this.
+    const NullThrower = defineComponent({
+      name: 'NullThrower',
+      setup() {
+        return () => {
+          throw null
+        }
+      },
+    })
+
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const wrapper = mount(ErrorBoundary, {
+      global: { plugins: [router] },
+      slots: { default: () => h(NullThrower) },
+    })
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="error-boundary-fallback"]').exists()).toBe(true)
   })
 })

--- a/frontend/taskdeck-web/src/tests/utils/errorReporting.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/errorReporting.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h } from 'vue'
+import {
+  installVueErrorHandler,
+  installWindowErrorListeners,
+  reportToSentry,
+} from '../../utils/errorReporting'
+
+describe('errorReporting utilities', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    delete (globalThis as { Sentry?: unknown }).Sentry
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+    delete (globalThis as { Sentry?: unknown }).Sentry
+  })
+
+  describe('reportToSentry', () => {
+    it('returns false when window.Sentry is not present', () => {
+      expect(reportToSentry(new Error('nope'))).toBe(false)
+    })
+
+    it('calls Sentry.captureException and returns true when present', () => {
+      const captureException = vi.fn()
+      ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
+      const err = new Error('boom')
+
+      expect(reportToSentry(err)).toBe(true)
+      expect(captureException).toHaveBeenCalledWith(err, undefined)
+    })
+
+    it('swallows exceptions thrown by Sentry.captureException', () => {
+      ;(globalThis as { Sentry?: unknown }).Sentry = {
+        captureException: () => {
+          throw new Error('sentry exploded')
+        },
+      }
+      expect(() => reportToSentry(new Error('x'))).not.toThrow()
+      expect(reportToSentry(new Error('x'))).toBe(false)
+    })
+
+    it('returns false when Sentry exists but captureException is not a function', () => {
+      ;(globalThis as { Sentry?: unknown }).Sentry = { captureException: 'not-a-fn' }
+      expect(reportToSentry(new Error('x'))).toBe(false)
+    })
+  })
+
+  describe('installVueErrorHandler', () => {
+    it('installs a handler on app.config.errorHandler that logs to console', () => {
+      const app = createApp(defineComponent({ render: () => h('div') }))
+      installVueErrorHandler(app)
+
+      expect(typeof app.config.errorHandler).toBe('function')
+
+      const err = new Error('vue-boom')
+      app.config.errorHandler!(err, null, 'render')
+
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      const logged = consoleErrorSpy.mock.calls.flat().map(String).join(' ')
+      expect(logged).toContain('vue:errorHandler')
+    })
+
+    it('forwards the error to Sentry when Sentry is present', () => {
+      const captureException = vi.fn()
+      ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
+
+      const app = createApp(defineComponent({ render: () => h('div') }))
+      installVueErrorHandler(app)
+
+      const err = new Error('forward-me')
+      app.config.errorHandler!(err, null, 'render')
+
+      expect(captureException).toHaveBeenCalledWith(err, { info: 'render' })
+    })
+  })
+
+  describe('installWindowErrorListeners', () => {
+    it('logs and reports unhandledrejection events', () => {
+      const captureException = vi.fn()
+      ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
+
+      const dispose = installWindowErrorListeners(window)
+
+      const reason = new Error('rejected')
+      // happy-dom supports PromiseRejectionEvent dispatch via a generic Event.
+      const event = new Event('unhandledrejection') as PromiseRejectionEvent
+      Object.defineProperty(event, 'reason', { value: reason })
+      window.dispatchEvent(event)
+
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      const logged = consoleErrorSpy.mock.calls.flat().map(String).join(' ')
+      expect(logged).toContain('unhandledrejection')
+      expect(captureException).toHaveBeenCalledWith(reason, { source: 'unhandledrejection' })
+
+      dispose()
+    })
+
+    it('logs and reports window error events', () => {
+      const captureException = vi.fn()
+      ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
+
+      const dispose = installWindowErrorListeners(window)
+
+      const err = new Error('uncaught')
+      const event = new Event('error') as ErrorEvent
+      Object.defineProperty(event, 'error', { value: err })
+      Object.defineProperty(event, 'message', { value: 'uncaught' })
+      window.dispatchEvent(event)
+
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      const logged = consoleErrorSpy.mock.calls.flat().map(String).join(' ')
+      expect(logged).toContain('window:error')
+      expect(captureException).toHaveBeenCalledWith(err, { source: 'window.error' })
+
+      dispose()
+    })
+
+    it('dispose() removes the listeners so later events are not handled', () => {
+      const captureException = vi.fn()
+      ;(globalThis as { Sentry?: unknown }).Sentry = { captureException }
+
+      const dispose = installWindowErrorListeners(window)
+      dispose()
+
+      const event = new Event('unhandledrejection') as PromiseRejectionEvent
+      Object.defineProperty(event, 'reason', { value: new Error('late') })
+      window.dispatchEvent(event)
+
+      expect(captureException).not.toHaveBeenCalled()
+    })
+
+    it('does not throw when there is no Sentry global', () => {
+      const dispose = installWindowErrorListeners(window)
+      const event = new Event('unhandledrejection') as PromiseRejectionEvent
+      Object.defineProperty(event, 'reason', { value: new Error('x') })
+      expect(() => window.dispatchEvent(event)).not.toThrow()
+      dispose()
+    })
+  })
+})

--- a/frontend/taskdeck-web/src/utils/errorReporting.ts
+++ b/frontend/taskdeck-web/src/utils/errorReporting.ts
@@ -1,0 +1,82 @@
+/**
+ * Global error reporting plumbing for the Vue app.
+ *
+ * Responsibilities:
+ *   - Install `app.config.errorHandler` as the top-level Vue backstop.
+ *   - Install `window.addEventListener('unhandledrejection', ...)` to catch
+ *     async rejections that Vue's errorCaptured hook cannot see.
+ *   - Install `window.addEventListener('error', ...)` for uncaught runtime
+ *     errors thrown outside Vue's render pipeline.
+ *
+ * These hooks log to the console and, if the host page has pre-installed
+ * Sentry on `window.Sentry`, forward the exception. No new npm dependency
+ * is added — the integration is intentionally opt-in and runtime-detected.
+ */
+import type { App } from 'vue'
+
+type SentryLike = {
+  captureException?: (err: unknown, hint?: unknown) => void
+}
+
+/** Read a Sentry-like global, if present, without declaring a hard dependency. */
+function getSentry(): SentryLike | null {
+  const sentry = (globalThis as unknown as { Sentry?: SentryLike }).Sentry
+  if (sentry && typeof sentry.captureException === 'function') {
+    return sentry
+  }
+  return null
+}
+
+/** Safely forward an error to Sentry. Never throws. */
+export function reportToSentry(err: unknown, hint?: unknown): boolean {
+  const sentry = getSentry()
+  if (!sentry || !sentry.captureException) return false
+  try {
+    sentry.captureException(err, hint)
+    return true
+  } catch {
+    // Reporting must never itself propagate.
+    return false
+  }
+}
+
+/** Install `app.config.errorHandler` as a last-resort logger/reporter. */
+export function installVueErrorHandler(app: App): void {
+  app.config.errorHandler = (err, _instance, info) => {
+    // eslint-disable-next-line no-console
+    console.error('[vue:errorHandler]', err, info)
+    reportToSentry(err, { info })
+  }
+}
+
+type DisposeFn = () => void
+
+/**
+ * Install window-level listeners for unhandled promise rejections and
+ * uncaught errors. Returns a dispose function (primarily for tests /
+ * hot-reload cleanup).
+ */
+export function installWindowErrorListeners(target: Window = window): DisposeFn {
+  const onRejection = (event: PromiseRejectionEvent) => {
+    const reason = event?.reason
+    // eslint-disable-next-line no-console
+    console.error('[window:unhandledrejection]', reason)
+    reportToSentry(reason, { source: 'unhandledrejection' })
+  }
+
+  const onError = (event: ErrorEvent) => {
+    // Prefer event.error (the real Error instance) over event.message.
+    const err = event?.error ?? event?.message ?? event
+    // eslint-disable-next-line no-console
+    console.error('[window:error]', err)
+    reportToSentry(err, { source: 'window.error' })
+  }
+
+  target.addEventListener('unhandledrejection', onRejection)
+  target.addEventListener('error', onError)
+
+  return () => {
+    target.removeEventListener('unhandledrejection', onRejection)
+    target.removeEventListener('error', onError)
+  }
+}

--- a/frontend/taskdeck-web/src/utils/errorReporting.ts
+++ b/frontend/taskdeck-web/src/utils/errorReporting.ts
@@ -43,7 +43,6 @@ export function reportToSentry(err: unknown, hint?: unknown): boolean {
 /** Install `app.config.errorHandler` as a last-resort logger/reporter. */
 export function installVueErrorHandler(app: App): void {
   app.config.errorHandler = (err, _instance, info) => {
-    // eslint-disable-next-line no-console
     console.error('[vue:errorHandler]', err, info)
     reportToSentry(err, { info })
   }
@@ -59,7 +58,6 @@ type DisposeFn = () => void
 export function installWindowErrorListeners(target: Window = window): DisposeFn {
   const onRejection = (event: PromiseRejectionEvent) => {
     const reason = event?.reason
-    // eslint-disable-next-line no-console
     console.error('[window:unhandledrejection]', reason)
     reportToSentry(reason, { source: 'unhandledrejection' })
   }
@@ -67,7 +65,6 @@ export function installWindowErrorListeners(target: Window = window): DisposeFn 
   const onError = (event: ErrorEvent) => {
     // Prefer event.error (the real Error instance) over event.message.
     const err = event?.error ?? event?.message ?? event
-    // eslint-disable-next-line no-console
     console.error('[window:error]', err)
     reportToSentry(err, { source: 'window.error' })
   }


### PR DESCRIPTION
## Summary

Adds a global Vue error boundary + crash-prevention fallback:
- `ErrorBoundary.vue` uses `onErrorCaptured` to catch descendant render/lifecycle errors and render a recoverable fallback (Reload + Go-to-Home actions)
- `App.vue` wraps `<RouterView />` in `<ErrorBoundary>`
- `main.ts` installs `app.config.errorHandler` as a top-level backstop, plus `window` listeners for `error` / `unhandledrejection`
- Optional Sentry passthrough via `window.Sentry?.captureException` — no hard dependency
- Dev-only stack trace display, prod-safe messaging

Closes #852

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npx vitest --run ErrorBoundary` passes
- [ ] `npm run lint` passes
- [ ] Reload button restores the app without losing persisted session