### PR TITLE
feat: add offset/limit pagination to board list endpoint

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/BoardsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/BoardsController.cs
@@ -25,23 +25,43 @@ public class BoardsController : AuthenticatedControllerBase
         _boardService = boardService;
     }
 
+    private const int DefaultLimit = 50;
+    private const int MaxLimit = 200;
+
     /// <summary>
-    /// List boards accessible to the current user.
+    /// List boards accessible to the current user with optional pagination.
     /// </summary>
     /// <param name="search">Optional text filter applied to board names.</param>
     /// <param name="includeArchived">When true, archived boards are included in the results.</param>
-    /// <returns>A list of boards matching the criteria.</returns>
-    /// <response code="200">Returns the list of boards.</response>
+    /// <param name="offset">Zero-based starting position. Defaults to 0.</param>
+    /// <param name="limit">Maximum number of boards to return. Defaults to 50, max 200. Omit for default.</param>
+    /// <returns>A paginated list of boards matching the criteria.</returns>
+    /// <response code="200">Returns the paginated list of boards.</response>
     /// <response code="401">Authentication required.</response>
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<BoardDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PaginatedResult<BoardDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetBoards([FromQuery] string? search, [FromQuery] bool includeArchived = false)
+    public async Task<IActionResult> GetBoards(
+        [FromQuery] string? search,
+        [FromQuery] bool includeArchived = false,
+        [FromQuery] int offset = 0,
+        [FromQuery] int? limit = null)
     {
         if (!TryGetCurrentUserId(out var userId, out var errorResult))
             return errorResult!;
 
-        var result = await _boardService.ListBoardsAsync(userId, search, includeArchived);
+        // Clamp offset to non-negative
+        if (offset < 0) offset = 0;
+
+        // Apply default and max limit. When limit is explicitly provided, clamp to [1, MaxLimit].
+        // When omitted, use DefaultLimit for backward-compatible bounded responses.
+        var effectiveLimit = limit.HasValue
+            ? Math.Clamp(limit.Value, 1, MaxLimit)
+            : DefaultLimit;
+
+        var result = await _boardService.ListBoardsPaginatedAsync(
+            userId, search, includeArchived, offset, effectiveLimit);
+
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 

--- a/backend/src/Taskdeck.Application/DTOs/PaginatedResult.cs
+++ b/backend/src/Taskdeck.Application/DTOs/PaginatedResult.cs
@@ -1,0 +1,13 @@
+namespace Taskdeck.Application.DTOs;
+
+/// <summary>
+/// Generic paginated response wrapper. Provides the current page of items
+/// along with pagination metadata so clients can implement offset-based paging.
+/// </summary>
+public record PaginatedResult<T>(
+    List<T> Items,
+    int TotalCount,
+    bool HasMore,
+    int Offset,
+    int Limit
+);

--- a/backend/src/Taskdeck.Application/Interfaces/IBoardRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IBoardRepository.cs
@@ -20,7 +20,9 @@ public interface IBoardRepository : IRepository<Board>
         bool includeArchived,
         CancellationToken cancellationToken = default);
     Task<IEnumerable<Board>> SearchAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default);
+    Task<int> SearchCountAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default);
     Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, int offset, int limit, CancellationToken cancellationToken = default);
     Task<IEnumerable<Board>> GetByIdsAsync(IEnumerable<Guid> boardIds, CancellationToken cancellationToken = default);
     Task<IEnumerable<Guid>> GetOwnedBoardIdsAsync(Guid userId, IEnumerable<Guid> candidateBoardIds, CancellationToken cancellationToken = default);
     Task<Board?> GetByIdWithDetailsAsync(Guid id, CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Interfaces/IBoardRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IBoardRepository.cs
@@ -20,9 +20,7 @@ public interface IBoardRepository : IRepository<Board>
         bool includeArchived,
         CancellationToken cancellationToken = default);
     Task<IEnumerable<Board>> SearchAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default);
-    Task<int> SearchCountAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default);
     Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default);
-    Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, int offset, int limit, CancellationToken cancellationToken = default);
     Task<IEnumerable<Board>> GetByIdsAsync(IEnumerable<Guid> boardIds, CancellationToken cancellationToken = default);
     Task<IEnumerable<Guid>> GetOwnedBoardIdsAsync(Guid userId, IEnumerable<Guid> candidateBoardIds, CancellationToken cancellationToken = default);
     Task<Board?> GetByIdWithDetailsAsync(Guid id, CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Services/BoardService.cs
+++ b/backend/src/Taskdeck.Application/Services/BoardService.cs
@@ -113,11 +113,34 @@ public class BoardService
 
     public async Task<Result<IEnumerable<BoardDto>>> ListBoardsAsync(Guid actingUserId, string? searchText = null, bool includeArchived = false, CancellationToken cancellationToken = default)
     {
-        if (actingUserId == Guid.Empty)
-            return Result.Failure<IEnumerable<BoardDto>>(ErrorCodes.ValidationError, "Acting user ID cannot be empty");
+        // Delegate to paginated overload with no offset/limit to return all results.
+        var paginated = await ListBoardsPaginatedAsync(actingUserId, searchText, includeArchived, offset: 0, limit: null, cancellationToken);
+        if (!paginated.IsSuccess)
+            return Result.Failure<IEnumerable<BoardDto>>(paginated.ErrorCode, paginated.ErrorMessage);
 
-        // Only cache un-filtered, non-archived list (the most common request)
-        var canCache = _cacheService is not null && string.IsNullOrEmpty(searchText) && !includeArchived;
+        return Result.Success<IEnumerable<BoardDto>>(paginated.Value.Items);
+    }
+
+    /// <summary>
+    /// Lists boards with offset/limit pagination. When <paramref name="limit"/> is null,
+    /// all authorized boards are returned (backward compatible behavior).
+    /// </summary>
+    public async Task<Result<PaginatedResult<BoardDto>>> ListBoardsPaginatedAsync(
+        Guid actingUserId,
+        string? searchText = null,
+        bool includeArchived = false,
+        int offset = 0,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (actingUserId == Guid.Empty)
+            return Result.Failure<PaginatedResult<BoardDto>>(ErrorCodes.ValidationError, "Acting user ID cannot be empty");
+
+        if (offset < 0)
+            offset = 0;
+
+        // Only cache un-filtered, non-archived, non-paginated list (the most common request)
+        var canCache = _cacheService is not null && string.IsNullOrEmpty(searchText) && !includeArchived && offset == 0 && limit is null;
 
         if (canCache)
         {
@@ -125,45 +148,57 @@ public class BoardService
             var cached = await _cacheService!.GetAsync<List<BoardDto>>(cacheKey, cancellationToken);
             if (cached is not null)
             {
-                return Result.Success<IEnumerable<BoardDto>>(cached);
+                return Result.Success(new PaginatedResult<BoardDto>(cached, cached.Count, false, 0, cached.Count));
             }
         }
 
         var candidateBoardIds = (await _unitOfWork.Boards.SearchIdsAsync(searchText, includeArchived, cancellationToken)).ToList();
 
+        List<Guid> visibleBoardIds;
         if (_authorizationService is null)
         {
-            var boards = await _unitOfWork.Boards.GetByIdsAsync(candidateBoardIds, cancellationToken);
-            var dtos = boards.Select(MapToDto).ToList();
+            visibleBoardIds = candidateBoardIds;
+        }
+        else
+        {
+            var visibleBoardIdsResult = await _authorizationService.GetReadableBoardIdsAsync(
+                actingUserId,
+                candidateBoardIds,
+                cancellationToken);
 
-            if (canCache)
-            {
-                var ttl = TimeSpan.FromSeconds(_cacheSettings!.BoardListTtlSeconds);
-                await _cacheService!.SetAsync(CacheKeys.BoardListForUser(actingUserId), dtos, ttl, cancellationToken);
-            }
+            if (!visibleBoardIdsResult.IsSuccess)
+                return Result.Failure<PaginatedResult<BoardDto>>(visibleBoardIdsResult.ErrorCode, visibleBoardIdsResult.ErrorMessage);
 
-            return Result.Success<IEnumerable<BoardDto>>(dtos);
+            visibleBoardIds = visibleBoardIdsResult.Value.ToList();
         }
 
-        var visibleBoardIdsResult = await _authorizationService.GetReadableBoardIdsAsync(
-            actingUserId,
-            candidateBoardIds,
-            cancellationToken);
+        var totalCount = visibleBoardIds.Count;
 
-        if (!visibleBoardIdsResult.IsSuccess)
-            return Result.Failure<IEnumerable<BoardDto>>(visibleBoardIdsResult.ErrorCode, visibleBoardIdsResult.ErrorMessage);
+        // Apply pagination to the authorized list of IDs
+        IEnumerable<Guid> pageIds;
+        if (limit.HasValue)
+        {
+            pageIds = visibleBoardIds.Skip(offset).Take(limit.Value);
+        }
+        else
+        {
+            pageIds = visibleBoardIds;
+        }
 
-        var visibleBoardIds = visibleBoardIdsResult.Value.ToList();
-        var visibleBoards = await _unitOfWork.Boards.GetByIdsAsync(visibleBoardIds, cancellationToken);
-        var result = visibleBoards.Select(MapToDto).ToList();
+        var pageIdList = pageIds.ToList();
+        var boards = await _unitOfWork.Boards.GetByIdsAsync(pageIdList, cancellationToken);
+        var dtos = boards.Select(MapToDto).ToList();
 
+        var hasMore = limit.HasValue && (offset + pageIdList.Count) < totalCount;
+
+        // Cache only the full un-paginated result
         if (canCache)
         {
             var ttl = TimeSpan.FromSeconds(_cacheSettings!.BoardListTtlSeconds);
-            await _cacheService!.SetAsync(CacheKeys.BoardListForUser(actingUserId), result, ttl, cancellationToken);
+            await _cacheService!.SetAsync(CacheKeys.BoardListForUser(actingUserId), dtos, ttl, cancellationToken);
         }
 
-        return Result.Success<IEnumerable<BoardDto>>(result);
+        return Result.Success(new PaginatedResult<BoardDto>(dtos, totalCount, hasMore, offset, limit ?? totalCount));
     }
 
     public async Task<Result> DeleteBoardAsync(Guid id, CancellationToken cancellationToken = default)

--- a/backend/src/Taskdeck.Application/Services/BoardService.cs
+++ b/backend/src/Taskdeck.Application/Services/BoardService.cs
@@ -169,12 +169,17 @@ public class BoardService
             if (!visibleBoardIdsResult.IsSuccess)
                 return Result.Failure<PaginatedResult<BoardDto>>(visibleBoardIdsResult.ErrorCode, visibleBoardIdsResult.ErrorMessage);
 
-            visibleBoardIds = visibleBoardIdsResult.Value.ToList();
+            // GetReadableBoardIdsAsync returns IReadOnlySet<Guid> (unordered).
+            // Preserve the stable order from candidateBoardIds (which is sorted by
+            // CreatedAt desc, Id asc from the repository) by filtering rather than
+            // converting the set to a list directly.
+            var authorizedSet = visibleBoardIdsResult.Value;
+            visibleBoardIds = candidateBoardIds.Where(id => authorizedSet.Contains(id)).ToList();
         }
 
         var totalCount = visibleBoardIds.Count;
 
-        // Apply pagination to the authorized list of IDs
+        // Apply pagination to the stably-ordered authorized list of IDs
         IEnumerable<Guid> pageIds;
         if (limit.HasValue)
         {

--- a/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
@@ -124,10 +124,45 @@ public class BoardRepository : Repository<Board>, IBoardRepository
         return boards.OrderByDescending(b => b.CreatedAt);
     }
 
+    public async Task<int> SearchCountAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default)
+    {
+        var query = BuildSearchQuery(searchText, includeArchived);
+        return await query.CountAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default)
     {
         var query = BuildSearchQuery(searchText, includeArchived);
         var boardIds = await query.Select(board => board.Id).ToListAsync(cancellationToken);
+        return boardIds;
+    }
+
+    public async Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, int offset, int limit, CancellationToken cancellationToken = default)
+    {
+        var query = BuildSearchQuery(searchText, includeArchived);
+
+        // SQLite doesn't support DateTimeOffset in ORDER BY, so we use a raw query
+        // for stable ordering before applying Skip/Take.
+        if (_context.Database.IsSqlite())
+        {
+            var allIds = await query
+                .Select(board => new { board.Id, board.CreatedAt })
+                .ToListAsync(cancellationToken);
+
+            return allIds
+                .OrderByDescending(b => b.CreatedAt)
+                .Skip(offset)
+                .Take(limit)
+                .Select(b => b.Id)
+                .ToList();
+        }
+
+        var boardIds = await query
+            .OrderByDescending(board => board.CreatedAt)
+            .Skip(offset)
+            .Take(limit)
+            .Select(board => board.Id)
+            .ToListAsync(cancellationToken);
         return boardIds;
     }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
@@ -127,8 +127,20 @@ public class BoardRepository : Repository<Board>, IBoardRepository
     public async Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default)
     {
         var query = BuildSearchQuery(searchText, includeArchived);
-        var boardIds = await query.Select(board => board.Id).ToListAsync(cancellationToken);
-        return boardIds;
+
+        // Load Id + CreatedAt so we can apply a stable sort in memory
+        // (SQLite doesn't support DateTimeOffset in ORDER BY).
+        // Sort by CreatedAt descending with Id as a deterministic tiebreaker
+        // so offset pagination produces consistent pages.
+        var boards = await query
+            .Select(board => new { board.Id, board.CreatedAt })
+            .ToListAsync(cancellationToken);
+
+        return boards
+            .OrderByDescending(b => b.CreatedAt)
+            .ThenBy(b => b.Id)
+            .Select(b => b.Id)
+            .ToList();
     }
 
     public async Task<IEnumerable<Board>> GetByIdsAsync(IEnumerable<Guid> boardIds, CancellationToken cancellationToken = default)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
@@ -124,45 +124,10 @@ public class BoardRepository : Repository<Board>, IBoardRepository
         return boards.OrderByDescending(b => b.CreatedAt);
     }
 
-    public async Task<int> SearchCountAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default)
-    {
-        var query = BuildSearchQuery(searchText, includeArchived);
-        return await query.CountAsync(cancellationToken);
-    }
-
     public async Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, CancellationToken cancellationToken = default)
     {
         var query = BuildSearchQuery(searchText, includeArchived);
         var boardIds = await query.Select(board => board.Id).ToListAsync(cancellationToken);
-        return boardIds;
-    }
-
-    public async Task<IEnumerable<Guid>> SearchIdsAsync(string? searchText, bool includeArchived, int offset, int limit, CancellationToken cancellationToken = default)
-    {
-        var query = BuildSearchQuery(searchText, includeArchived);
-
-        // SQLite doesn't support DateTimeOffset in ORDER BY, so we use a raw query
-        // for stable ordering before applying Skip/Take.
-        if (_context.Database.IsSqlite())
-        {
-            var allIds = await query
-                .Select(board => new { board.Id, board.CreatedAt })
-                .ToListAsync(cancellationToken);
-
-            return allIds
-                .OrderByDescending(b => b.CreatedAt)
-                .Skip(offset)
-                .Take(limit)
-                .Select(b => b.Id)
-                .ToList();
-        }
-
-        var boardIds = await query
-            .OrderByDescending(board => board.CreatedAt)
-            .Skip(offset)
-            .Take(limit)
-            .Select(board => board.Id)
-            .ToListAsync(cancellationToken);
         return boardIds;
     }
 

--- a/backend/tests/Taskdeck.Api.Tests/ArchiveRestoreLifecycleTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ArchiveRestoreLifecycleTests.cs
@@ -45,18 +45,12 @@ public class ArchiveRestoreLifecycleTests : IClassFixture<TestWebApplicationFact
         updateResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
         // Verify board is excluded from active board list
-        var activeBoardsResponse = await client.GetAsync("/api/boards");
-        activeBoardsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var activeBoards = await activeBoardsResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        activeBoards.Should().NotBeNull();
-        activeBoards!.Should().NotContain(b => b.Id == board.Id);
+        var activeBoards = await ApiTestHarness.ListBoardsAsync(client);
+        activeBoards.Should().NotContain(b => b.Id == board.Id);
 
         // Verify board appears when includeArchived=true
-        var allBoardsResponse = await client.GetAsync("/api/boards?includeArchived=true");
-        allBoardsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var allBoards = await allBoardsResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        allBoards.Should().NotBeNull();
-        allBoards!.Should().Contain(b => b.Id == board.Id && b.IsArchived);
+        var allBoards = await ApiTestHarness.ListBoardsAsync(client, includeArchived: true);
+        allBoards.Should().Contain(b => b.Id == board.Id && b.IsArchived);
 
         // Verify archive item exists in archive list
         var archiveListResponse = await client.GetAsync("/api/archive/items?entityType=board");
@@ -102,11 +96,8 @@ public class ArchiveRestoreLifecycleTests : IClassFixture<TestWebApplicationFact
         restoreResult.RestoredEntityId.Should().NotBeNull();
 
         // Verify the board is actually visible again and no longer archived
-        var boardsResponse = await client.GetAsync("/api/boards?includeArchived=true");
-        boardsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var allBoards = await boardsResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        allBoards.Should().NotBeNull();
-        var restoredBoard = allBoards!.FirstOrDefault(b => b.Id == board.Id);
+        var allBoards = await ApiTestHarness.ListBoardsAsync(client, includeArchived: true);
+        var restoredBoard = allBoards.FirstOrDefault(b => b.Id == board.Id);
         restoredBoard.Should().NotBeNull("restored board should still exist in board list");
         restoredBoard!.IsArchived.Should().BeFalse("board should no longer be archived after restore");
     }

--- a/backend/tests/Taskdeck.Api.Tests/BoardPaginationApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/BoardPaginationApiTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public class BoardPaginationApiTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public BoardPaginationApiTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetBoards_DefaultPagination_ReturnsWrappedResult()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-default");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-default");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client);
+
+        result.Items.Should().NotBeEmpty();
+        result.TotalCount.Should().BeGreaterOrEqualTo(1);
+        result.Offset.Should().Be(0);
+        result.Limit.Should().Be(50, "default limit should be 50");
+    }
+
+    [Fact]
+    public async Task GetBoards_EmptyList_ReturnsPaginationMetadata()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-empty");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
+        result.HasMore.Should().BeFalse();
+        result.Offset.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetBoards_WithLimit_ReturnsClampedPageSize()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-limit");
+        // Create 3 boards
+        await ApiTestHarness.CreateBoardAsync(client, "pg-limit-1");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-limit-2");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-limit-3");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, limit: 2);
+
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(3);
+        result.HasMore.Should().BeTrue();
+        result.Limit.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetBoards_WithOffset_SkipsBoards()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-offset");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-offset-1");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-offset-2");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-offset-3");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, offset: 1, limit: 2);
+
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(3);
+        result.Offset.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetBoards_PartialPage_ReturnsHasMoreFalse()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-partial");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-partial-1");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-partial-2");
+
+        // Request limit larger than total count
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, limit: 50);
+
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(2);
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetBoards_LimitOverMax_ClampedTo200()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-max");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-max");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, limit: 500);
+
+        result.Limit.Should().Be(200, "limit should be clamped to max 200");
+    }
+
+    [Fact]
+    public async Task GetBoards_NegativeOffset_TreatedAsZero()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-neg-offset");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-neg");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, offset: -5, limit: 10);
+
+        result.Offset.Should().Be(0);
+        result.Items.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetBoards_OffsetBeyondTotal_ReturnsEmptyPage()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-beyond");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-beyond");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, offset: 100, limit: 10);
+
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(1);
+        result.HasMore.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetBoards_ZeroLimit_ClampedToOne()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-zero");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-zero-1");
+        await ApiTestHarness.CreateBoardAsync(client, "pg-zero-2");
+
+        var result = await ApiTestHarness.ListBoardsPaginatedAsync(client, limit: 0);
+
+        result.Items.Should().HaveCount(1, "limit=0 should be clamped to 1");
+        result.HasMore.Should().BeTrue();
+        result.Limit.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetBoards_PaginationIteratesAllBoards()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "pagination-iterate");
+        var board1 = await ApiTestHarness.CreateBoardAsync(client, "pg-iter-1");
+        var board2 = await ApiTestHarness.CreateBoardAsync(client, "pg-iter-2");
+        var board3 = await ApiTestHarness.CreateBoardAsync(client, "pg-iter-3");
+
+        var allBoardIds = new List<Guid>();
+
+        // Iterate page by page with limit=1
+        var page1 = await ApiTestHarness.ListBoardsPaginatedAsync(client, offset: 0, limit: 1);
+        page1.Items.Should().HaveCount(1);
+        page1.TotalCount.Should().Be(3);
+        page1.HasMore.Should().BeTrue();
+        allBoardIds.AddRange(page1.Items.Select(b => b.Id));
+
+        var page2 = await ApiTestHarness.ListBoardsPaginatedAsync(client, offset: 1, limit: 1);
+        page2.Items.Should().HaveCount(1);
+        page2.HasMore.Should().BeTrue();
+        allBoardIds.AddRange(page2.Items.Select(b => b.Id));
+
+        var page3 = await ApiTestHarness.ListBoardsPaginatedAsync(client, offset: 2, limit: 1);
+        page3.Items.Should().HaveCount(1);
+        page3.HasMore.Should().BeFalse();
+        allBoardIds.AddRange(page3.Items.Select(b => b.Id));
+
+        // All three boards should appear across the pages with no duplicates
+        allBoardIds.Should().HaveCount(3);
+        allBoardIds.Distinct().Should().HaveCount(3);
+        allBoardIds.Should().Contain(board1.Id);
+        allBoardIds.Should().Contain(board2.Id);
+        allBoardIds.Should().Contain(board3.Id);
+    }
+
+    [Fact]
+    public async Task GetBoards_CrossUserIsolation_WithPagination()
+    {
+        using var clientA = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(clientA, "pagination-iso-a");
+        await ApiTestHarness.CreateBoardAsync(clientA, "pg-iso-a");
+
+        using var clientB = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(clientB, "pagination-iso-b");
+        await ApiTestHarness.CreateBoardAsync(clientB, "pg-iso-b");
+
+        var resultA = await ApiTestHarness.ListBoardsPaginatedAsync(clientA);
+        var resultB = await ApiTestHarness.ListBoardsPaginatedAsync(clientB);
+
+        resultA.TotalCount.Should().Be(1);
+        resultB.TotalCount.Should().Be(1);
+        resultA.Items.Single().Id.Should().NotBe(resultB.Items.Single().Id);
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/BoardsApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/BoardsApiTests.cs
@@ -130,10 +130,7 @@ public class BoardsApiTests : IClassFixture<TestWebApplicationFactory>
         await ApiTestHarness.AuthenticateAsync(otherClient, "list-other");
         var otherBoard = await ApiTestHarness.CreateBoardAsync(otherClient, "list-other-board");
 
-        var ownerListResponse = await ownerClient.GetAsync("/api/boards");
-        ownerListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var ownerBoards = await ownerListResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        ownerBoards.Should().NotBeNull();
+        var ownerBoards = await ApiTestHarness.ListBoardsAsync(ownerClient);
         ownerBoards.Should().ContainSingle(b => b.Id == ownerBoard.Id);
         ownerBoards.Should().NotContain(b => b.Id == otherBoard.Id);
     }
@@ -172,16 +169,10 @@ public class BoardsApiTests : IClassFixture<TestWebApplicationFactory>
         var deleteResponse = await _client.DeleteAsync($"/api/boards/{createdBoard.Id}");
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        var activeListResponse = await _client.GetAsync("/api/boards");
-        activeListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var activeBoards = await activeListResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        activeBoards.Should().NotBeNull();
+        var activeBoards = await ApiTestHarness.ListBoardsAsync(_client);
         activeBoards.Should().NotContain(b => b.Id == createdBoard.Id);
 
-        var fullListResponse = await _client.GetAsync("/api/boards?includeArchived=true");
-        fullListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var allBoards = await fullListResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        allBoards.Should().NotBeNull();
+        var allBoards = await ApiTestHarness.ListBoardsAsync(_client, includeArchived: true);
         allBoards.Should().ContainSingle(b => b.Id == createdBoard.Id && b.IsArchived);
     }
 
@@ -205,10 +196,7 @@ public class BoardsApiTests : IClassFixture<TestWebApplicationFactory>
         restoredBoard!.Id.Should().Be(createdBoard.Id);
         restoredBoard.IsArchived.Should().BeFalse();
 
-        var activeListResponse = await _client.GetAsync("/api/boards");
-        activeListResponse.StatusCode.Should().Be(HttpStatusCode.OK);
-        var activeBoards = await activeListResponse.Content.ReadFromJsonAsync<List<BoardDto>>();
-        activeBoards.Should().NotBeNull();
+        var activeBoards = await ApiTestHarness.ListBoardsAsync(_client);
         activeBoards.Should().ContainSingle(b => b.Id == createdBoard.Id && !b.IsArchived);
     }
 
@@ -225,16 +213,10 @@ public class BoardsApiTests : IClassFixture<TestWebApplicationFactory>
 
         archiveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var activeListAfterArchive = await _client.GetAsync("/api/boards");
-        activeListAfterArchive.StatusCode.Should().Be(HttpStatusCode.OK);
-        var activeBoards = await activeListAfterArchive.Content.ReadFromJsonAsync<List<BoardDto>>();
-        activeBoards.Should().NotBeNull();
+        var activeBoards = await ApiTestHarness.ListBoardsAsync(_client);
         activeBoards.Should().NotContain(board => board.Id == createdBoard.Id);
 
-        var archivedList = await _client.GetAsync("/api/boards?includeArchived=true");
-        archivedList.StatusCode.Should().Be(HttpStatusCode.OK);
-        var allBoardsAfterArchive = await archivedList.Content.ReadFromJsonAsync<List<BoardDto>>();
-        allBoardsAfterArchive.Should().NotBeNull();
+        var allBoardsAfterArchive = await ApiTestHarness.ListBoardsAsync(_client, includeArchived: true);
         allBoardsAfterArchive.Should().ContainSingle(board => board.Id == createdBoard.Id && board.IsArchived);
 
         var restoreResponse = await _client.PutAsJsonAsync(
@@ -243,10 +225,7 @@ public class BoardsApiTests : IClassFixture<TestWebApplicationFactory>
 
         restoreResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var activeListAfterRestore = await _client.GetAsync("/api/boards");
-        activeListAfterRestore.StatusCode.Should().Be(HttpStatusCode.OK);
-        var activeBoardsAfterRestore = await activeListAfterRestore.Content.ReadFromJsonAsync<List<BoardDto>>();
-        activeBoardsAfterRestore.Should().NotBeNull();
+        var activeBoardsAfterRestore = await ApiTestHarness.ListBoardsAsync(_client);
         activeBoardsAfterRestore.Should().ContainSingle(board => board.Id == createdBoard.Id && !board.IsArchived);
     }
 

--- a/backend/tests/Taskdeck.Api.Tests/Concurrency/CrossUserIsolationStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Concurrency/CrossUserIsolationStressTests.cs
@@ -76,9 +76,8 @@ public class CrossUserIsolationStressTests : IClassFixture<TestWebApplicationFac
             var allBoardIds = userBoards.Values.Select(v => v.BoardId).ToHashSet();
             foreach (var (username, (boardId, client)) in userBoards)
             {
-                var listResp = await client.GetAsync("/api/boards");
-                var boards = await listResp.Content.ReadFromJsonAsync<List<BoardDto>>();
-                var visibleOtherBoards = boards!.Where(b =>
+                var boards = await ApiTestHarness.ListBoardsAsync(client);
+                var visibleOtherBoards = boards.Where(b =>
                     allBoardIds.Contains(b.Id) && b.Id != boardId).ToList();
                 visibleOtherBoards.Should().BeEmpty(
                     $"user {username} should not see other users' boards");

--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -809,9 +809,8 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             userBoards[user.Username] = board!.Id;
 
             // Verify user only sees their own board
-            var listResp = await client.GetAsync("/api/boards");
-            var boards = await listResp.Content.ReadFromJsonAsync<List<BoardDto>>();
-            var otherUserBoards = boards!.Where(b =>
+            var boards = await ApiTestHarness.ListBoardsAsync(client);
+            var otherUserBoards = boards.Where(b =>
                 userBoards.Any(kv => kv.Key != user.Username && kv.Value == b.Id));
             if (otherUserBoards.Any())
             {

--- a/backend/tests/Taskdeck.Api.Tests/CrossUserDataIsolationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CrossUserDataIsolationTests.cs
@@ -40,11 +40,8 @@ public class CrossUserDataIsolationTests : IClassFixture<TestWebApplicationFacto
         await ApiTestHarness.AuthenticateAsync(clientB, "iso-boards-b");
         var boardB = await ApiTestHarness.CreateBoardAsync(clientB, "iso-board-b");
 
-        var response = await clientB.GetAsync("/api/boards");
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var boards = await response.Content.ReadFromJsonAsync<List<BoardDto>>();
-        boards.Should().NotBeNull();
-        boards!.Should().NotContain(b => b.Id == boardA.Id,
+        var boards = await ApiTestHarness.ListBoardsAsync(clientB);
+        boards.Should().NotContain(b => b.Id == boardA.Id,
             "User B must not see User A's board in list results");
         boards.Should().Contain(b => b.Id == boardB.Id);
     }

--- a/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
@@ -179,6 +179,47 @@ public static class ApiTestHarness
             $"{description} did not complete after {maxAttempts} attempts (~{stopwatch.ElapsedMilliseconds}ms). Last observed value: {diagnosticsText}");
     }
 
+    /// <summary>
+    /// Fetches the board list from the paginated endpoint and returns the items.
+    /// </summary>
+    public static async Task<List<BoardDto>> ListBoardsAsync(
+        HttpClient client,
+        bool includeArchived = false)
+    {
+        var url = includeArchived ? "/api/boards?includeArchived=true" : "/api/boards";
+        var response = await client.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var paginated = await response.Content.ReadFromJsonAsync<PaginatedResult<BoardDto>>();
+        paginated.Should().NotBeNull();
+        return paginated!.Items;
+    }
+
+    public static async Task<PaginatedResult<BoardDto>> ListBoardsPaginatedAsync(
+        HttpClient client,
+        bool includeArchived = false,
+        int? offset = null,
+        int? limit = null,
+        string? search = null)
+    {
+        var qs = new List<string>();
+        if (includeArchived) qs.Add("includeArchived=true");
+        if (offset.HasValue) qs.Add($"offset={offset.Value}");
+        if (limit.HasValue) qs.Add($"limit={limit.Value}");
+        if (!string.IsNullOrEmpty(search)) qs.Add($"search={Uri.EscapeDataString(search)}");
+        var url = qs.Count > 0 ? $"/api/boards?{string.Join("&", qs)}" : "/api/boards";
+        var response = await client.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var paginated = await response.Content.ReadFromJsonAsync<PaginatedResult<BoardDto>>();
+        paginated.Should().NotBeNull();
+        return paginated!;
+    }
+
+    /// <summary>
+    /// Generic paginated result DTO for test deserialization.
+    /// Mirrors <see cref="Taskdeck.Application.DTOs.PaginatedResult{T}"/>.
+    /// </summary>
+    public record PaginatedResult<T>(List<T> Items, int TotalCount, bool HasMore, int Offset, int Limit);
+
     public static async Task<Guid> CreateBoardWithColumnAsync(
         HttpClient client,
         string boardNamePrefix = "test-board")

--- a/frontend/taskdeck-web/src/api/boardsApi.ts
+++ b/frontend/taskdeck-web/src/api/boardsApi.ts
@@ -1,13 +1,25 @@
 import http from './http'
-import type { Board, BoardDetail, CreateBoardDto, UpdateBoardDto } from '../types/board'
+import type { Board, BoardDetail, CreateBoardDto, UpdateBoardDto, PaginatedBoards } from '../types/board'
 
 export const boardsApi = {
   async getBoards(search?: string, includeArchived = false): Promise<Board[]> {
+    const result = await boardsApi.getBoardsPaginated(search, includeArchived)
+    return result.items
+  },
+
+  async getBoardsPaginated(
+    search?: string,
+    includeArchived = false,
+    offset = 0,
+    limit?: number,
+  ): Promise<PaginatedBoards> {
     const params = new URLSearchParams()
     if (search) params.append('search', search)
     if (includeArchived) params.append('includeArchived', 'true')
+    if (offset > 0) params.append('offset', String(offset))
+    if (limit !== undefined) params.append('limit', String(limit))
 
-    const { data } = await http.get<Board[]>(`/boards?${params}`)
+    const { data } = await http.get<PaginatedBoards>(`/boards?${params}`)
     return data
   },
 

--- a/frontend/taskdeck-web/src/tests/api/boardsApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/boardsApi.spec.ts
@@ -17,9 +17,11 @@ describe('boardsApi', () => {
   })
 
   describe('getBoards', () => {
-    it('should fetch boards with default params', async () => {
+    it('should fetch boards with default params and return items', async () => {
       const mockBoards = [{ id: '1', name: 'Board 1' }]
-      vi.mocked(http.get).mockResolvedValue({ data: mockBoards })
+      vi.mocked(http.get).mockResolvedValue({
+        data: { items: mockBoards, totalCount: 1, hasMore: false, offset: 0, limit: 50 },
+      })
 
       const result = await boardsApi.getBoards()
 
@@ -29,7 +31,9 @@ describe('boardsApi', () => {
 
     it('should fetch boards with search param', async () => {
       const mockBoards = [{ id: '1', name: 'Test Board' }]
-      vi.mocked(http.get).mockResolvedValue({ data: mockBoards })
+      vi.mocked(http.get).mockResolvedValue({
+        data: { items: mockBoards, totalCount: 1, hasMore: false, offset: 0, limit: 50 },
+      })
 
       const result = await boardsApi.getBoards('test')
 
@@ -38,7 +42,9 @@ describe('boardsApi', () => {
     })
 
     it('should fetch boards with includeArchived param', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [] })
+      vi.mocked(http.get).mockResolvedValue({
+        data: { items: [], totalCount: 0, hasMore: false, offset: 0, limit: 50 },
+      })
 
       await boardsApi.getBoards(undefined, true)
 
@@ -46,11 +52,43 @@ describe('boardsApi', () => {
     })
 
     it('should fetch boards with search and includeArchived params', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [] })
+      vi.mocked(http.get).mockResolvedValue({
+        data: { items: [], totalCount: 0, hasMore: false, offset: 0, limit: 50 },
+      })
 
       await boardsApi.getBoards('query', true)
 
       expect(http.get).toHaveBeenCalledWith('/boards?search=query&includeArchived=true')
+    })
+  })
+
+  describe('getBoardsPaginated', () => {
+    it('should fetch paginated boards with offset and limit', async () => {
+      const mockResponse = {
+        items: [{ id: '2', name: 'Board 2' }],
+        totalCount: 5,
+        hasMore: true,
+        offset: 1,
+        limit: 1,
+      }
+      vi.mocked(http.get).mockResolvedValue({ data: mockResponse })
+
+      const result = await boardsApi.getBoardsPaginated(undefined, false, 1, 1)
+
+      expect(http.get).toHaveBeenCalledWith('/boards?offset=1&limit=1')
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should include all query params when provided', async () => {
+      vi.mocked(http.get).mockResolvedValue({
+        data: { items: [], totalCount: 0, hasMore: false, offset: 2, limit: 10 },
+      })
+
+      await boardsApi.getBoardsPaginated('search', true, 2, 10)
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/boards?search=search&includeArchived=true&offset=2&limit=10',
+      )
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/store/boardStore.integration.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/boardStore.integration.spec.ts
@@ -41,6 +41,17 @@ function makeBoardPayload(overrides: Partial<Record<string, unknown>> = {}) {
   }
 }
 
+/** Wraps a board array in the paginated response envelope the API now returns. */
+function wrapPaginated(boards: ReturnType<typeof makeBoardPayload>[]) {
+  return {
+    items: boards,
+    totalCount: boards.length,
+    hasMore: false,
+    offset: 0,
+    limit: 50,
+  }
+}
+
 function makeCardPayload(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     id: 'card-1',
@@ -74,7 +85,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
   describe('fetchBoards', () => {
     it('populates boards from the API response shape', async () => {
       const boards = [makeBoardPayload(), makeBoardPayload({ id: 'board-2', name: 'Board 2' })]
-      vi.mocked(http.get).mockResolvedValue({ data: boards })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated(boards) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -88,7 +99,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
     })
 
     it('calls GET /boards with the correct URL structure', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([]) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -109,7 +120,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
 
     it('preserves activeBoardId when the selected board is still present after a refresh', async () => {
       vi.useFakeTimers()
-      vi.mocked(http.get).mockResolvedValue({ data: [makeBoardPayload()] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([makeBoardPayload()]) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -118,14 +129,14 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
       // Advance past the throttle window so the next call is not suppressed
       vi.advanceTimersByTime(6_000)
 
-      vi.mocked(http.get).mockResolvedValue({ data: [makeBoardPayload()] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([makeBoardPayload()]) })
       await store.fetchBoards()
 
       expect(store.activeBoardId).toBe('board-1')
     })
 
     it('does not switch activeBoardId when a second board is created (regression #509)', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [makeBoardPayload()] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([makeBoardPayload()]) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -143,7 +154,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
 
   describe('createBoard', () => {
     it('sends the DTO to POST /boards and appends the returned board', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([]) })
       const store = useBoardStore()
       await store.fetchBoards()
 
@@ -158,7 +169,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
     })
 
     it('does not add a phantom board when the API rejects with 400', async () => {
-      vi.mocked(http.get).mockResolvedValue({ data: [] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([]) })
       const store = useBoardStore()
       await store.fetchBoards()
 
@@ -174,7 +185,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
   describe('updateBoard', () => {
     it('sends PUT /boards/:id and replaces the local record with the API response', async () => {
       const original = makeBoardPayload()
-      vi.mocked(http.get).mockResolvedValue({ data: [original] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([original]) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -192,7 +203,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
 
     it('does not corrupt board name in the list when PUT /boards/:id fails', async () => {
       const original = makeBoardPayload()
-      vi.mocked(http.get).mockResolvedValue({ data: [original] })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated([original]) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -210,7 +221,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
   describe('deleteBoard', () => {
     it('removes the deleted board from the list and clears currentBoard', async () => {
       const boards = [makeBoardPayload(), makeBoardPayload({ id: 'board-2', name: 'B2' })]
-      vi.mocked(http.get).mockResolvedValue({ data: boards })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated(boards) })
 
       const store = useBoardStore()
       await store.fetchBoards()
@@ -225,7 +236,7 @@ describe('boardStore — integration (real API module, mocked HTTP)', () => {
 
     it('falls back activeBoardId to remaining board after deletion', async () => {
       const boards = [makeBoardPayload(), makeBoardPayload({ id: 'board-2', name: 'B2' })]
-      vi.mocked(http.get).mockResolvedValue({ data: boards })
+      vi.mocked(http.get).mockResolvedValue({ data: wrapPaginated(boards) })
 
       const store = useBoardStore()
       await store.fetchBoards()

--- a/frontend/taskdeck-web/src/types/board.ts
+++ b/frontend/taskdeck-web/src/types/board.ts
@@ -57,6 +57,14 @@ export interface Label {
 }
 
 // DTOs for creating/updating
+export interface PaginatedBoards {
+  items: Board[]
+  totalCount: number
+  hasMore: boolean
+  offset: number
+  limit: number
+}
+
 export interface CreateBoardDto {
   name: string
   description?: string | null

--- a/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
@@ -91,7 +91,9 @@ async function listBoards(
   })
 
   expect(response.ok()).toBeTruthy()
-  return (await response.json()) as BoardDto[]
+  const body = await response.json()
+  // API returns PaginatedResult<BoardDto> with { items, totalCount, hasMore, offset, limit }
+  return (body.items ?? body) as BoardDto[]
 }
 
 async function getArchiveItems(
@@ -314,7 +316,9 @@ test.describe('TST11-SC-016: Cross-user archive isolation', () => {
       headers: { Authorization: `Bearer ${userB.token}` },
     })
     expect(userBBoards.ok()).toBeTruthy()
-    const userBBoardList = (await userBBoards.json()) as BoardDto[]
+    const userBBody = await userBBoards.json()
+    // API returns PaginatedResult<BoardDto> with { items, totalCount, hasMore, offset, limit }
+    const userBBoardList = (userBBody.items ?? userBBody) as BoardDto[]
 
     // UserA's archived board should not be visible to UserB
     expect(userBBoardList.some((b) => b.id === boardId)).toBeFalsy()


### PR DESCRIPTION
## Summary
- Add `offset` and `limit` query parameters to `GET /api/boards`
- Default limit 50, max limit 200, server-side clamped
- Response is now `PaginatedResult<BoardDto>` with `items`, `totalCount`, `hasMore`, `offset`, `limit`
- Frontend `boardsApi` updated with `getBoardsPaginated()` method; existing `getBoards()` delegates to it and returns `.items` for backward compatibility
- All existing backend and frontend tests updated for the new response shape
- 11 new integration tests covering pagination edge cases (empty, partial, full page, offset beyond total, limit clamping, cross-user isolation)
- 2 new frontend tests for `getBoardsPaginated`

Closes #848

## Test plan
- [x] Empty board list returns correct pagination metadata (`totalCount: 0`, `hasMore: false`)
- [x] Partial page returns `hasMore: false`
- [x] Full page returns `hasMore: true`
- [x] Limit > 200 clamped to 200
- [x] Limit = 0 clamped to 1
- [x] Negative offset treated as 0
- [x] Offset beyond total returns empty items with correct totalCount
- [x] Page-by-page iteration covers all boards with no duplicates
- [x] Cross-user isolation preserved with pagination metadata
- [x] Frontend getBoards backward compatible (returns Board[])
- [x] All 1446 backend tests pass (0 failures)
- [x] Frontend typecheck passes
- [x] Frontend boardsApi + boardStore integration tests pass