### PR TITLE
fix: remove dev JWT secret from appsettings.Development.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,38 @@ dotnet run --project backend/src/Taskdeck.Api/Taskdeck.Api.csproj
 
 The API starts on `http://localhost:5000` with Swagger at `http://localhost:5000/swagger`.
 
+#### JWT Secret
+
+The backend requires a JWT signing secret (at least 32 characters). On first
+run, `FirstRunBootstrapper` automatically generates a cryptographically random
+secret and saves it to `appsettings.local.json` (which is gitignored). No
+manual setup is needed for most developers.
+
+If you prefer to manage the secret yourself, you have two options:
+
+**Option A: `dotnet user-secrets`** (recommended for shared machines)
+
+```bash
+cd backend/src/Taskdeck.Api
+dotnet user-secrets init   # one-time setup
+dotnet user-secrets set "Jwt:SecretKey" "YourSecretKeyAtLeast32CharactersLong!"
+```
+
+**Option B: Environment variable**
+
+```bash
+export Jwt__SecretKey="YourSecretKeyAtLeast32CharactersLong!"
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:Jwt__SecretKey = "YourSecretKeyAtLeast32CharactersLong!"
+```
+
+Environment variables take precedence over `appsettings.local.json`, which
+takes precedence over all `appsettings.*.json` files.
+
 ### Frontend (Vue 3 + Vite)
 
 In a second terminal:

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -82,10 +82,10 @@ public static class FirstRunBootstrapper
     /// <remarks>
     /// <para>
     /// JWT secret generation runs in <em>all</em> environments (including
-    /// Development) so that no hardcoded secret is required in checked-in
-    /// config files.  When the secret is missing or is the well-known
-    /// placeholder, a cryptographically random value is generated into
-    /// <c>appsettings.local.json</c>.
+    /// Development and CI/headless) so that no hardcoded secret is required
+    /// in checked-in config files.  When the secret is missing or is the
+    /// well-known placeholder, a cryptographically random value is generated
+    /// into <c>appsettings.local.json</c>.
     /// </para>
     /// <para>
     /// DB-path resolution and other packaged-distribution checks are still
@@ -96,21 +96,13 @@ public static class FirstRunBootstrapper
         this WebApplicationBuilder builder,
         ILogger logger)
     {
-        // JWT secret generation runs unconditionally so developers do not
-        // need a hardcoded secret in appsettings.Development.json.
-        if (!IsHeadlessEnvironment())
-        {
-            EnsureJwtSecret(builder.Configuration, logger);
-        }
+        // JWT secret generation runs unconditionally (including headless/CI)
+        // so that no hardcoded secret is required in appsettings.Development.json.
+        EnsureJwtSecret(builder.Configuration, logger);
 
         // Remaining first-run checks are for the self-hosted packaged
-        // distribution only.
-        if (builder.Environment.IsDevelopment())
-        {
-            return builder;
-        }
-
-        if (IsHeadlessEnvironment())
+        // distribution only -- skip in Development and CI/headless.
+        if (builder.Environment.IsDevelopment() || IsHeadlessEnvironment())
         {
             return builder;
         }
@@ -146,16 +138,31 @@ public static class FirstRunBootstrapper
         }
 
         var generated = GenerateSecret();
-        PersistValue("Jwt", "SecretKey", generated);
-        // Reload so subsequent configuration reads get the new value.
-        if (configuration is IConfigurationRoot root)
+        try
         {
-            root.Reload();
-        }
+            PersistValue("Jwt", "SecretKey", generated);
+            // Reload so subsequent configuration reads get the new value.
+            if (configuration is IConfigurationRoot root)
+            {
+                root.Reload();
+            }
 
-        logger.LogInformation(
-            "First-run: JWT secret was not configured. A random secret has been " +
-            "generated and saved to {ConfigFile}.", LocalConfigPath);
+            logger.LogInformation(
+                "First-run: JWT secret was not configured. A random secret has been " +
+                "generated and saved to {ConfigFile}.", LocalConfigPath);
+        }
+        catch (IOException ex)
+        {
+            // File may be locked by another process (e.g. parallel test
+            // factories sharing the same output directory).  Fall back to
+            // setting the value in-memory so the current startup still
+            // succeeds.
+            configuration["Jwt:SecretKey"] = generated;
+            logger.LogWarning(
+                "First-run: Could not persist JWT secret to {ConfigFile} ({Error}). " +
+                "A transient in-memory secret has been generated instead.",
+                LocalConfigPath, ex.Message);
+        }
     }
 
     private static void EnsureDbPath(IConfiguration configuration, ILogger logger)

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -80,27 +80,41 @@ public static class FirstRunBootstrapper
     /// loaded (i.e. after the builder is constructed).
     /// </summary>
     /// <remarks>
-    /// Checks are skipped in Development and in CI/headless environments.
-    /// They are intended for the packaged self-hosted production scenario.
+    /// <para>
+    /// JWT secret generation runs in <em>all</em> environments (including
+    /// Development) so that no hardcoded secret is required in checked-in
+    /// config files.  When the secret is missing or is the well-known
+    /// placeholder, a cryptographically random value is generated into
+    /// <c>appsettings.local.json</c>.
+    /// </para>
+    /// <para>
+    /// DB-path resolution and other packaged-distribution checks are still
+    /// skipped in Development and in CI/headless environments.
+    /// </para>
     /// </remarks>
     public static WebApplicationBuilder RunFirstRunChecks(
         this WebApplicationBuilder builder,
         ILogger logger)
     {
-        // First-run checks are for the self-hosted packaged distribution.
-        // In Development the developer supplies their own config values.
+        // JWT secret generation runs unconditionally so developers do not
+        // need a hardcoded secret in appsettings.Development.json.
+        if (!IsHeadlessEnvironment())
+        {
+            EnsureJwtSecret(builder.Configuration, logger);
+        }
+
+        // Remaining first-run checks are for the self-hosted packaged
+        // distribution only.
         if (builder.Environment.IsDevelopment())
         {
             return builder;
         }
 
-        // Also skip in CI / automated environments.
         if (IsHeadlessEnvironment())
         {
             return builder;
         }
 
-        EnsureJwtSecret(builder.Configuration, logger);
         EnsureDbPath(builder.Configuration, logger);
         return builder;
     }

--- a/backend/src/Taskdeck.Api/appsettings.Development.json
+++ b/backend/src/Taskdeck.Api/appsettings.Development.json
@@ -6,7 +6,6 @@
     }
   },
   "Jwt": {
-    "SecretKey": "TaskdeckDevelopmentOnlySecretKeyChangeMe123!",
     "Issuer": "Taskdeck",
     "Audience": "TaskdeckUsers",
     "ExpirationMinutes": 1440

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
@@ -33,6 +33,9 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             var overrideSettings = new Dictionary<string, string?>
             {
                 ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}",
+                // Provide a stable test JWT secret so tests do not depend on
+                // appsettings.Development.json or FirstRunBootstrapper side-effects.
+                ["Jwt:SecretKey"] = "TaskdeckTestsOnlySecretKeyMustBeLongEnough123!",
                 ["RateLimiting:Enabled"] = "false",
                 ["Workers:QueuePollIntervalSeconds"] = "1",
                 ["Workers:MaxBatchSize"] = "10",

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -92,12 +92,12 @@ authentication services (`AuthenticationRegistration.cs`). Because
 `app.UseAuthentication()`, this results in a startup failure (the pipeline
 cannot resolve the missing authentication services) rather than authenticated
 endpoints simply returning 401. `FirstRunBootstrapper.EnsureJwtSecret` runs
-in all environments (including Development) and generates a random 32-byte
-base64 secret into `appsettings.local.json` when the key is missing or equal
-to the well-known placeholder. This startup failure is therefore only reached
-when operators explicitly set an invalid value. Developers can alternatively
-supply the secret via `dotnet user-secrets` or the `Jwt__SecretKey`
-environment variable.
+unconditionally in all environments (including Development and CI/headless)
+and generates a random 32-byte base64 secret into `appsettings.local.json`
+when the key is missing or equal to the well-known placeholder. This startup
+failure is therefore only reached when operators explicitly set an invalid
+value. Developers can alternatively supply the secret via `dotnet user-secrets`
+or the `Jwt__SecretKey` environment variable.
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -91,16 +91,17 @@ authentication services (`AuthenticationRegistration.cs`). Because
 `PipelineConfiguration.ConfigureTaskdeckPipeline` always calls
 `app.UseAuthentication()`, this results in a startup failure (the pipeline
 cannot resolve the missing authentication services) rather than authenticated
-endpoints simply returning 401. In packaged non-development runs,
-`FirstRunBootstrapper.EnsureJwtSecret` generates a random 32-byte base64
-secret into `appsettings.local.json` when the key is missing or equal to the
-development placeholder, so this startup failure is normally only reached
-when operators explicitly set an invalid value (for example, deleting the
-Development placeholder without providing a replacement).
+endpoints simply returning 401. `FirstRunBootstrapper.EnsureJwtSecret` runs
+in all environments (including Development) and generates a random 32-byte
+base64 secret into `appsettings.local.json` when the key is missing or equal
+to the well-known placeholder. This startup failure is therefore only reached
+when operators explicitly set an invalid value. Developers can alternatively
+supply the secret via `dotnet user-secrets` or the `Jwt__SecretKey`
+environment variable.
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |
-| `Jwt:SecretKey` | `string` | `""` in production; `TaskdeckDevelopmentOnlySecretKeyChangeMe123!` in Development via `appsettings.Development.json` | HMAC signing key. Must be at least 32 characters (`AuthenticationService.ValidateAsync` + `AuthenticationRegistration`). Never commit a real value. | Yes (see note above) |
+| `Jwt:SecretKey` | `string` | `""` (auto-generated to `appsettings.local.json` on first run by `FirstRunBootstrapper`) | HMAC signing key. Must be at least 32 characters (`AuthenticationService.ValidateAsync` + `AuthenticationRegistration`). Never commit a real value. Alternatively, use `dotnet user-secrets` or the `Jwt__SecretKey` environment variable. | Yes (see note above) |
 | `Jwt:Issuer` | `string` | `Taskdeck` | `iss` claim and validation value. | Yes |
 | `Jwt:Audience` | `string` | `TaskdeckUsers` | `aud` claim and validation value. | Yes |
 | `Jwt:ExpirationMinutes` | `int` | `1440` (24h) | Access-token lifetime in minutes. | No |

--- a/docs/security/SECRETS_MANAGEMENT_BASELINE.md
+++ b/docs/security/SECRETS_MANAGEMENT_BASELINE.md
@@ -24,7 +24,7 @@ Related docs:
 
 | Secret | Purpose | Local/Dev | Staging/Prod | Rotation Trigger |
 | --- | --- | --- | --- | --- |
-| `Jwt:SecretKey` | JWT signing for auth tokens | `appsettings.Development.json` (dev-only placeholder) | AWS SSM SecureString via `jwt_secret_ssm_parameter_name` | Scheduled (90 days) or on compromise |
+| `Jwt:SecretKey` | JWT signing for auth tokens | Auto-generated to `appsettings.local.json` by `FirstRunBootstrapper`; or `dotnet user-secrets` / env var | AWS SSM SecureString via `jwt_secret_ssm_parameter_name` | Scheduled (90 days) or on compromise |
 | `Llm:OpenAi:ApiKey` | OpenAI API access | Environment variable or user secrets | SSM SecureString or CI-injected env var | On compromise or key expiry |
 | `Llm:Gemini:ApiKey` | Gemini API access | Environment variable or user secrets | SSM SecureString or CI-injected env var | On compromise or key expiry |
 | `TASKDECK_JWT_SECRET` | Compose-level JWT secret injection | `deploy/.env` (untracked) | SSM SecureString pulled at boot | Scheduled (90 days) or on compromise |
@@ -36,7 +36,7 @@ Related docs:
 
 ### Local Development
 
-- **JWT secret**: Hardcoded dev-only value in `appsettings.Development.json`. This value is intentionally weak and clearly marked; it must never be used outside local dev.
+- **JWT secret**: Auto-generated to `appsettings.local.json` on first run by `FirstRunBootstrapper`. No hardcoded secret in committed files. Alternatively, use `dotnet user-secrets set "Jwt:SecretKey" "<value>"` or the `Jwt__SecretKey` environment variable.
 - **LLM API keys**: Not required (Mock provider is default). When needed for live-provider demos, set via environment variables (`Llm__OpenAi__ApiKey`, `Llm__Gemini__ApiKey`) or .NET user secrets (`dotnet user-secrets set "Llm:OpenAi:ApiKey" "<key>"`).
 - **GitHub PAT**: Set in user environment or root `.env` (gitignored).
 - **No secrets required in committed files.** `appsettings.json` contains only empty placeholder values for optional provider keys.
@@ -67,7 +67,7 @@ The following committed files contain secret-shaped keys. All values are empty p
 | --- | --- | --- | --- |
 | `appsettings.json` | `Llm:OpenAi:ApiKey` | `""` (empty) | Safe -- placeholder only |
 | `appsettings.json` | `Llm:Gemini:ApiKey` | `""` (empty) | Safe -- placeholder only |
-| `appsettings.Development.json` | `Jwt:SecretKey` | Dev-only marker value | Safe -- clearly marked, dev-only |
+| `appsettings.Development.json` | `Jwt:SecretKey` | Removed (no longer present) | Safe -- secret auto-generated at runtime |
 | `deploy/.env.example` | `TASKDECK_JWT_SECRET` | `""` (empty) | Safe -- template only |
 | `.env.example` | `GITHUB_PAT` | `""` (empty) | Safe -- template only |
 | `terraform.tfvars.example` (all envs) | `jwt_secret_ssm_parameter_name` | Example path | Safe -- example only |


### PR DESCRIPTION
## Summary
- Remove hardcoded JWT development secret (`TaskdeckDevelopmentOnlySecretKeyChangeMe123!`) from `appsettings.Development.json`
- Update `FirstRunBootstrapper` to run JWT secret generation in all environments (including Development), so developers get an auto-generated secret in `appsettings.local.json` on first run
- Document `dotnet user-secrets` and environment variable alternatives in `CONTRIBUTING.md`
- Update `docs/platform/CONFIGURATION_REFERENCE.md` and `docs/security/SECRETS_MANAGEMENT_BASELINE.md` to reflect the new behavior

Closes #851

## Test plan
- [x] Backend builds without errors
- [x] All backend tests pass (1391 API tests, 2146 Application tests, 899 Domain tests, 16 CLI tests, 8 Architecture tests, 20 Integration tests)
- [x] `FirstRunBootstrapper` tests pass (10/10)
- [x] Existing tests that reference the old secret (OAuthTokenLifecycleTests) continue to pass since they test rejection scenarios
- [ ] Backend starts cleanly without hardcoded secret (FirstRunBootstrapper generates to appsettings.local.json)
- [ ] FirstRunBootstrapper generates secret on first run in Development mode