### PR TITLE
fix: stabilize ActivityView test on Windows

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/ActivityView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ActivityView.spec.ts
@@ -107,6 +107,18 @@ function findButtonByText(wrapper: ReturnType<typeof mount>, text: string) {
   return button!
 }
 
+// Deterministic timestamps ensure `boardOptions` sort order is stable across
+// platforms. The component sorts by `updatedAt` DESC, so board-1 must have a
+// strictly later timestamp than board-2 to land first in selector defaults.
+// Previously this used `new Date().toISOString()` twice in succession, which
+// produced different ordering on Windows (where Node's high-resolution clock
+// advanced between calls) vs. other platforms (where both timestamps were
+// equal and stable-sort preserved declaration order). That manifested as a
+// Windows-only flake: `fetchBoard` was called with 'board-2' instead of
+// 'board-1' because the default selection flipped.
+const BOARD_1_TIMESTAMP = '2025-01-02T00:00:00.000Z'
+const BOARD_2_TIMESTAMP = '2025-01-01T00:00:00.000Z'
+
 function seedBoards() {
   mockBoardStore.boards = [
     {
@@ -114,16 +126,16 @@ function seedBoards() {
       name: 'Board One',
       isArchived: false,
       description: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      createdAt: BOARD_1_TIMESTAMP,
+      updatedAt: BOARD_1_TIMESTAMP,
     },
     {
       id: 'board-2',
       name: 'Board Two',
       isArchived: false,
       description: null,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      createdAt: BOARD_2_TIMESTAMP,
+      updatedAt: BOARD_2_TIMESTAMP,
     },
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a Windows-only flaky unit test (`ActivityView.spec.ts > fetches entity history from discoverable selectors`) that has been blocking PRs on `windows-latest` CI, including PR #902.

## Root cause

`seedBoards()` used `new Date().toISOString()` twice in immediate succession to populate `createdAt` / `updatedAt` on two mock boards. On Windows runners where Node's high-resolution clock advances between the two calls (measured ~1% locally, apparently more frequent on `windows-latest` CI), the second board's timestamp is strictly greater than the first.

The component sorts `boardOptions` by `updatedAt` DESC, so when timestamps diverge, `board-2` lands at index 0 and `applySelectorDefaults()` picks it as the default selection. The test asserted `fetchBoard` was called with `board-1`, but the component correctly called it with `board-2`.

On platforms/runs where both timestamps resolve to the same millisecond, stable sort preserved declaration order and the test passed.

## Fix

Assign explicit, ordered ISO timestamps (`board-1 = 2025-01-02`, `board-2 = 2025-01-01`) so the `boardOptions` sort order is deterministic regardless of OS clock resolution. This mirrors the intent of the test (board-1 should be the "most recently updated" default choice).

Diff is 12 lines + explanatory comment; no product code is touched.

## Why this is a root-cause fix, not a flake suppression

The assertion in the test is correct: the component's default-selection logic is designed to pick the first `boardOption`, and the test expects that to be `board-1`. The bug is that the test fixture failed to pin the sort key deterministically. Fixing the fixture (not the assertion) preserves the original test intent.

## Unblocks

- PR #902 (gitleaks secrets detection) — CI was red only on this test
- Any future PR that hits `windows-latest` runners on the frontend test job

## Test plan

- [x] Local `npx vitest run src/tests/views/ActivityView.spec.ts` passes 10/10 consecutive runs
- [x] Full frontend test suite (2550 tests) passes with fix applied
- [x] `npm run typecheck` passes
- [ ] CI `windows-latest` job passes on this PR