### PR TITLE
Remove unused FluentValidation dependency from Application project

### DIFF
--- a/backend/src/Taskdeck.Application/Taskdeck.Application.csproj
+++ b/backend/src/Taskdeck.Application/Taskdeck.Application.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-    <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />


### PR DESCRIPTION
## Summary
- Remove the unused `FluentValidation` (v12.1.1) PackageReference from `Taskdeck.Application.csproj`
- No source files in the backend import `FluentValidation` namespaces, so the package was dead weight

Fixes #950

## Test plan
- [x] Grep confirms zero `using FluentValidation` imports across all backend `.cs` files
- [x] `dotnet build backend/Taskdeck.sln -c Release` succeeds with 0 errors
- [x] `dotnet test backend/Taskdeck.sln -c Release -m:1` passes all tests (0 failures)