### PR TITLE
fix: no-op redundant AddExternalLoginsUserForeignKey migration

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260422183834_AddExternalLoginsUserForeignKey.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260422183834_AddExternalLoginsUserForeignKey.cs
@@ -10,21 +10,18 @@ namespace Taskdeck.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddForeignKey(
-                name: "FK_ExternalLogins_Users_UserId",
-                table: "ExternalLogins",
-                column: "UserId",
-                principalTable: "Users",
-                principalColumn: "Id",
-                onDelete: ReferentialAction.Cascade);
+            // Intentionally empty: FK_ExternalLogins_Users_UserId was already added
+            // in migration 20260402230822_AddTokenInvalidatedAt. This migration is
+            // retained as a no-op because it may already be recorded in
+            // __EFMigrationsHistory on existing databases.
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropForeignKey(
-                name: "FK_ExternalLogins_Users_UserId",
-                table: "ExternalLogins");
+            // Intentionally empty: the FK this migration originally added was already
+            // present from 20260402230822_AddTokenInvalidatedAt, so there is nothing
+            // to reverse here.
         }
     }
 }


### PR DESCRIPTION
## Summary

- No-ops the `20260422183834_AddExternalLoginsUserForeignKey` migration whose `Up`/`Down` bodies redundantly re-added `FK_ExternalLogins_Users_UserId`, which was already added in `20260402230822_AddTokenInvalidatedAt`
- The migration file is retained (not deleted) because it may already be recorded in `__EFMigrationsHistory` on existing databases
- Empty method bodies with explanatory comments replace the redundant `AddForeignKey`/`DropForeignKey` calls

Closes #932

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors
- [x] `dotnet test backend/Taskdeck.sln -c Release -m:1` -- all test suites pass (5 pre-existing env-specific failures in CORS/HSTS/MCP telemetry tests are unrelated)
- [x] Verified only the `.cs` migration file changed; Designer file and model snapshot are untouched
- [x] Confirmed the FK is present in the earlier migration `20260402230822_AddTokenInvalidatedAt.cs` (lines 20-26)