### PR TITLE
fix: resolve 5 pre-existing CI test failures in API Integration

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/CorsApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CorsApiTests.cs
@@ -96,6 +96,7 @@ public class CorsApiTests : IClassFixture<TestWebApplicationFactory>
         {
             builder.UseEnvironment("Production");
             builder.UseSetting("Jwt:SecretKey", ApiTestHarness.ProductionTestJwtSecret);
+            builder.UseSetting("Connectors:EncryptionKey", ApiTestHarness.TestEncryptionKey);
             builder.UseSetting("Cors:DevelopmentAllowedOrigins:0", alternateOrigin);
         });
         using var client = factory.CreateClient();
@@ -155,6 +156,7 @@ public class CorsApiTests : IClassFixture<TestWebApplicationFactory>
         {
             builder.UseEnvironment("Production");
             builder.UseSetting("Jwt:SecretKey", ApiTestHarness.ProductionTestJwtSecret);
+            builder.UseSetting("Connectors:EncryptionKey", ApiTestHarness.TestEncryptionKey);
         });
         using var client = factory.CreateClient();
 

--- a/backend/tests/Taskdeck.Api.Tests/McpTelemetryMiddlewareTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpTelemetryMiddlewareTests.cs
@@ -65,7 +65,7 @@ public class McpTelemetryMiddlewareTests
 
         await middleware.InvokeAsync(context);
 
-        _logger.Entries[0].Message.Should().Contain(userId.ToString());
+        _logger.Entries[1].Message.Should().Contain(userId.ToString());
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/SecurityHeadersApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SecurityHeadersApiTests.cs
@@ -69,6 +69,7 @@ public class SecurityHeadersApiTests : IClassFixture<TestWebApplicationFactory>
         {
             builder.UseEnvironment("Production");
             builder.UseSetting("Jwt:SecretKey", ApiTestHarness.ProductionTestJwtSecret);
+            builder.UseSetting("Connectors:EncryptionKey", ApiTestHarness.TestEncryptionKey);
         });
         using var client = factory.CreateClient(new WebApplicationFactoryClientOptions
         {

--- a/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
@@ -27,6 +27,14 @@ public static class ApiTestHarness
     public const string ProductionTestJwtSecret =
         "VGVzdE9ubHlKd3RTZWNyZXRGb3JQcm9kdWN0aW9uTW9kZVRlc3Rz";
 
+    /// <summary>
+    /// Test-only 256-bit encryption key for tests that switch to Production mode.
+    /// Production mode validates <c>Connectors:EncryptionKey</c> is present
+    /// (the Development.json fallback is not loaded in Production).
+    /// </summary>
+    public const string TestEncryptionKey =
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
     public static async Task<TestUserContext> AuthenticateAsync(HttpClient client, string stem)
     {
         var suffix = Guid.NewGuid().ToString("N")[..8];


### PR DESCRIPTION
## Summary
- Fixes 5 pre-existing test failures in the API Integration CI lane that affected all PRs
- **Root cause 1** (4 tests): Production-mode tests didn't receive `Connectors:EncryptionKey` because `appsettings.Development.json` isn't loaded in Production. Added `UseSetting` with the test key, matching the existing `Jwt:SecretKey` pattern.
- **Root cause 2** (1 test): `McpTelemetryMiddlewareTests.IncludesUserId` asserted against `Entries[0]` (started log, always `null`) instead of `Entries[1]` (completed log, where userId is captured after auth middleware runs).

## Test plan
- [x] All 25 CORS/Security/MCP tests pass locally (0 failures)
- [ ] CI API Integration lane passes on both ubuntu and windows