### PR TITLE
fix: correct docs drift — ADR numbering, EF Core version, project listings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Its scope applies to the entire repo unless overridden by more specific `AGENTS.
 
 ## Project Structure & Modules
 - Backend (.NET): `backend/Taskdeck.sln` with layered projects under `backend/src`
-  (`Taskdeck.Api`, `Taskdeck.Application`, `Taskdeck.Domain`, `Taskdeck.Infrastructure`).
+  (`Taskdeck.Api`, `Taskdeck.Application`, `Taskdeck.Domain`, `Taskdeck.Infrastructure`, `Taskdeck.Cli`).
 - Backend tests: `backend/tests` with project-per-layer test suites.
 - Frontend (Vue 3 + Vite): `frontend/taskdeck-web` with app source in `src`, static assets in `public`.
 - Docs and planning: Start with `docs/STATUS.md` (source of truth),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ docker compose -f deploy/docker-compose.yml --env-file deploy/.env --profile bas
 - **Taskdeck.Api**: ASP.NET Core HTTP endpoints, integration layer, auth, SignalR hubs. Wires everything up via DI.
 - **Taskdeck.Cli**: CLI entry point (separate from API).
 
-Tests mirror this layout in `backend/tests/` with an additional `Taskdeck.Architecture.Tests` project for structural enforcement.
+Tests mirror this layout in `backend/tests/` (`Domain.Tests`, `Application.Tests`, `Api.Tests`, `Cli.Tests`, `Integration.Tests`, `Architecture.Tests`).
 
 ### Frontend -- `frontend/taskdeck-web/src/`
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -167,7 +167,7 @@ Direction guardrails (explicit):
 ### Backend
 
 - Architecture: Clean Architecture (`Domain`, `Application`, `Infrastructure`, `Api`)
-- Persistence: EF Core 8.0.14 + SQLite (aligned to net8.0 TFM as of `#760`/`#767`)
+- Persistence: EF Core 8.0.26 + SQLite (aligned to net8.0 TFM as of `#760`/`#767`)
 - Core controllers: boards, columns, cards, labels
 - Extended controllers: auth, users, board-access, audit, export/import, external-imports, llm-queue, automation proposals, archive, chat, notifications, ops-cli, logs, health, starter-packs, search, metrics, data-portability, note-import, telemetry, api-keys, forecast, mfa, oidc, integrations
 - Worker runtime:

--- a/docs/decisions/ADR-0024-distributed-caching-cache-aside.md
+++ b/docs/decisions/ADR-0024-distributed-caching-cache-aside.md
@@ -1,4 +1,4 @@
-# ADR-0023: Distributed Caching — Cache-Aside Pattern with Redis
+# ADR-0024: Distributed Caching — Cache-Aside Pattern with Redis
 
 - **Status**: Proposed
 - **Date**: 2026-04-09

--- a/docs/decisions/ADR-0027-cloud-target-topology-autoscaling.md
+++ b/docs/decisions/ADR-0027-cloud-target-topology-autoscaling.md
@@ -1,4 +1,4 @@
-# ADR-0023: Cloud Target Topology and Autoscaling Reference Architecture
+# ADR-0027: Cloud Target Topology and Autoscaling Reference Architecture
 
 - **Status**: Proposed
 - **Date**: 2026-04-09


### PR DESCRIPTION
## Summary

Fixes documentation drift identified by a comprehensive docs accuracy review.

### CRITICAL fixes
- **ADR file numbering collision**: Three files shared the `ADR-0023` prefix. `ADR-0023-distributed-caching-cache-aside.md` renamed to `ADR-0024`, `ADR-0023-cloud-target-topology-autoscaling.md` renamed to `ADR-0027`. Internal heading numbers updated to match. INDEX.md links to these files are now valid.
- **EF Core version**: STATUS.md said 8.0.14, actual csproj versions are 8.0.26.

### MEDIUM fixes
- **AGENTS.md**: Added `Taskdeck.Cli` to the project structure listing (was missing).
- **CLAUDE.md**: Test project enumeration now lists all 6 test projects instead of just `Architecture.Tests`.

### Acknowledged but not fixed in this PR
- STATUS.md mojibake (UTF-8 double-encoding) — needs manual cleanup pass
- Test count estimates in TESTING_GUIDE.md — needs actual test run recertification
- ISSUE_EXECUTION_GUIDE.md issue #326 listed in two stages — needs scope clarification
- Legacy E2E command form in CLAUDE.md/README.md — minor, both forms still work

## Test plan
- [x] No code changes — docs/config only
- [x] ADR file renames verified via `git mv`