### PR TITLE
fix: address unresolved bot findings from merged PRs #906, #907, #909

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
@@ -127,6 +127,17 @@ public class MigrationBootstrapTests : IDisposable
         // Assert — no duplicate migration IDs
         allMigrations.Should().OnlyHaveUniqueItems(
             "each migration must have a unique timestamp-based identifier");
+
+        // Assert — no duplicate timestamp prefixes (first 14 digits: YYYYMMDDHHmmss).
+        // Two migrations with the same timestamp but different names would pass the
+        // uniqueness check above but indicate a scaffolding collision.
+        var timestamps = allMigrations
+            .Select(m => m.Split('_')[0])
+            .ToList();
+
+        timestamps.Should().OnlyHaveUniqueItems(
+            "each migration must have a unique timestamp prefix; " +
+            "collisions indicate migrations were scaffolded in the same second");
     }
 
     private List<string> GetUserTables()

--- a/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
@@ -60,11 +60,11 @@ internal sealed class CliTestHarness : IAsyncDisposable
 
         process.Start();
 
-        var stdOut = await process.StandardOutput.ReadToEndAsync(cts.Token);
-        var stdErr = await process.StandardError.ReadToEndAsync(cts.Token);
-
+        string stdOut, stdErr;
         try
         {
+            stdOut = await process.StandardOutput.ReadToEndAsync(cts.Token);
+            stdErr = await process.StandardError.ReadToEndAsync(cts.Token);
             await process.WaitForExitAsync(cts.Token);
         }
         catch (OperationCanceledException)

--- a/frontend/taskdeck-web/src/api/boardsApi.ts
+++ b/frontend/taskdeck-web/src/api/boardsApi.ts
@@ -3,7 +3,7 @@ import type { Board, BoardDetail, CreateBoardDto, UpdateBoardDto, PaginatedBoard
 
 export const boardsApi = {
   async getBoards(search?: string, includeArchived = false): Promise<Board[]> {
-    const result = await boardsApi.getBoardsPaginated(search, includeArchived)
+    const result = await boardsApi.getBoardsPaginated(search, includeArchived, 0, 200)
     return result.items
   },
 

--- a/frontend/taskdeck-web/src/tests/api/boardsApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/boardsApi.spec.ts
@@ -25,7 +25,7 @@ describe('boardsApi', () => {
 
       const result = await boardsApi.getBoards()
 
-      expect(http.get).toHaveBeenCalledWith('/boards?')
+      expect(http.get).toHaveBeenCalledWith('/boards?limit=200')
       expect(result).toEqual(mockBoards)
     })
 
@@ -37,7 +37,7 @@ describe('boardsApi', () => {
 
       const result = await boardsApi.getBoards('test')
 
-      expect(http.get).toHaveBeenCalledWith('/boards?search=test')
+      expect(http.get).toHaveBeenCalledWith('/boards?search=test&limit=200')
       expect(result).toEqual(mockBoards)
     })
 
@@ -48,7 +48,7 @@ describe('boardsApi', () => {
 
       await boardsApi.getBoards(undefined, true)
 
-      expect(http.get).toHaveBeenCalledWith('/boards?includeArchived=true')
+      expect(http.get).toHaveBeenCalledWith('/boards?includeArchived=true&limit=200')
     })
 
     it('should fetch boards with search and includeArchived params', async () => {
@@ -58,7 +58,7 @@ describe('boardsApi', () => {
 
       await boardsApi.getBoards('query', true)
 
-      expect(http.get).toHaveBeenCalledWith('/boards?search=query&includeArchived=true')
+      expect(http.get).toHaveBeenCalledWith('/boards?search=query&includeArchived=true&limit=200')
     })
   })
 


### PR DESCRIPTION
## Summary

Addresses 3 unresolved chatgpt-codex-connector findings from previously merged PRs that were identified during a post-merge audit.

- **PR #906 (CLI tests)**: `CliTestHarness.RunAsync` — the try/catch only wrapped `WaitForExitAsync`, so if `ReadToEndAsync` timed out first, the `OperationCanceledException` escaped without killing the child process. Now wraps all three async calls in a single try/catch that kills the process tree on any timeout.
- **PR #907 (Migration bootstrap)**: `All_migrations_have_distinct_timestamps` test only asserted full migration ID uniqueness. Added a second assertion that extracts timestamp prefixes (first segment before `_`) and checks those are unique too — catches two migrations scaffolded in the same second with different names.
- **PR #909 (Board pagination)**: `boardsApi.getBoards()` called `getBoardsPaginated()` without a limit, defaulting to the backend's `DefaultLimit = 50`. Users with >50 boards would see a silently truncated list. Now passes `limit: 200` (matching backend `MaxLimit`) to fetch all boards.

### Not fixed (acknowledged)
- **PR #907 P1** — Redundant `AddExternalLoginsUserForeignKey` migration: the same FK was already added in `AddTokenInvalidatedAt`. However, this migration is already applied to existing databases and cannot be safely deleted. SQLite handles the duplicate gracefully. Leaving as technical debt.

## Test plan
- [x] `dotnet build backend/Taskdeck.sln -c Release` — 0 errors
- [x] `dotnet test` MigrationBootstrapTests — 5/5 passed
- [x] `dotnet test` Taskdeck.Cli.Tests — 82/82 passed
- [x] `npx vue-tsc --noEmit` — clean