### PR TITLE
feat: add database migration validation to CI (TST-61)

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -9,6 +9,7 @@
 #     ├── reusable-backend-architecture.yml    architecture boundary tests
 #     ├── reusable-backend-unit.yml            domain / application / CLI unit tests (Ubuntu + Windows)
 #     ├── reusable-api-integration.yml         API integration tests (Ubuntu + Windows)
+#     ├── reusable-migration-validation.yml    EF Core migration chain validation (TST-61)
 #     ├── reusable-frontend-unit.yml           lint + typecheck + build + unit tests (Ubuntu + Windows)
 #     ├── reusable-container-images.yml        compose validation + image build + artifact export
 #     └── reusable-e2e-smoke.yml               Playwright smoke (depends on all above)
@@ -102,6 +103,12 @@ jobs:
     with:
       dotnet-version: 8.0.x
 
+  migration-validation:
+    name: Migration Validation
+    uses: ./.github/workflows/reusable-migration-validation.yml
+    with:
+      dotnet-version: 8.0.x
+
   frontend-unit:
     name: Frontend Unit
     uses: ./.github/workflows/reusable-frontend-unit.yml
@@ -119,6 +126,7 @@ jobs:
       - backend-architecture
       - backend-unit
       - api-integration
+      - migration-validation
       - frontend-unit
     uses: ./.github/workflows/reusable-e2e-smoke.yml
     with:

--- a/.github/workflows/reusable-migration-validation.yml
+++ b/.github/workflows/reusable-migration-validation.yml
@@ -1,0 +1,45 @@
+name: Reusable Migration Validation
+
+on:
+  workflow_call:
+    inputs:
+      dotnet-version:
+        description: .NET SDK version used for migration validation
+        required: false
+        default: "8.0.x"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+jobs:
+  migration-validation:
+    name: Migration Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+          cache: true
+          cache-dependency-path: |
+            backend/Taskdeck.sln
+            backend/**/*.csproj
+
+      - name: Install dotnet-ef tool
+        run: dotnet tool install --global dotnet-ef --version 8.0.*
+
+      - name: Restore backend
+        run: dotnet restore backend/Taskdeck.sln
+
+      - name: Build backend
+        run: dotnet build backend/Taskdeck.sln --configuration Release --no-restore
+
+      - name: Validate migrations against empty database
+        run: bash scripts/ci/validate-migrations.sh

--- a/docs/platform/EF_MIGRATION_WORKFLOW.md
+++ b/docs/platform/EF_MIGRATION_WORKFLOW.md
@@ -100,7 +100,7 @@ dotnet ef database update <PreviousMigrationName> --startup-project ../Taskdeck.
 
 ## Migration Chain
 
-As of 2026-04-22, the migration chain contains 21 migrations from `20251118031819_InitialCreate` through `20260416161303_AddPerfIndexes`. All migrations apply cleanly from an empty SQLite database.
+As of 2026-04-22, the migration chain contains 21 migrations from `20251118031819_InitialCreate` through `20260422183834_AddExternalLoginsUserForeignKey`. All migrations apply cleanly from an empty SQLite database.
 
 ## Bootstrap Verification
 
@@ -116,6 +116,25 @@ Run the bootstrap tests:
 
 ```bash
 dotnet test backend/Taskdeck.sln -c Release --filter "FullyQualifiedName~MigrationBootstrapTests"
+```
+
+## CI Validation
+
+The `reusable-migration-validation.yml` workflow (wired into `ci-required.yml`) validates the migration chain on every PR:
+
+1. Installs the `dotnet-ef` CLI tool
+2. Runs `dotnet ef database update` against an empty SQLite database
+3. Queries `sqlite_master` to verify all user tables were created
+4. Checks `__EFMigrationsHistory` for recorded migrations
+5. Runs `dotnet ef migrations has-pending-model-changes` to detect model drift
+
+This complements the programmatic `MigrationBootstrapTests` by exercising the CLI tooling path that deployment pipelines use.
+
+Run the validation script locally:
+
+```bash
+dotnet build backend/Taskdeck.sln -c Release
+bash scripts/ci/validate-migrations.sh
 ```
 
 ## Best Practices

--- a/scripts/ci/validate-migrations.sh
+++ b/scripts/ci/validate-migrations.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# =============================================================================
+# validate-migrations.sh
+# Validates that EF Core migrations apply cleanly to a fresh SQLite database
+# and that the resulting schema contains all expected tables.
+#
+# Usage: bash scripts/ci/validate-migrations.sh
+#
+# Exit codes:
+#   0 — All migrations applied cleanly and schema is valid
+#   1 — Migration or schema validation failure
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+INFRA_PROJECT="$REPO_ROOT/backend/src/Taskdeck.Infrastructure/Taskdeck.Infrastructure.csproj"
+STARTUP_PROJECT="$REPO_ROOT/backend/src/Taskdeck.Api/Taskdeck.Api.csproj"
+
+# Create a temp directory for the test database
+TEMP_DIR="$(mktemp -d)"
+DB_PATH="$TEMP_DIR/migration-validation.db"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+echo "=== EF Core Migration Validation ==="
+echo "Database: $DB_PATH"
+echo ""
+
+# ---- Step 1: Apply all migrations to an empty database ----
+echo "--- Step 1: Applying migrations to empty database ---"
+
+dotnet ef database update \
+  --project "$INFRA_PROJECT" \
+  --startup-project "$STARTUP_PROJECT" \
+  --connection "Data Source=$DB_PATH" \
+  --no-build \
+  --verbose 2>&1 | tail -20
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "FAIL: Database file was not created at $DB_PATH"
+  exit 1
+fi
+
+echo ""
+echo "OK: Migrations applied successfully."
+echo ""
+
+# ---- Step 2: Verify tables exist ----
+echo "--- Step 2: Verifying schema tables ---"
+
+# sqlite3 is available on ubuntu-latest and macos runners.
+# Query all user tables (excluding internal EF and SQLite tables).
+ACTUAL_TABLES=$(sqlite3 "$DB_PATH" \
+  "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name != '__EFMigrationsHistory' ORDER BY name;")
+
+if [ -z "$ACTUAL_TABLES" ]; then
+  echo "FAIL: No user tables found in the database after migration."
+  exit 1
+fi
+
+TABLE_COUNT=$(echo "$ACTUAL_TABLES" | wc -l | tr -d ' ')
+echo "Found $TABLE_COUNT user tables:"
+echo "$ACTUAL_TABLES" | sed 's/^/  - /'
+echo ""
+
+# ---- Step 3: Verify migration history ----
+echo "--- Step 3: Verifying migration history ---"
+
+MIGRATION_COUNT=$(sqlite3 "$DB_PATH" \
+  "SELECT COUNT(*) FROM __EFMigrationsHistory;")
+
+if [ "$MIGRATION_COUNT" -eq 0 ]; then
+  echo "FAIL: No migrations recorded in __EFMigrationsHistory."
+  exit 1
+fi
+
+echo "OK: $MIGRATION_COUNT migrations recorded in history."
+
+# List all applied migrations
+echo ""
+echo "Applied migrations:"
+sqlite3 "$DB_PATH" \
+  "SELECT MigrationId FROM __EFMigrationsHistory ORDER BY MigrationId;" \
+  | sed 's/^/  - /'
+echo ""
+
+# ---- Step 4: Check for pending model changes ----
+echo "--- Step 4: Checking for pending model changes ---"
+
+PENDING_OUTPUT=$(dotnet ef migrations has-pending-model-changes \
+  --project "$INFRA_PROJECT" \
+  --startup-project "$STARTUP_PROJECT" \
+  --no-build 2>&1) || true
+
+if echo "$PENDING_OUTPUT" | grep -qi "no pending model changes"; then
+  echo "OK: No pending model changes detected."
+elif echo "$PENDING_OUTPUT" | grep -qi "changes have been made"; then
+  echo "FAIL: Pending model changes detected. Run 'dotnet ef migrations add <Name>' to capture them."
+  echo "$PENDING_OUTPUT"
+  exit 1
+else
+  # The command output format may vary; log it for debugging but do not fail
+  # if we cannot parse the output deterministically.
+  echo "INFO: Could not determine pending model change status from output:"
+  echo "$PENDING_OUTPUT"
+  echo "Continuing (non-blocking)."
+fi
+
+echo ""
+echo "=== Migration validation passed ==="

--- a/scripts/ci/validate-migrations.sh
+++ b/scripts/ci/validate-migrations.sh
@@ -18,6 +18,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 INFRA_PROJECT="$REPO_ROOT/backend/src/Taskdeck.Infrastructure/Taskdeck.Infrastructure.csproj"
 STARTUP_PROJECT="$REPO_ROOT/backend/src/Taskdeck.Api/Taskdeck.Api.csproj"
 
+# The CI workflow builds with --configuration Release, so dotnet-ef must also
+# use Release to find the correct bin output (bin/Release/net8.0/).  Without
+# this flag dotnet-ef defaults to Debug and fails with "deps.json does not
+# exist" on a clean runner.
+CONFIGURATION="${DOTNET_CONFIGURATION:-Release}"
+
 # Create a temp directory for the test database
 TEMP_DIR="$(mktemp -d)"
 DB_PATH="$TEMP_DIR/migration-validation.db"
@@ -35,6 +41,7 @@ MIGRATION_LOG="$TEMP_DIR/migration-output.log"
 if ! dotnet ef database update \
   --project "$INFRA_PROJECT" \
   --startup-project "$STARTUP_PROJECT" \
+  --configuration "$CONFIGURATION" \
   --connection "Data Source=$DB_PATH" \
   --no-build \
   --verbose > "$MIGRATION_LOG" 2>&1; then
@@ -106,6 +113,7 @@ PENDING_EXIT=0
 PENDING_OUTPUT=$(dotnet ef migrations has-pending-model-changes \
   --project "$INFRA_PROJECT" \
   --startup-project "$STARTUP_PROJECT" \
+  --configuration "$CONFIGURATION" \
   --no-build 2>&1) || PENDING_EXIT=$?
 
 if [ "$PENDING_EXIT" -eq 0 ]; then

--- a/scripts/ci/validate-migrations.sh
+++ b/scripts/ci/validate-migrations.sh
@@ -30,12 +30,23 @@ echo ""
 # ---- Step 1: Apply all migrations to an empty database ----
 echo "--- Step 1: Applying migrations to empty database ---"
 
-dotnet ef database update \
+MIGRATION_LOG="$TEMP_DIR/migration-output.log"
+
+if ! dotnet ef database update \
   --project "$INFRA_PROJECT" \
   --startup-project "$STARTUP_PROJECT" \
   --connection "Data Source=$DB_PATH" \
   --no-build \
-  --verbose 2>&1 | tail -20
+  --verbose > "$MIGRATION_LOG" 2>&1; then
+  echo "FAIL: dotnet ef database update failed."
+  echo ""
+  echo "--- Full output ---"
+  cat "$MIGRATION_LOG"
+  exit 1
+fi
+
+# Show summary (last 10 lines of verbose output)
+tail -10 "$MIGRATION_LOG"
 
 if [ ! -f "$DB_PATH" ]; then
   echo "FAIL: Database file was not created at $DB_PATH"
@@ -88,23 +99,23 @@ echo ""
 # ---- Step 4: Check for pending model changes ----
 echo "--- Step 4: Checking for pending model changes ---"
 
+# has-pending-model-changes exits 0 when no changes are pending, non-zero when
+# the model has drifted from the last migration snapshot.
+PENDING_OUTPUT=""
+PENDING_EXIT=0
 PENDING_OUTPUT=$(dotnet ef migrations has-pending-model-changes \
   --project "$INFRA_PROJECT" \
   --startup-project "$STARTUP_PROJECT" \
-  --no-build 2>&1) || true
+  --no-build 2>&1) || PENDING_EXIT=$?
 
-if echo "$PENDING_OUTPUT" | grep -qi "no pending model changes"; then
+if [ "$PENDING_EXIT" -eq 0 ]; then
   echo "OK: No pending model changes detected."
-elif echo "$PENDING_OUTPUT" | grep -qi "changes have been made"; then
-  echo "FAIL: Pending model changes detected. Run 'dotnet ef migrations add <Name>' to capture them."
+else
+  echo "FAIL: Pending model changes detected (exit code $PENDING_EXIT)."
+  echo "Run 'dotnet ef migrations add <Name>' to capture the drift."
+  echo ""
   echo "$PENDING_OUTPUT"
   exit 1
-else
-  # The command output format may vary; log it for debugging but do not fail
-  # if we cannot parse the output deterministically.
-  echo "INFO: Could not determine pending model change status from output:"
-  echo "$PENDING_OUTPUT"
-  echo "Continuing (non-blocking)."
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds a new CI step that validates EF Core migrations apply cleanly to a fresh SQLite database using the `dotnet ef` CLI tool (not just programmatic `Database.Migrate()`)
- Creates `scripts/ci/validate-migrations.sh` which runs `dotnet ef database update` against an empty DB, verifies all tables exist via `sqlite_master`, checks `__EFMigrationsHistory`, and detects pending model changes
- Wires the validation into `ci-required.yml` as a parallel job in the PR merge gate
- Documents the CI validation workflow in `docs/platform/EF_MIGRATION_WORKFLOW.md`

Closes #869

## Test plan

- [ ] CI workflow runs successfully on this PR (migration validation job passes)
- [ ] Verify the migration validation script detects broken migration chains (can test by temporarily removing a migration file and confirming CI failure)
- [ ] Verify the script reports pending model changes when the EF model drifts from the last migration snapshot
- [ ] Confirm CI wall-clock time is not significantly impacted (migration validation runs in parallel with other checks)