### PR TITLE
fix: add missing test attributes to CLI test files for proper discovery

### DIFF
--- a/backend/src/Taskdeck.Cli/Taskdeck.Cli.csproj
+++ b/backend/src/Taskdeck.Cli/Taskdeck.Cli.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Taskdeck.Cli.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Taskdeck.Application\Taskdeck.Application.csproj" />
     <ProjectReference Include="..\Taskdeck.Infrastructure\Taskdeck.Infrastructure.csproj" />
   </ItemGroup>

--- a/backend/tests/Taskdeck.Cli.Tests/ApiKeyCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ApiKeyCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using FluentAssertions;
 using Xunit;
@@ -10,7 +9,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyCreate_ReturnsJsonWithTdskPrefix()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key create --name \"Test Key\"");
 
@@ -24,7 +23,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyCreate_WithExpires_SetsExpiresAt()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key create --name \"Expiring\" --expires 90d");
 
@@ -37,7 +36,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyCreate_WithNumericExpires_AcceptsDaysWithoutSuffix()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key create --name \"NumExpiry\" --expires 30");
 
@@ -50,7 +49,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyCreate_MissingName_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key create");
 
@@ -61,7 +60,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyCreate_InvalidExpires_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key create --name \"Bad\" --expires abc");
 
@@ -72,7 +71,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyList_ReturnsCreatedKeys()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         await harness.RunAsync("api-key create --name \"List Key A\"");
         await harness.RunAsync("api-key create --name \"List Key B\"");
@@ -93,7 +92,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyList_ShowsKeyPrefixNotFullKey()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         await harness.RunAsync("api-key create --name \"Prefix Key\"");
 
@@ -109,7 +108,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyRevoke_ByName_SetsRevokedStatus()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         await harness.RunAsync("api-key create --name \"Revoke Me\"");
 
@@ -129,7 +128,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyRevoke_ById_SetsRevokedStatus()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var createResult = await harness.RunAsync("api-key create --name \"Revoke By Id\"");
         using var createDoc = JsonDocument.Parse(createResult.StdOut);
@@ -142,7 +141,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyRevoke_NonexistentName_ReturnsFailure()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key revoke --name \"Does Not Exist\"");
 
@@ -153,7 +152,7 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKeyRevoke_MissingIdentifier_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key revoke");
 
@@ -164,106 +163,11 @@ public class ApiKeyCommandTests
     [Fact]
     public async Task ApiKey_UnknownSubcommand_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-apikey");
 
         var result = await harness.RunAsync("api-key unknown");
 
         result.ExitCode.Should().Be(2);
         result.StdErr.Should().Contain("Unknown api-key command");
     }
-
-    /// <summary>
-    /// Shared harness that runs the CLI as a subprocess against an ephemeral database.
-    /// </summary>
-    private sealed class CliHarness : IAsyncDisposable
-    {
-        private readonly string _repoRoot;
-        private readonly string _databasePath;
-        private readonly string _connectionString;
-
-        public CliHarness()
-        {
-            _repoRoot = FindRepoRoot();
-            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-apikey-tests-{Guid.NewGuid():N}.db");
-            _connectionString = $"Data Source={_databasePath}";
-        }
-
-        public async Task<CliCommandResult> RunAsync(string arguments)
-        {
-            var cliDllPath = ResolveCliDllPath(_repoRoot);
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = $"\"{cliDllPath}\" {arguments}",
-                WorkingDirectory = _repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
-            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-
-            using var process = new Process { StartInfo = startInfo };
-            process.Start();
-
-            var stdOut = await process.StandardOutput.ReadToEndAsync();
-            var stdErr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
-            {
-                try
-                {
-                    if (File.Exists(path)) File.Delete(path);
-                }
-                catch (IOException) { }
-            }
-
-            return ValueTask.CompletedTask;
-        }
-
-        private static string FindRepoRoot()
-        {
-            var current = new DirectoryInfo(AppContext.BaseDirectory);
-
-            while (current != null)
-            {
-                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
-                if (File.Exists(solutionPath))
-                {
-                    return current.FullName;
-                }
-
-                current = current.Parent;
-            }
-
-            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
-        }
-
-        private static string ResolveCliDllPath(string repoRoot)
-        {
-            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
-            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(debugPath))
-            {
-                return debugPath;
-            }
-
-            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(releasePath))
-            {
-                return releasePath;
-            }
-
-            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
-        }
-    }
-
-    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
 }

--- a/backend/tests/Taskdeck.Cli.Tests/ArgParserTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ArgParserTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Taskdeck.Cli.Commands;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class ArgParserTests
+{
+    [Fact]
+    public void HasFlag_WhenFlagPresent_ReturnsTrue()
+    {
+        var args = new[] { "--board", "abc", "--json" };
+
+        ArgParser.HasFlag(args, "--json").Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasFlag_WhenFlagAbsent_ReturnsFalse()
+    {
+        var args = new[] { "--board", "abc" };
+
+        ArgParser.HasFlag(args, "--json").Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasFlag_IsCaseInsensitive()
+    {
+        var args = new[] { "--JSON" };
+
+        ArgParser.HasFlag(args, "--json").Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasFlag_EmptyArgs_ReturnsFalse()
+    {
+        var args = Array.Empty<string>();
+
+        ArgParser.HasFlag(args, "--json").Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetOption_ReturnsValueAfterOptionName()
+    {
+        var args = new[] { "--board", "abc-123", "--name", "Test" };
+
+        ArgParser.GetOption(args, "--board").Should().Be("abc-123");
+        ArgParser.GetOption(args, "--name").Should().Be("Test");
+    }
+
+    [Fact]
+    public void GetOption_WhenOptionAbsent_ReturnsNull()
+    {
+        var args = new[] { "--board", "abc-123" };
+
+        ArgParser.GetOption(args, "--name").Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOption_WhenOptionIsLastArg_ReturnsNull()
+    {
+        // If --board is the last argument, there's no value after it
+        var args = new[] { "--board" };
+
+        ArgParser.GetOption(args, "--board").Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOption_IsCaseInsensitive()
+    {
+        var args = new[] { "--BOARD", "abc-123" };
+
+        ArgParser.GetOption(args, "--board").Should().Be("abc-123");
+    }
+
+    [Fact]
+    public void GetOption_EmptyArgs_ReturnsNull()
+    {
+        var args = Array.Empty<string>();
+
+        ArgParser.GetOption(args, "--board").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("d1a7b8c0-1234-5678-9abc-def012345678", true)]
+    [InlineData("D1A7B8C0-1234-5678-9ABC-DEF012345678", true)]
+    [InlineData("not-a-guid", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void TryParseGuid_ValidatesCorrectly(string? text, bool expectedResult)
+    {
+        var result = ArgParser.TryParseGuid(text, out var value);
+
+        result.Should().Be(expectedResult);
+        if (expectedResult)
+        {
+            value.Should().NotBe(Guid.Empty);
+        }
+    }
+
+    [Fact]
+    public void StripFlag_RemovesFlagFromArgs()
+    {
+        var args = new[] { "--board", "abc", "--json", "--name", "Test" };
+
+        var result = ArgParser.StripFlag(args, "--json");
+
+        result.Should().Equal("--board", "abc", "--name", "Test");
+    }
+
+    [Fact]
+    public void StripFlag_WhenFlagAbsent_ReturnsAllArgs()
+    {
+        var args = new[] { "--board", "abc" };
+
+        var result = ArgParser.StripFlag(args, "--json");
+
+        result.Should().Equal("--board", "abc");
+    }
+
+    [Fact]
+    public void StripFlag_IsCaseInsensitive()
+    {
+        var args = new[] { "--JSON", "--board", "abc" };
+
+        var result = ArgParser.StripFlag(args, "--json");
+
+        result.Should().Equal("--board", "abc");
+    }
+
+    [Fact]
+    public void StripFlag_EmptyArgs_ReturnsEmpty()
+    {
+        var args = Array.Empty<string>();
+
+        var result = ArgParser.StripFlag(args, "--json");
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void StripFlag_MultipleOccurrences_RemovesAll()
+    {
+        var args = new[] { "--json", "--board", "abc", "--json" };
+
+        var result = ArgParser.StripFlag(args, "--json");
+
+        result.Should().Equal("--board", "abc");
+    }
+}

--- a/backend/tests/Taskdeck.Cli.Tests/BoardsCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/BoardsCommandTests.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class BoardsCommandTests
+{
+    [Fact]
+    public async Task BoardsList_EmptyDatabase_ReturnsEmptyJsonArray()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("boards list --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+        doc.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BoardsCreate_MissingName_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("boards create --json");
+
+        // When "--json" is the first positional arg, it is treated as the board name.
+        // So "boards create" without any name should fail.
+        // Actually, looking at the handler: create expects args[0] as name.
+        // With "--json" stripped, there would be no args left.
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("Missing board name");
+    }
+
+    [Fact]
+    public async Task BoardsCreate_WithDescription_IncludesDescription()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("boards create DescBoard \"A nice description\" --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.GetProperty("name").GetString().Should().Be("DescBoard");
+    }
+
+    [Fact]
+    public async Task BoardsUpdate_WithName_UpdatesBoardName()
+    {
+        await using var harness = new CliHarness();
+
+        var createResult = await harness.RunAsync("boards create OrigName --json");
+        createResult.ExitCode.Should().Be(0, createResult.StdErr);
+        using var createDoc = JsonDocument.Parse(createResult.StdOut);
+        var boardId = createDoc.RootElement.GetProperty("id").GetGuid();
+
+        var updateResult = await harness.RunAsync($"boards update --board {boardId} --name NewName --json");
+
+        updateResult.ExitCode.Should().Be(0, updateResult.StdErr);
+        using var updateDoc = JsonDocument.Parse(updateResult.StdOut);
+        updateDoc.RootElement.GetProperty("name").GetString().Should().Be("NewName");
+    }
+
+    [Fact]
+    public async Task BoardsUpdate_NoUpdateValues_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var createResult = await harness.RunAsync("boards create NoUpdBoard --json");
+        createResult.ExitCode.Should().Be(0, createResult.StdErr);
+        using var createDoc = JsonDocument.Parse(createResult.StdOut);
+        var boardId = createDoc.RootElement.GetProperty("id").GetGuid();
+
+        var updateResult = await harness.RunAsync($"boards update --board {boardId} --json");
+
+        updateResult.ExitCode.Should().Be(2);
+        updateResult.StdErr.Should().Contain("No update values");
+    }
+
+    [Fact]
+    public async Task BoardsUpdate_ArchiveAndUnarchiveTogether_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var createResult = await harness.RunAsync("boards create ConflictBoard --json");
+        createResult.ExitCode.Should().Be(0, createResult.StdErr);
+        using var createDoc = JsonDocument.Parse(createResult.StdOut);
+        var boardId = createDoc.RootElement.GetProperty("id").GetGuid();
+
+        var updateResult = await harness.RunAsync($"boards update --board {boardId} --archive --unarchive --json");
+
+        updateResult.ExitCode.Should().Be(2);
+        updateResult.StdErr.Should().Contain("--archive and --unarchive");
+    }
+
+    [Fact]
+    public async Task Boards_UnknownCommand_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("boards unknown");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("Unknown boards command");
+    }
+
+    private sealed class CliHarness : IAsyncDisposable
+    {
+        private readonly string _repoRoot;
+        private readonly string _databasePath;
+        private readonly string _connectionString;
+
+        public CliHarness()
+        {
+            _repoRoot = FindRepoRoot();
+            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-boards-tests-{Guid.NewGuid():N}.db");
+            _connectionString = $"Data Source={_databasePath}";
+        }
+
+        public async Task<CliCommandResult> RunAsync(string arguments)
+        {
+            var cliDllPath = ResolveCliDllPath(_repoRoot);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"\"{cliDllPath}\" {arguments}",
+                WorkingDirectory = _repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
+            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+
+            var stdOut = await process.StandardOutput.ReadToEndAsync();
+            var stdErr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
+            {
+                try
+                {
+                    if (File.Exists(path)) File.Delete(path);
+                }
+                catch (IOException) { }
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        private static string FindRepoRoot()
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (current != null)
+            {
+                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
+                if (File.Exists(solutionPath))
+                {
+                    return current.FullName;
+                }
+
+                current = current.Parent;
+            }
+
+            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
+        }
+
+        private static string ResolveCliDllPath(string repoRoot)
+        {
+            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
+            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(debugPath))
+            {
+                return debugPath;
+            }
+
+            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(releasePath))
+            {
+                return releasePath;
+            }
+
+            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
+        }
+    }
+
+    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/backend/tests/Taskdeck.Cli.Tests/BoardsCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/BoardsCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using FluentAssertions;
 using Xunit;
@@ -10,7 +9,7 @@ public class BoardsCommandTests
     [Fact]
     public async Task BoardsList_EmptyDatabase_ReturnsEmptyJsonArray()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var result = await harness.RunAsync("boards list --json");
 
@@ -23,14 +22,11 @@ public class BoardsCommandTests
     [Fact]
     public async Task BoardsCreate_MissingName_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var result = await harness.RunAsync("boards create --json");
 
-        // When "--json" is the first positional arg, it is treated as the board name.
-        // So "boards create" without any name should fail.
-        // Actually, looking at the handler: create expects args[0] as name.
-        // With "--json" stripped, there would be no args left.
+        // With "--json" stripped, there are no remaining args so create fails.
         result.ExitCode.Should().Be(2);
         result.StdErr.Should().Contain("Missing board name");
     }
@@ -38,7 +34,7 @@ public class BoardsCommandTests
     [Fact]
     public async Task BoardsCreate_WithDescription_IncludesDescription()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var result = await harness.RunAsync("boards create DescBoard \"A nice description\" --json");
 
@@ -50,7 +46,7 @@ public class BoardsCommandTests
     [Fact]
     public async Task BoardsUpdate_WithName_UpdatesBoardName()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var createResult = await harness.RunAsync("boards create OrigName --json");
         createResult.ExitCode.Should().Be(0, createResult.StdErr);
@@ -67,7 +63,7 @@ public class BoardsCommandTests
     [Fact]
     public async Task BoardsUpdate_NoUpdateValues_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var createResult = await harness.RunAsync("boards create NoUpdBoard --json");
         createResult.ExitCode.Should().Be(0, createResult.StdErr);
@@ -83,7 +79,7 @@ public class BoardsCommandTests
     [Fact]
     public async Task BoardsUpdate_ArchiveAndUnarchiveTogether_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var createResult = await harness.RunAsync("boards create ConflictBoard --json");
         createResult.ExitCode.Should().Be(0, createResult.StdErr);
@@ -99,103 +95,11 @@ public class BoardsCommandTests
     [Fact]
     public async Task Boards_UnknownCommand_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-boards");
 
         var result = await harness.RunAsync("boards unknown");
 
         result.ExitCode.Should().Be(2);
         result.StdErr.Should().Contain("Unknown boards command");
     }
-
-    private sealed class CliHarness : IAsyncDisposable
-    {
-        private readonly string _repoRoot;
-        private readonly string _databasePath;
-        private readonly string _connectionString;
-
-        public CliHarness()
-        {
-            _repoRoot = FindRepoRoot();
-            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-boards-tests-{Guid.NewGuid():N}.db");
-            _connectionString = $"Data Source={_databasePath}";
-        }
-
-        public async Task<CliCommandResult> RunAsync(string arguments)
-        {
-            var cliDllPath = ResolveCliDllPath(_repoRoot);
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = $"\"{cliDllPath}\" {arguments}",
-                WorkingDirectory = _repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
-            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-
-            using var process = new Process { StartInfo = startInfo };
-            process.Start();
-
-            var stdOut = await process.StandardOutput.ReadToEndAsync();
-            var stdErr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
-            {
-                try
-                {
-                    if (File.Exists(path)) File.Delete(path);
-                }
-                catch (IOException) { }
-            }
-
-            return ValueTask.CompletedTask;
-        }
-
-        private static string FindRepoRoot()
-        {
-            var current = new DirectoryInfo(AppContext.BaseDirectory);
-
-            while (current != null)
-            {
-                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
-                if (File.Exists(solutionPath))
-                {
-                    return current.FullName;
-                }
-
-                current = current.Parent;
-            }
-
-            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
-        }
-
-        private static string ResolveCliDllPath(string repoRoot)
-        {
-            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
-            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(debugPath))
-            {
-                return debugPath;
-            }
-
-            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(releasePath))
-            {
-                return releasePath;
-            }
-
-            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
-        }
-    }
-
-    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
 }

--- a/backend/tests/Taskdeck.Cli.Tests/CardsCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CardsCommandTests.cs
@@ -1,0 +1,269 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class CardsCommandTests
+{
+    [Fact]
+    public async Task CardsAdd_WithJson_CreatesCard()
+    {
+        await using var harness = new CliHarness();
+        var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
+
+        var result = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Test Card\" --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.GetProperty("title").GetString().Should().Be("Test Card");
+        doc.RootElement.GetProperty("id").GetGuid().Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task CardsAdd_MissingBoard_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("cards add --column 00000000-0000-0000-0000-000000000001 --title \"No Board\" --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--board");
+    }
+
+    [Fact]
+    public async Task CardsAdd_MissingColumn_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+        var (boardId, _) = await harness.CreateBoardAndColumnAsync();
+
+        var result = await harness.RunAsync($"cards add --board {boardId} --title \"No Column\" --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--column");
+    }
+
+    [Fact]
+    public async Task CardsAdd_MissingTitle_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+        var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
+
+        var result = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--title");
+    }
+
+    [Fact]
+    public async Task CardsAdd_WithDescription_IncludesDescription()
+    {
+        await using var harness = new CliHarness();
+        var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
+
+        var result = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Described\" --description \"A description\" --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.GetProperty("title").GetString().Should().Be("Described");
+        doc.RootElement.GetProperty("description").GetString().Should().Be("A description");
+    }
+
+    [Fact]
+    public async Task CardsList_WithJson_ReturnsCreatedCards()
+    {
+        await using var harness = new CliHarness();
+        var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
+
+        await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Card A\" --json");
+        await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Card B\" --json");
+
+        var result = await harness.RunAsync($"cards list --board {boardId} --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        var titles = doc.RootElement.EnumerateArray()
+            .Select(x => x.GetProperty("title").GetString())
+            .ToList();
+        titles.Should().Contain("Card A");
+        titles.Should().Contain("Card B");
+    }
+
+    [Fact]
+    public async Task CardsList_MissingBoard_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("cards list --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--board");
+    }
+
+    [Fact]
+    public async Task CardsMove_MovesCardToTargetColumn()
+    {
+        await using var harness = new CliHarness();
+        var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
+
+        // Create a second column
+        var col2Result = await harness.RunAsync($"columns create --board {boardId} --name Done --json");
+        col2Result.ExitCode.Should().Be(0, col2Result.StdErr);
+        using var col2Doc = JsonDocument.Parse(col2Result.StdOut);
+        var targetColumnId = col2Doc.RootElement.GetProperty("id").GetGuid();
+
+        // Create a card in the first column
+        var cardResult = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Movable\" --json");
+        cardResult.ExitCode.Should().Be(0, cardResult.StdErr);
+        using var cardDoc = JsonDocument.Parse(cardResult.StdOut);
+        var cardId = cardDoc.RootElement.GetProperty("id").GetGuid();
+
+        // Move the card
+        var moveResult = await harness.RunAsync($"cards move --card {cardId} --target-column {targetColumnId} --json");
+
+        moveResult.ExitCode.Should().Be(0, moveResult.StdErr);
+        using var moveDoc = JsonDocument.Parse(moveResult.StdOut);
+        moveDoc.RootElement.GetProperty("columnId").GetGuid().Should().Be(targetColumnId);
+    }
+
+    [Fact]
+    public async Task CardsMove_MissingCard_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("cards move --target-column 00000000-0000-0000-0000-000000000001 --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--card");
+    }
+
+    [Fact]
+    public async Task CardsMove_MissingTargetColumn_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("cards move --card 00000000-0000-0000-0000-000000000001 --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--target-column");
+    }
+
+    [Fact]
+    public async Task Cards_UnknownCommand_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("cards unknown");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("Unknown cards command");
+    }
+
+    private sealed class CliHarness : IAsyncDisposable
+    {
+        private readonly string _repoRoot;
+        private readonly string _databasePath;
+        private readonly string _connectionString;
+
+        public CliHarness()
+        {
+            _repoRoot = FindRepoRoot();
+            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-cards-tests-{Guid.NewGuid():N}.db");
+            _connectionString = $"Data Source={_databasePath}";
+        }
+
+        public async Task<(Guid BoardId, Guid ColumnId)> CreateBoardAndColumnAsync()
+        {
+            var boardResult = await RunAsync("boards create CardTestBoard --json");
+            boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+            using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+            var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+            var columnResult = await RunAsync($"columns create --board {boardId} --name Todo --json");
+            columnResult.ExitCode.Should().Be(0, columnResult.StdErr);
+            using var columnDoc = JsonDocument.Parse(columnResult.StdOut);
+            var columnId = columnDoc.RootElement.GetProperty("id").GetGuid();
+
+            return (boardId, columnId);
+        }
+
+        public async Task<CliCommandResult> RunAsync(string arguments)
+        {
+            var cliDllPath = ResolveCliDllPath(_repoRoot);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"\"{cliDllPath}\" {arguments}",
+                WorkingDirectory = _repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
+            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+
+            var stdOut = await process.StandardOutput.ReadToEndAsync();
+            var stdErr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
+            {
+                try
+                {
+                    if (File.Exists(path)) File.Delete(path);
+                }
+                catch (IOException) { }
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        private static string FindRepoRoot()
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (current != null)
+            {
+                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
+                if (File.Exists(solutionPath))
+                {
+                    return current.FullName;
+                }
+
+                current = current.Parent;
+            }
+
+            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
+        }
+
+        private static string ResolveCliDllPath(string repoRoot)
+        {
+            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
+            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(debugPath))
+            {
+                return debugPath;
+            }
+
+            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(releasePath))
+            {
+                return releasePath;
+            }
+
+            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
+        }
+    }
+
+    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/backend/tests/Taskdeck.Cli.Tests/CardsCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CardsCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using FluentAssertions;
 using Xunit;
@@ -10,7 +9,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsAdd_WithJson_CreatesCard()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
         var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
 
         var result = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Test Card\" --json");
@@ -24,7 +23,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsAdd_MissingBoard_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
 
         var result = await harness.RunAsync("cards add --column 00000000-0000-0000-0000-000000000001 --title \"No Board\" --json");
 
@@ -35,7 +34,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsAdd_MissingColumn_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
         var (boardId, _) = await harness.CreateBoardAndColumnAsync();
 
         var result = await harness.RunAsync($"cards add --board {boardId} --title \"No Column\" --json");
@@ -47,7 +46,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsAdd_MissingTitle_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
         var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
 
         var result = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --json");
@@ -59,7 +58,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsAdd_WithDescription_IncludesDescription()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
         var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
 
         var result = await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Described\" --description \"A description\" --json");
@@ -73,7 +72,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsList_WithJson_ReturnsCreatedCards()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
         var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
 
         await harness.RunAsync($"cards add --board {boardId} --column {columnId} --title \"Card A\" --json");
@@ -93,7 +92,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsList_MissingBoard_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
 
         var result = await harness.RunAsync("cards list --json");
 
@@ -104,7 +103,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsMove_MovesCardToTargetColumn()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
         var (boardId, columnId) = await harness.CreateBoardAndColumnAsync();
 
         // Create a second column
@@ -130,7 +129,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsMove_MissingCard_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
 
         var result = await harness.RunAsync("cards move --target-column 00000000-0000-0000-0000-000000000001 --json");
 
@@ -141,7 +140,7 @@ public class CardsCommandTests
     [Fact]
     public async Task CardsMove_MissingTargetColumn_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
 
         var result = await harness.RunAsync("cards move --card 00000000-0000-0000-0000-000000000001 --json");
 
@@ -152,118 +151,11 @@ public class CardsCommandTests
     [Fact]
     public async Task Cards_UnknownCommand_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-cards");
 
         var result = await harness.RunAsync("cards unknown");
 
         result.ExitCode.Should().Be(2);
         result.StdErr.Should().Contain("Unknown cards command");
     }
-
-    private sealed class CliHarness : IAsyncDisposable
-    {
-        private readonly string _repoRoot;
-        private readonly string _databasePath;
-        private readonly string _connectionString;
-
-        public CliHarness()
-        {
-            _repoRoot = FindRepoRoot();
-            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-cards-tests-{Guid.NewGuid():N}.db");
-            _connectionString = $"Data Source={_databasePath}";
-        }
-
-        public async Task<(Guid BoardId, Guid ColumnId)> CreateBoardAndColumnAsync()
-        {
-            var boardResult = await RunAsync("boards create CardTestBoard --json");
-            boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
-            using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
-            var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
-
-            var columnResult = await RunAsync($"columns create --board {boardId} --name Todo --json");
-            columnResult.ExitCode.Should().Be(0, columnResult.StdErr);
-            using var columnDoc = JsonDocument.Parse(columnResult.StdOut);
-            var columnId = columnDoc.RootElement.GetProperty("id").GetGuid();
-
-            return (boardId, columnId);
-        }
-
-        public async Task<CliCommandResult> RunAsync(string arguments)
-        {
-            var cliDllPath = ResolveCliDllPath(_repoRoot);
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = $"\"{cliDllPath}\" {arguments}",
-                WorkingDirectory = _repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
-            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-
-            using var process = new Process { StartInfo = startInfo };
-            process.Start();
-
-            var stdOut = await process.StandardOutput.ReadToEndAsync();
-            var stdErr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
-            {
-                try
-                {
-                    if (File.Exists(path)) File.Delete(path);
-                }
-                catch (IOException) { }
-            }
-
-            return ValueTask.CompletedTask;
-        }
-
-        private static string FindRepoRoot()
-        {
-            var current = new DirectoryInfo(AppContext.BaseDirectory);
-
-            while (current != null)
-            {
-                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
-                if (File.Exists(solutionPath))
-                {
-                    return current.FullName;
-                }
-
-                current = current.Parent;
-            }
-
-            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
-        }
-
-        private static string ResolveCliDllPath(string repoRoot)
-        {
-            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
-            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(debugPath))
-            {
-                return debugPath;
-            }
-
-            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(releasePath))
-            {
-                return releasePath;
-            }
-
-            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
-        }
-    }
-
-    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
 }

--- a/backend/tests/Taskdeck.Cli.Tests/CliActorIdentityTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliActorIdentityTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Taskdeck.Cli.Commands;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class CliActorIdentityTests
+{
+    [Fact]
+    public void ActorUsername_IsNotEmpty()
+    {
+        CliActorIdentity.ActorUsername.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ActorEmail_UsesNonRoutableDomain()
+    {
+        CliActorIdentity.ActorEmail.Should().Contain("@system.taskdeck");
+    }
+
+    [Fact]
+    public void ActorEmail_IsValidFormat()
+    {
+        CliActorIdentity.ActorEmail.Should().Contain("@");
+        var parts = CliActorIdentity.ActorEmail.Split('@');
+        parts.Should().HaveCount(2);
+        parts[0].Should().NotBeNullOrWhiteSpace();
+        parts[1].Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void ActorUsername_MatchesExpectedValue()
+    {
+        // Guard against accidental renames that could break identity resolution
+        CliActorIdentity.ActorUsername.Should().Be("taskdeck_cli_actor");
+    }
+
+    [Fact]
+    public void ActorEmail_MatchesExpectedValue()
+    {
+        // Guard against accidental renames that could break identity resolution
+        CliActorIdentity.ActorEmail.Should().Be("cli-actor@system.taskdeck");
+    }
+}

--- a/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace Taskdeck.Cli.Tests;
+
+/// <summary>
+/// Shared test harness that runs the CLI as a subprocess against an ephemeral SQLite database.
+/// Each harness instance gets its own database file, so tests are isolated.
+/// </summary>
+internal sealed class CliTestHarness : IAsyncDisposable
+{
+    private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly string _databasePath;
+    private readonly string _connectionString;
+
+    public CliTestHarness(string dbPrefix = "taskdeck-cli-tests")
+    {
+        _databasePath = Path.Combine(Path.GetTempPath(), $"{dbPrefix}-{Guid.NewGuid():N}.db");
+        _connectionString = $"Data Source={_databasePath}";
+    }
+
+    public async Task<(Guid BoardId, Guid ColumnId)> CreateBoardAndColumnAsync(
+        string boardName = "TestBoard",
+        string columnName = "Todo")
+    {
+        var boardResult = await RunAsync($"boards create {boardName} --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var columnResult = await RunAsync($"columns create --board {boardId} --name {columnName} --json");
+        columnResult.ExitCode.Should().Be(0, columnResult.StdErr);
+        using var columnDoc = JsonDocument.Parse(columnResult.StdOut);
+        var columnId = columnDoc.RootElement.GetProperty("id").GetGuid();
+
+        return (boardId, columnId);
+    }
+
+    public async Task<CliCommandResult> RunAsync(string arguments)
+    {
+        var cliDllPath = ResolveCliDllPath();
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = string.IsNullOrWhiteSpace(arguments)
+                ? $"\"{cliDllPath}\""
+                : $"\"{cliDllPath}\" {arguments}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
+        startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+        using var process = new Process { StartInfo = startInfo };
+        using var cts = new CancellationTokenSource(ProcessTimeout);
+
+        process.Start();
+
+        var stdOut = await process.StandardOutput.ReadToEndAsync(cts.Token);
+        var stdErr = await process.StandardError.ReadToEndAsync(cts.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+            throw new TimeoutException(
+                $"CLI process did not exit within {ProcessTimeout.TotalSeconds}s. Args: {arguments}");
+        }
+
+        return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
+        {
+            try
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch (IOException) { }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private static string ResolveCliDllPath()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Taskdeck.Cli.dll");
+        if (File.Exists(path))
+        {
+            return path;
+        }
+
+        throw new FileNotFoundException(
+            $"Taskdeck.Cli.dll was not found in the test execution directory ({AppContext.BaseDirectory}). " +
+            "Ensure the CLI project is referenced and built.");
+    }
+}
+
+/// <summary>
+/// Result of a CLI subprocess invocation.
+/// </summary>
+internal sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);

--- a/backend/tests/Taskdeck.Cli.Tests/ColumnsCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ColumnsCommandTests.cs
@@ -1,0 +1,254 @@
+using System.Diagnostics;
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class ColumnsCommandTests
+{
+    [Fact]
+    public async Task ColumnsList_WithJson_RequiresBoard()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("columns list --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--board");
+    }
+
+    [Fact]
+    public async Task ColumnsList_WithInvalidBoardId_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("columns list --board not-a-guid --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--board");
+    }
+
+    [Fact]
+    public async Task ColumnsCreate_WithJson_CreatesColumn()
+    {
+        await using var harness = new CliHarness();
+
+        var boardResult = await harness.RunAsync("boards create ColumnTestBoard --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var result = await harness.RunAsync($"columns create --board {boardId} --name Todo --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.GetProperty("name").GetString().Should().Be("Todo");
+        doc.RootElement.GetProperty("id").GetGuid().Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public async Task ColumnsCreate_MissingName_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var boardResult = await harness.RunAsync("boards create ColNoNameBoard --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var result = await harness.RunAsync($"columns create --board {boardId} --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--name");
+    }
+
+    [Fact]
+    public async Task ColumnsCreate_MissingBoard_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("columns create --name Todo --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--board");
+    }
+
+    [Fact]
+    public async Task ColumnsList_WithJson_ReturnsCreatedColumn()
+    {
+        await using var harness = new CliHarness();
+
+        var boardResult = await harness.RunAsync("boards create ColListBoard --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var createResult = await harness.RunAsync($"columns create --board {boardId} --name InProgress --json");
+        createResult.ExitCode.Should().Be(0, createResult.StdErr);
+        using var createDoc = JsonDocument.Parse(createResult.StdOut);
+        var columnId = createDoc.RootElement.GetProperty("id").GetGuid();
+
+        var listResult = await harness.RunAsync($"columns list --board {boardId} --json");
+
+        listResult.ExitCode.Should().Be(0, listResult.StdErr);
+        using var listDoc = JsonDocument.Parse(listResult.StdOut);
+        listDoc.RootElement.EnumerateArray()
+            .Select(x => x.GetProperty("id").GetGuid())
+            .Should()
+            .Contain(columnId);
+    }
+
+    [Fact]
+    public async Task Columns_UnknownCommand_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("columns unknown");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("Unknown columns command");
+    }
+
+    [Fact]
+    public async Task ColumnsCreate_WithPosition_SetsPosition()
+    {
+        await using var harness = new CliHarness();
+
+        var boardResult = await harness.RunAsync("boards create ColPosBoard --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var result = await harness.RunAsync($"columns create --board {boardId} --name Done --position 2 --json");
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.GetProperty("name").GetString().Should().Be("Done");
+        doc.RootElement.GetProperty("position").GetInt32().Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ColumnsCreate_WithInvalidPosition_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var boardResult = await harness.RunAsync("boards create ColBadPosBoard --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var result = await harness.RunAsync($"columns create --board {boardId} --name BadPos --position abc --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--position");
+    }
+
+    [Fact]
+    public async Task ColumnsCreate_WithInvalidWip_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var boardResult = await harness.RunAsync("boards create ColBadWipBoard --json");
+        boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
+        using var boardDoc = JsonDocument.Parse(boardResult.StdOut);
+        var boardId = boardDoc.RootElement.GetProperty("id").GetGuid();
+
+        var result = await harness.RunAsync($"columns create --board {boardId} --name BadWip --wip 0 --json");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("--wip");
+    }
+
+    private sealed class CliHarness : IAsyncDisposable
+    {
+        private readonly string _repoRoot;
+        private readonly string _databasePath;
+        private readonly string _connectionString;
+
+        public CliHarness()
+        {
+            _repoRoot = FindRepoRoot();
+            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-columns-tests-{Guid.NewGuid():N}.db");
+            _connectionString = $"Data Source={_databasePath}";
+        }
+
+        public async Task<CliCommandResult> RunAsync(string arguments)
+        {
+            var cliDllPath = ResolveCliDllPath(_repoRoot);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"\"{cliDllPath}\" {arguments}",
+                WorkingDirectory = _repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
+            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+
+            var stdOut = await process.StandardOutput.ReadToEndAsync();
+            var stdErr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
+            {
+                try
+                {
+                    if (File.Exists(path)) File.Delete(path);
+                }
+                catch (IOException) { }
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        private static string FindRepoRoot()
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (current != null)
+            {
+                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
+                if (File.Exists(solutionPath))
+                {
+                    return current.FullName;
+                }
+
+                current = current.Parent;
+            }
+
+            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
+        }
+
+        private static string ResolveCliDllPath(string repoRoot)
+        {
+            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
+            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(debugPath))
+            {
+                return debugPath;
+            }
+
+            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(releasePath))
+            {
+                return releasePath;
+            }
+
+            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
+        }
+    }
+
+    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/backend/tests/Taskdeck.Cli.Tests/ColumnsCommandTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ColumnsCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using FluentAssertions;
 using Xunit;
@@ -10,7 +9,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsList_WithJson_RequiresBoard()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var result = await harness.RunAsync("columns list --json");
 
@@ -21,7 +20,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsList_WithInvalidBoardId_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var result = await harness.RunAsync("columns list --board not-a-guid --json");
 
@@ -32,7 +31,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsCreate_WithJson_CreatesColumn()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var boardResult = await harness.RunAsync("boards create ColumnTestBoard --json");
         boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
@@ -50,7 +49,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsCreate_MissingName_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var boardResult = await harness.RunAsync("boards create ColNoNameBoard --json");
         boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
@@ -66,7 +65,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsCreate_MissingBoard_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var result = await harness.RunAsync("columns create --name Todo --json");
 
@@ -77,7 +76,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsList_WithJson_ReturnsCreatedColumn()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var boardResult = await harness.RunAsync("boards create ColListBoard --json");
         boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
@@ -102,7 +101,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task Columns_UnknownCommand_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var result = await harness.RunAsync("columns unknown");
 
@@ -113,7 +112,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsCreate_WithPosition_SetsPosition()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var boardResult = await harness.RunAsync("boards create ColPosBoard --json");
         boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
@@ -131,7 +130,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsCreate_WithInvalidPosition_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var boardResult = await harness.RunAsync("boards create ColBadPosBoard --json");
         boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
@@ -147,7 +146,7 @@ public class ColumnsCommandTests
     [Fact]
     public async Task ColumnsCreate_WithInvalidWip_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-columns");
 
         var boardResult = await harness.RunAsync("boards create ColBadWipBoard --json");
         boardResult.ExitCode.Should().Be(0, boardResult.StdErr);
@@ -159,96 +158,4 @@ public class ColumnsCommandTests
         result.ExitCode.Should().Be(2);
         result.StdErr.Should().Contain("--wip");
     }
-
-    private sealed class CliHarness : IAsyncDisposable
-    {
-        private readonly string _repoRoot;
-        private readonly string _databasePath;
-        private readonly string _connectionString;
-
-        public CliHarness()
-        {
-            _repoRoot = FindRepoRoot();
-            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-columns-tests-{Guid.NewGuid():N}.db");
-            _connectionString = $"Data Source={_databasePath}";
-        }
-
-        public async Task<CliCommandResult> RunAsync(string arguments)
-        {
-            var cliDllPath = ResolveCliDllPath(_repoRoot);
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = $"\"{cliDllPath}\" {arguments}",
-                WorkingDirectory = _repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
-            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-
-            using var process = new Process { StartInfo = startInfo };
-            process.Start();
-
-            var stdOut = await process.StandardOutput.ReadToEndAsync();
-            var stdErr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
-            {
-                try
-                {
-                    if (File.Exists(path)) File.Delete(path);
-                }
-                catch (IOException) { }
-            }
-
-            return ValueTask.CompletedTask;
-        }
-
-        private static string FindRepoRoot()
-        {
-            var current = new DirectoryInfo(AppContext.BaseDirectory);
-
-            while (current != null)
-            {
-                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
-                if (File.Exists(solutionPath))
-                {
-                    return current.FullName;
-                }
-
-                current = current.Parent;
-            }
-
-            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
-        }
-
-        private static string ResolveCliDllPath(string repoRoot)
-        {
-            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
-            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(debugPath))
-            {
-                return debugPath;
-            }
-
-            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(releasePath))
-            {
-                return releasePath;
-            }
-
-            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
-        }
-    }
-
-    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
 }

--- a/backend/tests/Taskdeck.Cli.Tests/CommandDispatcherTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CommandDispatcherTests.cs
@@ -1,0 +1,162 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class CommandDispatcherTests
+{
+    [Fact]
+    public async Task NoArgs_PrintsHelpAndReturnsUsageExitCode()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("");
+
+        result.ExitCode.Should().Be(2);
+        result.StdOut.Should().Contain("Taskdeck CLI");
+        result.StdOut.Should().Contain("Usage:");
+    }
+
+    [Fact]
+    public async Task Help_PrintsHelpAndReturnsSuccess()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("help");
+
+        result.ExitCode.Should().Be(0);
+        result.StdOut.Should().Contain("Taskdeck CLI");
+        result.StdOut.Should().Contain("boards");
+        result.StdOut.Should().Contain("columns");
+        result.StdOut.Should().Contain("cards");
+        result.StdOut.Should().Contain("api-key");
+    }
+
+    [Fact]
+    public async Task UnknownCommandGroup_ReturnsUsageError()
+    {
+        await using var harness = new CliHarness();
+
+        var result = await harness.RunAsync("nonexistent");
+
+        result.ExitCode.Should().Be(2);
+        result.StdErr.Should().Contain("Unknown command group");
+    }
+
+    [Fact]
+    public async Task ExitCodes_SuccessIsZero()
+    {
+        await using var harness = new CliHarness();
+
+        // "help" should return exit code 0
+        var result = await harness.RunAsync("help");
+
+        result.ExitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExitCodes_UsageIsTwo()
+    {
+        await using var harness = new CliHarness();
+
+        // Unknown command should return exit code 2
+        var result = await harness.RunAsync("nonexistent");
+
+        result.ExitCode.Should().Be(2);
+    }
+
+    private sealed class CliHarness : IAsyncDisposable
+    {
+        private readonly string _repoRoot;
+        private readonly string _databasePath;
+        private readonly string _connectionString;
+
+        public CliHarness()
+        {
+            _repoRoot = FindRepoRoot();
+            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-dispatch-tests-{Guid.NewGuid():N}.db");
+            _connectionString = $"Data Source={_databasePath}";
+        }
+
+        public async Task<CliCommandResult> RunAsync(string arguments)
+        {
+            var cliDllPath = ResolveCliDllPath(_repoRoot);
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = string.IsNullOrWhiteSpace(arguments)
+                    ? $"\"{cliDllPath}\""
+                    : $"\"{cliDllPath}\" {arguments}",
+                WorkingDirectory = _repoRoot,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
+            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+
+            using var process = new Process { StartInfo = startInfo };
+            process.Start();
+
+            var stdOut = await process.StandardOutput.ReadToEndAsync();
+            var stdErr = await process.StandardError.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
+            {
+                try
+                {
+                    if (File.Exists(path)) File.Delete(path);
+                }
+                catch (IOException) { }
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        private static string FindRepoRoot()
+        {
+            var current = new DirectoryInfo(AppContext.BaseDirectory);
+
+            while (current != null)
+            {
+                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
+                if (File.Exists(solutionPath))
+                {
+                    return current.FullName;
+                }
+
+                current = current.Parent;
+            }
+
+            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
+        }
+
+        private static string ResolveCliDllPath(string repoRoot)
+        {
+            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
+            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(debugPath))
+            {
+                return debugPath;
+            }
+
+            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
+            if (File.Exists(releasePath))
+            {
+                return releasePath;
+            }
+
+            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
+        }
+    }
+
+    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
+}

--- a/backend/tests/Taskdeck.Cli.Tests/CommandDispatcherTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CommandDispatcherTests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using FluentAssertions;
 using Xunit;
 
@@ -9,7 +8,7 @@ public class CommandDispatcherTests
     [Fact]
     public async Task NoArgs_PrintsHelpAndReturnsUsageExitCode()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-dispatch");
 
         var result = await harness.RunAsync("");
 
@@ -21,7 +20,7 @@ public class CommandDispatcherTests
     [Fact]
     public async Task Help_PrintsHelpAndReturnsSuccess()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-dispatch");
 
         var result = await harness.RunAsync("help");
 
@@ -36,127 +35,11 @@ public class CommandDispatcherTests
     [Fact]
     public async Task UnknownCommandGroup_ReturnsUsageError()
     {
-        await using var harness = new CliHarness();
+        await using var harness = new CliTestHarness("cli-dispatch");
 
         var result = await harness.RunAsync("nonexistent");
 
         result.ExitCode.Should().Be(2);
         result.StdErr.Should().Contain("Unknown command group");
     }
-
-    [Fact]
-    public async Task ExitCodes_SuccessIsZero()
-    {
-        await using var harness = new CliHarness();
-
-        // "help" should return exit code 0
-        var result = await harness.RunAsync("help");
-
-        result.ExitCode.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task ExitCodes_UsageIsTwo()
-    {
-        await using var harness = new CliHarness();
-
-        // Unknown command should return exit code 2
-        var result = await harness.RunAsync("nonexistent");
-
-        result.ExitCode.Should().Be(2);
-    }
-
-    private sealed class CliHarness : IAsyncDisposable
-    {
-        private readonly string _repoRoot;
-        private readonly string _databasePath;
-        private readonly string _connectionString;
-
-        public CliHarness()
-        {
-            _repoRoot = FindRepoRoot();
-            _databasePath = Path.Combine(Path.GetTempPath(), $"taskdeck-cli-dispatch-tests-{Guid.NewGuid():N}.db");
-            _connectionString = $"Data Source={_databasePath}";
-        }
-
-        public async Task<CliCommandResult> RunAsync(string arguments)
-        {
-            var cliDllPath = ResolveCliDllPath(_repoRoot);
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = "dotnet",
-                Arguments = string.IsNullOrWhiteSpace(arguments)
-                    ? $"\"{cliDllPath}\""
-                    : $"\"{cliDllPath}\" {arguments}",
-                WorkingDirectory = _repoRoot,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
-            startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-
-            using var process = new Process { StartInfo = startInfo };
-            process.Start();
-
-            var stdOut = await process.StandardOutput.ReadToEndAsync();
-            var stdErr = await process.StandardError.ReadToEndAsync();
-            await process.WaitForExitAsync();
-
-            return new CliCommandResult(process.ExitCode, stdOut.Trim(), stdErr.Trim());
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
-            {
-                try
-                {
-                    if (File.Exists(path)) File.Delete(path);
-                }
-                catch (IOException) { }
-            }
-
-            return ValueTask.CompletedTask;
-        }
-
-        private static string FindRepoRoot()
-        {
-            var current = new DirectoryInfo(AppContext.BaseDirectory);
-
-            while (current != null)
-            {
-                var solutionPath = Path.Combine(current.FullName, "backend", "Taskdeck.sln");
-                if (File.Exists(solutionPath))
-                {
-                    return current.FullName;
-                }
-
-                current = current.Parent;
-            }
-
-            throw new InvalidOperationException("Could not locate repository root from test execution directory.");
-        }
-
-        private static string ResolveCliDllPath(string repoRoot)
-        {
-            var cliProjectBin = Path.Combine(repoRoot, "backend", "src", "Taskdeck.Cli", "bin");
-            var debugPath = Path.Combine(cliProjectBin, "Debug", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(debugPath))
-            {
-                return debugPath;
-            }
-
-            var releasePath = Path.Combine(cliProjectBin, "Release", "net8.0", "Taskdeck.Cli.dll");
-            if (File.Exists(releasePath))
-            {
-                return releasePath;
-            }
-
-            throw new FileNotFoundException("Taskdeck.Cli.dll was not found in Debug or Release output directories.");
-        }
-    }
-
-    private sealed record CliCommandResult(int ExitCode, string StdOut, string StdErr);
 }

--- a/backend/tests/Taskdeck.Cli.Tests/ConsoleOutputTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ConsoleOutputTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Taskdeck.Cli.Tests;
 
+[Collection("Console Tests")]
 public class ConsoleOutputTests
 {
     [Fact]

--- a/backend/tests/Taskdeck.Cli.Tests/ConsoleOutputTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ConsoleOutputTests.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using FluentAssertions;
+using Taskdeck.Cli.Commands;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class ConsoleOutputTests
+{
+    [Fact]
+    public void JsonOptions_UsesCamelCase()
+    {
+        ConsoleOutput.JsonOptions.PropertyNamingPolicy.Should().Be(JsonNamingPolicy.CamelCase);
+    }
+
+    [Fact]
+    public void JsonOptions_DoesNotWriteIndented()
+    {
+        ConsoleOutput.JsonOptions.WriteIndented.Should().BeFalse();
+    }
+
+    [Fact]
+    public void PrintUsageError_ReturnsUsageExitCode()
+    {
+        var originalErr = Console.Error;
+        using var sw = new StringWriter();
+        Console.SetError(sw);
+        try
+        {
+            var exitCode = ConsoleOutput.PrintUsageError("test message", "taskdeck test");
+
+            exitCode.Should().Be(ExitCodes.Usage);
+            sw.ToString().Should().Contain("test message");
+            sw.ToString().Should().Contain("Usage: taskdeck test");
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public void PrintFailure_ReturnsFailureExitCode()
+    {
+        var originalErr = Console.Error;
+        using var sw = new StringWriter();
+        Console.SetError(sw);
+        try
+        {
+            var exitCode = ConsoleOutput.PrintFailure("NOT_FOUND", "Board not found");
+
+            exitCode.Should().Be(ExitCodes.Failure);
+            sw.ToString().Should().Contain("NOT_FOUND");
+            sw.ToString().Should().Contain("Board not found");
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public void WriteJson_WritesCompactCamelCaseJson()
+    {
+        var originalOut = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            ConsoleOutput.WriteJson(new { MyProperty = "hello", AnotherValue = 42 });
+
+            var output = sw.ToString().Trim();
+            output.Should().Contain("\"myProperty\"");
+            output.Should().Contain("\"anotherValue\"");
+            output.Should().NotContain("\n  "); // Not indented
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void WriteJson_SerializesArrays()
+    {
+        var originalOut = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            ConsoleOutput.WriteJson(new[] { new { Name = "A" }, new { Name = "B" } });
+
+            var output = sw.ToString().Trim();
+            using var doc = JsonDocument.Parse(output);
+            doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+            doc.RootElement.GetArrayLength().Should().Be(2);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public void PrintHelp_OutputsUsageInformation()
+    {
+        var originalOut = Console.Out;
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        try
+        {
+            ConsoleOutput.PrintHelp();
+
+            var output = sw.ToString();
+            output.Should().Contain("Taskdeck CLI");
+            output.Should().Contain("boards list");
+            output.Should().Contain("boards create");
+            output.Should().Contain("columns list");
+            output.Should().Contain("cards add");
+            output.Should().Contain("api-key create");
+            output.Should().Contain("Exit codes:");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Cli.Tests/ExitCodesTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/ExitCodesTests.cs
@@ -1,0 +1,33 @@
+using FluentAssertions;
+using Taskdeck.Cli.Commands;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+public class ExitCodesTests
+{
+    [Fact]
+    public void Success_IsZero()
+    {
+        ExitCodes.Success.Should().Be(0);
+    }
+
+    [Fact]
+    public void Failure_IsOne()
+    {
+        ExitCodes.Failure.Should().Be(1);
+    }
+
+    [Fact]
+    public void Usage_IsTwo()
+    {
+        ExitCodes.Usage.Should().Be(2);
+    }
+
+    [Fact]
+    public void ExitCodes_AreDistinct()
+    {
+        var codes = new[] { ExitCodes.Success, ExitCodes.Failure, ExitCodes.Usage };
+        codes.Should().OnlyHaveUniqueItems();
+    }
+}


### PR DESCRIPTION
## Summary
- Add 6 new CLI test files with proper `[Fact]`/`[Theory]` attributes covering all CLI source components
- Add `InternalsVisibleTo` to Taskdeck.Cli project enabling direct unit testing of internal types
- Test count increases from 16 to 84 (68 new tests)
- New test files: `ArgParserTests`, `BoardsCommandTests`, `ColumnsCommandTests`, `CardsCommandTests`, `CommandDispatcherTests`, `ConsoleOutputTests`, `ExitCodesTests`, `CliActorIdentityTests`
- All 84 tests pass, full backend suite green (0 failures)

Closes #862

## Test plan
- [x] All CLI test methods have `[Fact]` or `[Theory]` attributes
- [x] `dotnet test --list-tests` discovers all 84 CLI tests
- [x] All tests pass (0 skipped, 0 failed)
- [x] Full backend test suite passes