### PR TITLE
feat: add session timeout warning before JWT expiry (FE-20)

### DIFF
--- a/frontend/taskdeck-web/src/App.vue
+++ b/frontend/taskdeck-web/src/App.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import ToastContainer from './components/common/ToastContainer.vue'
+import SessionTimeoutWarning from './components/common/SessionTimeoutWarning.vue'
 import AppShell from './components/shell/AppShell.vue'
 import ErrorBoundary from './components/ErrorBoundary.vue'
 import { useSessionStore } from './store/sessionStore'
@@ -48,6 +49,7 @@ watch(
       <router-view />
     </ErrorBoundary>
     <ToastContainer />
+    <SessionTimeoutWarning />
   </div>
 </template>
 

--- a/frontend/taskdeck-web/src/api/authApi.ts
+++ b/frontend/taskdeck-web/src/api/authApi.ts
@@ -79,7 +79,13 @@ export const authApi = {
   },
 
   async refreshToken(): Promise<AuthResponse> {
-    const { data } = await http.post<AuthResponse>('/auth/refresh')
+    // skipAuth401: prevent the 401 interceptor from redirecting to /login
+    // before the caller's catch block can handle the error gracefully.
+    // skipRetry: refresh is not idempotent and should fail fast.
+    const { data } = await http.post<AuthResponse>('/auth/refresh', null, {
+      skipAuth401: true,
+      skipRetry: true,
+    } as Record<string, unknown>)
     return data
   },
 }

--- a/frontend/taskdeck-web/src/api/authApi.ts
+++ b/frontend/taskdeck-web/src/api/authApi.ts
@@ -77,4 +77,9 @@ export const authApi = {
   async disableMfa(request: MfaVerifyRequest): Promise<void> {
     await http.post('/auth/mfa/disable', request)
   },
+
+  async refreshToken(): Promise<AuthResponse> {
+    const { data } = await http.post<AuthResponse>('/auth/refresh')
+    return data
+  },
 }

--- a/frontend/taskdeck-web/src/api/http.ts
+++ b/frontend/taskdeck-web/src/api/http.ts
@@ -53,8 +53,11 @@ http.interceptors.response.use(
     if (error.response) {
       console.error('API Error:', error.response.data)
 
-      // Handle 401 - clear session and redirect to login (skip in demo mode)
-      if (error.response.status === 401 && !isDemoMode) {
+      // Handle 401 - clear session and redirect to login (skip in demo mode).
+      // Callers can set `skipAuth401` on the request config to suppress this
+      // behaviour (e.g. token refresh attempts that want to handle 401 locally).
+      const skipAuth401 = (error.config as Record<string, unknown> | undefined)?.skipAuth401 === true
+      if (error.response.status === 401 && !isDemoMode && !skipAuth401) {
         tokenStorage.clearAll()
         const pathname = window.location.pathname
         const currentPath = `${pathname}${window.location.search}`

--- a/frontend/taskdeck-web/src/components/common/SessionTimeoutWarning.vue
+++ b/frontend/taskdeck-web/src/components/common/SessionTimeoutWarning.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useSessionTimeout } from '../../composables/useSessionTimeout'
+
+const { showWarning, secondsRemaining, extending, dismiss, extend } = useSessionTimeout()
+
+const formattedTime = computed(() => {
+  const secs = secondsRemaining.value
+  if (secs === null || secs <= 0) return '0:00'
+  const minutes = Math.floor(secs / 60)
+  const seconds = secs % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+})
+</script>
+
+<template>
+  <Transition name="session-warning">
+    <div
+      v-if="showWarning"
+      class="fixed bottom-4 right-4 z-50 max-w-sm rounded-lg border border-yellow-300 bg-yellow-50 px-4 py-3 shadow-lg"
+      role="alert"
+      aria-live="assertive"
+    >
+      <div class="flex items-start gap-3">
+        <!-- Warning icon -->
+        <div class="flex-shrink-0 mt-0.5" aria-hidden="true">
+          <svg class="h-5 w-5 text-yellow-600" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fill-rule="evenodd"
+              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </div>
+
+        <div class="flex-1">
+          <p class="text-sm font-medium text-yellow-800">
+            Session expires in
+            <span class="font-mono font-bold" aria-live="polite">{{ formattedTime }}</span>
+          </p>
+          <p class="mt-1 text-xs text-yellow-700">
+            Save your work or extend your session to continue.
+          </p>
+          <div class="mt-2 flex gap-2">
+            <button
+              class="rounded bg-yellow-600 px-3 py-1 text-xs font-medium text-white hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-1 disabled:opacity-50"
+              :disabled="extending"
+              @click="extend"
+            >
+              {{ extending ? 'Extending...' : 'Extend Session' }}
+            </button>
+            <button
+              class="rounded border border-yellow-400 px-3 py-1 text-xs font-medium text-yellow-700 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-1"
+              @click="dismiss"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+
+        <!-- Close button -->
+        <button
+          class="flex-shrink-0 text-yellow-600 hover:text-yellow-800"
+          aria-label="Dismiss session warning"
+          @click="dismiss"
+        >
+          <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fill-rule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.session-warning-enter-active,
+.session-warning-leave-active {
+  transition: all 0.3s ease;
+}
+
+.session-warning-enter-from {
+  opacity: 0;
+  transform: translateY(1rem);
+}
+
+.session-warning-leave-to {
+  opacity: 0;
+  transform: translateY(1rem);
+}
+</style>

--- a/frontend/taskdeck-web/src/components/common/SessionTimeoutWarning.vue
+++ b/frontend/taskdeck-web/src/components/common/SessionTimeoutWarning.vue
@@ -36,7 +36,7 @@ const formattedTime = computed(() => {
         <div class="flex-1">
           <p class="text-sm font-medium text-yellow-800">
             Session expires in
-            <span class="font-mono font-bold" aria-live="polite">{{ formattedTime }}</span>
+            <span class="font-mono font-bold">{{ formattedTime }}</span>
           </p>
           <p class="mt-1 text-xs text-yellow-700">
             Save your work or extend your session to continue.

--- a/frontend/taskdeck-web/src/composables/useSessionTimeout.ts
+++ b/frontend/taskdeck-web/src/composables/useSessionTimeout.ts
@@ -1,0 +1,239 @@
+import { ref, watch, onUnmounted, getCurrentInstance, readonly, type Ref } from 'vue'
+import { useSessionStore } from '../store/sessionStore'
+import { parseJwtPayload } from '../utils/jwt'
+
+/**
+ * How long before token expiry to show the warning (milliseconds).
+ * Default: 5 minutes.
+ */
+export const WARNING_BEFORE_EXPIRY_MS = 5 * 60 * 1000
+
+/**
+ * How often to tick the countdown display (milliseconds).
+ */
+const COUNTDOWN_TICK_MS = 1_000
+
+export interface SessionTimeoutState {
+  /** Whether the warning banner is currently visible. */
+  showWarning: Readonly<Ref<boolean>>
+  /** Seconds remaining until the token expires. Null when no warning is active. */
+  secondsRemaining: Readonly<Ref<number | null>>
+  /** Whether a session extension attempt is in progress. */
+  extending: Readonly<Ref<boolean>>
+  /** Dismiss the warning banner without extending. */
+  dismiss: () => void
+  /** Attempt to extend the session (silent re-auth). */
+  extend: () => Promise<void>
+  /** Stop all timers (for cleanup/testing). */
+  teardown: () => void
+}
+
+/**
+ * Composable that monitors JWT expiry and shows a warning before the session expires.
+ *
+ * Features:
+ * - Shows a warning `WARNING_BEFORE_EXPIRY_MS` before the token expires
+ * - Live countdown in seconds
+ * - "Extend Session" action that attempts a token refresh
+ * - No duplicate warnings per token (deduplication by token string)
+ * - Skips entirely in demo mode or when unauthenticated
+ * - Cleans up all timers on unmount or token change
+ *
+ * @param deps Injectable dependencies for testing
+ */
+export function useSessionTimeout(deps?: {
+  refreshToken?: () => Promise<{ token: string; user: { id: string; username: string; email: string; defaultRole: number; isActive: boolean; createdAt: string; updatedAt: string } }>
+  nowFn?: () => number
+}): SessionTimeoutState {
+  const session = useSessionStore()
+
+  const showWarning = ref(false)
+  const secondsRemaining = ref<number | null>(null)
+  const extending = ref(false)
+
+  let warningTimer: ReturnType<typeof setTimeout> | null = null
+  let countdownInterval: ReturnType<typeof setInterval> | null = null
+  let warnedForToken: string | null = null
+  let tokenExpiryMs: number | null = null
+
+  const nowFn = deps?.nowFn ?? (() => Date.now())
+
+  function clearTimers() {
+    if (warningTimer !== null) {
+      clearTimeout(warningTimer)
+      warningTimer = null
+    }
+    if (countdownInterval !== null) {
+      clearInterval(countdownInterval)
+      countdownInterval = null
+    }
+  }
+
+  function resetState() {
+    clearTimers()
+    showWarning.value = false
+    secondsRemaining.value = null
+    tokenExpiryMs = null
+  }
+
+  function startCountdown() {
+    if (countdownInterval !== null) {
+      clearInterval(countdownInterval)
+    }
+    updateCountdown()
+    countdownInterval = setInterval(updateCountdown, COUNTDOWN_TICK_MS)
+  }
+
+  function updateCountdown() {
+    if (tokenExpiryMs === null) {
+      secondsRemaining.value = null
+      return
+    }
+    const remaining = Math.max(0, Math.ceil((tokenExpiryMs - nowFn()) / 1000))
+    secondsRemaining.value = remaining
+
+    if (remaining <= 0) {
+      // Token has expired — the HTTP interceptor / session store will handle logout
+      resetState()
+    }
+  }
+
+  function activateWarning() {
+    showWarning.value = true
+    startCountdown()
+  }
+
+  function scheduleWarning(token: string) {
+    resetState()
+
+    // Skip if we already warned for this exact token
+    if (token === warnedForToken) return
+
+    const payload = parseJwtPayload(token)
+    if (!payload?.exp) return
+
+    tokenExpiryMs = payload.exp * 1000
+    const now = nowFn()
+    const msUntilExpiry = tokenExpiryMs - now
+
+    // Token already expired
+    if (msUntilExpiry <= 0) return
+
+    const msUntilWarning = msUntilExpiry - WARNING_BEFORE_EXPIRY_MS
+
+    if (msUntilWarning <= 0) {
+      // Already within warning window — show immediately
+      warnedForToken = token
+      activateWarning()
+    } else {
+      warningTimer = setTimeout(() => {
+        // Double-check token hasn't changed while we waited
+        if (session.token === token) {
+          warnedForToken = token
+          activateWarning()
+        }
+      }, msUntilWarning)
+    }
+  }
+
+  function dismiss() {
+    showWarning.value = false
+    secondsRemaining.value = null
+    if (countdownInterval !== null) {
+      clearInterval(countdownInterval)
+      countdownInterval = null
+    }
+  }
+
+  async function extend() {
+    if (extending.value) return
+
+    extending.value = true
+    try {
+      const refreshToken = deps?.refreshToken
+      if (!refreshToken) {
+        // No refresh capability — dynamic import to avoid circular dependency
+        const { authApi } = await import('../api/authApi')
+        const response = await authApi.refreshToken()
+        // The session store will pick up the new token via setSession,
+        // which triggers the watcher and reschedules the warning timer
+        const { useSessionStore: getStore } = await import('../store/sessionStore')
+        const store = getStore()
+        // Use internal setSession logic: update store state with new token
+        store.token = response.token
+        store.expiresAt = new Date(
+          (parseJwtPayload(response.token)?.exp ?? 0) * 1000,
+        ).toISOString()
+
+        // Persist the new token
+        const tokenStorage = await import('../utils/tokenStorage')
+        tokenStorage.setToken(response.token)
+
+        // Reset warning state for the new token
+        warnedForToken = null
+        dismiss()
+        return
+      }
+
+      // Injected refreshToken (used in tests)
+      const response = await refreshToken()
+      session.token = response.token
+      session.expiresAt = new Date(
+        (parseJwtPayload(response.token)?.exp ?? 0) * 1000,
+      ).toISOString()
+      warnedForToken = null
+      dismiss()
+    } catch {
+      // Refresh failed — show a fallback message.
+      // The toast store will be used by the component layer.
+      // We keep the warning visible so the user knows to save work.
+      const { useToastStore } = await import('../store/toastStore')
+      const toast = useToastStore()
+      toast.warning(
+        'Could not extend session. Please save your work and log in again.',
+        8000,
+      )
+    } finally {
+      extending.value = false
+    }
+  }
+
+  function teardown() {
+    resetState()
+    warnedForToken = null
+  }
+
+  // Watch token changes to schedule/reset warning
+  const stopWatch = watch(
+    () => ({ token: session.token, isDemo: session.isDemo }),
+    ({ token, isDemo }) => {
+      if (isDemo || !token) {
+        resetState()
+        // Do not clear warnedForToken here — if the same token returns
+        // (e.g. from a brief reactive fluctuation), we still suppress
+        // the warning. warnedForToken is cleared only in teardown(),
+        // extend(), or when scheduleWarning runs for a genuinely new token.
+        return
+      }
+      scheduleWarning(token)
+    },
+    { immediate: true },
+  )
+
+  // Cleanup on unmount (only register if inside a component)
+  if (getCurrentInstance()) {
+    onUnmounted(() => {
+      stopWatch()
+      teardown()
+    })
+  }
+
+  return {
+    showWarning: readonly(showWarning),
+    secondsRemaining: readonly(secondsRemaining),
+    extending: readonly(extending),
+    dismiss,
+    extend,
+    teardown,
+  }
+}

--- a/frontend/taskdeck-web/src/composables/useSessionTimeout.ts
+++ b/frontend/taskdeck-web/src/composables/useSessionTimeout.ts
@@ -198,13 +198,20 @@ export function useSessionTimeout(deps?: {
     }
   }
 
+  // Forward-declared so teardown() can stop the watcher
+  let stopWatch: (() => void) | null = null
+
   function teardown() {
     resetState()
     warnedForToken = null
+    if (stopWatch) {
+      stopWatch()
+      stopWatch = null
+    }
   }
 
   // Watch token changes to schedule/reset warning
-  const stopWatch = watch(
+  stopWatch = watch(
     () => ({ token: session.token, isDemo: session.isDemo }),
     ({ token, isDemo }) => {
       if (isDemo || !token) {
@@ -223,7 +230,6 @@ export function useSessionTimeout(deps?: {
   // Cleanup on unmount (only register if inside a component)
   if (getCurrentInstance()) {
     onUnmounted(() => {
-      stopWatch()
       teardown()
     })
   }

--- a/frontend/taskdeck-web/src/composables/useSessionTimeout.ts
+++ b/frontend/taskdeck-web/src/composables/useSessionTimeout.ts
@@ -1,6 +1,7 @@
 import { ref, watch, onUnmounted, getCurrentInstance, readonly, type Ref } from 'vue'
 import { useSessionStore } from '../store/sessionStore'
 import { parseJwtPayload } from '../utils/jwt'
+import type { AuthResponse } from '../types/auth'
 
 /**
  * How long before token expiry to show the warning (milliseconds).
@@ -42,7 +43,7 @@ export interface SessionTimeoutState {
  * @param deps Injectable dependencies for testing
  */
 export function useSessionTimeout(deps?: {
-  refreshToken?: () => Promise<{ token: string; user: { id: string; username: string; email: string; defaultRole: number; isActive: boolean; createdAt: string; updatedAt: string } }>
+  refreshToken?: () => Promise<AuthResponse>
   nowFn?: () => number
 }): SessionTimeoutState {
   const session = useSessionStore()
@@ -150,42 +151,24 @@ export function useSessionTimeout(deps?: {
 
     extending.value = true
     try {
-      const refreshToken = deps?.refreshToken
-      if (!refreshToken) {
-        // No refresh capability — dynamic import to avoid circular dependency
-        const { authApi } = await import('../api/authApi')
-        const response = await authApi.refreshToken()
-        // The session store will pick up the new token via setSession,
-        // which triggers the watcher and reschedules the warning timer
-        const { useSessionStore: getStore } = await import('../store/sessionStore')
-        const store = getStore()
-        // Use internal setSession logic: update store state with new token
-        store.token = response.token
-        store.expiresAt = new Date(
+      if (deps?.refreshToken) {
+        // Injected refreshToken (used in tests)
+        const response = await deps.refreshToken()
+        session.token = response.token
+        session.expiresAt = new Date(
           (parseJwtPayload(response.token)?.exp ?? 0) * 1000,
         ).toISOString()
-
-        // Persist the new token
-        const tokenStorage = await import('../utils/tokenStorage')
-        tokenStorage.setToken(response.token)
-
-        // Reset warning state for the new token
-        warnedForToken = null
-        dismiss()
-        return
+      } else {
+        // Production path: delegate to the store's centralized refresh action
+        // which calls authApi.refreshToken() and passes the response through
+        // setSession(), updating all session state and persistence correctly.
+        await session.refreshSession()
       }
 
-      // Injected refreshToken (used in tests)
-      const response = await refreshToken()
-      session.token = response.token
-      session.expiresAt = new Date(
-        (parseJwtPayload(response.token)?.exp ?? 0) * 1000,
-      ).toISOString()
       warnedForToken = null
       dismiss()
     } catch {
       // Refresh failed — show a fallback message.
-      // The toast store will be used by the component layer.
       // We keep the warning visible so the user knows to save work.
       const { useToastStore } = await import('../store/toastStore')
       const toast = useToastStore()

--- a/frontend/taskdeck-web/src/store/sessionStore.ts
+++ b/frontend/taskdeck-web/src/store/sessionStore.ts
@@ -238,6 +238,16 @@ export const useSessionStore = defineStore('session', () => {
     }
   }
 
+  /**
+   * Silently refresh the session by calling the backend token refresh endpoint.
+   * Updates all session state and persistence through the canonical `setSession` path.
+   * Throws on failure so callers can handle the error (e.g. show a warning toast).
+   */
+  async function refreshSession(): Promise<void> {
+    const response = await authApi.refreshToken()
+    setSession(response)
+  }
+
   function logout() {
     clearSession()
     toast.info('Logged out')
@@ -268,6 +278,7 @@ export const useSessionStore = defineStore('session', () => {
     changePassword,
     exchangeOAuthCode,
     exchangeOidcCode,
+    refreshSession,
     logout,
     restoreSession,
     clearSession,

--- a/frontend/taskdeck-web/src/tests/composables/useSessionTimeout.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useSessionTimeout.spec.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useSessionStore } from '../../store/sessionStore'
+import { useSessionTimeout, WARNING_BEFORE_EXPIRY_MS } from '../../composables/useSessionTimeout'
+import type { SessionTimeoutState } from '../../composables/useSessionTimeout'
+
+// Mock authApi to prevent real HTTP calls
+vi.mock('../../api/authApi', () => ({
+  authApi: {
+    login: vi.fn(),
+    register: vi.fn(),
+    changePassword: vi.fn(),
+    getProviders: vi.fn(),
+    exchangeOAuthCode: vi.fn(),
+    exchangeOidcCode: vi.fn(),
+    refreshToken: vi.fn(),
+    getLinkedAccounts: vi.fn(),
+    linkGitHub: vi.fn(),
+    unlinkGitHub: vi.fn(),
+    getMfaStatus: vi.fn(),
+    setupMfa: vi.fn(),
+    confirmMfa: vi.fn(),
+    verifyMfa: vi.fn(),
+    disableMfa: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/usersApi', () => ({
+  usersApi: {
+    getUser: vi.fn(),
+  },
+}))
+
+function toBase64Url(value: string): string {
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function fakeJwt(exp: number): string {
+  const header = toBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = toBase64Url(JSON.stringify({ exp }))
+  return `${header}.${payload}.sig`
+}
+
+describe('useSessionTimeout', () => {
+  let session: ReturnType<typeof useSessionStore>
+  let state: SessionTimeoutState
+  let currentTime: number
+
+  function nowFn() {
+    return currentTime
+  }
+
+  function setTokenWithExpiry(secondsFromNow: number) {
+    const exp = Math.floor(currentTime / 1000) + secondsFromNow
+    session.token = fakeJwt(exp)
+    session.expiresAt = new Date(exp * 1000).toISOString()
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    session = useSessionStore()
+    currentTime = Date.now()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    state?.teardown()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('exports WARNING_BEFORE_EXPIRY_MS as 5 minutes', () => {
+    expect(WARNING_BEFORE_EXPIRY_MS).toBe(5 * 60 * 1000)
+  })
+
+  it('does not show warning when unauthenticated', () => {
+    state = useSessionTimeout({ nowFn })
+    expect(state.showWarning.value).toBe(false)
+    expect(state.secondsRemaining.value).toBeNull()
+  })
+
+  it('does not show warning when in demo mode', () => {
+    session.isDemo = true
+    state = useSessionTimeout({ nowFn })
+    expect(state.showWarning.value).toBe(false)
+  })
+
+  it('does not show warning when token expires far in the future', () => {
+    setTokenWithExpiry(3600) // 1 hour from now
+    state = useSessionTimeout({ nowFn })
+    expect(state.showWarning.value).toBe(false)
+    expect(state.secondsRemaining.value).toBeNull()
+  })
+
+  it('shows warning when timer fires at 5 minutes before expiry', () => {
+    setTokenWithExpiry(600) // 10 minutes from now
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(false)
+
+    // Advance to 5 minutes before expiry (5 minutes forward)
+    currentTime += 5 * 60 * 1000
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    expect(state.showWarning.value).toBe(true)
+    expect(state.secondsRemaining.value).toBe(300) // 5 minutes
+  })
+
+  it('shows warning immediately when token is already within warning window', () => {
+    setTokenWithExpiry(180) // 3 minutes from now (< 5 min warning window)
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+    expect(state.secondsRemaining.value).toBe(180)
+  })
+
+  it('counts down seconds remaining', () => {
+    setTokenWithExpiry(180) // 3 minutes from now
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.secondsRemaining.value).toBe(180)
+
+    // Advance 10 seconds
+    currentTime += 10_000
+    vi.advanceTimersByTime(1000)
+
+    expect(state.secondsRemaining.value).toBe(170)
+  })
+
+  it('resets state when countdown reaches zero', () => {
+    setTokenWithExpiry(5) // 5 seconds from now
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+    expect(state.secondsRemaining.value).toBe(5)
+
+    // Advance past expiry
+    currentTime += 6000
+    vi.advanceTimersByTime(1000)
+
+    expect(state.showWarning.value).toBe(false)
+    expect(state.secondsRemaining.value).toBeNull()
+  })
+
+  it('dismiss hides the warning', () => {
+    setTokenWithExpiry(120) // 2 minutes
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+
+    state.dismiss()
+
+    expect(state.showWarning.value).toBe(false)
+    expect(state.secondsRemaining.value).toBeNull()
+  })
+
+  it('does not show warning again for the same token after dismiss', async () => {
+    setTokenWithExpiry(120) // 2 minutes
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+    state.dismiss()
+    expect(state.showWarning.value).toBe(false)
+
+    // Re-setting the same token should not re-trigger
+    const currentToken = session.token
+    session.token = null
+    await nextTick()
+    session.token = currentToken
+    await nextTick()
+
+    expect(state.showWarning.value).toBe(false)
+  })
+
+  it('shows warning for a new token after dismiss of old one', async () => {
+    setTokenWithExpiry(120) // 2 minutes
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+    state.dismiss()
+
+    // Set a different token that's also in warning window
+    const exp2 = Math.floor(currentTime / 1000) + 150
+    session.token = fakeJwt(exp2)
+    session.expiresAt = new Date(exp2 * 1000).toISOString()
+
+    await nextTick()
+
+    expect(state.showWarning.value).toBe(true)
+  })
+
+  it('resets warning when token is cleared (logout)', async () => {
+    setTokenWithExpiry(120)
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+
+    session.token = null
+    await nextTick()
+
+    expect(state.showWarning.value).toBe(false)
+    expect(state.secondsRemaining.value).toBeNull()
+  })
+
+  it('resets when switching to demo mode', async () => {
+    setTokenWithExpiry(120)
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(true)
+
+    session.isDemo = true
+    session.token = null
+    await nextTick()
+
+    expect(state.showWarning.value).toBe(false)
+  })
+
+  it('extend calls refreshToken and dismisses on success', async () => {
+    const newExp = Math.floor(currentTime / 1000) + 3600
+    const newToken = fakeJwt(newExp)
+    const mockRefresh = vi.fn().mockResolvedValue({
+      token: newToken,
+      user: {
+        id: 'user-1',
+        username: 'test',
+        email: 'test@example.com',
+        defaultRole: 0,
+        isActive: true,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    })
+
+    setTokenWithExpiry(120)
+    state = useSessionTimeout({ nowFn, refreshToken: mockRefresh })
+
+    expect(state.showWarning.value).toBe(true)
+
+    await state.extend()
+
+    expect(mockRefresh).toHaveBeenCalledOnce()
+    expect(state.showWarning.value).toBe(false)
+    expect(session.token).toBe(newToken)
+  })
+
+  it('extend shows toast on failure and keeps warning visible', async () => {
+    const mockRefresh = vi.fn().mockRejectedValue(new Error('Network error'))
+
+    setTokenWithExpiry(120)
+    state = useSessionTimeout({ nowFn, refreshToken: mockRefresh })
+
+    expect(state.showWarning.value).toBe(true)
+
+    await state.extend()
+
+    expect(mockRefresh).toHaveBeenCalledOnce()
+    // Warning should remain visible
+    expect(state.showWarning.value).toBe(true)
+  })
+
+  it('extend is idempotent (no double calls while in progress)', async () => {
+    let resolveFn: (value: unknown) => void
+    const mockRefresh = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFn = resolve
+      }),
+    )
+
+    setTokenWithExpiry(120)
+    state = useSessionTimeout({ nowFn, refreshToken: mockRefresh })
+
+    const p1 = state.extend()
+    const p2 = state.extend() // should be a no-op
+
+    expect(state.extending.value).toBe(true)
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+
+    const newExp = Math.floor(currentTime / 1000) + 3600
+    resolveFn!({
+      token: fakeJwt(newExp),
+      user: {
+        id: 'u1',
+        username: 'test',
+        email: 'test@example.com',
+        defaultRole: 0,
+        isActive: true,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    })
+
+    await p1
+    await p2
+
+    expect(state.extending.value).toBe(false)
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show warning for expired tokens', () => {
+    // Token already expired
+    setTokenWithExpiry(-10)
+    state = useSessionTimeout({ nowFn })
+
+    expect(state.showWarning.value).toBe(false)
+  })
+
+  it('teardown clears all state and timers', () => {
+    setTokenWithExpiry(600) // 10 minutes
+    state = useSessionTimeout({ nowFn })
+
+    // Not in warning window yet
+    expect(state.showWarning.value).toBe(false)
+
+    state.teardown()
+
+    // Advance to where warning would have fired
+    currentTime += 5 * 60 * 1000
+    vi.advanceTimersByTime(5 * 60 * 1000)
+
+    // Should not show since teardown was called
+    expect(state.showWarning.value).toBe(false)
+  })
+
+  it('reschedules warning when token changes to a new one', async () => {
+    // First token: 10 min from now
+    setTokenWithExpiry(600)
+    state = useSessionTimeout({ nowFn })
+    expect(state.showWarning.value).toBe(false)
+
+    // Change to a token that's 2 min from now
+    const exp2 = Math.floor(currentTime / 1000) + 120
+    session.token = fakeJwt(exp2)
+    session.expiresAt = new Date(exp2 * 1000).toISOString()
+
+    await nextTick()
+
+    expect(state.showWarning.value).toBe(true)
+    expect(state.secondsRemaining.value).toBe(120)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a `useSessionTimeout` composable that monitors JWT expiry and shows a persistent warning banner 5 minutes before the token expires
- Warning includes a live countdown timer (mm:ss format), "Extend Session" button (attempts `/auth/refresh`, graceful fallback toast on failure), and "Dismiss" button
- Per-token deduplication prevents warning spam after dismissal
- Skips entirely in demo mode and unauthenticated states
- `SessionTimeoutWarning.vue` component wired into `App.vue` for global visibility
- `authApi.refreshToken()` added (backend endpoint not yet implemented; composable handles failure gracefully)

Closes #861

## Test plan

- [x] 19 vitest tests covering all composable logic paths (timer scheduling, countdown, dismiss, dedup, extend success/failure/idempotency, demo mode, logout, teardown, token reschedule)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`) -- 0 new warnings
- [x] Production build passes (`npm run build`)
- [x] Full test suite passes (2571 tests, 211 files)
- [ ] Manual: verify warning appears ~5min before real JWT expiry
- [ ] Manual: verify Extend Session button shows fallback toast (no backend refresh endpoint yet)
- [ ] Manual: verify Dismiss prevents re-show for same session
- [ ] Manual: verify demo mode never shows warning