### PR TITLE
feat: implement POST /auth/refresh endpoint for session extension

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -142,6 +142,33 @@ public class AuthController : AuthenticatedControllerBase
     }
 
     /// <summary>
+    /// Refreshes the current JWT token, issuing a new token with a fresh expiry.
+    /// Requires a valid (non-expired) JWT. The caller's identity is derived from
+    /// the current token claims — no request body is needed.
+    /// Rate-limited per user to prevent token farming.
+    /// </summary>
+    /// <returns>Fresh JWT token and user profile.</returns>
+    /// <response code="200">Token refreshed — new JWT returned.</response>
+    /// <response code="401">Not authenticated or token is invalid.</response>
+    /// <response code="403">User account is inactive.</response>
+    /// <response code="429">Rate limit exceeded.</response>
+    [HttpPost("refresh")]
+    [Authorize]
+    [EnableRateLimiting(RateLimitingPolicyNames.TokenRefreshPerUser)]
+    [ProducesResponseType(typeof(AuthResultDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status429TooManyRequests)]
+    public async Task<IActionResult> RefreshToken()
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var result = await _authService.RefreshTokenAsync(callerUserId);
+        return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
+    }
+
+    /// <summary>
     /// Initiates GitHub OAuth login or account-linking flow. Only available when GitHub OAuth is configured.
     /// The flow is determined entirely from server-side state: if the caller is already authenticated
     /// (carries a valid JWT), this starts an account-linking flow bound to their identity; otherwise

--- a/backend/src/Taskdeck.Api/Extensions/RateLimitingRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/RateLimitingRegistration.cs
@@ -86,6 +86,12 @@ public static class RateLimitingRegistration
             var partitionKey = $"mcp-apikey:{ResolveUserOrClientIdentifier(httpContext)}";
             return BuildFixedWindowPartition(partitionKey, settings.McpPerApiKey);
         });
+
+        options.AddPolicy(RateLimitingPolicyNames.TokenRefreshPerUser, httpContext =>
+        {
+            var partitionKey = $"token-refresh-user:{ResolveUserOrClientIdentifier(httpContext)}";
+            return BuildFixedWindowPartition(partitionKey, settings.TokenRefreshPerUser);
+        });
     }
 
     private static RateLimitPartition<string> BuildFixedWindowPartition(string partitionKey, RateLimitPolicySettings policy)

--- a/backend/src/Taskdeck.Api/RateLimiting/RateLimitingPolicyNames.cs
+++ b/backend/src/Taskdeck.Api/RateLimiting/RateLimitingPolicyNames.cs
@@ -7,4 +7,5 @@ public static class RateLimitingPolicyNames
     public const string CaptureWritePerUser = "CaptureWritePerUser";
     public const string NoteImportPerUser = "NoteImportPerUser";
     public const string McpPerApiKey = "McpPerApiKey";
+    public const string TokenRefreshPerUser = "TokenRefreshPerUser";
 }

--- a/backend/src/Taskdeck.Api/Validation/RateLimitingSettingsValidator.cs
+++ b/backend/src/Taskdeck.Api/Validation/RateLimitingSettingsValidator.cs
@@ -25,6 +25,7 @@ public sealed class RateLimitingSettingsValidator : IValidateOptions<RateLimitin
         ValidatePolicy(failures, nameof(options.CaptureWritePerUser), options.CaptureWritePerUser);
         ValidatePolicy(failures, nameof(options.NoteImportPerUser), options.NoteImportPerUser);
         ValidatePolicy(failures, nameof(options.McpPerApiKey), options.McpPerApiKey);
+        ValidatePolicy(failures, nameof(options.TokenRefreshPerUser), options.TokenRefreshPerUser);
 
         return failures.Count > 0
             ? ValidateOptionsResult.Fail(failures)

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -310,9 +310,10 @@ public class AuthenticationService : IAuthenticationService
         {
             return Result.Failure<AuthResultDto>(ex.ErrorCode, ex.Message);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, $"Token refresh failed: {ex.Message}");
+            // Do not expose internal details in error messages
+            return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, "Token refresh failed due to an unexpected error");
         }
     }
 

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -286,6 +286,36 @@ public class AuthenticationService : IAuthenticationService
         }
     }
 
+    public async Task<Result<AuthResultDto>> RefreshTokenAsync(Guid userId)
+    {
+        try
+        {
+            if (!TryValidateJwtSettings(out var jwtValidationError))
+                return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, jwtValidationError);
+
+            if (userId == Guid.Empty)
+                return Result.Failure<AuthResultDto>(ErrorCodes.ValidationError, "User ID is required");
+
+            var user = await _unitOfWork.Users.GetByIdAsync(userId);
+            if (user == null)
+                return Result.Failure<AuthResultDto>(ErrorCodes.Unauthorized, "User not found");
+
+            if (!user.IsActive)
+                return Result.Failure<AuthResultDto>(ErrorCodes.Forbidden, "User account is inactive");
+
+            var token = GenerateJwtToken(user);
+            return Result.Success(new AuthResultDto(token, MapToDto(user)));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<AuthResultDto>(ex.ErrorCode, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<AuthResultDto>(ErrorCodes.UnexpectedError, $"Token refresh failed: {ex.Message}");
+        }
+    }
+
     public async Task<Result> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword)
     {
         try

--- a/backend/src/Taskdeck.Application/Services/IAuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/IAuthenticationService.cs
@@ -16,4 +16,5 @@ public interface IAuthenticationService
     Task<Result<AuthResultDto>> ExternalLoginAsync(ExternalLoginDto dto);
     Task<Result<LinkedAccountDto>> CompleteAccountLinkAsync(Guid userId, string provider, string providerUserId, string? displayName, string? avatarUrl);
     Task<Result> UnlinkExternalLoginAsync(Guid userId, string provider);
+    Task<Result<AuthResultDto>> RefreshTokenAsync(Guid userId);
 }

--- a/backend/src/Taskdeck.Application/Services/RateLimitingSettings.cs
+++ b/backend/src/Taskdeck.Application/Services/RateLimitingSettings.cs
@@ -24,6 +24,13 @@ public sealed class RateLimitingSettings
 
     [Required]
     public RateLimitPolicySettings McpPerApiKey { get; set; } = new(60, 60);
+
+    /// <summary>
+    /// Rate limit for token refresh endpoint. Tight limit to prevent token farming:
+    /// max 5 refreshes per 60 seconds per user.
+    /// </summary>
+    [Required]
+    public RateLimitPolicySettings TokenRefreshPerUser { get; set; } = new(5, 60);
 }
 
 public sealed class RateLimitPolicySettings

--- a/backend/tests/Taskdeck.Api.Tests/AuthRefreshEndpointTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuthRefreshEndpointTests.cs
@@ -1,0 +1,317 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Moq;
+using Taskdeck.Api.Contracts;
+using Taskdeck.Api.Controllers;
+using Taskdeck.Api.RateLimiting;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Tests for the POST /auth/refresh endpoint (#933).
+/// Covers happy path, authentication requirements, inactive user rejection,
+/// and rate limiting.
+/// </summary>
+public class AuthRefreshEndpointTests : IClassFixture<TestWebApplicationFactory>
+{
+    private static readonly JwtSettings DefaultJwtSettings = new()
+    {
+        SecretKey = "TaskdeckTestsOnlySecretKeyMustBeLongEnough123!",
+        Issuer = "TaskdeckTests",
+        Audience = "TaskdeckUsers",
+        ExpirationMinutes = 60
+    };
+
+    private readonly TestWebApplicationFactory _factory;
+
+    public AuthRefreshEndpointTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Integration tests (full HTTP pipeline)
+    // ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Refresh_ShouldReturnNewToken_WhenAuthenticated()
+    {
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "refresh-happy");
+
+        var response = await client.PostAsync("/api/auth/refresh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<AuthResultDto>();
+        result.Should().NotBeNull();
+        result!.Token.Should().NotBeNullOrWhiteSpace();
+        result.Token.Should().NotBe(user.Token, "refresh should issue a new token, not return the same one");
+        result.User.Should().NotBeNull();
+        result.User.Id.Should().Be(user.UserId);
+        result.User.Username.Should().Be(user.Username);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldReturn401_WhenNotAuthenticated()
+    {
+        using var client = _factory.CreateClient();
+        // No authentication header set
+
+        var response = await client.PostAsync("/api/auth/refresh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldReturnSameUserProfile_AsOriginalLogin()
+    {
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "refresh-profile");
+
+        var response = await client.PostAsync("/api/auth/refresh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<AuthResultDto>();
+        result.Should().NotBeNull();
+        result!.User.Id.Should().Be(user.UserId);
+        result.User.Email.Should().Be(user.Email);
+        result.User.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Refresh_NewTokenShouldBeUsableForAuthenticatedRequests()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "refresh-usable");
+
+        var refreshResponse = await client.PostAsync("/api/auth/refresh", null);
+        refreshResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await refreshResponse.Content.ReadFromJsonAsync<AuthResultDto>();
+        result.Should().NotBeNull();
+
+        // Use the new token for a subsequent authenticated request
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", result!.Token);
+
+        // Try accessing an authenticated endpoint with the new token
+        var boardsResponse = await client.GetAsync("/api/boards");
+        boardsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldThrottlePerUser_WhenRateLimited()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("RateLimiting:Enabled", "true");
+            builder.UseSetting("RateLimiting:AuthPerIp:PermitLimit", "200");
+            builder.UseSetting("RateLimiting:AuthPerIp:WindowSeconds", "60");
+            builder.UseSetting("RateLimiting:TokenRefreshPerUser:PermitLimit", "1");
+            builder.UseSetting("RateLimiting:TokenRefreshPerUser:WindowSeconds", "60");
+        });
+        using var client = factory.CreateClient();
+
+        await ApiTestHarness.AuthenticateAsync(client, "refresh-rate");
+
+        // First refresh should succeed
+        var first = await client.PostAsync("/api/auth/refresh", null);
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Update token from first refresh so second request is still authenticated
+        var firstResult = await first.Content.ReadFromJsonAsync<AuthResultDto>();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", firstResult!.Token);
+
+        // Second refresh should be rate-limited
+        var second = await client.PostAsync("/api/auth/refresh", null);
+        second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+
+        second.Headers.TryGetValues("X-RateLimit-Policy", out var policyValues).Should().BeTrue();
+        policyValues.Should().ContainSingle().Which.Should().Be(RateLimitingPolicyNames.TokenRefreshPerUser);
+    }
+
+    [Fact]
+    public async Task Refresh_ShouldNotThrottleDifferentUsers()
+    {
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("RateLimiting:Enabled", "true");
+            builder.UseSetting("RateLimiting:AuthPerIp:PermitLimit", "200");
+            builder.UseSetting("RateLimiting:AuthPerIp:WindowSeconds", "60");
+            builder.UseSetting("RateLimiting:TokenRefreshPerUser:PermitLimit", "1");
+            builder.UseSetting("RateLimiting:TokenRefreshPerUser:WindowSeconds", "60");
+        });
+        using var client1 = factory.CreateClient();
+        using var client2 = factory.CreateClient();
+
+        await ApiTestHarness.AuthenticateAsync(client1, "refresh-user-a");
+        await ApiTestHarness.AuthenticateAsync(client2, "refresh-user-b");
+
+        // User A refreshes (consumes their 1 permit)
+        var response1 = await client1.PostAsync("/api/auth/refresh", null);
+        response1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // User B should still be able to refresh (different rate limit partition)
+        var response2 = await client2.PostAsync("/api/auth/refresh", null);
+        response2.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Unit tests (controller-level, mocked dependencies)
+    // ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RefreshToken_ShouldReturn401_WhenUserContextNotAuthenticated()
+    {
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var userContext = CreateMockUserContext(authenticated: false);
+        var controller = CreateController(authService, userContext.Object, uow.Object);
+
+        var result = await controller.RefreshToken();
+
+        var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        var error = unauthorized.Value.Should().BeOfType<ApiErrorResponse>().Subject;
+        error.ErrorCode.Should().Be(ErrorCodes.AuthenticationFailed);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ShouldReturnNewToken_WhenUserIsActive()
+    {
+        var userId = Guid.NewGuid();
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var userContext = CreateMockUserContext(authenticated: true, userId: userId);
+
+        var testUser = new User("testuser", "test@test.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(testUser, userId);
+
+        var userRepoMock = new Mock<IUserRepository>();
+        userRepoMock.Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testUser);
+        uow.Setup(u => u.Users).Returns(userRepoMock.Object);
+
+        var controller = CreateController(authService, userContext.Object, uow.Object);
+
+        var result = await controller.RefreshToken();
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var authResult = ok.Value.Should().BeOfType<AuthResultDto>().Subject;
+        authResult.Token.Should().NotBeNullOrWhiteSpace();
+        authResult.User.Id.Should().Be(userId);
+        authResult.User.Username.Should().Be("testuser");
+        authResult.User.Email.Should().Be("test@test.com");
+        authResult.User.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RefreshToken_ShouldReturn403_WhenUserIsInactive()
+    {
+        var userId = Guid.NewGuid();
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var userContext = CreateMockUserContext(authenticated: true, userId: userId);
+
+        var testUser = new User("inactiveuser", "inactive@test.com", BCrypt.Net.BCrypt.HashPassword("pass"));
+        SetUserId(testUser, userId);
+        testUser.Deactivate();
+
+        var userRepoMock = new Mock<IUserRepository>();
+        userRepoMock.Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(testUser);
+        uow.Setup(u => u.Users).Returns(userRepoMock.Object);
+
+        var controller = CreateController(authService, userContext.Object, uow.Object);
+
+        var result = await controller.RefreshToken();
+
+        // The service returns Forbidden for inactive users, which maps to 403
+        result.Should().BeAssignableTo<ObjectResult>();
+        var objectResult = (ObjectResult)result;
+        objectResult.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ShouldReturn401_WhenUserNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var (uow, authService) = CreateMockAuthServiceWithUow();
+        var userContext = CreateMockUserContext(authenticated: true, userId: userId);
+
+        var userRepoMock = new Mock<IUserRepository>();
+        userRepoMock.Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        uow.Setup(u => u.Users).Returns(userRepoMock.Object);
+
+        var controller = CreateController(authService, userContext.Object, uow.Object);
+
+        var result = await controller.RefreshToken();
+
+        var unauthorized = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        var error = unauthorized.Value.Should().BeOfType<ApiErrorResponse>().Subject;
+        error.ErrorCode.Should().Be(ErrorCodes.Unauthorized);
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────
+
+    private static AuthController CreateController(
+        AuthenticationService authService,
+        IUserContext userContext,
+        IUnitOfWork unitOfWork)
+    {
+        return new AuthController(
+            authService,
+            new GitHubOAuthSettings(),
+            new OidcSettings(),
+            CreateMockMfaService(),
+            userContext,
+            unitOfWork);
+    }
+
+    private static (Mock<IUnitOfWork> UnitOfWork, AuthenticationService AuthService) CreateMockAuthServiceWithUow()
+    {
+        var unitOfWorkMock = new Mock<IUnitOfWork>();
+        var userRepoMock = new Mock<IUserRepository>();
+        unitOfWorkMock.Setup(u => u.Users).Returns(userRepoMock.Object);
+        unitOfWorkMock.Setup(u => u.ExternalLogins).Returns(new Mock<IExternalLoginRepository>().Object);
+
+        var authService = new AuthenticationService(unitOfWorkMock.Object, DefaultJwtSettings);
+        return (unitOfWorkMock, authService);
+    }
+
+    private static Mock<IUserContext> CreateMockUserContext(bool authenticated = true, Guid? userId = null)
+    {
+        var mock = new Mock<IUserContext>();
+        mock.Setup(u => u.IsAuthenticated).Returns(authenticated);
+        mock.Setup(u => u.UserId).Returns(authenticated ? (userId ?? Guid.NewGuid()).ToString() : null!);
+        return mock;
+    }
+
+    private static MfaService CreateMockMfaService()
+    {
+        var unitOfWorkMock = new Mock<IUnitOfWork>();
+        unitOfWorkMock.Setup(u => u.Users).Returns(new Mock<IUserRepository>().Object);
+        unitOfWorkMock.Setup(u => u.MfaCredentials).Returns(new Mock<IMfaCredentialRepository>().Object);
+        var policySettings = new MfaPolicySettings();
+        return new MfaService(unitOfWorkMock.Object, policySettings);
+    }
+
+    private static void SetUserId(User user, Guid userId)
+    {
+        var idProperty = typeof(Domain.Common.Entity).GetProperty("Id");
+        idProperty!.SetValue(user, userId);
+    }
+}

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -331,6 +331,8 @@ defaults** come from `RateLimitingSettings` constructors; the
 | `RateLimiting:NoteImportPerUser:WindowSeconds` | `int` | `60` | same | Window length in seconds. | No |
 | `RateLimiting:McpPerApiKey:PermitLimit` | `int` | `60` (class default) | same | Per-API-key permits for the MCP HTTP transport. | No |
 | `RateLimiting:McpPerApiKey:WindowSeconds` | `int` | `60` (class default) | same | Window length in seconds. | No |
+| `RateLimiting:TokenRefreshPerUser:PermitLimit` | `int` | `5` (class default) | same | Per-user permits for the token refresh endpoint. Tight limit to prevent token farming. | No |
+| `RateLimiting:TokenRefreshPerUser:WindowSeconds` | `int` | `60` (class default) | same | Window length in seconds. | No |
 
 ## Circuit breaker
 


### PR DESCRIPTION
## Summary

Closes #933

- Adds `POST /api/auth/refresh` endpoint to `AuthController` that accepts the current JWT, validates the user (active status, existence), and issues a new token with a fresh expiry
- Returns the same `AuthResultDto` shape as login/register (token + user profile), matching what the frontend `useSessionTimeout` composable expects
- Adds a dedicated `TokenRefreshPerUser` rate limit policy (5 requests per 60 seconds per user) to prevent token farming, separate from the general `AuthPerIp` policy
- Adds `RefreshTokenAsync` method to `AuthenticationService` with proper error handling for missing/inactive users

## Security considerations

- **Authentication required**: Endpoint is `[Authorize]`-protected -- only valid JWT holders can refresh
- **Token validation**: The existing `TokenValidationMiddleware` already checks `TokenInvalidatedAt` and `IsActive` on every authenticated request, so invalidated/expired tokens are rejected before reaching this endpoint
- **Rate limiting**: Per-user rate limit (5/60s) prevents a compromised token from being used for rapid token farming
- **No request body needed**: User identity is derived from JWT claims only -- no client-supplied user ID

## Test plan

- [x] Happy path: authenticated user gets fresh token (integration + unit)
- [x] Unauthenticated request returns 401 (integration + unit)
- [x] Inactive user returns 403 (unit)
- [x] Deleted/missing user returns 401 (unit)
- [x] New token is usable for subsequent authenticated requests (integration)
- [x] Rate limiting throttles after burst (integration)
- [x] Rate limiting does not cross-pollinate between users (integration)
- [x] Same `AuthResultDto` shape as login/register
- [x] All 4877 existing backend tests still pass