### PR TITLE
fix: wait for input visibility before filling in E2E helpers

### DIFF
--- a/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
@@ -37,7 +37,9 @@ test('home landing and workspace mode preference should persist across navigatio
 async function createBoard(page: Page, boardName: string) {
   await gotoBoardsWorkspace(page)
   await page.getByRole('button', { name: '+ New Board' }).click()
-  await page.getByPlaceholder('Board name').fill(boardName)
+  const boardNameInput = page.getByPlaceholder('Board name')
+  await expect(boardNameInput).toBeVisible()
+  await boardNameInput.fill(boardName)
   await page.getByRole('button', { name: 'Create', exact: true }).click()
   await expect(page).toHaveURL(/\/workspace\/boards\/[a-f0-9-]+$/)
   await expect(page.getByRole('heading', { name: boardName })).toBeVisible()
@@ -75,7 +77,9 @@ function cardDragHandleByTitle(page: Page, cardTitle: string) {
 
 async function addColumn(page: Page, columnName: string) {
   await page.getByRole('button', { name: '+ Add Column' }).click()
-  await page.getByPlaceholder('Column name').fill(columnName)
+  const columnNameInput = page.getByPlaceholder('Column name')
+  await expect(columnNameInput).toBeVisible()
+  await columnNameInput.fill(columnName)
   await page.getByRole('button', { name: 'Create', exact: true }).click()
   await expect(page.getByRole('heading', { name: columnName, exact: true })).toBeVisible()
 }
@@ -171,7 +175,9 @@ test('filter panel shortcut should toggle panel', async ({ page }) => {
   await gotoBoardsWorkspace(page)
 
   await page.getByRole('button', { name: '+ New Board' }).click()
-  await page.getByPlaceholder('Board name').fill(boardName)
+  const boardNameInput = page.getByPlaceholder('Board name')
+  await expect(boardNameInput).toBeVisible()
+  await boardNameInput.fill(boardName)
   await page.getByRole('button', { name: 'Create', exact: true }).click()
   await expect(page).toHaveURL(/\/workspace\/boards\/[a-f0-9-]+$/)
 


### PR DESCRIPTION
## Summary

- Add `await expect(input).toBeVisible()` before `.fill()` in the `addColumn` E2E helper, fixing an intermittent timeout when the column creation form hasn't rendered yet on slow CI runners.
- Apply the same fix to the `createBoard` helper and its inline duplicate for consistency, matching the pattern already used in `addCard`.

## Root cause

The `addColumn` helper clicked `+ Add Column` then immediately called `.fill()` on the `Column name` placeholder. On slow CI runners the form toggle hadn't rendered the input yet, causing Playwright to timeout waiting for the element. A success toast from a previous column creation could also intercept the button click.

## Test plan

- [ ] CI E2E suite passes (the drag-and-drop test at `smoke.spec.ts:300` no longer flakes)
- [ ] `npx vue-tsc --noEmit` passes (verified locally)