### PR TITLE
Deduplicate MCP mode DI registration in Program.cs

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/McpApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/McpApplicationServiceRegistration.cs
@@ -1,0 +1,43 @@
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Extensions;
+
+/// <summary>
+/// Registers the minimal subset of Application services required by MCP
+/// resources and tools. Both MCP stdio and MCP HTTP standalone modes call
+/// this instead of the full <see cref="ApplicationServiceRegistration.AddApplicationServices"/>
+/// which includes web-only services (SignalR notifiers, workers, LLM providers, etc.).
+/// </summary>
+public static class McpApplicationServiceRegistration
+{
+    /// <summary>
+    /// Register the Application services that MCP resources and tools depend on.
+    /// Deliberately skips web-only services (SignalR notifiers, workers,
+    /// LLM providers, rate limiting, etc.) to keep the MCP host minimal.
+    /// </summary>
+    public static IServiceCollection AddMcpApplicationServices(this IServiceCollection services)
+    {
+        services.AddScoped<AuthorizationService>();
+        services.AddScoped<IAuthorizationService>(
+            sp => sp.GetRequiredService<AuthorizationService>());
+        services.AddScoped<BoardService>(sp =>
+            new BoardService(
+                sp.GetRequiredService<IUnitOfWork>(),
+                sp.GetRequiredService<IAuthorizationService>()));
+        services.AddScoped<ColumnService>();
+        services.AddScoped<CardService>();
+        services.AddScoped<LabelService>();
+        services.AddScoped<AutomationProposalService>();
+        services.AddScoped<IAutomationProposalService>(
+            sp => sp.GetRequiredService<AutomationProposalService>());
+        services.AddScoped<CaptureService>();
+        services.AddScoped<ICaptureService>(
+            sp => sp.GetRequiredService<CaptureService>());
+        services.AddScoped<NotificationService>();
+        services.AddScoped<INotificationService>(
+            sp => sp.GetRequiredService<NotificationService>());
+
+        return services;
+    }
+}

--- a/backend/src/Taskdeck.Api/Extensions/McpResourcesAndToolsRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/McpResourcesAndToolsRegistration.cs
@@ -1,0 +1,27 @@
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Server;
+using Taskdeck.Api.Mcp;
+
+namespace Taskdeck.Api.Extensions;
+
+/// <summary>
+/// Registers the shared set of MCP resources and tools used by all three
+/// hosting modes (co-hosted web, standalone HTTP, and stdio).
+/// </summary>
+public static class McpResourcesAndToolsRegistration
+{
+    /// <summary>
+    /// Add MCP resources (Board, Capture, Proposal) and tools (Read, Write, Proposal)
+    /// to the given MCP server builder.
+    /// </summary>
+    public static IMcpServerBuilder AddMcpResourcesAndTools(this IMcpServerBuilder builder)
+    {
+        return builder
+            .WithResources<BoardResources>()
+            .WithResources<CaptureResources>()
+            .WithResources<ProposalResources>()
+            .WithTools<ReadTools>()
+            .WithTools<WriteTools>()
+            .WithTools<ProposalTools>();
+    }
+}

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -69,26 +69,8 @@ if (args.Contains("--mcp"))
         // Infrastructure (DbContext, Repositories, UoW)
         mcpHttpBuilder.Services.AddInfrastructure(mcpHttpBuilder.Configuration);
 
-        // Register Application services needed by MCP resources and tools.
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.AuthorizationService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.IAuthorizationService>(
-            sp => sp.GetRequiredService<Taskdeck.Application.Services.AuthorizationService>());
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.BoardService>(sp =>
-            new Taskdeck.Application.Services.BoardService(
-                sp.GetRequiredService<IUnitOfWork>(),
-                sp.GetRequiredService<Taskdeck.Application.Services.IAuthorizationService>()));
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.ColumnService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.CardService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.LabelService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.AutomationProposalService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.IAutomationProposalService>(
-            sp => sp.GetRequiredService<Taskdeck.Application.Services.AutomationProposalService>());
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.CaptureService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.ICaptureService>(
-            sp => sp.GetRequiredService<Taskdeck.Application.Services.CaptureService>());
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.NotificationService>();
-        mcpHttpBuilder.Services.AddScoped<Taskdeck.Application.Services.INotificationService>(
-            sp => sp.GetRequiredService<Taskdeck.Application.Services.NotificationService>());
+        // Application services needed by MCP resources and tools (shared with stdio mode).
+        mcpHttpBuilder.Services.AddMcpApplicationServices();
 
         // HTTP identity: maps API key to user via HttpUserContextProvider.
         mcpHttpBuilder.Services.AddHttpContextAccessor();
@@ -119,12 +101,7 @@ if (args.Contains("--mcp"))
         // MCP server: HTTP transport + all resources and tools.
         mcpHttpBuilder.Services.AddMcpServer()
             .WithHttpTransport()
-            .WithResources<BoardResources>()
-            .WithResources<CaptureResources>()
-            .WithResources<ProposalResources>()
-            .WithTools<ReadTools>()
-            .WithTools<WriteTools>()
-            .WithTools<ProposalTools>();
+            .AddMcpResourcesAndTools();
 
         var mcpHttpApp = mcpHttpBuilder.Build();
 
@@ -189,28 +166,8 @@ if (args.Contains("--mcp"))
             // Infrastructure (DbContext, Repositories, UoW)
             services.AddInfrastructure(ctx.Configuration);
 
-            // Register Application services needed by MCP resources and tools.
-            // We deliberately skip web-only services (SignalR notifiers, workers,
-            // LLM providers, rate limiting, etc.) to keep the MCP host minimal.
-            services.AddScoped<Taskdeck.Application.Services.AuthorizationService>();
-            services.AddScoped<Taskdeck.Application.Services.IAuthorizationService>(
-                sp => sp.GetRequiredService<Taskdeck.Application.Services.AuthorizationService>());
-            services.AddScoped<Taskdeck.Application.Services.BoardService>(sp =>
-                new Taskdeck.Application.Services.BoardService(
-                    sp.GetRequiredService<IUnitOfWork>(),
-                    sp.GetRequiredService<Taskdeck.Application.Services.IAuthorizationService>()));
-            services.AddScoped<Taskdeck.Application.Services.ColumnService>();
-            services.AddScoped<Taskdeck.Application.Services.CardService>();
-            services.AddScoped<Taskdeck.Application.Services.LabelService>();
-            services.AddScoped<Taskdeck.Application.Services.AutomationProposalService>();
-            services.AddScoped<Taskdeck.Application.Services.IAutomationProposalService>(
-                sp => sp.GetRequiredService<Taskdeck.Application.Services.AutomationProposalService>());
-            services.AddScoped<Taskdeck.Application.Services.CaptureService>();
-            services.AddScoped<Taskdeck.Application.Services.ICaptureService>(
-                sp => sp.GetRequiredService<Taskdeck.Application.Services.CaptureService>());
-            services.AddScoped<Taskdeck.Application.Services.NotificationService>();
-            services.AddScoped<Taskdeck.Application.Services.INotificationService>(
-                sp => sp.GetRequiredService<Taskdeck.Application.Services.NotificationService>());
+            // Application services needed by MCP resources and tools (shared with HTTP mode).
+            services.AddMcpApplicationServices();
 
             // Stdio identity: maps the OS process owner to the local default user.
             services.AddScoped<IUserContextProvider, StdioUserContextProvider>();
@@ -221,12 +178,7 @@ if (args.Contains("--mcp"))
             // MCP server: stdio transport + all resources and tools.
             services.AddMcpServer()
                 .WithStdioServerTransport()
-                .WithResources<BoardResources>()
-                .WithResources<CaptureResources>()
-                .WithResources<ProposalResources>()
-                .WithTools<ReadTools>()
-                .WithTools<WriteTools>()
-                .WithTools<ProposalTools>();
+                .AddMcpResourcesAndTools();
         })
         .Build();
 
@@ -357,12 +309,7 @@ builder.Services.AddScoped<IUserContextProvider, Taskdeck.Infrastructure.Mcp.Htt
 builder.Services.AddMcpTelemetry();
 builder.Services.AddMcpServer()
     .WithHttpTransport()
-    .WithResources<BoardResources>()
-    .WithResources<CaptureResources>()
-    .WithResources<ProposalResources>()
-    .WithTools<ReadTools>()
-    .WithTools<WriteTools>()
-    .WithTools<ProposalTools>();
+    .AddMcpResourcesAndTools();
 
 // Add JWT Authentication (with optional GitHub OAuth and OIDC providers, circuit-breaker-protected backchannel)
 // CircuitBreakerStateTracker is already registered as a singleton by AddLlmProviders above.


### PR DESCRIPTION
## Summary

- Extract duplicated MCP application service registrations (AuthorizationService, BoardService, ColumnService, CardService, LabelService, AutomationProposalService, CaptureService, NotificationService) into `AddMcpApplicationServices()` extension method in `McpApplicationServiceRegistration.cs`
- Extract duplicated MCP resource and tool registrations (BoardResources, CaptureResources, ProposalResources, ReadTools, WriteTools, ProposalTools) into `AddMcpResourcesAndTools()` extension method in `McpResourcesAndToolsRegistration.cs`
- Replace all three inline registration blocks in `Program.cs` (MCP HTTP mode, MCP stdio mode, and co-hosted web mode) with calls to the shared helpers, removing ~50 lines of duplicate code

Closes #951

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors
- [x] `dotnet test backend/Taskdeck.sln -c Release -m:1` -- all 1671+ tests pass, 0 failures
- [x] MCP stdio mode still skips web server setup (uses `Host.CreateDefaultBuilder`, not `WebApplication.CreateBuilder`)
- [x] MCP HTTP mode still creates a minimal web server with API key auth, rate limiting, and observability
- [x] Co-hosted web mode continues to use the full `AddApplicationServices()` for the broader service set