### PR TITLE
fix: add SSRF protection for webhook and LLM provider URLs

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/LlmProviderRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/LlmProviderRegistration.cs
@@ -39,6 +39,10 @@ public static class LlmProviderRegistration
         var llmProviderSettings = configuration.GetSection("Llm").Get<LlmProviderSettings>() ?? new LlmProviderSettings();
         services.AddSingleton(llmProviderSettings);
 
+        // Determine once at startup whether localhost LLM endpoints are permitted.
+        // This is true only in development-like environments with AllowLiveProvidersInDevelopment.
+        var allowLocalhostLlm = IsLocalhostLlmAllowed(services, configuration);
+
         services.AddHttpClient<OpenAiLlmProvider>((sp, client) =>
         {
             var settings = sp.GetRequiredService<LlmProviderSettings>();
@@ -49,13 +53,15 @@ public static class LlmProviderRegistration
         {
             // SSRF protection: DNS-level check prevents connections to private/internal IPs
             // even if the BaseUrl hostname resolves to a private address (DNS rebinding defense).
+            // In development with AllowLiveProvidersInDevelopment, localhost is permitted
+            // so developers can use local LLM gateways (Ollama, LM Studio, etc.).
             return new SocketsHttpHandler
             {
                 AllowAutoRedirect = false,
                 ConnectCallback = (context, cancellationToken) =>
                     OutboundWebhookConnectCallback.ConnectAsync(
                         context,
-                        allowLocalhostEndpoints: false,
+                        allowLocalhostEndpoints: allowLocalhostLlm,
                         cancellationToken)
             };
         });
@@ -69,13 +75,14 @@ public static class LlmProviderRegistration
         {
             // SSRF protection: DNS-level check prevents connections to private/internal IPs
             // even if the BaseUrl hostname resolves to a private address (DNS rebinding defense).
+            // In development with AllowLiveProvidersInDevelopment, localhost is permitted.
             return new SocketsHttpHandler
             {
                 AllowAutoRedirect = false,
                 ConnectCallback = (context, cancellationToken) =>
                     OutboundWebhookConnectCallback.ConnectAsync(
                         context,
-                        allowLocalhostEndpoints: false,
+                        allowLocalhostEndpoints: allowLocalhostLlm,
                         cancellationToken)
             };
         });
@@ -102,5 +109,36 @@ public static class LlmProviderRegistration
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Determines whether localhost LLM endpoints should be permitted based on the
+    /// hosting environment and LLM provider configuration. Returns true only in
+    /// development-like environments when AllowLiveProvidersInDevelopment is enabled,
+    /// enabling developers to use local LLM gateways (Ollama, LM Studio, etc.).
+    /// </summary>
+    private static bool IsLocalhostLlmAllowed(
+        IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var llmSettings = configuration.GetSection("Llm").Get<LlmProviderSettings>();
+        if (llmSettings is null || !llmSettings.AllowLiveProvidersInDevelopment)
+        {
+            return false;
+        }
+
+        // Check for a registered IWebHostEnvironment to determine if we're in development.
+        // During startup the environment is already registered as a singleton.
+        var envDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IWebHostEnvironment));
+        if (envDescriptor?.ImplementationInstance is IWebHostEnvironment env)
+        {
+            var name = env.EnvironmentName;
+            return name.Equals("Development", StringComparison.OrdinalIgnoreCase) ||
+                   name.Equals("Test", StringComparison.OrdinalIgnoreCase) ||
+                   name.Equals("Testing", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
     }
 }

--- a/backend/src/Taskdeck.Api/Extensions/LlmProviderRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/LlmProviderRegistration.cs
@@ -1,3 +1,5 @@
+using System.Net.Sockets;
+using Taskdeck.Api.Workers;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 
@@ -42,12 +44,40 @@ public static class LlmProviderRegistration
             var settings = sp.GetRequiredService<LlmProviderSettings>();
             var timeoutSeconds = settings.OpenAi?.TimeoutSeconds > 0 ? settings.OpenAi.TimeoutSeconds : 30;
             client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        })
+        .ConfigurePrimaryHttpMessageHandler(_ =>
+        {
+            // SSRF protection: DNS-level check prevents connections to private/internal IPs
+            // even if the BaseUrl hostname resolves to a private address (DNS rebinding defense).
+            return new SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                ConnectCallback = (context, cancellationToken) =>
+                    OutboundWebhookConnectCallback.ConnectAsync(
+                        context,
+                        allowLocalhostEndpoints: false,
+                        cancellationToken)
+            };
         });
         services.AddHttpClient<GeminiLlmProvider>((sp, client) =>
         {
             var settings = sp.GetRequiredService<LlmProviderSettings>();
             var timeoutSeconds = settings.Gemini?.TimeoutSeconds > 0 ? settings.Gemini.TimeoutSeconds : 30;
             client.Timeout = TimeSpan.FromSeconds(timeoutSeconds);
+        })
+        .ConfigurePrimaryHttpMessageHandler(_ =>
+        {
+            // SSRF protection: DNS-level check prevents connections to private/internal IPs
+            // even if the BaseUrl hostname resolves to a private address (DNS rebinding defense).
+            return new SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                ConnectCallback = (context, cancellationToken) =>
+                    OutboundWebhookConnectCallback.ConnectAsync(
+                        context,
+                        allowLocalhostEndpoints: false,
+                        cancellationToken)
+            };
         });
 
         services.AddScoped<MockLlmProvider>();

--- a/backend/src/Taskdeck.Application/Services/LlmProviderSelectionPolicy.cs
+++ b/backend/src/Taskdeck.Application/Services/LlmProviderSelectionPolicy.cs
@@ -42,9 +42,13 @@ public static class LlmProviderSelectionPolicy
                 "Live providers are disabled for development-like environments.");
         }
 
+        // In development with AllowLiveProvidersInDevelopment, permit localhost endpoints
+        // so developers can use local LLM gateways (Ollama, LM Studio, etc.).
+        var allowLocalhostEndpoints = IsDevelopmentLike(environmentName) && settings.AllowLiveProvidersInDevelopment;
+
         if (requestedProvider.Value == LlmProviderKind.OpenAi)
         {
-            if (!TryValidateOpenAiSettings(settings, out var validationError))
+            if (!TryValidateOpenAiSettings(settings, out var validationError, allowLocalhostEndpoints))
             {
                 return new LlmProviderDecision(
                     LlmProviderKind.Mock,
@@ -56,7 +60,7 @@ public static class LlmProviderSelectionPolicy
                 "OpenAI provider selected.");
         }
 
-        if (!TryValidateGeminiSettings(settings, out var geminiValidationError))
+        if (!TryValidateGeminiSettings(settings, out var geminiValidationError, allowLocalhostEndpoints))
         {
             return new LlmProviderDecision(
                 LlmProviderKind.Mock,
@@ -68,7 +72,10 @@ public static class LlmProviderSelectionPolicy
             "Gemini provider selected.");
     }
 
-    public static bool TryValidateOpenAiSettings(LlmProviderSettings settings, out string error)
+    public static bool TryValidateOpenAiSettings(
+        LlmProviderSettings settings,
+        out string error,
+        bool allowLocalhostEndpoints = false)
     {
         if (settings.OpenAi is null)
         {
@@ -97,8 +104,10 @@ public static class LlmProviderSelectionPolicy
             return false;
         }
 
-        // SSRF protection: block private IP ranges, cloud metadata endpoints, and internal hostnames
-        var ssrfResult = SsrfProtectionService.ValidateLlmProviderUrl(openAi.BaseUrl);
+        // SSRF protection: block private IP ranges, cloud metadata endpoints, and internal hostnames.
+        // In development with AllowLiveProvidersInDevelopment, localhost is permitted for local
+        // LLM gateways (Ollama, LM Studio, etc.).
+        var ssrfResult = SsrfProtectionService.ValidateLlmProviderUrl(openAi.BaseUrl, allowLocalhostEndpoints);
         if (!ssrfResult.IsAllowed)
         {
             error = $"BaseUrl blocked by SSRF protection: {ssrfResult.ErrorMessage}";
@@ -115,7 +124,10 @@ public static class LlmProviderSelectionPolicy
         return true;
     }
 
-    public static bool TryValidateGeminiSettings(LlmProviderSettings settings, out string error)
+    public static bool TryValidateGeminiSettings(
+        LlmProviderSettings settings,
+        out string error,
+        bool allowLocalhostEndpoints = false)
     {
         if (settings.Gemini is null)
         {
@@ -144,8 +156,10 @@ public static class LlmProviderSelectionPolicy
             return false;
         }
 
-        // SSRF protection: block private IP ranges, cloud metadata endpoints, and internal hostnames
-        var ssrfResult = SsrfProtectionService.ValidateLlmProviderUrl(gemini.BaseUrl);
+        // SSRF protection: block private IP ranges, cloud metadata endpoints, and internal hostnames.
+        // In development with AllowLiveProvidersInDevelopment, localhost is permitted for local
+        // LLM gateways (Ollama, LM Studio, etc.).
+        var ssrfResult = SsrfProtectionService.ValidateLlmProviderUrl(gemini.BaseUrl, allowLocalhostEndpoints);
         if (!ssrfResult.IsAllowed)
         {
             error = $"BaseUrl blocked by SSRF protection: {ssrfResult.ErrorMessage}";

--- a/backend/src/Taskdeck.Application/Services/LlmProviderSelectionPolicy.cs
+++ b/backend/src/Taskdeck.Application/Services/LlmProviderSelectionPolicy.cs
@@ -97,6 +97,14 @@ public static class LlmProviderSelectionPolicy
             return false;
         }
 
+        // SSRF protection: block private IP ranges, cloud metadata endpoints, and internal hostnames
+        var ssrfResult = SsrfProtectionService.ValidateLlmProviderUrl(openAi.BaseUrl);
+        if (!ssrfResult.IsAllowed)
+        {
+            error = $"BaseUrl blocked by SSRF protection: {ssrfResult.ErrorMessage}";
+            return false;
+        }
+
         if (openAi.TimeoutSeconds <= 0)
         {
             error = "TimeoutSeconds must be greater than zero.";
@@ -133,6 +141,14 @@ public static class LlmProviderSelectionPolicy
             (baseUri.Scheme != Uri.UriSchemeHttps && baseUri.Scheme != Uri.UriSchemeHttp))
         {
             error = "BaseUrl must be an absolute HTTP(S) URI.";
+            return false;
+        }
+
+        // SSRF protection: block private IP ranges, cloud metadata endpoints, and internal hostnames
+        var ssrfResult = SsrfProtectionService.ValidateLlmProviderUrl(gemini.BaseUrl);
+        if (!ssrfResult.IsAllowed)
+        {
+            error = $"BaseUrl blocked by SSRF protection: {ssrfResult.ErrorMessage}";
             return false;
         }
 

--- a/backend/src/Taskdeck.Application/Services/OutboundWebhookEndpointGuard.cs
+++ b/backend/src/Taskdeck.Application/Services/OutboundWebhookEndpointGuard.cs
@@ -15,6 +15,17 @@ public static partial class OutboundWebhookEndpointGuard
         ".localtest.me"
     ];
 
+    /// <summary>
+    /// Exact hostnames that are always blocked regardless of suffix matching.
+    /// Provides defense-in-depth for cloud metadata endpoints and well-known
+    /// internal service hostnames that an attacker could use for SSRF.
+    /// </summary>
+    private static readonly string[] BlockedExactHostnames =
+    [
+        "metadata.goog",           // GCP metadata (no suffix match covers this)
+        "100.100.100.200",         // Alibaba Cloud metadata endpoint
+    ];
+
     private static readonly string[] DynamicDnsRoots =
     [
         "nip.io",
@@ -109,6 +120,12 @@ public static partial class OutboundWebhookEndpointGuard
 
     private static bool IsBlockedByHostnamePolicy(string host)
     {
+        if (BlockedExactHostnames.Any(blocked =>
+                host.Equals(blocked, StringComparison.Ordinal)))
+        {
+            return true;
+        }
+
         if (BlockedHostnameSuffixes.Any(suffix =>
                 host.EndsWith(suffix, StringComparison.Ordinal)))
         {

--- a/backend/src/Taskdeck.Application/Services/SsrfProtectionService.cs
+++ b/backend/src/Taskdeck.Application/Services/SsrfProtectionService.cs
@@ -1,5 +1,3 @@
-using System.Net;
-
 namespace Taskdeck.Application.Services;
 
 /// <summary>
@@ -7,23 +5,13 @@ namespace Taskdeck.Application.Services;
 /// cloud metadata endpoints, and other dangerous targets. Used for webhook endpoints,
 /// LLM provider BaseUrl configuration, and any other user-provided URLs that the
 /// server will make outbound requests to.
+///
+/// Cloud metadata hostnames and blocked IP ranges are maintained in a single source
+/// of truth: <see cref="OutboundWebhookEndpointGuard"/>. This service delegates all
+/// host-level checks there to avoid duplication.
 /// </summary>
 public static class SsrfProtectionService
 {
-    /// <summary>
-    /// Exact hostnames that must always be blocked regardless of suffix matching.
-    /// These are well-known cloud metadata and internal service endpoints.
-    /// </summary>
-    private static readonly string[] BlockedExactHostnames =
-    [
-        "metadata.google.internal",
-        "metadata.goog",
-        "169.254.169.254",         // AWS/GCP/Azure metadata (also blocked as link-local IP)
-        "fd00:ec2::254",           // AWS IMDSv2 IPv6 endpoint
-        "100.100.100.200",         // Alibaba Cloud metadata
-        "[fd00:ec2::254]",         // Bracketed IPv6 form
-    ];
-
     /// <summary>
     /// Validates a URL for SSRF safety. Returns a result indicating whether the URL
     /// is safe to make outbound requests to.
@@ -58,13 +46,8 @@ public static class SsrfProtectionService
 
         var host = parsed.Host;
 
-        // Check explicit blocked hostnames (defense in depth for cloud metadata)
-        if (IsExactBlockedHostname(host))
-        {
-            return SsrfValidationResult.Blocked($"Host '{host}' is not allowed (cloud metadata or internal service endpoint).");
-        }
-
-        // Delegate to the existing endpoint guard for comprehensive IP/hostname checking
+        // Delegate to the endpoint guard for comprehensive IP/hostname/metadata checking.
+        // OutboundWebhookEndpointGuard is the single source of truth for blocked hosts.
         if (OutboundWebhookEndpointGuard.IsHostBlockedByStaticPolicy(host, allowLocalhostEndpoints))
         {
             return SsrfValidationResult.Blocked($"Host '{host}' is not allowed.");
@@ -132,20 +115,6 @@ public static class SsrfProtectionService
         }
 
         return result;
-    }
-
-    private static bool IsExactBlockedHostname(string host)
-    {
-        var normalized = host.Trim().ToLowerInvariant();
-        foreach (var blocked in BlockedExactHostnames)
-        {
-            if (string.Equals(normalized, blocked, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }
 

--- a/backend/src/Taskdeck.Application/Services/SsrfProtectionService.cs
+++ b/backend/src/Taskdeck.Application/Services/SsrfProtectionService.cs
@@ -1,0 +1,168 @@
+using System.Net;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Reusable SSRF protection service that validates URLs against private IP ranges,
+/// cloud metadata endpoints, and other dangerous targets. Used for webhook endpoints,
+/// LLM provider BaseUrl configuration, and any other user-provided URLs that the
+/// server will make outbound requests to.
+/// </summary>
+public static class SsrfProtectionService
+{
+    /// <summary>
+    /// Exact hostnames that must always be blocked regardless of suffix matching.
+    /// These are well-known cloud metadata and internal service endpoints.
+    /// </summary>
+    private static readonly string[] BlockedExactHostnames =
+    [
+        "metadata.google.internal",
+        "metadata.goog",
+        "169.254.169.254",         // AWS/GCP/Azure metadata (also blocked as link-local IP)
+        "fd00:ec2::254",           // AWS IMDSv2 IPv6 endpoint
+        "100.100.100.200",         // Alibaba Cloud metadata
+        "[fd00:ec2::254]",         // Bracketed IPv6 form
+    ];
+
+    /// <summary>
+    /// Validates a URL for SSRF safety. Returns a result indicating whether the URL
+    /// is safe to make outbound requests to.
+    /// </summary>
+    /// <param name="url">The URL to validate.</param>
+    /// <param name="allowLocalhostEndpoints">Whether to allow localhost URLs (for development).</param>
+    /// <returns>A validation result with success/failure and an error message if blocked.</returns>
+    public static SsrfValidationResult ValidateUrl(string? url, bool allowLocalhostEndpoints = false)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return SsrfValidationResult.Blocked("URL is required.");
+        }
+
+        var trimmed = url.Trim();
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var parsed))
+        {
+            return SsrfValidationResult.Blocked("URL must be an absolute URI.");
+        }
+
+        var isHttps = string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+        var isHttp = string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase);
+        if (!isHttps && !isHttp)
+        {
+            return SsrfValidationResult.Blocked("URL must use http or https scheme.");
+        }
+
+        if (!string.IsNullOrEmpty(parsed.UserInfo))
+        {
+            return SsrfValidationResult.Blocked("URL must not contain embedded credentials.");
+        }
+
+        var host = parsed.Host;
+
+        // Check explicit blocked hostnames (defense in depth for cloud metadata)
+        if (IsExactBlockedHostname(host))
+        {
+            return SsrfValidationResult.Blocked($"Host '{host}' is not allowed (cloud metadata or internal service endpoint).");
+        }
+
+        // Delegate to the existing endpoint guard for comprehensive IP/hostname checking
+        if (OutboundWebhookEndpointGuard.IsHostBlockedByStaticPolicy(host, allowLocalhostEndpoints))
+        {
+            return SsrfValidationResult.Blocked($"Host '{host}' is not allowed.");
+        }
+
+        return SsrfValidationResult.Allowed(parsed);
+    }
+
+    /// <summary>
+    /// Validates a URL for SSRF safety with DNS resolution. This performs the static
+    /// policy check first, then resolves the hostname via DNS and checks the resolved
+    /// IP addresses against blocked ranges.
+    /// </summary>
+    /// <param name="url">The URL to validate.</param>
+    /// <param name="allowLocalhostEndpoints">Whether to allow localhost URLs (for development).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A validation result with success/failure and an error message if blocked.</returns>
+    public static async Task<SsrfValidationResult> ValidateUrlWithDnsAsync(
+        string? url,
+        bool allowLocalhostEndpoints = false,
+        CancellationToken cancellationToken = default)
+    {
+        var staticResult = ValidateUrl(url, allowLocalhostEndpoints);
+        if (!staticResult.IsAllowed)
+        {
+            return staticResult;
+        }
+
+        // Now resolve DNS and check the actual IP addresses
+        var host = staticResult.ParsedUri!.Host;
+        var isBlocked = await OutboundWebhookEndpointGuard.IsHostBlockedAsync(
+            host,
+            allowLocalhostEndpoints,
+            cancellationToken);
+
+        if (isBlocked)
+        {
+            return SsrfValidationResult.Blocked($"Host '{host}' resolves to a blocked IP address.");
+        }
+
+        return staticResult;
+    }
+
+    /// <summary>
+    /// Validates an LLM provider BaseUrl for SSRF safety. This is a convenience method
+    /// that checks the URL against SSRF protections and ensures it uses HTTPS
+    /// (unless localhost is explicitly allowed for development).
+    /// </summary>
+    public static SsrfValidationResult ValidateLlmProviderUrl(
+        string? baseUrl,
+        bool allowLocalhostEndpoints = false)
+    {
+        var result = ValidateUrl(baseUrl, allowLocalhostEndpoints);
+        if (!result.IsAllowed)
+        {
+            return result;
+        }
+
+        // LLM provider URLs must use HTTPS unless localhost is allowed
+        var isHttps = string.Equals(result.ParsedUri!.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+        var isLocalhost = string.Equals(result.ParsedUri.Host, "localhost", StringComparison.OrdinalIgnoreCase);
+        if (!isHttps && !(isLocalhost && allowLocalhostEndpoints))
+        {
+            return SsrfValidationResult.Blocked("LLM provider URL must use HTTPS.");
+        }
+
+        return result;
+    }
+
+    private static bool IsExactBlockedHostname(string host)
+    {
+        var normalized = host.Trim().ToLowerInvariant();
+        foreach (var blocked in BlockedExactHostnames)
+        {
+            if (string.Equals(normalized, blocked, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Result of an SSRF URL validation check.
+/// </summary>
+public sealed class SsrfValidationResult
+{
+    public bool IsAllowed { get; private init; }
+    public string? ErrorMessage { get; private init; }
+    public Uri? ParsedUri { get; private init; }
+
+    private SsrfValidationResult() { }
+
+    public static SsrfValidationResult Allowed(Uri parsedUri) =>
+        new() { IsAllowed = true, ParsedUri = parsedUri };
+
+    public static SsrfValidationResult Blocked(string errorMessage) =>
+        new() { IsAllowed = false, ErrorMessage = errorMessage };
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/LlmProviderSelectionPolicyTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LlmProviderSelectionPolicyTests.cs
@@ -369,6 +369,99 @@ public class LlmProviderSelectionPolicyTests
         isValid.Should().BeTrue();
     }
 
+    // -----------------------------------------------------------------------
+    // Development localhost bypass — local LLM gateways (Ollama, LM Studio)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Evaluate_ShouldSelectOpenAi_WhenLocalhostInDevelopmentWithAllowLiveProviders()
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.AllowLiveProvidersInDevelopment = true;
+        settings.Provider = "OpenAI";
+        settings.OpenAi.BaseUrl = "http://localhost:11434/v1";
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Development");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.OpenAi,
+            "localhost should be allowed in development with AllowLiveProvidersInDevelopment for local LLM gateways like Ollama");
+    }
+
+    [Fact]
+    public void Evaluate_ShouldSelectGemini_WhenLocalhostInDevelopmentWithAllowLiveProviders()
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.AllowLiveProvidersInDevelopment = true;
+        settings.Provider = "Gemini";
+        settings.Gemini.BaseUrl = "http://localhost:8080/v1beta";
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Development");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Gemini,
+            "localhost should be allowed in development with AllowLiveProvidersInDevelopment");
+    }
+
+    [Fact]
+    public void Evaluate_ShouldSelectMock_WhenLocalhostInProductionEvenWithAllowLiveProviders()
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.AllowLiveProvidersInDevelopment = true;
+        settings.Provider = "OpenAI";
+        settings.OpenAi.BaseUrl = "http://localhost:11434/v1";
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Production");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Mock,
+            "localhost should still be blocked in production even if AllowLiveProvidersInDevelopment is set");
+        result.Reason.Should().Contain("SSRF");
+    }
+
+    [Fact]
+    public void TryValidateOpenAiSettings_ShouldAcceptLocalhostWhenAllowed()
+    {
+        var settings = BuildValidSettings();
+        settings.OpenAi.BaseUrl = "http://localhost:11434/v1";
+
+        var isValid = LlmProviderSelectionPolicy.TryValidateOpenAiSettings(
+            settings, out _, allowLocalhostEndpoints: true);
+
+        isValid.Should().BeTrue(
+            "localhost should be accepted when allowLocalhostEndpoints is true (development mode)");
+    }
+
+    [Fact]
+    public void TryValidateOpenAiSettings_ShouldRejectLocalhostWhenNotAllowed()
+    {
+        var settings = BuildValidSettings();
+        settings.OpenAi.BaseUrl = "http://localhost:11434/v1";
+
+        var isValid = LlmProviderSelectionPolicy.TryValidateOpenAiSettings(
+            settings, out var error, allowLocalhostEndpoints: false);
+
+        isValid.Should().BeFalse(
+            "localhost should be rejected when allowLocalhostEndpoints is false (production mode)");
+        error.Should().Contain("SSRF");
+    }
+
+    [Fact]
+    public void Evaluate_ShouldStillBlockPrivateIps_InDevelopmentWithAllowLiveProviders()
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.AllowLiveProvidersInDevelopment = true;
+        settings.Provider = "OpenAI";
+        settings.OpenAi.BaseUrl = "https://10.0.0.1/v1";
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Development");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Mock,
+            "private IPs (not localhost) should still be blocked even in development mode");
+        result.Reason.Should().Contain("SSRF");
+    }
+
     private static LlmProviderSettings BuildValidSettings()
     {
         return new LlmProviderSettings

--- a/backend/tests/Taskdeck.Application.Tests/Services/LlmProviderSelectionPolicyTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LlmProviderSelectionPolicyTests.cs
@@ -242,6 +242,133 @@ public class LlmProviderSelectionPolicyTests
         result.Reason.Should().Be("Mock provider selected.");
     }
 
+    // -----------------------------------------------------------------------
+    // SSRF protection for LLM provider BaseUrl (SEC-26)
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://10.0.0.1/v1")]
+    [InlineData("https://192.168.1.1/v1")]
+    [InlineData("https://172.16.0.1/v1")]
+    [InlineData("https://127.0.0.1/v1")]
+    [InlineData("https://[::1]/v1")]
+    [InlineData("https://metadata.google.internal/v1")]
+    [InlineData("https://metadata.goog/v1")]
+    public void Evaluate_ShouldSelectMock_WhenOpenAiBaseUrlTargetsPrivateOrInternalHost(string baseUrl)
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.Provider = "OpenAI";
+        settings.OpenAi.BaseUrl = baseUrl;
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Production");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Mock,
+            $"OpenAI BaseUrl '{baseUrl}' targets a private/internal host and should be blocked by SSRF protection");
+        result.Reason.Should().Contain("SSRF");
+    }
+
+    [Theory]
+    [InlineData("https://10.0.0.1/v1beta")]
+    [InlineData("https://192.168.1.1/v1beta")]
+    [InlineData("https://172.16.0.1/v1beta")]
+    [InlineData("https://127.0.0.1/v1beta")]
+    [InlineData("https://[::1]/v1beta")]
+    [InlineData("https://metadata.google.internal/v1beta")]
+    [InlineData("https://metadata.goog/v1beta")]
+    public void Evaluate_ShouldSelectMock_WhenGeminiBaseUrlTargetsPrivateOrInternalHost(string baseUrl)
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.Provider = "Gemini";
+        settings.Gemini.BaseUrl = baseUrl;
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Production");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Mock,
+            $"Gemini BaseUrl '{baseUrl}' targets a private/internal host and should be blocked by SSRF protection");
+        result.Reason.Should().Contain("SSRF");
+    }
+
+    [Theory]
+    [InlineData("http://api.openai.com/v1")]
+    public void Evaluate_ShouldSelectMock_WhenOpenAiBaseUrlUsesHttp(string baseUrl)
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.Provider = "OpenAI";
+        settings.OpenAi.BaseUrl = baseUrl;
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Production");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Mock,
+            $"LLM provider BaseUrl '{baseUrl}' uses HTTP, which is not allowed");
+        result.Reason.Should().Contain("SSRF");
+    }
+
+    [Theory]
+    [InlineData("https://[::ffff:10.0.0.1]/v1")]
+    [InlineData("https://[::ffff:192.168.1.1]/v1")]
+    public void Evaluate_ShouldSelectMock_WhenOpenAiBaseUrlUsesIpv4MappedIpv6(string baseUrl)
+    {
+        var settings = BuildValidSettings();
+        settings.EnableLiveProviders = true;
+        settings.Provider = "OpenAI";
+        settings.OpenAi.BaseUrl = baseUrl;
+
+        var result = LlmProviderSelectionPolicy.Evaluate(settings, "Production");
+
+        result.ProviderKind.Should().Be(LlmProviderKind.Mock,
+            $"OpenAI BaseUrl '{baseUrl}' uses IPv4-mapped IPv6 to target private addresses");
+        result.Reason.Should().Contain("SSRF");
+    }
+
+    [Fact]
+    public void TryValidateOpenAiSettings_ShouldRejectPrivateIpBaseUrl()
+    {
+        var settings = BuildValidSettings();
+        settings.OpenAi.BaseUrl = "https://10.0.0.5/v1";
+
+        var isValid = LlmProviderSelectionPolicy.TryValidateOpenAiSettings(settings, out var error);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("SSRF");
+    }
+
+    [Fact]
+    public void TryValidateGeminiSettings_ShouldRejectPrivateIpBaseUrl()
+    {
+        var settings = BuildValidSettings();
+        settings.Gemini.BaseUrl = "https://192.168.1.1/v1beta";
+
+        var isValid = LlmProviderSelectionPolicy.TryValidateGeminiSettings(settings, out var error);
+
+        isValid.Should().BeFalse();
+        error.Should().Contain("SSRF");
+    }
+
+    [Fact]
+    public void TryValidateOpenAiSettings_ShouldAcceptLegitimateBaseUrl()
+    {
+        var settings = BuildValidSettings();
+        settings.OpenAi.BaseUrl = "https://api.openai.com/v1";
+
+        var isValid = LlmProviderSelectionPolicy.TryValidateOpenAiSettings(settings, out _);
+
+        isValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryValidateGeminiSettings_ShouldAcceptLegitimateBaseUrl()
+    {
+        var settings = BuildValidSettings();
+        settings.Gemini.BaseUrl = "https://generativelanguage.googleapis.com/v1beta";
+
+        var isValid = LlmProviderSelectionPolicy.TryValidateGeminiSettings(settings, out _);
+
+        isValid.Should().BeTrue();
+    }
+
     private static LlmProviderSettings BuildValidSettings()
     {
         return new LlmProviderSettings

--- a/backend/tests/Taskdeck.Application.Tests/Services/OutboundWebhookEndpointGuardTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/OutboundWebhookEndpointGuardTests.cs
@@ -229,6 +229,34 @@ public class OutboundWebhookEndpointGuardTests
     }
 
     // -----------------------------------------------------------------------
+    // SSRF: cloud metadata exact hostnames (defense in depth)
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("metadata.goog")]
+    public void IsHostBlockedByStaticPolicy_ShouldBlockCloudMetadataExactHostnames(string host)
+    {
+        OutboundWebhookEndpointGuard.IsHostBlockedByStaticPolicy(host, allowLocalhostEndpoints: false)
+            .Should().BeTrue($"{host} is a cloud metadata endpoint that must be blocked");
+    }
+
+    [Fact]
+    public void IsHostBlockedByStaticPolicy_ShouldBlockAlibabaCloudMetadataIp()
+    {
+        // 100.100.100.200 is in the CGNAT range (100.64.0.0/10) — already blocked
+        OutboundWebhookEndpointGuard.IsHostBlockedByStaticPolicy("100.100.100.200", allowLocalhostEndpoints: false)
+            .Should().BeTrue("100.100.100.200 is the Alibaba Cloud metadata endpoint (also in CGNAT range)");
+    }
+
+    [Fact]
+    public void IsHostBlockedByStaticPolicy_ShouldBlockMetadataGoogleInternal()
+    {
+        // metadata.google.internal is blocked by .internal suffix
+        OutboundWebhookEndpointGuard.IsHostBlockedByStaticPolicy("metadata.google.internal", allowLocalhostEndpoints: false)
+            .Should().BeTrue("metadata.google.internal is blocked by .internal suffix");
+    }
+
+    // -----------------------------------------------------------------------
     // SSRF: public IP addresses that MUST be allowed
     // -----------------------------------------------------------------------
 

--- a/backend/tests/Taskdeck.Application.Tests/Services/SsrfProtectionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SsrfProtectionServiceTests.cs
@@ -305,6 +305,36 @@ public class SsrfProtectionServiceTests
     }
 
     // -----------------------------------------------------------------------
+    // ValidateUrl — decimal/hex/octal IP notation bypass attempts
+    // .NET's Uri normalizes these to dotted-decimal, so the IP check catches them
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://2130706433")]         // decimal for 127.0.0.1
+    [InlineData("https://0x7f000001")]         // hex for 127.0.0.1
+    [InlineData("https://0177.0.0.1")]         // octal for 127.0.0.1
+    [InlineData("https://127.1")]              // short form for 127.0.0.1
+    [InlineData("https://127.0.1")]            // short form for 127.0.0.1
+    public void ValidateUrl_ShouldBlockDecimalHexOctalIpBypasses(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse(
+            $"{url} uses decimal/hex/octal notation to disguise a private IP — " +
+            ".NET Uri normalizes it, and the IP check should catch it");
+    }
+
+    [Theory]
+    [InlineData("https://167772161")]          // decimal for 10.0.0.1
+    [InlineData("https://0xA000001")]          // hex for 10.0.0.1
+    [InlineData("https://0xC0A80101")]         // hex for 192.168.1.1
+    public void ValidateUrl_ShouldBlockDecimalHexPrivateIpBypasses(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse(
+            $"{url} uses non-standard notation for a private IP");
+    }
+
+    // -----------------------------------------------------------------------
     // ValidateLlmProviderUrl — HTTPS enforcement
     // -----------------------------------------------------------------------
 

--- a/backend/tests/Taskdeck.Application.Tests/Services/SsrfProtectionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SsrfProtectionServiceTests.cs
@@ -1,0 +1,418 @@
+using FluentAssertions;
+using Taskdeck.Application.Services;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class SsrfProtectionServiceTests
+{
+    // -----------------------------------------------------------------------
+    // ValidateUrl — scheme validation
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com")]
+    public void ValidateUrl_ShouldAllowHttpAndHttpsSchemes(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeTrue($"{url} uses an allowed scheme");
+    }
+
+    [Theory]
+    [InlineData("ftp://example.com")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("gopher://evil.com")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("data:text/html,<h1>hi</h1>")]
+    public void ValidateUrl_ShouldBlockNonHttpSchemes(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} uses a disallowed scheme");
+        result.ErrorMessage.Should().Contain("http or https");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — null / empty / whitespace
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateUrl_ShouldBlockNullOrEmptyUrl(string? url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("required");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — malformed URLs
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("://missing-scheme")]
+    [InlineData("http://")]
+    public void ValidateUrl_ShouldBlockMalformedUrls(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"'{url}' is malformed");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — embedded credentials
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://user:pass@example.com")]
+    [InlineData("https://admin@example.com")]
+    public void ValidateUrl_ShouldBlockUrlsWithEmbeddedCredentials(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"'{url}' contains embedded credentials");
+        result.ErrorMessage.Should().Contain("credentials");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — private IPv4 ranges
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://127.0.0.1/api")]
+    [InlineData("https://127.1.2.3/webhook")]
+    [InlineData("https://127.255.255.255")]
+    public void ValidateUrl_ShouldBlockLoopbackIpv4(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets loopback (127.0.0.0/8)");
+    }
+
+    [Theory]
+    [InlineData("https://10.0.0.1")]
+    [InlineData("https://10.128.0.1/path")]
+    [InlineData("https://10.255.255.255")]
+    public void ValidateUrl_ShouldBlockClassA_10_PrivateRange(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets 10.0.0.0/8 private range");
+    }
+
+    [Theory]
+    [InlineData("https://172.16.0.1")]
+    [InlineData("https://172.20.5.10/api")]
+    [InlineData("https://172.31.255.255")]
+    public void ValidateUrl_ShouldBlock_172_16_PrivateRange(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets 172.16.0.0/12 private range");
+    }
+
+    [Theory]
+    [InlineData("https://192.168.0.1")]
+    [InlineData("https://192.168.100.5/hook")]
+    [InlineData("https://192.168.255.254")]
+    public void ValidateUrl_ShouldBlock_192_168_PrivateRange(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets 192.168.0.0/16 private range");
+    }
+
+    [Theory]
+    [InlineData("https://0.0.0.0")]
+    public void ValidateUrl_ShouldBlockUnspecifiedAddress(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets the unspecified address");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — link-local and cloud metadata IP
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("http://169.254.169.254")]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("https://169.254.169.254/computeMetadata/v1/")]
+    public void ValidateUrl_ShouldBlockCloudMetadataIp(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets cloud metadata endpoint (169.254.169.254)");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — private IPv6 ranges
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://[::1]")]
+    [InlineData("https://[::1]/api")]
+    public void ValidateUrl_ShouldBlockIpv6Loopback(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets IPv6 loopback (::1)");
+    }
+
+    [Theory]
+    [InlineData("https://[fc00::1]")]
+    [InlineData("https://[fd00::1]")]
+    [InlineData("https://[fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]")]
+    public void ValidateUrl_ShouldBlockIpv6UniqueLocal(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets IPv6 unique-local (fc00::/7)");
+    }
+
+    [Theory]
+    [InlineData("https://[fe80::1]")]
+    [InlineData("https://[fe80::abcd:ef01]")]
+    public void ValidateUrl_ShouldBlockIpv6LinkLocal(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets IPv6 link-local (fe80::/10)");
+    }
+
+    [Theory]
+    [InlineData("https://[::ffff:127.0.0.1]")]
+    [InlineData("https://[::ffff:10.0.0.1]")]
+    [InlineData("https://[::ffff:192.168.1.1]")]
+    [InlineData("https://[::ffff:172.16.0.1]")]
+    public void ValidateUrl_ShouldBlockIpv4MappedToIpv6(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets IPv4-mapped IPv6 private address");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — cloud metadata hostnames
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://metadata.google.internal")]
+    [InlineData("https://metadata.google.internal/computeMetadata/v1/")]
+    public void ValidateUrl_ShouldBlockGoogleMetadataHostname(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets Google Cloud metadata endpoint");
+    }
+
+    [Theory]
+    [InlineData("https://metadata.goog")]
+    [InlineData("https://metadata.goog/computeMetadata/v1/")]
+    public void ValidateUrl_ShouldBlockGoogleMetadataGoogHostname(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets Google Cloud metadata.goog endpoint");
+    }
+
+    [Theory]
+    [InlineData("https://100.100.100.200")]
+    [InlineData("https://100.100.100.200/latest/meta-data/")]
+    public void ValidateUrl_ShouldBlockAlibabaCloudMetadata(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} targets Alibaba Cloud metadata endpoint");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — localhost handling
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ValidateUrl_ShouldBlockLocalhost_WhenNotAllowed()
+    {
+        var result = SsrfProtectionService.ValidateUrl("https://localhost/api", allowLocalhostEndpoints: false);
+        result.IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateUrl_ShouldAllowLocalhost_WhenExplicitlyPermitted()
+    {
+        var result = SsrfProtectionService.ValidateUrl("https://localhost/api", allowLocalhostEndpoints: true);
+        result.IsAllowed.Should().BeTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — blocked hostname suffixes
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://myservice.local")]
+    [InlineData("https://anything.internal")]
+    [InlineData("https://host.home.arpa")]
+    [InlineData("https://something.localhost")]
+    [InlineData("https://test.localtest.me")]
+    public void ValidateUrl_ShouldBlockInternalHostnameSuffixes(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} matches a blocked internal hostname suffix");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — dynamic DNS with embedded private IPs
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://127.0.0.1.nip.io")]
+    [InlineData("https://10.0.0.1.nip.io")]
+    [InlineData("https://192.168.1.1.nip.io")]
+    [InlineData("https://10-0-0-1.sslip.io")]
+    public void ValidateUrl_ShouldBlockDynamicDnsWithEmbeddedPrivateIp(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} uses dynamic DNS to embed a private IP");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — public URLs that MUST be allowed
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://example.com/webhook")]
+    [InlineData("https://api.openai.com/v1/chat/completions")]
+    [InlineData("https://hooks.slack.com/services/T00/B00/xxx")]
+    [InlineData("https://93.184.216.34/api")]
+    [InlineData("https://8.8.8.8")]
+    [InlineData("https://1.1.1.1")]
+    public void ValidateUrl_ShouldAllowPublicUrls(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeTrue($"{url} is a public URL that should be allowed");
+        result.ParsedUri.Should().NotBeNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrl — SSRF bypass attempts
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("https://127.0.0.1.nip.io")]     // DNS rebinding via nip.io
+    [InlineData("https://10-0-0-1.sslip.io")]     // DNS rebinding via sslip.io
+    public void ValidateUrl_ShouldBlockDnsRebindingAttempts(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} is a DNS rebinding bypass attempt");
+    }
+
+    [Theory]
+    [InlineData("https://[::ffff:7f00:1]")]  // IPv4-mapped IPv6 for 127.0.0.1
+    [InlineData("https://[::ffff:a00:1]")]   // IPv4-mapped IPv6 for 10.0.0.1
+    public void ValidateUrl_ShouldBlockIpv4MappedIpv6Bypasses(string url)
+    {
+        var result = SsrfProtectionService.ValidateUrl(url);
+        result.IsAllowed.Should().BeFalse($"{url} uses IPv4-mapped IPv6 to bypass filters");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateLlmProviderUrl — HTTPS enforcement
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ValidateLlmProviderUrl_ShouldRequireHttps()
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl("http://api.openai.com/v1");
+        result.IsAllowed.Should().BeFalse("LLM provider URLs must use HTTPS");
+        result.ErrorMessage.Should().Contain("HTTPS");
+    }
+
+    [Fact]
+    public void ValidateLlmProviderUrl_ShouldAllowHttps()
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl("https://api.openai.com/v1");
+        result.IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateLlmProviderUrl_ShouldAllowHttpForLocalhost_WhenPermitted()
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl(
+            "http://localhost:11434/v1",
+            allowLocalhostEndpoints: true);
+        result.IsAllowed.Should().BeTrue("localhost with HTTP is allowed when explicitly permitted (e.g., for Ollama)");
+    }
+
+    [Fact]
+    public void ValidateLlmProviderUrl_ShouldBlockHttpForLocalhost_WhenNotPermitted()
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl("http://localhost:11434/v1");
+        result.IsAllowed.Should().BeFalse("localhost not allowed by default");
+    }
+
+    [Fact]
+    public void ValidateLlmProviderUrl_ShouldBlockPrivateIp()
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl("https://10.0.0.5/v1/chat/completions");
+        result.IsAllowed.Should().BeFalse("private IPs should be blocked for LLM providers");
+    }
+
+    [Fact]
+    public void ValidateLlmProviderUrl_ShouldBlockCloudMetadataEndpoint()
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl("https://metadata.google.internal/computeMetadata/v1/");
+        result.IsAllowed.Should().BeFalse("cloud metadata endpoint should be blocked for LLM providers");
+    }
+
+    [Theory]
+    [InlineData("https://api.openai.com/v1")]
+    [InlineData("https://generativelanguage.googleapis.com/v1beta")]
+    public void ValidateLlmProviderUrl_ShouldAllowLegitimateProviderUrls(string url)
+    {
+        var result = SsrfProtectionService.ValidateLlmProviderUrl(url);
+        result.IsAllowed.Should().BeTrue($"{url} is a legitimate LLM provider URL");
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateUrlWithDnsAsync — basic async validation
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ValidateUrlWithDnsAsync_ShouldBlockPrivateIp()
+    {
+        var result = await SsrfProtectionService.ValidateUrlWithDnsAsync("https://10.0.0.1/api");
+        result.IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ValidateUrlWithDnsAsync_ShouldBlockNull()
+    {
+        var result = await SsrfProtectionService.ValidateUrlWithDnsAsync(null);
+        result.IsAllowed.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("required");
+    }
+
+    [Fact]
+    public async Task ValidateUrlWithDnsAsync_ShouldBlockNonExistentHost()
+    {
+        var result = await SsrfProtectionService.ValidateUrlWithDnsAsync(
+            "https://nonexistent-ssrf-test-host.invalid/api");
+        result.IsAllowed.Should().BeFalse("non-existent hosts should fail closed");
+    }
+
+    // -----------------------------------------------------------------------
+    // Error messages — clarity
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ValidateUrl_ErrorMessage_ShouldBeClearForPrivateIp()
+    {
+        var result = SsrfProtectionService.ValidateUrl("https://192.168.1.1/api");
+        result.ErrorMessage.Should().Contain("not allowed");
+    }
+
+    [Fact]
+    public void ValidateUrl_ErrorMessage_ShouldBeClearForCloudMetadata()
+    {
+        var result = SsrfProtectionService.ValidateUrl("https://metadata.goog/api");
+        result.ErrorMessage.Should().Contain("not allowed");
+    }
+
+    [Fact]
+    public void ValidateUrl_ErrorMessage_ShouldNotLeakInternalDetails()
+    {
+        var result = SsrfProtectionService.ValidateUrl("https://10.0.0.1/api");
+        result.ErrorMessage.Should().NotContain("Bearer");
+        result.ErrorMessage.Should().NotContain("password");
+        result.ErrorMessage.Should().NotContain("token");
+    }
+}


### PR DESCRIPTION
## Summary
- Add reusable `SsrfProtectionService` in the Application layer that validates URLs against private IP ranges, cloud metadata endpoints, and internal hostnames
- Enhance `OutboundWebhookEndpointGuard` with explicit cloud metadata hostname blocking (metadata.goog, Alibaba Cloud 100.100.100.200) as defense-in-depth
- Apply SSRF protection to LLM provider BaseUrl validation in `LlmProviderSelectionPolicy` — private/internal URLs cause fallback to Mock provider
- Add 83 new `SsrfProtectionServiceTests` covering all blocked ranges plus bypass attempts
- Enhance existing endpoint guard and LLM provider selection policy tests with SSRF-specific scenarios

### SSRF Protection Coverage
- **IPv4 ranges**: 127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 0.0.0.0/8, 169.254.0.0/16, 100.64.0.0/10, 224.0.0.0/4+
- **IPv6 ranges**: ::1, fc00::/7, fe80::/10, IPv4-mapped IPv6 (::ffff:x.x.x.x)
- **Hostnames**: localhost, metadata.google.internal, metadata.goog, *.internal, *.local, *.localhost, *.home.arpa, *.localtest.me
- **Cloud metadata IPs**: 169.254.169.254, 100.100.100.200, fd00:ec2::254
- **Dynamic DNS bypass**: nip.io, xip.io, sslip.io with embedded private IPs
- **Scheme enforcement**: Only http/https allowed; LLM providers require HTTPS
- **Credential stripping**: URLs with embedded userinfo rejected

Closes #850

## Test plan
- [x] Unit tests cover all private IPv4/IPv6 ranges
- [x] Unit tests cover cloud metadata hostnames and IPs
- [x] Unit tests cover DNS rebinding bypass attempts (nip.io, sslip.io)
- [x] Unit tests cover IPv4-mapped IPv6 bypass attempts
- [x] Webhook URLs validated on create/update (pre-existing via `OutboundWebhookEndpointGuard`)
- [x] LLM provider URLs validated via `SsrfProtectionService.ValidateLlmProviderUrl`
- [x] Clear error messages for blocked URLs
- [x] All backend tests pass (0 failures)