### PR TITLE
fix: UserPreferences UNIQUE constraint race condition in E2E (#931)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/UserPreferenceRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UserPreferenceRepository.cs
@@ -39,8 +39,6 @@ public class UserPreferenceRepository : Repository<UserPreference>, IUserPrefere
             userId,
             defaultPreference.WorkspaceMode.ToString(),
             defaultPreference.OnboardingVisibility.ToString(),
-            (object?)defaultPreference.OnboardingDismissedAt ?? DBNull.Value,
-            (object?)defaultPreference.OnboardingCompletedAt ?? DBNull.Value,
             now,
             now
         ];
@@ -49,7 +47,7 @@ public class UserPreferenceRepository : Repository<UserPreference>, IUserPrefere
             @"INSERT OR IGNORE INTO UserPreferences
               (Id, UserId, WorkspaceMode, OnboardingVisibility,
                OnboardingDismissedAt, OnboardingCompletedAt, CreatedAt, UpdatedAt)
-              VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
+              VALUES ({0}, {1}, {2}, {3}, NULL, NULL, {4}, {5})",
             parameters,
             cancellationToken);
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UserPreferenceRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UserPreferenceRepository.cs
@@ -1,19 +1,13 @@
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
 using Taskdeck.Infrastructure.Persistence;
 
 namespace Taskdeck.Infrastructure.Repositories;
 
 public class UserPreferenceRepository : Repository<UserPreference>, IUserPreferenceRepository
 {
-    private static readonly TimeSpan[] DuplicatePreferenceRetryDelays =
-    [
-        TimeSpan.Zero,
-        TimeSpan.FromMilliseconds(15),
-        TimeSpan.FromMilliseconds(30),
-    ];
-
     public UserPreferenceRepository(TaskdeckDbContext context) : base(context)
     {
     }
@@ -35,71 +29,28 @@ public class UserPreferenceRepository : Repository<UserPreference>, IUserPrefere
         }
 
         var defaultPreference = UserPreference.CreateDefault(userId);
+        var now = defaultPreference.CreatedAt;
 
-        try
-        {
-            await AddAsync(defaultPreference, cancellationToken);
-            await _context.SaveChangesAsync(cancellationToken);
-            return defaultPreference;
-        }
-        catch (DbUpdateException ex)
-        {
-            if (!IsUniqueConstraintViolation(ex))
-            {
-                throw;
-            }
+        // Use INSERT OR IGNORE to atomically skip the insert when a concurrent
+        // request has already created the row, avoiding UNIQUE-constraint
+        // exceptions and the retry loop they previously required.
+        await _context.Database.ExecuteSqlRawAsync(
+            @"INSERT OR IGNORE INTO UserPreferences
+              (Id, UserId, WorkspaceMode, OnboardingVisibility,
+               OnboardingDismissedAt, OnboardingCompletedAt, CreatedAt, UpdatedAt)
+              VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
+            defaultPreference.Id,
+            userId,
+            nameof(WorkspaceMode.Guided),
+            nameof(WorkspaceOnboardingVisibility.Active),
+            (object?)null!,
+            (object?)null!,
+            now,
+            now);
 
-            _context.Entry(defaultPreference).State = EntityState.Detached;
-            var persistedPreference = await WaitForPersistedPreferenceAsync(userId, cancellationToken);
-            if (persistedPreference is not null)
-            {
-                return persistedPreference;
-            }
-
-            throw;
-        }
-    }
-
-    private async Task<UserPreference?> WaitForPersistedPreferenceAsync(
-        Guid userId,
-        CancellationToken cancellationToken)
-    {
-        foreach (var delay in DuplicatePreferenceRetryDelays)
-        {
-            if (delay > TimeSpan.Zero)
-            {
-                await Task.Delay(delay, cancellationToken);
-            }
-
-            var existingPreference = await GetByUserIdAsync(userId, cancellationToken);
-            if (existingPreference is not null)
-            {
-                return existingPreference;
-            }
-        }
-
-        return null;
-    }
-
-    private static bool IsUniqueConstraintViolation(DbUpdateException exception)
-    {
-        Exception? current = exception;
-
-        while (current is not null)
-        {
-            var message = current.Message;
-            if (!string.IsNullOrWhiteSpace(message) &&
-                (message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase) ||
-                 message.Contains("UNIQUE KEY constraint", StringComparison.OrdinalIgnoreCase) ||
-                 message.Contains("duplicate key", StringComparison.OrdinalIgnoreCase) ||
-                 message.Contains("unique constraint", StringComparison.OrdinalIgnoreCase)))
-            {
-                return true;
-            }
-
-            current = current.InnerException;
-        }
-
-        return false;
+        // The row now exists -- either we just inserted it or another request
+        // did. Query it back so EF Core's change tracker is aware of it.
+        var preference = await GetByUserIdAsync(userId, cancellationToken);
+        return preference!;
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UserPreferenceRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UserPreferenceRepository.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
-using Taskdeck.Domain.Enums;
 using Taskdeck.Infrastructure.Persistence;
 
 namespace Taskdeck.Infrastructure.Repositories;
@@ -34,19 +33,25 @@ public class UserPreferenceRepository : Repository<UserPreference>, IUserPrefere
         // Use INSERT OR IGNORE to atomically skip the insert when a concurrent
         // request has already created the row, avoiding UNIQUE-constraint
         // exceptions and the retry loop they previously required.
+        object[] parameters =
+        [
+            defaultPreference.Id,
+            userId,
+            defaultPreference.WorkspaceMode.ToString(),
+            defaultPreference.OnboardingVisibility.ToString(),
+            (object?)defaultPreference.OnboardingDismissedAt ?? DBNull.Value,
+            (object?)defaultPreference.OnboardingCompletedAt ?? DBNull.Value,
+            now,
+            now
+        ];
+
         await _context.Database.ExecuteSqlRawAsync(
             @"INSERT OR IGNORE INTO UserPreferences
               (Id, UserId, WorkspaceMode, OnboardingVisibility,
                OnboardingDismissedAt, OnboardingCompletedAt, CreatedAt, UpdatedAt)
               VALUES ({0}, {1}, {2}, {3}, {4}, {5}, {6}, {7})",
-            defaultPreference.Id,
-            userId,
-            nameof(WorkspaceMode.Guided),
-            nameof(WorkspaceOnboardingVisibility.Active),
-            (object?)null!,
-            (object?)null!,
-            now,
-            now);
+            parameters,
+            cancellationToken);
 
         // The row now exists -- either we just inserted it or another request
         // did. Query it back so EF Core's change tracker is aware of it.

--- a/backend/tests/Taskdeck.Api.Tests/Concurrency/UserPreferenceRaceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Concurrency/UserPreferenceRaceTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Enums;
 using Taskdeck.Infrastructure.Persistence;

--- a/backend/tests/Taskdeck.Api.Tests/Concurrency/UserPreferenceRaceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Concurrency/UserPreferenceRaceTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Persistence;
+using Taskdeck.Infrastructure.Repositories;
+using Xunit;
+
+namespace Taskdeck.Api.Tests.Concurrency;
+
+/// <summary>
+/// Tests that GetOrCreateDefaultByUserIdAsync handles concurrent calls for the
+/// same user without throwing UNIQUE constraint violations. Validates the
+/// INSERT OR IGNORE upsert pattern that replaced the try-catch-retry approach.
+///
+/// See GitHub issue #931.
+/// </summary>
+public class UserPreferenceRaceTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public UserPreferenceRaceTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetOrCreateDefault_FirstCall_CreatesPreferenceWithDefaults()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+
+        var user = new User("pref-create-user", "pref-create@example.com", "hash");
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+
+        var repo = new UserPreferenceRepository(db);
+        var preference = await repo.GetOrCreateDefaultByUserIdAsync(user.Id);
+
+        preference.Should().NotBeNull();
+        preference.UserId.Should().Be(user.Id);
+        preference.WorkspaceMode.Should().Be(WorkspaceMode.Guided);
+        preference.OnboardingVisibility.Should().Be(WorkspaceOnboardingVisibility.Active);
+    }
+
+    [Fact]
+    public async Task GetOrCreateDefault_SubsequentCall_ReturnsSamePreference()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+
+        var user = new User("pref-existing-user", "pref-existing@example.com", "hash");
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+
+        var repo = new UserPreferenceRepository(db);
+        var first = await repo.GetOrCreateDefaultByUserIdAsync(user.Id);
+        var second = await repo.GetOrCreateDefaultByUserIdAsync(user.Id);
+
+        second.Id.Should().Be(first.Id);
+        second.UserId.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task GetOrCreateDefault_ConcurrentCalls_NoExceptionsAndSamePreference()
+    {
+        // Create a user that all concurrent calls will target
+        Guid userId;
+        using (var setupScope = _factory.Services.CreateScope())
+        {
+            var setupDb = setupScope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+            var user = new User("pref-race-user", "pref-race@example.com", "hash");
+            setupDb.Users.Add(user);
+            await setupDb.SaveChangesAsync();
+            userId = user.Id;
+        }
+
+        const int concurrency = 10;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var tasks = Enumerable.Range(0, concurrency).Select(async _ =>
+        {
+            // Each concurrent call gets its own scope and DbContext to simulate
+            // independent requests hitting the repository simultaneously.
+            using var scope = _factory.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+            var repo = new UserPreferenceRepository(db);
+
+            // Wait at the gate so all tasks start ~simultaneously
+            await gate.Task;
+
+            return await repo.GetOrCreateDefaultByUserIdAsync(userId);
+        }).ToArray();
+
+        // Release all tasks at once
+        gate.SetResult();
+
+        // All should complete without throwing
+        var results = await Task.WhenAll(tasks);
+
+        // All should return a valid preference for this user
+        results.Should().AllSatisfy(pref =>
+        {
+            pref.Should().NotBeNull();
+            pref.UserId.Should().Be(userId);
+            pref.WorkspaceMode.Should().Be(WorkspaceMode.Guided);
+        });
+
+        // Verify only one row was created in the database
+        using var verifyScope = _factory.Services.CreateScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var count = await verifyDb.UserPreferences
+            .CountAsync(p => p.UserId == userId);
+        count.Should().Be(1, "exactly one preference row should exist for the user");
+    }
+
+    [Fact]
+    public async Task GetOrCreateDefault_ExistingPreference_ReturnsExistingNotNew()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+
+        var user = new User("pref-preexist-user", "pref-preexist@example.com", "hash");
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+
+        // Pre-create a preference with non-default mode
+        var existing = UserPreference.CreateDefault(user.Id);
+        existing.UpdateWorkspaceMode(WorkspaceMode.Workbench);
+        db.UserPreferences.Add(existing);
+        await db.SaveChangesAsync();
+
+        var repo = new UserPreferenceRepository(db);
+        var result = await repo.GetOrCreateDefaultByUserIdAsync(user.Id);
+
+        // Should return the existing preference, not create a new one
+        result.Id.Should().Be(existing.Id);
+        result.WorkspaceMode.Should().Be(WorkspaceMode.Workbench);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the try-catch-retry pattern in `UserPreferenceRepository.GetOrCreateDefaultByUserIdAsync` with SQLite `INSERT OR IGNORE` to atomically handle concurrent default preference creation
- Eliminates 20+ `UNIQUE constraint failed: UserPreferences.UserId` log errors per E2E CI run
- Removes the `WaitForPersistedPreferenceAsync` retry-with-delay mechanism (up to 45ms latency) and the `IsUniqueConstraintViolation` exception inspector, reducing the file from 105 lines to 51

## Approach

Instead of inserting via EF Core's change tracker (which throws on duplicate), the fix uses `ExecuteSqlRawAsync` with `INSERT OR IGNORE INTO UserPreferences ...` to atomically skip the insert when the row already exists. A subsequent `SELECT` via EF Core loads the tracked entity regardless of whether this request or a concurrent one created it.

## Test plan

- [x] New test: first call creates preference with correct default values (`Guided`, `Active`)
- [x] New test: subsequent call returns same preference (idempotency)
- [x] New test: 10 concurrent calls via `TaskCompletionSource` gate all succeed without exceptions and produce exactly one database row
- [x] New test: pre-existing preference with modified mode is returned unchanged (no overwrite)
- [x] Full backend test suite passes (5 pre-existing failures in unrelated tests)

Closes #931