### PR TITLE
fix: add content validation for file imports (SEC-30)

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/ExportController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/ExportController.cs
@@ -67,9 +67,13 @@ public class ExportController : AuthenticatedControllerBase
 
         var rawJson = json.GetRawText();
 
+        // Skip byte-size check (maxBytes: 0) — ASP.NET Core's MaxRequestBodySize
+        // is the outer bound. A fixed cap here would prevent round-trip import of
+        // large boards that were exported without a size limit.
         var jsonValidation = FileContentValidator.ValidateJsonContent(
             rawJson,
-            "Board import JSON");
+            "Board import JSON",
+            maxBytes: 0);
         if (!jsonValidation.IsSuccess)
         {
             return BadRequest(new ApiErrorResponse(

--- a/backend/src/Taskdeck.Api/Controllers/ExportController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/ExportController.cs
@@ -65,7 +65,19 @@ public class ExportController : AuthenticatedControllerBase
         if (!TryGetCurrentUserId(out var userId, out var errorResult))
             return errorResult!;
 
-        var result = await _exportImportService.ImportBoardFromJsonAsync(json.GetRawText(), userId);
+        var rawJson = json.GetRawText();
+
+        var jsonValidation = FileContentValidator.ValidateJsonContent(
+            rawJson,
+            "Board import JSON");
+        if (!jsonValidation.IsSuccess)
+        {
+            return BadRequest(new ApiErrorResponse(
+                jsonValidation.ErrorCode,
+                jsonValidation.ErrorMessage));
+        }
+
+        var result = await _exportImportService.ImportBoardFromJsonAsync(rawJson, userId);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 

--- a/backend/src/Taskdeck.Api/Controllers/ExternalImportsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/ExternalImportsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Api.Contracts;
 using Taskdeck.Api.Extensions;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
@@ -56,6 +57,18 @@ public class ExternalImportsController : AuthenticatedControllerBase
             return Result
                 .Failure(ErrorCodes.ValidationError, "Request body is required.")
                 .ToErrorActionResult();
+        }
+
+        // Validate import payload content before processing
+        var contentValidation = FileContentValidator.ValidateTextContent(
+            dto.Payload,
+            "Import payload",
+            FileContentValidator.MaxCsvPayloadBytes);
+        if (!contentValidation.IsSuccess)
+        {
+            return BadRequest(new ApiErrorResponse(
+                contentValidation.ErrorCode,
+                contentValidation.ErrorMessage));
         }
 
         var result = await _externalImportService.ImportToBoardAsync(boardId, dto, cancellationToken);

--- a/backend/src/Taskdeck.Api/Controllers/NoteImportController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/NoteImportController.cs
@@ -62,6 +62,17 @@ public class NoteImportController : AuthenticatedControllerBase
                 "Request body is required"));
         }
 
+        var contentValidation = FileContentValidator.ValidateTextContent(
+            dto.Content,
+            "Markdown content",
+            FileContentValidator.MaxMarkdownContentBytes);
+        if (!contentValidation.IsSuccess)
+        {
+            return BadRequest(new ApiErrorResponse(
+                contentValidation.ErrorCode,
+                contentValidation.ErrorMessage));
+        }
+
         var result = await _noteImportService.ImportMarkdownAsync(userId, dto, cancellationToken);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
@@ -95,6 +106,17 @@ public class NoteImportController : AuthenticatedControllerBase
             return BadRequest(new ApiErrorResponse(
                 "VALIDATION_ERROR",
                 "Request body is required"));
+        }
+
+        var contentValidation = FileContentValidator.ValidateTextContent(
+            dto.Content,
+            "Web clip content",
+            FileContentValidator.MaxWebClipContentBytes);
+        if (!contentValidation.IsSuccess)
+        {
+            return BadRequest(new ApiErrorResponse(
+                contentValidation.ErrorCode,
+                contentValidation.ErrorMessage));
         }
 
         var result = await _noteImportService.ImportWebClipAsync(userId, dto, cancellationToken);

--- a/backend/src/Taskdeck.Api/Controllers/NoteImportController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/NoteImportController.cs
@@ -62,10 +62,13 @@ public class NoteImportController : AuthenticatedControllerBase
                 "Request body is required"));
         }
 
+        // Use character-based limit to match NoteImportService.MaxMarkdownContentLength.
+        // Skip byte-based check (maxBytes: 0) — the service enforces character limits.
         var contentValidation = FileContentValidator.ValidateTextContent(
             dto.Content,
             "Markdown content",
-            FileContentValidator.MaxMarkdownContentBytes);
+            maxBytes: 0,
+            maxChars: FileContentValidator.MaxMarkdownContentChars);
         if (!contentValidation.IsSuccess)
         {
             return BadRequest(new ApiErrorResponse(
@@ -108,10 +111,13 @@ public class NoteImportController : AuthenticatedControllerBase
                 "Request body is required"));
         }
 
+        // Use character-based limit to match NoteImportService.MaxWebClipContentLength.
+        // Skip byte-based check (maxBytes: 0) — the service enforces character limits.
         var contentValidation = FileContentValidator.ValidateTextContent(
             dto.Content,
             "Web clip content",
-            FileContentValidator.MaxWebClipContentBytes);
+            maxBytes: 0,
+            maxChars: FileContentValidator.MaxWebClipContentChars);
         if (!contentValidation.IsSuccess)
         {
             return BadRequest(new ApiErrorResponse(

--- a/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
@@ -121,10 +121,12 @@ public static class FileContentValidator
                 $"{contentLabel} does not contain valid JSON. Expected content starting with '{{' or '['.");
         }
 
-        // Attempt a full parse to catch malformed JSON
+        // Attempt a full parse to catch malformed JSON.
+        // Use the BOM-stripped content since JsonDocument.Parse does not always
+        // handle the BOM marker gracefully.
         try
         {
-            using var doc = JsonDocument.Parse(json);
+            using var doc = JsonDocument.Parse(trimmed);
         }
         catch (JsonException)
         {

--- a/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
@@ -14,7 +14,7 @@ public static class FileContentValidator
 {
     /// <summary>
     /// Maximum allowed content size for text imports (1 MB).
-    /// Individual endpoints may enforce tighter limits.
+    /// Individual endpoints may enforce tighter limits via the maxBytes parameter.
     /// </summary>
     public const int DefaultMaxTextContentBytes = 1_048_576;
 
@@ -22,6 +22,15 @@ public static class FileContentValidator
     /// Maximum allowed content size for JSON imports (2 MB).
     /// </summary>
     public const int DefaultMaxJsonContentBytes = 2_097_152;
+
+    /// <summary>Maximum markdown content size in bytes (100 KB), matching NoteImportService.</summary>
+    public const int MaxMarkdownContentBytes = 102_400;
+
+    /// <summary>Maximum web clip content size in bytes (20 KB), matching NoteImportService.</summary>
+    public const int MaxWebClipContentBytes = 20_000;
+
+    /// <summary>Maximum CSV payload size in bytes (1 MB), matching CsvExternalImportAdapter.</summary>
+    public const int MaxCsvPayloadBytes = 1_048_576;
 
     /// <summary>
     /// Validates that string content is safe text (no binary content disguised as text).

--- a/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
@@ -23,11 +23,11 @@ public static class FileContentValidator
     /// </summary>
     public const int DefaultMaxJsonContentBytes = 2_097_152;
 
-    /// <summary>Maximum markdown content size in bytes (100 KB), matching NoteImportService.</summary>
-    public const int MaxMarkdownContentBytes = 102_400;
+    /// <summary>Maximum markdown content length in characters (100 KB), matching NoteImportService.MaxMarkdownContentLength.</summary>
+    public const int MaxMarkdownContentChars = 102_400;
 
-    /// <summary>Maximum web clip content size in bytes (20 KB), matching NoteImportService.</summary>
-    public const int MaxWebClipContentBytes = 20_000;
+    /// <summary>Maximum web clip content length in characters (20 KB), matching NoteImportService.MaxWebClipContentLength.</summary>
+    public const int MaxWebClipContentChars = 20_000;
 
     /// <summary>Maximum CSV payload size in bytes (1 MB), matching CsvExternalImportAdapter.</summary>
     public const int MaxCsvPayloadBytes = 1_048_576;
@@ -40,12 +40,21 @@ public static class FileContentValidator
     /// <param name="content">The string content to validate.</param>
     /// <param name="contentLabel">Human-readable label for error messages (e.g. "Markdown content").</param>
     /// <param name="maxBytes">Maximum allowed size in UTF-8 bytes. Use 0 to skip size check.</param>
+    /// <param name="maxChars">Maximum allowed length in characters. Use 0 to skip character check.
+    /// Prefer this over maxBytes when the downstream service enforces character limits (e.g. NoteImportService).</param>
     /// <returns>Success or failure with a descriptive error message.</returns>
-    public static Result ValidateTextContent(string? content, string contentLabel, int maxBytes = DefaultMaxTextContentBytes)
+    public static Result ValidateTextContent(string? content, string contentLabel, int maxBytes = DefaultMaxTextContentBytes, int maxChars = 0)
     {
         if (string.IsNullOrEmpty(content))
         {
             return Result.Failure(ErrorCodes.ValidationError, $"{contentLabel} is required.");
+        }
+
+        if (maxChars > 0 && content.Length > maxChars)
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"{contentLabel} exceeds maximum allowed length of {maxChars} characters.");
         }
 
         if (maxBytes > 0)
@@ -199,16 +208,15 @@ public static class FileContentValidator
             if (ch == 0x7F)
                 return true;
 
-            // C1 control characters (0x80-0x9F) — these are control codes in ISO-8859-1.
-            // In valid UTF-8, these code points appear only in multibyte sequences.
-            // When they appear as literal chars in a C# string (which is UTF-16),
-            // they indicate content that is not standard text.
+            // C1 control characters (0x80-0x9F) are control codes in Unicode/ISO-8859-1.
+            // In C# strings (UTF-16), these are genuine control characters — NOT
+            // Windows-1252 smart quotes/dashes, which map to U+2000+ range when
+            // properly decoded. Presence of C1 controls indicates binary content.
             if (ch >= 0x80 && ch <= 0x9F)
             {
-                // Exception: some of these are used in Windows-1252 text.
-                // Allow commonly seen Windows-1252 characters that map to C1 range:
-                // 0x85 (NEL/ellipsis), 0x91-0x94 (smart quotes), 0x96-0x97 (dashes)
-                if (ch == 0x85 || (ch >= 0x91 && ch <= 0x94) || ch == 0x96 || ch == 0x97)
+                // Allow NEL (U+0085, Next Line) which is a legitimate text control
+                // character used in some document formats.
+                if (ch == 0x85)
                     continue;
 
                 return true;

--- a/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/FileContentValidator.cs
@@ -1,0 +1,226 @@
+using System.Text;
+using System.Text.Json;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Validates file content for import operations. Ensures text-based imports
+/// contain valid UTF-8 text (no disguised binary content), validates JSON
+/// structure for JSON imports, and enforces size limits.
+/// </summary>
+public static class FileContentValidator
+{
+    /// <summary>
+    /// Maximum allowed content size for text imports (1 MB).
+    /// Individual endpoints may enforce tighter limits.
+    /// </summary>
+    public const int DefaultMaxTextContentBytes = 1_048_576;
+
+    /// <summary>
+    /// Maximum allowed content size for JSON imports (2 MB).
+    /// </summary>
+    public const int DefaultMaxJsonContentBytes = 2_097_152;
+
+    /// <summary>
+    /// Validates that string content is safe text (no binary content disguised as text).
+    /// Rejects content containing null bytes or non-whitespace control characters,
+    /// which indicate binary data being passed as text.
+    /// </summary>
+    /// <param name="content">The string content to validate.</param>
+    /// <param name="contentLabel">Human-readable label for error messages (e.g. "Markdown content").</param>
+    /// <param name="maxBytes">Maximum allowed size in UTF-8 bytes. Use 0 to skip size check.</param>
+    /// <returns>Success or failure with a descriptive error message.</returns>
+    public static Result ValidateTextContent(string? content, string contentLabel, int maxBytes = DefaultMaxTextContentBytes)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return Result.Failure(ErrorCodes.ValidationError, $"{contentLabel} is required.");
+        }
+
+        if (maxBytes > 0)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(content);
+            if (byteCount > maxBytes)
+            {
+                return Result.Failure(
+                    ErrorCodes.ValidationError,
+                    $"{contentLabel} exceeds maximum allowed size of {maxBytes} bytes.");
+            }
+        }
+
+        if (ContainsBinaryContent(content))
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"{contentLabel} contains binary data. Only valid text content is accepted.");
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Validates that string content is valid JSON and safe text.
+    /// Checks for binary content, validates JSON structure (must start
+    /// with { or [ after optional BOM/whitespace), and attempts a parse.
+    /// </summary>
+    /// <param name="json">The JSON string to validate.</param>
+    /// <param name="contentLabel">Human-readable label for error messages.</param>
+    /// <param name="maxBytes">Maximum allowed size in UTF-8 bytes. Use 0 to skip size check.</param>
+    /// <returns>Success or failure with a descriptive error message.</returns>
+    public static Result ValidateJsonContent(string? json, string contentLabel, int maxBytes = DefaultMaxJsonContentBytes)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return Result.Failure(ErrorCodes.ValidationError, $"{contentLabel} is required.");
+        }
+
+        if (maxBytes > 0)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(json);
+            if (byteCount > maxBytes)
+            {
+                return Result.Failure(
+                    ErrorCodes.ValidationError,
+                    $"{contentLabel} exceeds maximum allowed size of {maxBytes} bytes.");
+            }
+        }
+
+        if (ContainsBinaryContent(json))
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"{contentLabel} contains binary data. Only valid JSON text is accepted.");
+        }
+
+        // Verify JSON structure: after stripping optional BOM and whitespace,
+        // content must start with { or [
+        var trimmed = StripBomAndWhitespace(json);
+        if (trimmed.Length == 0)
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"{contentLabel} is empty after removing whitespace.");
+        }
+
+        var firstChar = trimmed[0];
+        if (firstChar != '{' && firstChar != '[')
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"{contentLabel} does not contain valid JSON. Expected content starting with '{{' or '['.");
+        }
+
+        // Attempt a full parse to catch malformed JSON
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"{contentLabel} contains malformed JSON that could not be parsed.");
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Validates that a byte array has the expected SQLite magic bytes.
+    /// This is a convenience wrapper — the existing DatabaseFileExportImportService
+    /// already performs this check, but this provides a consistent API.
+    /// </summary>
+    /// <param name="data">The byte array to validate.</param>
+    /// <param name="maxBytes">Maximum allowed size in bytes.</param>
+    /// <returns>Success or failure with a descriptive error message.</returns>
+    public static Result ValidateSqliteContent(byte[]? data, int maxBytes)
+    {
+        if (data == null || data.Length == 0)
+        {
+            return Result.Failure(ErrorCodes.ValidationError, "Database file content is required.");
+        }
+
+        if (data.Length > maxBytes)
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                $"Database file exceeds maximum allowed size of {maxBytes} bytes.");
+        }
+
+        // SQLite files start with "SQLite format 3\0" (16 bytes)
+        ReadOnlySpan<byte> sqliteHeader = "SQLite format 3\0"u8;
+        if (data.Length < sqliteHeader.Length || !data.AsSpan(0, sqliteHeader.Length).SequenceEqual(sqliteHeader))
+        {
+            return Result.Failure(
+                ErrorCodes.ValidationError,
+                "File content does not match expected database format. Expected a valid SQLite file.");
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Detects binary content in a string by scanning for null bytes and
+    /// non-whitespace control characters. Common text control characters
+    /// (tab, newline, carriage return) are permitted.
+    /// </summary>
+    internal static bool ContainsBinaryContent(string content)
+    {
+        for (var i = 0; i < content.Length; i++)
+        {
+            var ch = content[i];
+
+            // Null byte is the strongest binary indicator
+            if (ch == '\0')
+                return true;
+
+            // Allow standard text whitespace/control: tab, newline, carriage return
+            if (ch == '\t' || ch == '\n' || ch == '\r')
+                continue;
+
+            // C0 control characters (0x01-0x1F excluding tab/LF/CR) indicate binary
+            if (ch < 0x20)
+                return true;
+
+            // DEL character (0x7F) indicates binary
+            if (ch == 0x7F)
+                return true;
+
+            // C1 control characters (0x80-0x9F) — these are control codes in ISO-8859-1.
+            // In valid UTF-8, these code points appear only in multibyte sequences.
+            // When they appear as literal chars in a C# string (which is UTF-16),
+            // they indicate content that is not standard text.
+            if (ch >= 0x80 && ch <= 0x9F)
+            {
+                // Exception: some of these are used in Windows-1252 text.
+                // Allow commonly seen Windows-1252 characters that map to C1 range:
+                // 0x85 (NEL/ellipsis), 0x91-0x94 (smart quotes), 0x96-0x97 (dashes)
+                if (ch == 0x85 || (ch >= 0x91 && ch <= 0x94) || ch == 0x96 || ch == 0x97)
+                    continue;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Strips the UTF-8 BOM marker and leading whitespace from content.
+    /// </summary>
+    internal static string StripBomAndWhitespace(string content)
+    {
+        var span = content.AsSpan();
+
+        // Strip UTF-8 BOM (U+FEFF) if present
+        if (span.Length > 0 && span[0] == '﻿')
+        {
+            span = span[1..];
+        }
+
+        // Trim leading whitespace
+        return span.TrimStart().ToString();
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/FileContentValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/FileContentValidatorTests.cs
@@ -141,14 +141,29 @@ public class FileContentValidatorTests
     }
 
     [Fact]
-    public void ValidateTextContent_WindowsSmartQuotes_ReturnsSuccess()
+    public void ValidateTextContent_UnicodeSmartQuotes_ReturnsSuccess()
     {
-        // Windows-1252 smart quotes (U+0091-0094) are allowed
+        // Actual Unicode smart quotes (U+201C/U+201D/U+2018/U+2019) are well above
+        // the C1 control range and should always pass.
         var content = "He said “Hello” and she replied ‘Hi’";
 
         var result = FileContentValidator.ValidateTextContent(content, "Test content");
 
         result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_C1ControlCharacters_ReturnsFailure()
+    {
+        // C1 control characters (0x80-0x9F, except NEL 0x85) should be rejected.
+        // These are genuine control characters, NOT Windows-1252 smart quotes
+        // (which map to U+2000+ range when properly decoded).
+        var content = "text with C1 control \x91 character";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("binary data");
     }
 
     [Fact]
@@ -172,6 +187,44 @@ public class FileContentValidatorTests
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorMessage.Should().Contain("maximum allowed size");
+    }
+
+    [Fact]
+    public void ValidateTextContent_CharLimitEnforced_RejectsLongContent()
+    {
+        var content = new string('A', 500);
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 0, maxChars: 200);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("maximum allowed length");
+        result.ErrorMessage.Should().Contain("200 characters");
+    }
+
+    [Fact]
+    public void ValidateTextContent_CharLimitWithMultibyteChars_CountsCharactersNotBytes()
+    {
+        // 100 CJK characters = 100 chars but 300 UTF-8 bytes.
+        // With character-based limit of 200, this should pass even though
+        // it would fail a 200-byte limit.
+        var content = new string('日', 100);
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 0, maxChars: 200);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_BothLimitsApplied_ByteLimitCheckedToo()
+    {
+        // When both maxBytes and maxChars are set, both are checked
+        var content = new string('日', 100); // 100 chars, 300 bytes
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 200, maxChars: 200);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("maximum allowed size");
+        result.ErrorMessage.Should().Contain("200 bytes");
     }
 
     // =====================================================================
@@ -256,6 +309,18 @@ public class FileContentValidatorTests
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorMessage.Should().Contain("maximum allowed size");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_ZeroMaxBytes_SkipsSizeCheck()
+    {
+        // When maxBytes is 0, size check is skipped (used for board JSON re-import
+        // where ASP.NET Core's MaxRequestBodySize is the outer bound).
+        var json = "{\"data\":\"" + new string('X', 5_000_000) + "\"}";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data", maxBytes: 0);
+
+        result.IsSuccess.Should().BeTrue();
     }
 
     [Fact]
@@ -380,21 +445,35 @@ public class FileContentValidatorTests
     }
 
     [Fact]
-    public void ContainsBinaryContent_C1ControlRange_DetectsBinaryExceptCommonWindows1252()
+    public void ContainsBinaryContent_C1ControlRange_DetectsBinaryExceptNel()
     {
-        // Uncommon C1 control chars (0x80, 0x81) should be detected as binary
+        // All C1 control chars (0x80-0x9F) should be detected as binary
+        // except NEL (0x85, Next Line).
         FileContentValidator.ContainsBinaryContent("\x80").Should().BeTrue();
         FileContentValidator.ContainsBinaryContent("\x81").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x91").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x92").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x93").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x94").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x96").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x97").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x9F").Should().BeTrue();
 
-        // Common Windows-1252 characters should be allowed:
-        // 0x85 (NEL/ellipsis), 0x91-0x94 (smart quotes), 0x96-0x97 (dashes)
+        // NEL (U+0085, Next Line) is a legitimate text control character
         FileContentValidator.ContainsBinaryContent("\x85").Should().BeFalse();
-        FileContentValidator.ContainsBinaryContent("\x91").Should().BeFalse();
-        FileContentValidator.ContainsBinaryContent("\x92").Should().BeFalse();
-        FileContentValidator.ContainsBinaryContent("\x93").Should().BeFalse();
-        FileContentValidator.ContainsBinaryContent("\x94").Should().BeFalse();
-        FileContentValidator.ContainsBinaryContent("\x96").Should().BeFalse();
-        FileContentValidator.ContainsBinaryContent("\x97").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsBinaryContent_UnicodeSmartQuotesAndDashes_ReturnsFalse()
+    {
+        // Real Unicode smart quotes/dashes (U+2018-U+201D, U+2013-U+2014)
+        // are well above the C1 range and should pass.
+        FileContentValidator.ContainsBinaryContent("‘").Should().BeFalse(); // left single quote
+        FileContentValidator.ContainsBinaryContent("’").Should().BeFalse(); // right single quote
+        FileContentValidator.ContainsBinaryContent("“").Should().BeFalse(); // left double quote
+        FileContentValidator.ContainsBinaryContent("”").Should().BeFalse(); // right double quote
+        FileContentValidator.ContainsBinaryContent("–").Should().BeFalse(); // en dash
+        FileContentValidator.ContainsBinaryContent("—").Should().BeFalse(); // em dash
     }
 
     // =====================================================================
@@ -489,15 +568,15 @@ public class FileContentValidatorTests
     // =====================================================================
 
     [Fact]
-    public void MaxMarkdownContentBytes_MatchesExpectedValue()
+    public void MaxMarkdownContentChars_MatchesExpectedValue()
     {
-        FileContentValidator.MaxMarkdownContentBytes.Should().Be(102_400);
+        FileContentValidator.MaxMarkdownContentChars.Should().Be(102_400);
     }
 
     [Fact]
-    public void MaxWebClipContentBytes_MatchesExpectedValue()
+    public void MaxWebClipContentChars_MatchesExpectedValue()
     {
-        FileContentValidator.MaxWebClipContentBytes.Should().Be(20_000);
+        FileContentValidator.MaxWebClipContentChars.Should().Be(20_000);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/FileContentValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/FileContentValidatorTests.cs
@@ -1,0 +1,520 @@
+using FluentAssertions;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class FileContentValidatorTests
+{
+    // =====================================================================
+    // ValidateTextContent tests
+    // =====================================================================
+
+    [Fact]
+    public void ValidateTextContent_ValidMarkdown_ReturnsSuccess()
+    {
+        var content = "# Hello World\n\nThis is a **markdown** document.\n\n- Item 1\n- Item 2";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Markdown content");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_ValidCsvPayload_ReturnsSuccess()
+    {
+        var content = "Name,Email,Company\nAlice,alice@example.com,Acme\nBob,bob@example.com,Widget Corp";
+
+        var result = FileContentValidator.ValidateTextContent(content, "CSV payload");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_NullContent_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateTextContent(null, "Test content");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("Test content");
+        result.ErrorMessage.Should().Contain("required");
+    }
+
+    [Fact]
+    public void ValidateTextContent_EmptyContent_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateTextContent("", "Test content");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void ValidateTextContent_ContentWithNullBytes_ReturnsFailure()
+    {
+        var content = "This looks like text\0but has null bytes";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("binary data");
+    }
+
+    [Fact]
+    public void ValidateTextContent_BinaryContentDisguisedAsText_ReturnsFailure()
+    {
+        // Simulate binary content: mix of valid text and control characters
+        var content = "Normal text\x01\x02\x03hidden binary";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Markdown content");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("binary data");
+    }
+
+    [Fact]
+    public void ValidateTextContent_ContentWithDelCharacter_ReturnsFailure()
+    {
+        var content = "Normal text\x7Fmore text";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("binary data");
+    }
+
+    [Fact]
+    public void ValidateTextContent_ContentWithTabsAndNewlines_ReturnsSuccess()
+    {
+        var content = "Column1\tColumn2\tColumn3\r\nValue1\tValue2\tValue3\n";
+
+        var result = FileContentValidator.ValidateTextContent(content, "CSV payload");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_ContentExceedsSizeLimit_ReturnsFailure()
+    {
+        var content = new string('A', 1000);
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 500);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("maximum allowed size");
+        result.ErrorMessage.Should().Contain("500 bytes");
+    }
+
+    [Fact]
+    public void ValidateTextContent_ContentExactlyAtSizeLimit_ReturnsSuccess()
+    {
+        var content = new string('A', 100);
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 100);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_ZeroMaxBytes_SkipsSizeCheck()
+    {
+        var content = new string('A', 10_000);
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 0);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_UnicodeContent_ReturnsSuccess()
+    {
+        var content = "日本語テスト\nEmoji: 🎉\nFrench: café\nArabic: مرحبا";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Unicode content");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_WindowsSmartQuotes_ReturnsSuccess()
+    {
+        // Windows-1252 smart quotes (U+0091-0094) are allowed
+        var content = "He said “Hello” and she replied ‘Hi’";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_ContentWithBom_ReturnsSuccess()
+    {
+        var content = "﻿# BOM-prefixed markdown";
+
+        var result = FileContentValidator.ValidateTextContent(content, "Markdown content");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateTextContent_MultibyteUnicodeExceedsByteLimitButNotCharLimit_ReturnsFailure()
+    {
+        // Each CJK character is 3 bytes in UTF-8
+        // 40 CJK characters = 120 bytes > 100 byte limit
+        var content = new string('日', 40);
+
+        var result = FileContentValidator.ValidateTextContent(content, "Test content", maxBytes: 100);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("maximum allowed size");
+    }
+
+    // =====================================================================
+    // ValidateJsonContent tests
+    // =====================================================================
+
+    [Fact]
+    public void ValidateJsonContent_ValidJsonObject_ReturnsSuccess()
+    {
+        var json = """{"name":"Test Board","columns":[{"name":"Todo"}]}""";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "Board JSON");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateJsonContent_ValidJsonArray_ReturnsSuccess()
+    {
+        var json = """[{"id":1},{"id":2}]""";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateJsonContent_NullContent_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateJsonContent(null, "JSON data");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("required");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_EmptyContent_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateJsonContent("", "JSON data");
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateJsonContent_NonJsonText_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateJsonContent("This is not JSON", "JSON data");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("Expected content starting with");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_MalformedJson_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateJsonContent("{invalid json: broken}", "JSON data");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("malformed JSON");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_JsonWithBinaryContent_ReturnsFailure()
+    {
+        var json = "{\"name\": \"test\0binary\"}";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("binary data");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_JsonExceedsSizeLimit_ReturnsFailure()
+    {
+        var json = "{\"data\":\"" + new string('X', 2000) + "\"}";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data", maxBytes: 1000);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("maximum allowed size");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_JsonWithBom_ReturnsSuccess()
+    {
+        var json = "﻿{\"name\": \"test\"}";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateJsonContent_WhitespaceOnlyContent_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateJsonContent("   \n\t  ", "JSON data");
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("empty after removing whitespace");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_JsonStartingWithWhitespace_ReturnsSuccess()
+    {
+        var json = "  \n  {\"name\": \"test\"}";
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // =====================================================================
+    // ValidateSqliteContent tests
+    // =====================================================================
+
+    [Fact]
+    public void ValidateSqliteContent_ValidSqliteHeader_ReturnsSuccess()
+    {
+        var data = CreateSqlitePayload();
+
+        var result = FileContentValidator.ValidateSqliteContent(data, maxBytes: 10 * 1024 * 1024);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateSqliteContent_NullData_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateSqliteContent(null, maxBytes: 10 * 1024 * 1024);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("required");
+    }
+
+    [Fact]
+    public void ValidateSqliteContent_EmptyData_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateSqliteContent(Array.Empty<byte>(), maxBytes: 10 * 1024 * 1024);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateSqliteContent_WrongMagicBytes_ReturnsFailure()
+    {
+        var data = System.Text.Encoding.UTF8.GetBytes("This is not a SQLite file at all");
+
+        var result = FileContentValidator.ValidateSqliteContent(data, maxBytes: 10 * 1024 * 1024);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("does not match expected database format");
+    }
+
+    [Fact]
+    public void ValidateSqliteContent_TruncatedHeader_ReturnsFailure()
+    {
+        var data = "SQLite for"u8.ToArray(); // Only 10 bytes, header needs 16
+
+        var result = FileContentValidator.ValidateSqliteContent(data, maxBytes: 10 * 1024 * 1024);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("does not match expected database format");
+    }
+
+    [Fact]
+    public void ValidateSqliteContent_ExceedsSizeLimit_ReturnsFailure()
+    {
+        var data = CreateSqlitePayload(size: 2000);
+
+        var result = FileContentValidator.ValidateSqliteContent(data, maxBytes: 1000);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("maximum allowed size");
+    }
+
+    // =====================================================================
+    // ContainsBinaryContent tests (internal)
+    // =====================================================================
+
+    [Theory]
+    [InlineData("\0")]
+    [InlineData("\x01")]
+    [InlineData("\x02")]
+    [InlineData("\x1F")]
+    [InlineData("\x7F")]
+    public void ContainsBinaryContent_ControlCharacters_ReturnsTrue(string content)
+    {
+        FileContentValidator.ContainsBinaryContent(content).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    [InlineData("\r\n")]
+    [InlineData("normal text")]
+    [InlineData("")]
+    public void ContainsBinaryContent_NormalTextChars_ReturnsFalse(string content)
+    {
+        FileContentValidator.ContainsBinaryContent(content).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsBinaryContent_C1ControlRange_DetectsBinaryExceptCommonWindows1252()
+    {
+        // Uncommon C1 control chars (0x80, 0x81) should be detected as binary
+        FileContentValidator.ContainsBinaryContent("\x80").Should().BeTrue();
+        FileContentValidator.ContainsBinaryContent("\x81").Should().BeTrue();
+
+        // Common Windows-1252 characters should be allowed:
+        // 0x85 (NEL/ellipsis), 0x91-0x94 (smart quotes), 0x96-0x97 (dashes)
+        FileContentValidator.ContainsBinaryContent("\x85").Should().BeFalse();
+        FileContentValidator.ContainsBinaryContent("\x91").Should().BeFalse();
+        FileContentValidator.ContainsBinaryContent("\x92").Should().BeFalse();
+        FileContentValidator.ContainsBinaryContent("\x93").Should().BeFalse();
+        FileContentValidator.ContainsBinaryContent("\x94").Should().BeFalse();
+        FileContentValidator.ContainsBinaryContent("\x96").Should().BeFalse();
+        FileContentValidator.ContainsBinaryContent("\x97").Should().BeFalse();
+    }
+
+    // =====================================================================
+    // StripBomAndWhitespace tests (internal)
+    // =====================================================================
+
+    [Fact]
+    public void StripBomAndWhitespace_BomPrefix_StripsIt()
+    {
+        var content = "﻿{\"test\": true}";
+
+        var result = FileContentValidator.StripBomAndWhitespace(content);
+
+        result.Should().Be("{\"test\": true}");
+    }
+
+    [Fact]
+    public void StripBomAndWhitespace_WhitespacePrefix_StripsIt()
+    {
+        var result = FileContentValidator.StripBomAndWhitespace("  \t\n  hello");
+
+        result.Should().Be("hello");
+    }
+
+    [Fact]
+    public void StripBomAndWhitespace_BomAndWhitespace_StripsBoth()
+    {
+        var result = FileContentValidator.StripBomAndWhitespace("﻿  {\"test\": true}");
+
+        result.Should().Be("{\"test\": true}");
+    }
+
+    [Fact]
+    public void StripBomAndWhitespace_NoBomNoWhitespace_ReturnsUnchanged()
+    {
+        var result = FileContentValidator.StripBomAndWhitespace("{\"test\": true}");
+
+        result.Should().Be("{\"test\": true}");
+    }
+
+    // =====================================================================
+    // Edge cases
+    // =====================================================================
+
+    [Fact]
+    public void ValidateTextContent_ErrorMessageIncludesContentLabel()
+    {
+        var result = FileContentValidator.ValidateTextContent("binary\0content", "Markdown content");
+
+        result.ErrorMessage.Should().Contain("Markdown content");
+    }
+
+    [Fact]
+    public void ValidateJsonContent_ErrorMessageIncludesContentLabel()
+    {
+        var result = FileContentValidator.ValidateJsonContent("not json", "Board import JSON");
+
+        result.ErrorMessage.Should().Contain("Board import JSON");
+    }
+
+    [Fact]
+    public void ValidateTextContent_OnlyNullByte_ReturnsFailure()
+    {
+        var result = FileContentValidator.ValidateTextContent("\0", "Content");
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateJsonContent_NestedJsonObject_ReturnsSuccess()
+    {
+        var json = """
+        {
+            "board": {
+                "name": "Test",
+                "columns": [
+                    {"name": "Todo", "position": 0},
+                    {"name": "Done", "position": 1}
+                ]
+            },
+            "metadata": {"version": "1.0"}
+        }
+        """;
+
+        var result = FileContentValidator.ValidateJsonContent(json, "JSON data");
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    // =====================================================================
+    // Constant value tests (ensures limits match between validator and services)
+    // =====================================================================
+
+    [Fact]
+    public void MaxMarkdownContentBytes_MatchesExpectedValue()
+    {
+        FileContentValidator.MaxMarkdownContentBytes.Should().Be(102_400);
+    }
+
+    [Fact]
+    public void MaxWebClipContentBytes_MatchesExpectedValue()
+    {
+        FileContentValidator.MaxWebClipContentBytes.Should().Be(20_000);
+    }
+
+    [Fact]
+    public void MaxCsvPayloadBytes_MatchesExpectedValue()
+    {
+        FileContentValidator.MaxCsvPayloadBytes.Should().Be(1_048_576);
+    }
+
+    // =====================================================================
+    // Helpers
+    // =====================================================================
+
+    private static byte[] CreateSqlitePayload(int size = 100)
+    {
+        var header = "SQLite format 3\0"u8.ToArray();
+        var payload = new byte[Math.Max(size, header.Length)];
+        header.CopyTo(payload, 0);
+        return payload;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FileContentValidator` in Application layer that validates uploaded file content against declared type
- Reject binary files disguised as text imports (null bytes, control characters)
- Validate JSON structure for JSON board imports (must start with `{` or `[`, parseable)
- Validate SQLite magic bytes for database imports (convenience wrapper, existing service already checks)
- Add configurable size limits matching existing service constants
- Apply validation in `NoteImportController` (markdown + web clip), `ExternalImportsController` (CSV), and `ExportController` (JSON board import)
- Validation runs at controller entry before content reaches service layer
- 55 new unit tests covering valid files, binary disguises, null bytes, control chars, oversized files, empty files, BOM handling, Unicode, and edge cases

Closes #857

## Test plan
- [x] Valid markdown/JSON/CSV files accepted
- [x] Binary files disguised as text rejected with clear error ("contains binary data")
- [x] Oversized files rejected with size limit in error message
- [x] Empty files handled gracefully
- [x] BOM-prefixed content handled correctly
- [x] All 55 new unit tests pass
- [x] Full backend test suite passes (4534 pass, 1 pre-existing timing flake in stress tests)