### PR TITLE
FE-19: mobile-responsive board, toolbar, and dialog

### DIFF
--- a/frontend/taskdeck-web/src/components/board/BoardActionRail.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardActionRail.vue
@@ -94,4 +94,20 @@ defineEmits<{
   font-size: var(--td-font-sm);
   color: var(--td-text-tertiary);
 }
+
+/* ── Mobile: 44px tap targets, full-width primary ── */
+@media (max-width: 640px) {
+  .td-action-rail {
+    padding: var(--td-space-3) var(--td-space-4);
+  }
+
+  .td-action-rail__btn {
+    min-height: 44px;
+    flex: 1 1 calc(50% - var(--td-space-2));
+  }
+
+  .td-action-rail__btn--primary {
+    flex: 1 1 100%;
+  }
+}
 </style>

--- a/frontend/taskdeck-web/src/components/board/BoardCanvas.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardCanvas.vue
@@ -106,7 +106,7 @@ defineEmits<{
     /* On mobile the board becomes a vertical list; allow the page to scroll
      * vertically instead of trapping it inside a fixed-height horizontal
      * scroller. */
-    overflow-x: hidden;
+    overflow-x: clip;
     overflow-y: visible;
   }
 

--- a/frontend/taskdeck-web/src/components/board/BoardCanvas.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardCanvas.vue
@@ -99,6 +99,28 @@ defineEmits<{
   min-height: 100%;
 }
 
+/* ── Mobile: vertical stack, full-width lanes ── */
+@media (max-width: 640px) {
+  .td-board-canvas {
+    height: auto;
+    /* On mobile the board becomes a vertical list; allow the page to scroll
+     * vertically instead of trapping it inside a fixed-height horizontal
+     * scroller. */
+    overflow-x: hidden;
+    overflow-y: visible;
+  }
+
+  .td-board-canvas__lanes {
+    flex-direction: column;
+    gap: var(--td-space-4);
+    padding: var(--td-space-4);
+  }
+
+  .td-board-canvas__empty {
+    padding: var(--td-space-8) var(--td-space-4);
+  }
+}
+
 .td-board-canvas__empty {
   flex: 1;
   display: flex;

--- a/frontend/taskdeck-web/src/components/board/BoardToolbar.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardToolbar.vue
@@ -340,4 +340,41 @@ defineEmits<{
   outline: none;
   box-shadow: var(--td-focus-ring);
 }
+
+/* ── Mobile: wrap controls, drop title scale, enforce 44px tap targets ── */
+@media (max-width: 640px) {
+  .td-board-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--td-space-3);
+  }
+
+  .td-board-toolbar__left {
+    gap: var(--td-space-3);
+  }
+
+  .td-board-toolbar__title {
+    font-size: var(--td-font-xl);
+  }
+
+  .td-board-toolbar__actions {
+    flex-wrap: wrap;
+    gap: var(--td-space-2);
+  }
+
+  .td-board-toolbar__icon-btn,
+  .td-board-toolbar__text-btn,
+  .td-board-toolbar__primary-btn,
+  .td-board-toolbar__back-btn {
+    min-height: 44px;
+  }
+
+  .td-board-toolbar__icon-btn {
+    min-width: 44px;
+  }
+
+  .td-board-toolbar__primary-btn {
+    flex: 1 1 100%;
+  }
+}
 </style>

--- a/frontend/taskdeck-web/src/components/board/BoardToolbar.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardToolbar.vue
@@ -369,8 +369,12 @@ defineEmits<{
     min-height: 44px;
   }
 
-  .td-board-toolbar__icon-btn {
+  .td-board-toolbar__icon-btn,
+  .td-board-toolbar__back-btn {
     min-width: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .td-board-toolbar__primary-btn {

--- a/frontend/taskdeck-web/src/components/board/ColumnLane.vue
+++ b/frontend/taskdeck-web/src/components/board/ColumnLane.vue
@@ -582,8 +582,9 @@ function handleCardDragOver(event: DragEvent) {
   }
 
   .td-column-lane__card-input {
-    /* Prevent iOS zoom on focus: font-size >= 16px. */
-    font-size: 16px;
+    /* Prevent iOS zoom on focus: font-size >= 16px. --td-font-lg is 1rem
+     * (16px), so we reuse the design token instead of hardcoding. */
+    font-size: var(--td-font-lg);
   }
 }
 </style>

--- a/frontend/taskdeck-web/src/components/board/ColumnLane.vue
+++ b/frontend/taskdeck-web/src/components/board/ColumnLane.vue
@@ -551,4 +551,39 @@ function handleCardDragOver(event: DragEvent) {
   font-size: var(--td-font-sm);
   color: var(--td-text-tertiary);
 }
+
+/* ── Mobile: full-width lanes, relaxed heights, larger tap targets ── */
+@media (max-width: 640px) {
+  .td-column-lane {
+    /* Drop the fixed 16rem width — on mobile lanes are full-width in a
+     * vertical stack (see BoardCanvas media query). */
+    min-width: 0;
+    max-width: none;
+    flex: 1 1 auto;
+    width: 100%;
+    padding: var(--td-space-4);
+  }
+
+  .td-column-lane__cards {
+    /* The column canvas already scrolls the page; let the list size to
+     * content so users don't hit nested-scroll traps on touch. */
+    max-height: none;
+    min-height: 0;
+  }
+
+  .td-column-lane__icon-btn,
+  .td-column-lane__add-card-btn {
+    min-height: 44px;
+  }
+
+  .td-column-lane__form-btn {
+    min-height: 44px;
+    flex: 1;
+  }
+
+  .td-column-lane__card-input {
+    /* Prevent iOS zoom on focus: font-size >= 16px. */
+    font-size: 16px;
+  }
+}
 </style>

--- a/frontend/taskdeck-web/src/components/ui/TdDialog.vue
+++ b/frontend/taskdeck-web/src/components/ui/TdDialog.vue
@@ -261,7 +261,7 @@ onUnmounted(() => {
     gap: var(--td-space-2);
   }
 
-  .td-dialog__footer > * {
+  .td-dialog__footer :deep(> *) {
     width: 100%;
     min-height: 44px;
   }

--- a/frontend/taskdeck-web/src/components/ui/TdDialog.vue
+++ b/frontend/taskdeck-web/src/components/ui/TdDialog.vue
@@ -233,13 +233,20 @@ onUnmounted(() => {
   .td-dialog {
     width: 100%;
     max-width: 100%;
+    /* vh fallback for iOS Safari <= 15.4 which doesn't support dvh; dvh
+     * handles browser chrome collapse so the close/footer stays reachable
+     * even when the URL bar is visible. */
     max-height: 100vh;
-    /* dvh handles iOS browser chrome collapse so the close/footer stays
-     * reachable even when the URL bar is visible. */
+    height: 100vh;
     max-height: 100dvh;
     height: 100dvh;
     border-radius: 0;
-    padding: var(--td-space-4);
+    /* Respect iOS safe-area insets so footer actions don't sit under the
+     * home indicator and the header doesn't collide with the notch. */
+    padding: max(var(--td-space-4), env(safe-area-inset-top))
+      max(var(--td-space-4), env(safe-area-inset-right))
+      max(var(--td-space-4), env(safe-area-inset-bottom))
+      max(var(--td-space-4), env(safe-area-inset-left));
   }
 
   .td-dialog__footer {

--- a/frontend/taskdeck-web/src/components/ui/TdDialog.vue
+++ b/frontend/taskdeck-web/src/components/ui/TdDialog.vue
@@ -250,8 +250,14 @@ onUnmounted(() => {
   }
 
   .td-dialog__footer {
-    /* Stack footer actions and keep tap targets at 44px. */
-    flex-direction: column-reverse;
+    /* Stack footer actions and keep tap targets at 44px.
+     *
+     * Use `column` (not `column-reverse`) so the visual order matches the
+     * DOM/tab order (WCAG 2.4.3 Focus Order). Slots emit secondary-then-
+     * primary actions (e.g. [Cancel, Delete]); `column-reverse` would show
+     * the primary on top but keyboard focus would still start on the
+     * secondary below it, confusing assistive tech users. */
+    flex-direction: column;
     gap: var(--td-space-2);
   }
 

--- a/frontend/taskdeck-web/src/components/ui/TdDialog.vue
+++ b/frontend/taskdeck-web/src/components/ui/TdDialog.vue
@@ -222,4 +222,35 @@ onUnmounted(() => {
 .td-dialog-leave-to .td-dialog {
   transform: scale(0.95) translateY(8px);
 }
+
+/* ── Mobile: full-screen dialog ── */
+@media (max-width: 640px) {
+  .td-dialog-backdrop {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .td-dialog {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100vh;
+    /* dvh handles iOS browser chrome collapse so the close/footer stays
+     * reachable even when the URL bar is visible. */
+    max-height: 100dvh;
+    height: 100dvh;
+    border-radius: 0;
+    padding: var(--td-space-4);
+  }
+
+  .td-dialog__footer {
+    /* Stack footer actions and keep tap targets at 44px. */
+    flex-direction: column-reverse;
+    gap: var(--td-space-2);
+  }
+
+  .td-dialog__footer > * {
+    width: 100%;
+    min-height: 44px;
+  }
+}
 </style>

--- a/frontend/taskdeck-web/tests/e2e/mobile-responsive.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/mobile-responsive.spec.ts
@@ -133,6 +133,47 @@ test('@mobile workspace views should render correctly on small screen', async ({
   expect(bodyBox!.width).toBeLessThanOrEqual(viewportSize!.width + 20)
 })
 
+test('@mobile board columns stack vertically without horizontal overflow', async ({ page }) => {
+  // FE-19: On mobile the board must switch from a horizontal kanban to a
+  // vertical card list so core navigation remains usable at ~375-412px.
+  const boardName = `Stack Board ${Date.now()}`
+  const firstColumn = `Backlog ${Date.now()}`
+  const secondColumn = `Doing ${Date.now()}`
+
+  await createBoard(page, boardName)
+  await addColumn(page, firstColumn)
+  await addColumn(page, secondColumn)
+
+  const firstLane = page
+    .locator('[data-column-id]')
+    .filter({ has: page.getByRole('heading', { name: firstColumn, exact: true }) })
+    .first()
+  const secondLane = page
+    .locator('[data-column-id]')
+    .filter({ has: page.getByRole('heading', { name: secondColumn, exact: true }) })
+    .first()
+
+  const firstBox = await firstLane.boundingBox()
+  const secondBox = await secondLane.boundingBox()
+  expect(firstBox).not.toBeNull()
+  expect(secondBox).not.toBeNull()
+
+  // Vertical stack: the second column sits below the first, not beside it.
+  expect(secondBox!.y).toBeGreaterThanOrEqual(firstBox!.y + firstBox!.height - 4)
+
+  // Each lane must fit entirely inside the viewport — no horizontal scroll.
+  const viewportSize = page.viewportSize()
+  expect(viewportSize).not.toBeNull()
+  expect(firstBox!.x + firstBox!.width).toBeLessThanOrEqual(viewportSize!.width + 2)
+  expect(secondBox!.x + secondBox!.width).toBeLessThanOrEqual(viewportSize!.width + 2)
+
+  // Document scroll width must not exceed viewport — confirms no horizontal overflow.
+  const scrollOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  )
+  expect(scrollOverflow).toBeLessThanOrEqual(2)
+})
+
 test('@mobile capture modal should be usable on small screen', async ({ page }) => {
   await page.goto('/workspace/home')
   await expect(page.getByRole('heading', { name: 'Home', exact: true })).toBeVisible()


### PR DESCRIPTION
Closes #860 (partially — see Deferred below).

## Summary
- Board view now stacks columns vertically on ≤640px viewports, removing the fixed 16rem column width and horizontal-only scroll that made the kanban unusable on phones.
- `TdDialog` (shared primitive powering CardModal, BoardSettingsModal, LabelManager, StarterPackCatalog, KeyboardHelp) becomes full-bleed at ≤640px with `100dvh` height and stacked footer actions.
- Board toolbar + action rail enforce 44×44px tap targets on mobile; primary actions span the row.
- New `@mobile` Playwright test asserts vertical-stack layout and zero horizontal document overflow on a two-column board.

## Surfaces covered
- `components/board/BoardCanvas.vue` — vertical lanes, page-level scroll on mobile
- `components/board/ColumnLane.vue` — full-width lanes, 16px input font to avoid iOS zoom, 44px buttons
- `components/board/BoardToolbar.vue` — wrap actions, 44px tap targets, full-row primary
- `components/board/BoardActionRail.vue` — 2-up wrap grid, 44px buttons, full-width primary
- `components/ui/TdDialog.vue` — full-screen dialog on mobile (cascades to all TdDialog consumers)

## Already in place (no change needed)
- `ShellSidebar` + `AppShell` already ship a hamburger/off-canvas drawer with 44px nav items.
- `CaptureModal` already had dedicated mobile styling.
- Tailwind default breakpoints (`sm:640 / md:768 / lg:1024`) already match the acceptance criteria.

## Deferred (follow-up)
The issue is sized at L (16h); this PR focuses on the highest-leverage board + dialog fixes. Out of scope for this slice:
- Mobile pass on secondary views (Review, AutomationChat, Calendar, Metrics, Ops). Most already have some responsive work; a dedicated follow-up should sweep the remaining scatter.
- Tablet (640–1024px) refinements — the kanban still renders horizontally at 768px which is usable but not optimized.
- Touch-optimized drag-and-drop between stacked columns (the existing \"Move to…\" menu in `CardItem` is still the recommended path on mobile).

Recommend filing a follow-up: \"FE-19 follow-up: tablet + secondary-view mobile polish\".

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 6 pre-existing warnings, 0 new (limit 20)
- [x] `npx vitest --run` — 2607 passed
- [ ] `@mobile` Playwright project (Pixel 7 + iPhone 14) — run in CI / nightly
- [ ] Manual verification on iPhone SE (375×667) via devtools responsive mode

## Adversarial notes
- Used `100dvh` (dynamic viewport units) in TdDialog so footer doesn't hide under collapsing iOS Safari chrome; paired with `100vh` fallback.
- All mobile CSS scoped under `@media (max-width: 640px)` so desktop ≥641px is untouched.
- No inline `style=` bindings added (respecting #855).