### PR TITLE
FE-22: Decompose CardModal into sub-components and composable

### DIFF
--- a/frontend/taskdeck-web/src/components/board/CardModal.vue
+++ b/frontend/taskdeck-web/src/components/board/CardModal.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref, computed, watch } from 'vue'
-import { useBoardStore } from '../../store/boardStore'
-import { useSessionStore } from '../../store/sessionStore'
 import { useEscapeToClose } from '../../composables/useEscapeToClose'
+import { useCardModal } from '../../composables/useCardModal'
 import TdDialog from '../ui/TdDialog.vue'
-import type { Card, CardCaptureProvenance, Label } from '../../types/board'
-import type { CardComment } from '../../types/comments'
-import { normalizeProposalStatus } from '../../utils/automation'
+import {
+  CardModalHeader,
+  CardModalForm,
+  CardModalLabels,
+  CardModalComments,
+  CardModalMetadata,
+  CardModalActions,
+} from './card-modal'
+import type { Card, Label } from '../../types/board'
 
 const props = defineProps<{
   card: Card
@@ -19,276 +23,66 @@ const emit = defineEmits<{
   (e: 'updated'): void
 }>()
 
-const boardStore = useBoardStore()
-const sessionStore = useSessionStore()
-
-// Form state
-const title = ref('')
-const description = ref('')
-const dueDate = ref('')
-const isBlocked = ref(false)
-const blockReason = ref('')
-const selectedLabelIds = ref<string[]>([])
-const expectedUpdatedAt = ref<string | null>(null)
-const newCommentContent = ref('')
-const replyDraftByParent = ref<Record<string, string>>({})
-const editingCommentId = ref<string | null>(null)
-const editingCommentContent = ref('')
-const captureProvenance = ref<CardCaptureProvenance | null>(null)
-const captureProvenanceError = ref<string | null>(null)
-const loadingCaptureProvenance = ref(false)
-const loadedCaptureProvenanceCardId = ref<string | null>(null)
-const showDeleteConfirm = ref(false)
-const isDeleting = ref(false)
-const deleteConfirmDescription = computed(
-  () => `Are you sure you want to delete "${props.card.title}"? This action cannot be undone.`
-)
-
-const comments = computed<CardComment[]>(() => boardStore.getCardComments(props.card.id))
-const topLevelComments = computed(() => comments.value.filter(comment => !comment.parentCommentId))
-
-// Watch for card changes
-watch(() => props.card, (newCard) => {
-  if (newCard) {
-    title.value = newCard.title
-    description.value = newCard.description || ''
-    dueDate.value = newCard.dueDate
-      ? new Date(newCard.dueDate).toISOString().split('T')[0] ?? ''
-      : ''
-    isBlocked.value = newCard.isBlocked
-    blockReason.value = newCard.blockReason || ''
-    selectedLabelIds.value = newCard.labels.map(l => l.id)
-    captureProvenance.value = null
-    captureProvenanceError.value = null
-    loadedCaptureProvenanceCardId.value = null
-
-    if (props.isOpen) {
-      void loadCaptureProvenance()
-    }
-  }
-}, { immediate: true })
-
-watch(
-  () => props.isOpen,
-  async (isOpen) => {
-    if (isOpen) {
-      expectedUpdatedAt.value = props.card.updatedAt
-      await boardStore.fetchCardComments(props.card.boardId, props.card.id)
-      await loadCaptureProvenance()
-      boardStore.setEditingCard(props.card.id)
-      return
-    }
-
-    newCommentContent.value = ''
-    replyDraftByParent.value = {}
-    editingCommentId.value = null
-    editingCommentContent.value = ''
-    captureProvenance.value = null
-    captureProvenanceError.value = null
-    loadingCaptureProvenance.value = false
-    loadedCaptureProvenanceCardId.value = null
-
-    if (boardStore.editingCardId === props.card.id) {
-      boardStore.setEditingCard(null)
-    }
-  },
-  { immediate: true }
-)
-
-const formattedDueDate = computed(() => {
-  if (!props.card.dueDate) return 'No due date'
-  const date = new Date(props.card.dueDate)
-  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
-})
-
-const isOverdue = computed(() => {
-  if (!props.card.dueDate) return false
-  return new Date(props.card.dueDate) < new Date()
-})
-
-const isFormValid = computed(() => {
-  if (title.value.trim().length === 0) return false
-  if (isBlocked.value && blockReason.value.trim().length === 0) return false
-  return true
-})
-
-function captureHref(captureItemId: string): string {
-  return `/workspace/inbox?boardId=${encodeURIComponent(props.card.boardId)}#capture-${encodeURIComponent(captureItemId)}`
-}
-
-function proposalHref(proposalId: string): string {
-  return `/workspace/review?boardId=${encodeURIComponent(props.card.boardId)}#proposal-${encodeURIComponent(proposalId)}`
-}
-
-function proposalStatusLabel(status: CardCaptureProvenance['proposalStatus']): string {
-  return normalizeProposalStatus(status)
-}
-
-async function loadCaptureProvenance() {
-  if (loadingCaptureProvenance.value || loadedCaptureProvenanceCardId.value === props.card.id) {
-    return
-  }
-
-  loadingCaptureProvenance.value = true
-  captureProvenanceError.value = null
-  try {
-    captureProvenance.value = await boardStore.fetchCardProvenance(props.card.boardId, props.card.id)
-    loadedCaptureProvenanceCardId.value = props.card.id
-  } catch {
-    captureProvenance.value = null
-    captureProvenanceError.value = 'Unable to load capture provenance.'
-    loadedCaptureProvenanceCardId.value = props.card.id
-  } finally {
-    loadingCaptureProvenance.value = false
-  }
-}
-
-async function handleSave() {
-  if (!isFormValid.value) return
-
-  try {
-    await boardStore.updateCard(props.card.boardId, props.card.id, {
-      title: title.value !== props.card.title ? title.value : null,
-      description: description.value !== props.card.description ? description.value : null,
-      dueDate: dueDate.value ? new Date(dueDate.value).toISOString() : null,
-      isBlocked: isBlocked.value !== props.card.isBlocked ? isBlocked.value : null,
-      blockReason: isBlocked.value ? blockReason.value : null,
-      labelIds: selectedLabelIds.value,
-      expectedUpdatedAt: expectedUpdatedAt.value,
-    })
-
-    emit('updated')
-    emit('close')
-  } catch (error) {
-    console.error('Failed to update card:', error)
-  }
-}
-
-function handleDeleteClick() {
-  showDeleteConfirm.value = true
-}
-
-function handleDeleteCancel() {
-  showDeleteConfirm.value = false
-}
-
-async function handleDeleteConfirm() {
-  if (isDeleting.value) return
-  isDeleting.value = true
-  try {
-    await boardStore.deleteCard(props.card.boardId, props.card.id)
-    showDeleteConfirm.value = false
-    emit('updated')
-    emit('close')
-  } catch (error) {
-    console.error('Failed to delete card:', error)
-  } finally {
-    isDeleting.value = false
-  }
-}
-
 function handleClose() {
   emit('close')
 }
 
-function clearDueDate() {
-  dueDate.value = ''
-}
+const {
+  // Form state
+  title,
+  description,
+  dueDate,
+  isBlocked,
+  blockReason,
+  selectedLabelIds,
+  isFormValid,
 
-function getReplies(parentCommentId: string) {
-  return comments.value.filter(comment => comment.parentCommentId === parentCommentId)
-}
+  // Due date
+  formattedDueDate,
+  isOverdue,
+  clearDueDate,
 
-function canEditComment(comment: CardComment) {
-  return sessionStore.userId === comment.authorUserId
-}
+  // Comments
+  newCommentContent,
+  replyDraftByParent,
+  editingCommentId,
+  editingCommentContent,
+  topLevelComments,
+  getReplies,
+  canEditComment,
+  handleAddComment,
+  handleStartEditComment,
+  handleCancelEditComment,
+  handleSaveEditComment,
+  handleDeleteComment,
 
-async function handleAddComment(parentCommentId?: string) {
-  const content = parentCommentId
-    ? (replyDraftByParent.value[parentCommentId] ?? '').trim()
-    : newCommentContent.value.trim()
+  // Provenance
+  captureProvenance,
+  captureProvenanceError,
+  loadingCaptureProvenance,
+  loadedCaptureProvenanceCardId,
+  captureHref,
+  proposalHref,
 
-  if (!content) {
-    return
-  }
+  // Delete
+  showDeleteConfirm,
+  isDeleting,
+  deleteConfirmDescription,
+  handleDeleteClick,
+  handleDeleteCancel,
+  handleDeleteConfirm,
 
-  try {
-    await boardStore.createCardComment(props.card.boardId, props.card.id, {
-      content,
-      parentCommentId: parentCommentId ?? null,
-    })
-
-    if (parentCommentId) {
-      replyDraftByParent.value[parentCommentId] = ''
-    } else {
-      newCommentContent.value = ''
-    }
-  } catch (error) {
-    console.error('Failed to add comment:', error)
-  }
-}
-
-function handleStartEditComment(comment: CardComment) {
-  if (!canEditComment(comment) || comment.isDeleted) {
-    return
-  }
-
-  editingCommentId.value = comment.id
-  editingCommentContent.value = comment.content
-}
-
-function handleCancelEditComment() {
-  editingCommentId.value = null
-  editingCommentContent.value = ''
-}
-
-async function handleSaveEditComment(commentId: string) {
-  const content = editingCommentContent.value.trim()
-  if (!content) {
-    return
-  }
-
-  try {
-    await boardStore.updateCardComment(props.card.boardId, props.card.id, commentId, { content })
-    handleCancelEditComment()
-  } catch (error) {
-    console.error('Failed to update comment:', error)
-  }
-}
-
-async function handleDeleteComment(comment: CardComment) {
-  if (!canEditComment(comment)) {
-    return
-  }
-
-  if (!confirm('Delete this comment?')) {
-    return
-  }
-
-  try {
-    await boardStore.deleteCardComment(props.card.boardId, props.card.id, comment.id)
-  } catch (error) {
-    console.error('Failed to delete comment:', error)
-  }
-}
+  // Save
+  handleSave,
+} = useCardModal({
+  getCard: () => props.card,
+  getIsOpen: () => props.isOpen,
+  getLabels: () => props.labels,
+  onUpdated: () => emit('updated'),
+  onClose: () => emit('close'),
+})
 
 useEscapeToClose(() => props.isOpen, handleClose)
-
-onBeforeUnmount(() => {
-  if (boardStore.editingCardId === props.card.id) {
-    boardStore.setEditingCard(null)
-  }
-
-  expectedUpdatedAt.value = null
-  newCommentContent.value = ''
-  replyDraftByParent.value = {}
-  editingCommentId.value = null
-  editingCommentContent.value = ''
-  captureProvenance.value = null
-  captureProvenanceError.value = null
-  loadingCaptureProvenance.value = false
-  loadedCaptureProvenanceCardId.value = null
-})
 </script>
 
 <template>
@@ -308,345 +102,60 @@ onBeforeUnmount(() => {
     <!-- Modal -->
     <div class="flex min-h-full items-center justify-center p-4">
       <div class="relative bg-surface-container rounded-lg shadow-xl max-w-2xl w-full p-6 border border-outline-variant/30" @click.stop>
-        <!-- Header -->
-        <div class="flex items-start justify-between mb-4">
-          <h2 class="text-2xl font-semibold text-on-surface">Edit Card</h2>
-          <button
-            @click="handleClose"
-            class="text-on-surface-variant hover:text-on-surface transition-colors"
-          >
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+        <CardModalHeader @close="handleClose" />
 
-        <!-- Form -->
         <div class="space-y-4">
-          <!-- Title -->
-          <div>
-            <label for="card-title" class="block text-sm font-medium text-on-surface-variant mb-1">
-              Title *
-            </label>
-            <input
-              id="card-title"
-              v-model="title"
-              type="text"
-              required
-              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
-              placeholder="Card title"
-            />
-          </div>
+          <CardModalForm
+            :card="card"
+            v-model:title="title"
+            v-model:description="description"
+            v-model:due-date="dueDate"
+            v-model:is-blocked="isBlocked"
+            v-model:block-reason="blockReason"
+            :formatted-due-date="formattedDueDate"
+            :is-overdue="isOverdue"
+            @clear-due-date="clearDueDate"
+          />
 
-          <!-- Description -->
-          <div>
-            <label for="card-description" class="block text-sm font-medium text-on-surface-variant mb-1">
-              Description
-            </label>
-            <textarea
-              id="card-description"
-              v-model="description"
-              rows="4"
-              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
-              placeholder="Add a more detailed description..."
-            ></textarea>
-          </div>
+          <CardModalLabels
+            :labels="labels"
+            v-model:selected-label-ids="selectedLabelIds"
+          />
 
-          <!-- Due Date -->
-          <div>
-            <label for="card-due-date" class="block text-sm font-medium text-on-surface-variant mb-1">
-              Due Date
-            </label>
-            <div class="flex gap-2">
-              <input
-                id="card-due-date"
-                v-model="dueDate"
-                type="date"
-                class="flex-1 px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50"
-              />
-              <button
-                v-if="dueDate"
-                @click="clearDueDate"
-                type="button"
-                class="px-3 py-2 text-sm text-on-surface-variant hover:text-on-surface border border-outline-variant/40 rounded-md hover:bg-surface-container-high transition-colors"
-              >
-                Clear
-              </button>
-            </div>
-            <p v-if="card.dueDate" class="mt-1 text-xs" :class="isOverdue ? 'text-error' : 'text-on-surface-variant'">
-              Current: {{ formattedDueDate }}
-              <span v-if="isOverdue" class="font-medium">(Overdue)</span>
-            </p>
-          </div>
+          <CardModalComments
+            :top-level-comments="topLevelComments"
+            :editing-comment-id="editingCommentId"
+            :editing-comment-content="editingCommentContent"
+            :reply-draft-by-parent="replyDraftByParent"
+            :can-edit-comment-fn="canEditComment"
+            :get-replies-fn="getReplies"
+            v-model:new-comment-content="newCommentContent"
+            @update:editing-comment-content="editingCommentContent = $event"
+            @update:reply-draft-by-parent="replyDraftByParent = $event"
+            @add-comment="handleAddComment($event)"
+            @start-edit-comment="handleStartEditComment($event)"
+            @cancel-edit-comment="handleCancelEditComment"
+            @save-edit-comment="handleSaveEditComment($event)"
+            @delete-comment="handleDeleteComment($event)"
+          />
 
-          <!-- Blocked Status -->
-          <div class="border border-outline-variant/30 rounded-md p-4">
-            <div class="flex items-center mb-2">
-              <input
-                id="card-is-blocked"
-                v-model="isBlocked"
-                type="checkbox"
-                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
-              />
-              <label for="card-is-blocked" class="ml-2 text-sm font-medium text-on-surface-variant">
-                Mark as blocked
-              </label>
-            </div>
-            <div v-if="isBlocked">
-              <label for="card-block-reason" class="block text-sm font-medium text-on-surface-variant mb-1">
-                Block Reason *
-              </label>
-              <textarea
-                id="card-block-reason"
-                v-model="blockReason"
-                rows="2"
-                required
-                class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
-                placeholder="Why is this card blocked?"
-              ></textarea>
-            </div>
-          </div>
-
-          <!-- Labels -->
-          <div>
-            <p class="block text-sm font-medium text-on-surface-variant mb-2">
-              Labels
-            </p>
-            <div v-if="labels.length > 0" class="flex flex-col gap-2">
-              <label
-                v-for="label in labels"
-                :key="label.id"
-                class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all cursor-pointer"
-                :class="selectedLabelIds.includes(label.id)
-                  ? 'text-white ring-2 ring-offset-2 ring-primary/50'
-                  : 'text-on-surface bg-surface-container-high hover:bg-surface-container-highest'"
-                :style="selectedLabelIds.includes(label.id) ? { backgroundColor: label.colorHex } : {}"
-              >
-                <input
-                  :id="`label-${label.id}`"
-                  v-model="selectedLabelIds"
-                  type="checkbox"
-                  :value="label.id"
-                  class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
-                />
-                <!-- Color swatch always visible so users can identify labels before selecting -->
-                <span
-                  class="inline-block w-3 h-3 rounded-full flex-shrink-0 bg-outline-variant"
-                  :style="label.colorHex ? { backgroundColor: label.colorHex } : {}"
-                  aria-hidden="true"
-                />
-                <span>{{ label.name }}</span>
-              </label>
-            </div>
-            <p v-else class="text-sm text-on-surface-variant italic">No labels available</p>
-          </div>
-
-          <!-- Comments -->
-          <div class="pt-4 border-t border-outline-variant/30 space-y-3">
-            <h3 class="text-sm font-semibold text-on-surface">Comments</h3>
-            <div class="space-y-2">
-              <textarea
-                id="new-card-comment"
-                v-model="newCommentContent"
-                rows="2"
-                class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
-                placeholder="Write a comment... Use @username to mention teammates."
-              ></textarea>
-              <div class="flex justify-end">
-                <button
-                  id="add-card-comment"
-                  type="button"
-                  class="px-3 py-1.5 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
-                  :disabled="newCommentContent.trim().length === 0"
-                  @click="handleAddComment()"
-                >
-                  Add Comment
-                </button>
-              </div>
-            </div>
-
-            <div v-if="topLevelComments.length === 0" class="text-sm text-on-surface-variant italic">
-              No comments yet.
-            </div>
-
-            <div v-else class="space-y-3">
-              <div
-                v-for="comment in topLevelComments"
-                :key="comment.id"
-                class="border border-outline-variant/30 rounded-md p-3 space-y-2 bg-surface-container-low"
-              >
-                <div class="flex items-start justify-between gap-2">
-                  <div class="text-xs text-on-surface-variant">
-                    <span class="font-medium text-on-surface">{{ comment.authorUsername }}</span>
-                    <span class="mx-1">•</span>
-                    <span>{{ new Date(comment.createdAt).toLocaleString() }}</span>
-                    <span v-if="comment.editedAt" class="ml-1 italic">(edited)</span>
-                  </div>
-                  <div v-if="canEditComment(comment) && !comment.isDeleted" class="flex gap-2 text-xs">
-                    <button
-                      type="button"
-                      class="text-primary hover:text-primary/80"
-                      @click="handleStartEditComment(comment)"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      type="button"
-                      class="text-error hover:text-error/80"
-                      @click="handleDeleteComment(comment)"
-                    >
-                      Delete
-                    </button>
-                  </div>
-                </div>
-
-                <div v-if="editingCommentId === comment.id" class="space-y-2">
-                  <textarea
-                    v-model="editingCommentContent"
-                    aria-label="Edit comment"
-                    rows="2"
-                    class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50"
-                  ></textarea>
-                  <div class="flex justify-end gap-2">
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm text-on-surface-variant border border-outline-variant/40 rounded-md hover:bg-surface-container-high transition-colors"
-                      @click="handleCancelEditComment"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="button"
-                      class="px-3 py-1.5 text-sm text-on-primary-container bg-primary-container rounded-md hover:brightness-110 disabled:opacity-40"
-                      :disabled="editingCommentContent.trim().length === 0"
-                      @click="handleSaveEditComment(comment.id)"
-                    >
-                      Save
-                    </button>
-                  </div>
-                </div>
-
-                <p
-                  v-else
-                  class="text-sm whitespace-pre-wrap"
-                  :class="comment.isDeleted ? 'text-on-surface-variant italic' : 'text-on-surface'"
-                >
-                  {{ comment.content }}
-                </p>
-
-                <div class="pl-3 border-l-2 border-outline-variant/30 space-y-2">
-                  <div
-                    v-for="reply in getReplies(comment.id)"
-                    :key="reply.id"
-                    class="space-y-1"
-                  >
-                    <div class="text-xs text-on-surface-variant">
-                      <span class="font-medium text-on-surface">{{ reply.authorUsername }}</span>
-                      <span class="mx-1">•</span>
-                      <span>{{ new Date(reply.createdAt).toLocaleString() }}</span>
-                    </div>
-                    <p
-                      class="text-sm whitespace-pre-wrap"
-                      :class="reply.isDeleted ? 'text-on-surface-variant italic' : 'text-on-surface'"
-                    >
-                      {{ reply.content }}
-                    </p>
-                  </div>
-
-                  <div v-if="!comment.isDeleted" class="space-y-2 pt-1">
-                    <textarea
-                      v-model="replyDraftByParent[comment.id]"
-                      aria-label="Reply to comment"
-                      rows="2"
-                      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
-                      placeholder="Reply..."
-                    ></textarea>
-                    <div class="flex justify-end">
-                      <button
-                        type="button"
-                        class="px-3 py-1.5 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
-                        :disabled="!(replyDraftByParent[comment.id] ?? '').trim().length"
-                        @click="handleAddComment(comment.id)"
-                      >
-                        Reply
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Metadata -->
-          <div class="pt-4 border-t border-outline-variant/30">
-            <div class="text-xs text-on-surface-variant space-y-1">
-              <p data-testid="timestamp">Created: {{ new Date(card.createdAt).toLocaleString() }}</p>
-              <p data-testid="timestamp">Last updated: {{ new Date(card.updatedAt).toLocaleString() }}</p>
-            </div>
-            <div class="mt-3 space-y-2">
-              <div v-if="loadingCaptureProvenance" class="text-xs text-on-surface-variant">
-                Loading capture provenance...
-              </div>
-              <div v-else-if="captureProvenanceError" class="text-xs text-error" role="alert">
-                {{ captureProvenanceError }}
-              </div>
-              <div v-else-if="captureProvenance" class="space-y-2">
-                <div class="flex flex-wrap items-center gap-2 text-xs">
-                  <span class="px-2 py-1 rounded-full bg-primary/20 text-primary font-semibold uppercase tracking-wide">
-                    Capture Origin
-                  </span>
-                  <span class="text-on-surface-variant">Proposal status: {{ proposalStatusLabel(captureProvenance.proposalStatus) }}</span>
-                </div>
-                <div class="flex flex-wrap items-center gap-2 text-xs">
-                  <a
-                    class="px-2 py-1 rounded-md border border-primary/30 text-primary hover:bg-primary/10"
-                    :href="captureHref(captureProvenance.captureItemId)"
-                  >
-                    Open Capture
-                  </a>
-                  <a
-                    class="px-2 py-1 rounded-md border border-primary/30 text-primary hover:bg-primary/10"
-                    :href="proposalHref(captureProvenance.proposalId)"
-                  >
-                    Open Proposal
-                  </a>
-                </div>
-                <p v-if="captureProvenance.triageRunId" class="text-xs text-on-surface-variant">
-                  Triage run: {{ captureProvenance.triageRunId }}
-                </p>
-              </div>
-              <p v-else-if="loadedCaptureProvenanceCardId === card.id" class="text-xs text-on-surface-variant italic" data-testid="provenance-empty-state">Created manually — no capture provenance.</p>
-            </div>
-          </div>
+          <CardModalMetadata
+            :card="card"
+            :loading-capture-provenance="loadingCaptureProvenance"
+            :capture-provenance-error="captureProvenanceError"
+            :capture-provenance="captureProvenance"
+            :loaded-capture-provenance-card-id="loadedCaptureProvenanceCardId"
+            :capture-href-fn="captureHref"
+            :proposal-href-fn="proposalHref"
+          />
         </div>
 
-        <!-- Actions -->
-        <div class="mt-6 flex items-center justify-between">
-          <button
-            @click="handleDeleteClick"
-            type="button"
-            class="px-4 py-2 text-sm font-medium text-error hover:text-error/80 hover:bg-error/10 border border-error/40 rounded-md transition-colors"
-          >
-            Delete Card
-          </button>
-          <div class="flex gap-2">
-            <button
-              @click="handleClose"
-              type="button"
-              class="px-4 py-2 text-sm font-medium text-on-surface-variant hover:bg-surface-container-high border border-outline-variant/40 rounded-md transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              @click="handleSave"
-              :disabled="!isFormValid"
-              type="button"
-              class="px-4 py-2 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
-            >
-              Save Changes
-            </button>
-          </div>
-        </div>
+        <CardModalActions
+          :is-form-valid="isFormValid"
+          @save="handleSave"
+          @close="handleClose"
+          @delete-click="handleDeleteClick"
+        />
       </div>
     </div>
   </div>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalActions.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalActions.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+defineProps<{
+  isFormValid: boolean
+}>()
+
+defineEmits<{
+  (e: 'save'): void
+  (e: 'close'): void
+  (e: 'delete-click'): void
+}>()
+</script>
+
+<template>
+  <div class="mt-6 flex items-center justify-between">
+    <button
+      @click="$emit('delete-click')"
+      type="button"
+      class="px-4 py-2 text-sm font-medium text-error hover:text-error/80 hover:bg-error/10 border border-error/40 rounded-md transition-colors"
+    >
+      Delete Card
+    </button>
+    <div class="flex gap-2">
+      <button
+        @click="$emit('close')"
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-on-surface-variant hover:bg-surface-container-high border border-outline-variant/40 rounded-md transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        @click="$emit('save')"
+        :disabled="!isFormValid"
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
+      >
+        Save Changes
+      </button>
+    </div>
+  </div>
+</template>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalComments.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalComments.vue
@@ -1,0 +1,168 @@
+<script setup lang="ts">
+import type { CardComment } from '../../../types/comments'
+
+const props = defineProps<{
+  topLevelComments: CardComment[]
+  editingCommentId: string | null
+  editingCommentContent: string
+  replyDraftByParent: Record<string, string>
+  canEditCommentFn: (comment: CardComment) => boolean
+  getRepliesFn: (parentCommentId: string) => CardComment[]
+}>()
+
+const emit = defineEmits<{
+  (e: 'add-comment', parentCommentId?: string): void
+  (e: 'start-edit-comment', comment: CardComment): void
+  (e: 'cancel-edit-comment'): void
+  (e: 'save-edit-comment', commentId: string): void
+  (e: 'delete-comment', comment: CardComment): void
+  (e: 'update:editingCommentContent', value: string): void
+  (e: 'update:replyDraftByParent', value: Record<string, string>): void
+}>()
+
+const newCommentContent = defineModel<string>('newCommentContent', { required: true })
+
+function updateReplyDraft(commentId: string, value: string) {
+  const updated = { ...props.replyDraftByParent, [commentId]: value }
+  emit('update:replyDraftByParent', updated)
+}
+</script>
+
+<template>
+  <div class="pt-4 border-t border-outline-variant/30 space-y-3">
+    <h3 class="text-sm font-semibold text-on-surface">Comments</h3>
+    <div class="space-y-2">
+      <textarea
+        id="new-card-comment"
+        v-model="newCommentContent"
+        rows="2"
+        class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+        placeholder="Write a comment... Use @username to mention teammates."
+      ></textarea>
+      <div class="flex justify-end">
+        <button
+          id="add-card-comment"
+          type="button"
+          class="px-3 py-1.5 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
+          :disabled="newCommentContent.trim().length === 0"
+          @click="$emit('add-comment')"
+        >
+          Add Comment
+        </button>
+      </div>
+    </div>
+
+    <div v-if="topLevelComments.length === 0" class="text-sm text-on-surface-variant italic">
+      No comments yet.
+    </div>
+
+    <div v-else class="space-y-3">
+      <div
+        v-for="comment in topLevelComments"
+        :key="comment.id"
+        class="border border-outline-variant/30 rounded-md p-3 space-y-2 bg-surface-container-low"
+      >
+        <div class="flex items-start justify-between gap-2">
+          <div class="text-xs text-on-surface-variant">
+            <span class="font-medium text-on-surface">{{ comment.authorUsername }}</span>
+            <span class="mx-1">&bull;</span>
+            <span>{{ new Date(comment.createdAt).toLocaleString() }}</span>
+            <span v-if="comment.editedAt" class="ml-1 italic">(edited)</span>
+          </div>
+          <div v-if="canEditCommentFn(comment) && !comment.isDeleted" class="flex gap-2 text-xs">
+            <button
+              type="button"
+              class="text-primary hover:text-primary/80"
+              @click="$emit('start-edit-comment', comment)"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              class="text-error hover:text-error/80"
+              @click="$emit('delete-comment', comment)"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+
+        <div v-if="editingCommentId === comment.id" class="space-y-2">
+          <textarea
+            :value="editingCommentContent"
+            aria-label="Edit comment"
+            rows="2"
+            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50"
+            @input="$emit('update:editingCommentContent', ($event.target as HTMLTextAreaElement).value)"
+          ></textarea>
+          <div class="flex justify-end gap-2">
+            <button
+              type="button"
+              class="px-3 py-1.5 text-sm text-on-surface-variant border border-outline-variant/40 rounded-md hover:bg-surface-container-high transition-colors"
+              @click="$emit('cancel-edit-comment')"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="px-3 py-1.5 text-sm text-on-primary-container bg-primary-container rounded-md hover:brightness-110 disabled:opacity-40"
+              :disabled="editingCommentContent.trim().length === 0"
+              @click="$emit('save-edit-comment', comment.id)"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+
+        <p
+          v-else
+          class="text-sm whitespace-pre-wrap"
+          :class="comment.isDeleted ? 'text-on-surface-variant italic' : 'text-on-surface'"
+        >
+          {{ comment.content }}
+        </p>
+
+        <div class="pl-3 border-l-2 border-outline-variant/30 space-y-2">
+          <div
+            v-for="reply in getRepliesFn(comment.id)"
+            :key="reply.id"
+            class="space-y-1"
+          >
+            <div class="text-xs text-on-surface-variant">
+              <span class="font-medium text-on-surface">{{ reply.authorUsername }}</span>
+              <span class="mx-1">&bull;</span>
+              <span>{{ new Date(reply.createdAt).toLocaleString() }}</span>
+            </div>
+            <p
+              class="text-sm whitespace-pre-wrap"
+              :class="reply.isDeleted ? 'text-on-surface-variant italic' : 'text-on-surface'"
+            >
+              {{ reply.content }}
+            </p>
+          </div>
+
+          <div v-if="!comment.isDeleted" class="space-y-2 pt-1">
+            <textarea
+              :value="replyDraftByParent[comment.id] ?? ''"
+              aria-label="Reply to comment"
+              rows="2"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              placeholder="Reply..."
+              @input="updateReplyDraft(comment.id, ($event.target as HTMLTextAreaElement).value)"
+            ></textarea>
+            <div class="flex justify-end">
+              <button
+                type="button"
+                class="px-3 py-1.5 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
+                :disabled="!(replyDraftByParent[comment.id] ?? '').trim().length"
+                @click="$emit('add-comment', comment.id)"
+              >
+                Reply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalForm.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalForm.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import type { Card } from '../../../types/board'
+
+defineProps<{
+  card: Card
+  formattedDueDate: string
+  isOverdue: boolean
+}>()
+
+const title = defineModel<string>('title', { required: true })
+const description = defineModel<string>('description', { required: true })
+const dueDate = defineModel<string>('dueDate', { required: true })
+const isBlocked = defineModel<boolean>('isBlocked', { required: true })
+const blockReason = defineModel<string>('blockReason', { required: true })
+
+defineEmits<{
+  (e: 'clear-due-date'): void
+}>()
+</script>
+
+<template>
+  <!-- Title -->
+  <div>
+    <label for="card-title" class="block text-sm font-medium text-on-surface-variant mb-1">
+      Title *
+    </label>
+    <input
+      id="card-title"
+      v-model="title"
+      type="text"
+      required
+      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+      placeholder="Card title"
+    />
+  </div>
+
+  <!-- Description -->
+  <div>
+    <label for="card-description" class="block text-sm font-medium text-on-surface-variant mb-1">
+      Description
+    </label>
+    <textarea
+      id="card-description"
+      v-model="description"
+      rows="4"
+      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+      placeholder="Add a more detailed description..."
+    ></textarea>
+  </div>
+
+  <!-- Due Date -->
+  <div>
+    <label for="card-due-date" class="block text-sm font-medium text-on-surface-variant mb-1">
+      Due Date
+    </label>
+    <div class="flex gap-2">
+      <input
+        id="card-due-date"
+        v-model="dueDate"
+        type="date"
+        class="flex-1 px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50"
+      />
+      <button
+        v-if="dueDate"
+        @click="$emit('clear-due-date')"
+        type="button"
+        class="px-3 py-2 text-sm text-on-surface-variant hover:text-on-surface border border-outline-variant/40 rounded-md hover:bg-surface-container-high transition-colors"
+      >
+        Clear
+      </button>
+    </div>
+    <p v-if="card.dueDate" class="mt-1 text-xs" :class="isOverdue ? 'text-error' : 'text-on-surface-variant'">
+      Current: {{ formattedDueDate }}
+      <span v-if="isOverdue" class="font-medium">(Overdue)</span>
+    </p>
+  </div>
+
+  <!-- Blocked Status -->
+  <div class="border border-outline-variant/30 rounded-md p-4">
+    <div class="flex items-center mb-2">
+      <input
+        id="card-is-blocked"
+        v-model="isBlocked"
+        type="checkbox"
+        class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+      />
+      <label for="card-is-blocked" class="ml-2 text-sm font-medium text-on-surface-variant">
+        Mark as blocked
+      </label>
+    </div>
+    <div v-if="isBlocked">
+      <label for="card-block-reason" class="block text-sm font-medium text-on-surface-variant mb-1">
+        Block Reason *
+      </label>
+      <textarea
+        id="card-block-reason"
+        v-model="blockReason"
+        rows="2"
+        required
+        class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+        placeholder="Why is this card blocked?"
+      ></textarea>
+    </div>
+  </div>
+</template>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalHeader.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalHeader.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+defineEmits<{
+  (e: 'close'): void
+}>()
+</script>
+
+<template>
+  <div class="flex items-start justify-between mb-4">
+    <h2 class="text-2xl font-semibold text-on-surface">Edit Card</h2>
+    <button
+      @click="$emit('close')"
+      class="text-on-surface-variant hover:text-on-surface transition-colors"
+    >
+      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+</template>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalLabels.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalLabels.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { Label } from '../../../types/board'
+
+defineProps<{
+  labels: Label[]
+}>()
+
+const selectedLabelIds = defineModel<string[]>('selectedLabelIds', { required: true })
+</script>
+
+<template>
+  <div>
+    <p class="block text-sm font-medium text-on-surface-variant mb-2">
+      Labels
+    </p>
+    <div v-if="labels.length > 0" class="flex flex-col gap-2">
+      <label
+        v-for="label in labels"
+        :key="label.id"
+        class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all cursor-pointer"
+        :class="selectedLabelIds.includes(label.id)
+          ? 'text-white ring-2 ring-offset-2 ring-primary/50'
+          : 'text-on-surface bg-surface-container-high hover:bg-surface-container-highest'"
+        :style="selectedLabelIds.includes(label.id) ? { backgroundColor: label.colorHex } : {}"
+      >
+        <input
+          :id="`label-${label.id}`"
+          v-model="selectedLabelIds"
+          type="checkbox"
+          :value="label.id"
+          class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+        />
+        <!-- Color swatch always visible so users can identify labels before selecting -->
+        <span
+          class="inline-block w-3 h-3 rounded-full flex-shrink-0 bg-outline-variant"
+          :style="label.colorHex ? { backgroundColor: label.colorHex } : {}"
+          aria-hidden="true"
+        />
+        <span>{{ label.name }}</span>
+      </label>
+    </div>
+    <p v-else class="text-sm text-on-surface-variant italic">No labels available</p>
+  </div>
+</template>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalMetadata.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalMetadata.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import type { Card, CardCaptureProvenance } from '../../../types/board'
+import { normalizeProposalStatus } from '../../../utils/automation'
+
+defineProps<{
+  card: Card
+  loadingCaptureProvenance: boolean
+  captureProvenanceError: string | null
+  captureProvenance: CardCaptureProvenance | null
+  loadedCaptureProvenanceCardId: string | null
+  captureHrefFn: (captureItemId: string) => string
+  proposalHrefFn: (proposalId: string) => string
+}>()
+
+function proposalStatusLabel(status: CardCaptureProvenance['proposalStatus']): string {
+  return normalizeProposalStatus(status)
+}
+</script>
+
+<template>
+  <div class="pt-4 border-t border-outline-variant/30">
+    <div class="text-xs text-on-surface-variant space-y-1">
+      <p data-testid="timestamp">Created: {{ new Date(card.createdAt).toLocaleString() }}</p>
+      <p data-testid="timestamp">Last updated: {{ new Date(card.updatedAt).toLocaleString() }}</p>
+    </div>
+    <div class="mt-3 space-y-2">
+      <div v-if="loadingCaptureProvenance" class="text-xs text-on-surface-variant">
+        Loading capture provenance...
+      </div>
+      <div v-else-if="captureProvenanceError" class="text-xs text-error" role="alert">
+        {{ captureProvenanceError }}
+      </div>
+      <div v-else-if="captureProvenance" class="space-y-2">
+        <div class="flex flex-wrap items-center gap-2 text-xs">
+          <span class="px-2 py-1 rounded-full bg-primary/20 text-primary font-semibold uppercase tracking-wide">
+            Capture Origin
+          </span>
+          <span class="text-on-surface-variant">Proposal status: {{ proposalStatusLabel(captureProvenance.proposalStatus) }}</span>
+        </div>
+        <div class="flex flex-wrap items-center gap-2 text-xs">
+          <a
+            class="px-2 py-1 rounded-md border border-primary/30 text-primary hover:bg-primary/10"
+            :href="captureHrefFn(captureProvenance.captureItemId)"
+          >
+            Open Capture
+          </a>
+          <a
+            class="px-2 py-1 rounded-md border border-primary/30 text-primary hover:bg-primary/10"
+            :href="proposalHrefFn(captureProvenance.proposalId)"
+          >
+            Open Proposal
+          </a>
+        </div>
+        <p v-if="captureProvenance.triageRunId" class="text-xs text-on-surface-variant">
+          Triage run: {{ captureProvenance.triageRunId }}
+        </p>
+      </div>
+      <p v-else-if="loadedCaptureProvenanceCardId === card.id" class="text-xs text-on-surface-variant italic" data-testid="provenance-empty-state">Created manually — no capture provenance.</p>
+    </div>
+  </div>
+</template>

--- a/frontend/taskdeck-web/src/components/board/card-modal/index.ts
+++ b/frontend/taskdeck-web/src/components/board/card-modal/index.ts
@@ -1,0 +1,6 @@
+export { default as CardModalHeader } from './CardModalHeader.vue'
+export { default as CardModalForm } from './CardModalForm.vue'
+export { default as CardModalLabels } from './CardModalLabels.vue'
+export { default as CardModalComments } from './CardModalComments.vue'
+export { default as CardModalMetadata } from './CardModalMetadata.vue'
+export { default as CardModalActions } from './CardModalActions.vue'

--- a/frontend/taskdeck-web/src/composables/useCardModal.ts
+++ b/frontend/taskdeck-web/src/composables/useCardModal.ts
@@ -1,0 +1,342 @@
+import { onBeforeUnmount, ref, computed, watch } from 'vue'
+import { useBoardStore } from '../store/boardStore'
+import { useSessionStore } from '../store/sessionStore'
+import type { Card, CardCaptureProvenance, Label } from '../types/board'
+import type { CardComment } from '../types/comments'
+
+export interface UseCardModalOptions {
+  getCard: () => Card
+  getIsOpen: () => boolean
+  getLabels: () => Label[]
+  onUpdated: () => void
+  onClose: () => void
+}
+
+export function useCardModal(options: UseCardModalOptions) {
+  const boardStore = useBoardStore()
+  const sessionStore = useSessionStore()
+
+  // Form state
+  const title = ref('')
+  const description = ref('')
+  const dueDate = ref('')
+  const isBlocked = ref(false)
+  const blockReason = ref('')
+  const selectedLabelIds = ref<string[]>([])
+  const expectedUpdatedAt = ref<string | null>(null)
+
+  // Comment state
+  const newCommentContent = ref('')
+  const replyDraftByParent = ref<Record<string, string>>({})
+  const editingCommentId = ref<string | null>(null)
+  const editingCommentContent = ref('')
+
+  // Provenance state
+  const captureProvenance = ref<CardCaptureProvenance | null>(null)
+  const captureProvenanceError = ref<string | null>(null)
+  const loadingCaptureProvenance = ref(false)
+  const loadedCaptureProvenanceCardId = ref<string | null>(null)
+
+  // Delete state
+  const showDeleteConfirm = ref(false)
+  const isDeleting = ref(false)
+
+  // Computed
+  const card = computed(() => options.getCard())
+
+  const deleteConfirmDescription = computed(
+    () => `Are you sure you want to delete "${card.value.title}"? This action cannot be undone.`
+  )
+
+  const comments = computed<CardComment[]>(() => boardStore.getCardComments(card.value.id))
+  const topLevelComments = computed(() => comments.value.filter(comment => !comment.parentCommentId))
+
+  const formattedDueDate = computed(() => {
+    if (!card.value.dueDate) return 'No due date'
+    const date = new Date(card.value.dueDate)
+    return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
+  })
+
+  const isOverdue = computed(() => {
+    if (!card.value.dueDate) return false
+    return new Date(card.value.dueDate) < new Date()
+  })
+
+  const isFormValid = computed(() => {
+    if (title.value.trim().length === 0) return false
+    if (isBlocked.value && blockReason.value.trim().length === 0) return false
+    return true
+  })
+
+  // Watchers
+  watch(() => options.getCard(), (newCard) => {
+    if (newCard) {
+      title.value = newCard.title
+      description.value = newCard.description || ''
+      dueDate.value = newCard.dueDate
+        ? new Date(newCard.dueDate).toISOString().split('T')[0] ?? ''
+        : ''
+      isBlocked.value = newCard.isBlocked
+      blockReason.value = newCard.blockReason || ''
+      selectedLabelIds.value = newCard.labels.map(l => l.id)
+      captureProvenance.value = null
+      captureProvenanceError.value = null
+      loadedCaptureProvenanceCardId.value = null
+
+      if (options.getIsOpen()) {
+        void loadCaptureProvenance()
+      }
+    }
+  }, { immediate: true })
+
+  watch(
+    () => options.getIsOpen(),
+    async (isOpen) => {
+      if (isOpen) {
+        expectedUpdatedAt.value = card.value.updatedAt
+        await boardStore.fetchCardComments(card.value.boardId, card.value.id)
+        await loadCaptureProvenance()
+        boardStore.setEditingCard(card.value.id)
+        return
+      }
+
+      newCommentContent.value = ''
+      replyDraftByParent.value = {}
+      editingCommentId.value = null
+      editingCommentContent.value = ''
+      captureProvenance.value = null
+      captureProvenanceError.value = null
+      loadingCaptureProvenance.value = false
+      loadedCaptureProvenanceCardId.value = null
+
+      if (boardStore.editingCardId === card.value.id) {
+        boardStore.setEditingCard(null)
+      }
+    },
+    { immediate: true }
+  )
+
+  // Provenance
+  async function loadCaptureProvenance() {
+    if (loadingCaptureProvenance.value || loadedCaptureProvenanceCardId.value === card.value.id) {
+      return
+    }
+
+    loadingCaptureProvenance.value = true
+    captureProvenanceError.value = null
+    try {
+      captureProvenance.value = await boardStore.fetchCardProvenance(card.value.boardId, card.value.id)
+      loadedCaptureProvenanceCardId.value = card.value.id
+    } catch {
+      captureProvenance.value = null
+      captureProvenanceError.value = 'Unable to load capture provenance.'
+      loadedCaptureProvenanceCardId.value = card.value.id
+    } finally {
+      loadingCaptureProvenance.value = false
+    }
+  }
+
+  // Save
+  async function handleSave() {
+    if (!isFormValid.value) return
+
+    try {
+      await boardStore.updateCard(card.value.boardId, card.value.id, {
+        title: title.value !== card.value.title ? title.value : null,
+        description: description.value !== card.value.description ? description.value : null,
+        dueDate: dueDate.value ? new Date(dueDate.value).toISOString() : null,
+        isBlocked: isBlocked.value !== card.value.isBlocked ? isBlocked.value : null,
+        blockReason: isBlocked.value ? blockReason.value : null,
+        labelIds: selectedLabelIds.value,
+        expectedUpdatedAt: expectedUpdatedAt.value,
+      })
+
+      options.onUpdated()
+      options.onClose()
+    } catch (error) {
+      console.error('Failed to update card:', error)
+    }
+  }
+
+  // Delete
+  function handleDeleteClick() {
+    showDeleteConfirm.value = true
+  }
+
+  function handleDeleteCancel() {
+    showDeleteConfirm.value = false
+  }
+
+  async function handleDeleteConfirm() {
+    if (isDeleting.value) return
+    isDeleting.value = true
+    try {
+      await boardStore.deleteCard(card.value.boardId, card.value.id)
+      showDeleteConfirm.value = false
+      options.onUpdated()
+      options.onClose()
+    } catch (error) {
+      console.error('Failed to delete card:', error)
+    } finally {
+      isDeleting.value = false
+    }
+  }
+
+  // Due date
+  function clearDueDate() {
+    dueDate.value = ''
+  }
+
+  // Comments
+  function getReplies(parentCommentId: string) {
+    return comments.value.filter(comment => comment.parentCommentId === parentCommentId)
+  }
+
+  function canEditComment(comment: CardComment) {
+    return sessionStore.userId === comment.authorUserId
+  }
+
+  async function handleAddComment(parentCommentId?: string) {
+    const content = parentCommentId
+      ? (replyDraftByParent.value[parentCommentId] ?? '').trim()
+      : newCommentContent.value.trim()
+
+    if (!content) {
+      return
+    }
+
+    try {
+      await boardStore.createCardComment(card.value.boardId, card.value.id, {
+        content,
+        parentCommentId: parentCommentId ?? null,
+      })
+
+      if (parentCommentId) {
+        replyDraftByParent.value[parentCommentId] = ''
+      } else {
+        newCommentContent.value = ''
+      }
+    } catch (error) {
+      console.error('Failed to add comment:', error)
+    }
+  }
+
+  function handleStartEditComment(comment: CardComment) {
+    if (!canEditComment(comment) || comment.isDeleted) {
+      return
+    }
+
+    editingCommentId.value = comment.id
+    editingCommentContent.value = comment.content
+  }
+
+  function handleCancelEditComment() {
+    editingCommentId.value = null
+    editingCommentContent.value = ''
+  }
+
+  async function handleSaveEditComment(commentId: string) {
+    const content = editingCommentContent.value.trim()
+    if (!content) {
+      return
+    }
+
+    try {
+      await boardStore.updateCardComment(card.value.boardId, card.value.id, commentId, { content })
+      handleCancelEditComment()
+    } catch (error) {
+      console.error('Failed to update comment:', error)
+    }
+  }
+
+  async function handleDeleteComment(comment: CardComment) {
+    if (!canEditComment(comment)) {
+      return
+    }
+
+    if (!confirm('Delete this comment?')) {
+      return
+    }
+
+    try {
+      await boardStore.deleteCardComment(card.value.boardId, card.value.id, comment.id)
+    } catch (error) {
+      console.error('Failed to delete comment:', error)
+    }
+  }
+
+  // Provenance links
+  function captureHref(captureItemId: string): string {
+    return `/workspace/inbox?boardId=${encodeURIComponent(card.value.boardId)}#capture-${encodeURIComponent(captureItemId)}`
+  }
+
+  function proposalHref(proposalId: string): string {
+    return `/workspace/review?boardId=${encodeURIComponent(card.value.boardId)}#proposal-${encodeURIComponent(proposalId)}`
+  }
+
+  // Cleanup
+  onBeforeUnmount(() => {
+    if (boardStore.editingCardId === card.value.id) {
+      boardStore.setEditingCard(null)
+    }
+
+    expectedUpdatedAt.value = null
+    newCommentContent.value = ''
+    replyDraftByParent.value = {}
+    editingCommentId.value = null
+    editingCommentContent.value = ''
+    captureProvenance.value = null
+    captureProvenanceError.value = null
+    loadingCaptureProvenance.value = false
+    loadedCaptureProvenanceCardId.value = null
+  })
+
+  return {
+    // Form state
+    title,
+    description,
+    dueDate,
+    isBlocked,
+    blockReason,
+    selectedLabelIds,
+    isFormValid,
+
+    // Due date
+    formattedDueDate,
+    isOverdue,
+    clearDueDate,
+
+    // Comments
+    newCommentContent,
+    replyDraftByParent,
+    editingCommentId,
+    editingCommentContent,
+    topLevelComments,
+    getReplies,
+    canEditComment,
+    handleAddComment,
+    handleStartEditComment,
+    handleCancelEditComment,
+    handleSaveEditComment,
+    handleDeleteComment,
+
+    // Provenance
+    captureProvenance,
+    captureProvenanceError,
+    loadingCaptureProvenance,
+    loadedCaptureProvenanceCardId,
+    captureHref,
+    proposalHref,
+
+    // Delete
+    showDeleteConfirm,
+    isDeleting,
+    deleteConfirmDescription,
+    handleDeleteClick,
+    handleDeleteCancel,
+    handleDeleteConfirm,
+
+    // Save
+    handleSave,
+  }
+}

--- a/frontend/taskdeck-web/src/tests/composables/useCardModal.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useCardModal.spec.ts
@@ -1,0 +1,985 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick, defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import { useCardModal, type UseCardModalOptions } from '../../composables/useCardModal'
+import type { Card, Label } from '../../types/board'
+import type { CardComment } from '../../types/comments'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockBoardStore = {
+  getCardComments: vi.fn().mockReturnValue([]),
+  fetchCardComments: vi.fn().mockResolvedValue([]),
+  fetchCardProvenance: vi.fn().mockResolvedValue(null),
+  updateCard: vi.fn().mockResolvedValue(undefined),
+  deleteCard: vi.fn().mockResolvedValue(undefined),
+  createCardComment: vi.fn().mockResolvedValue(undefined),
+  updateCardComment: vi.fn().mockResolvedValue(undefined),
+  deleteCardComment: vi.fn().mockResolvedValue(undefined),
+  editingCardId: null as string | null,
+  setEditingCard: vi.fn(),
+}
+
+const mockSessionStore = {
+  userId: 'user-1',
+}
+
+vi.mock('../../store/boardStore', () => ({
+  useBoardStore: () => mockBoardStore,
+}))
+
+vi.mock('../../store/sessionStore', () => ({
+  useSessionStore: () => mockSessionStore,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: 'card-1',
+    boardId: 'board-1',
+    columnId: 'col-1',
+    title: 'Test Card',
+    description: 'Some description',
+    dueDate: '2025-12-31T00:00:00Z',
+    isBlocked: false,
+    blockReason: null,
+    position: 0,
+    labels: [],
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-06-15T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeComment(overrides: Partial<CardComment> = {}): CardComment {
+  return {
+    id: 'comment-1',
+    boardId: 'board-1',
+    cardId: 'card-1',
+    parentCommentId: null,
+    authorUserId: 'user-1',
+    authorUsername: 'testuser',
+    content: 'Hello',
+    isDeleted: false,
+    editedAt: null,
+    mentions: [],
+    createdAt: '2025-06-01T00:00:00Z',
+    updatedAt: '2025-06-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeLabel(overrides: Partial<Label> = {}): Label {
+  return {
+    id: 'label-1',
+    boardId: 'board-1',
+    name: 'Bug',
+    colorHex: '#FF0000',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+/**
+ * Mount useCardModal inside a thin wrapper component so Vue lifecycle hooks
+ * (watchers, onBeforeUnmount) fire correctly.
+ */
+function mountComposable(optionOverrides: Partial<UseCardModalOptions> = {}) {
+  const cardRef = ref(makeCard())
+  const isOpenRef = ref(false)
+  const labelsRef = ref<Label[]>([])
+
+  const onUpdated = vi.fn()
+  const onClose = vi.fn()
+
+  let result: ReturnType<typeof useCardModal>
+
+  const TestComponent = defineComponent({
+    setup() {
+      result = useCardModal({
+        getCard: () => cardRef.value,
+        getIsOpen: () => isOpenRef.value,
+        getLabels: () => labelsRef.value,
+        onUpdated,
+        onClose,
+        ...optionOverrides,
+      })
+      return {}
+    },
+    template: '<div></div>',
+  })
+
+  const wrapper = mount(TestComponent)
+
+  return {
+    get result() { return result! },
+    wrapper,
+    cardRef,
+    isOpenRef,
+    labelsRef,
+    onUpdated,
+    onClose,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useCardModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+    mockBoardStore.editingCardId = null
+    mockBoardStore.getCardComments.mockReturnValue([])
+    mockBoardStore.fetchCardComments.mockResolvedValue([])
+    mockBoardStore.fetchCardProvenance.mockResolvedValue(null)
+    mockBoardStore.updateCard.mockResolvedValue(undefined)
+    mockBoardStore.deleteCard.mockResolvedValue(undefined)
+    mockBoardStore.createCardComment.mockResolvedValue(undefined)
+    mockBoardStore.updateCardComment.mockResolvedValue(undefined)
+    mockBoardStore.deleteCardComment.mockResolvedValue(undefined)
+    mockSessionStore.userId = 'user-1'
+  })
+
+  // -------------------------------------------------------------------------
+  // Initialisation & card watcher
+  // -------------------------------------------------------------------------
+
+  describe('card watcher', () => {
+    it('populates form fields from card on mount', async () => {
+      const { result } = mountComposable()
+      await nextTick()
+
+      expect(result.title.value).toBe('Test Card')
+      expect(result.description.value).toBe('Some description')
+      expect(result.dueDate.value).toBe('2025-12-31')
+      expect(result.isBlocked.value).toBe(false)
+      expect(result.blockReason.value).toBe('')
+    })
+
+    it('uses empty string when card description is null', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ description: '' })
+      await nextTick()
+
+      expect(ctx.result.description.value).toBe('')
+    })
+
+    it('uses empty string when card dueDate is null', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ dueDate: null })
+      await nextTick()
+
+      expect(ctx.result.dueDate.value).toBe('')
+    })
+
+    it('uses empty string when card blockReason is null', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ blockReason: null })
+      await nextTick()
+
+      expect(ctx.result.blockReason.value).toBe('')
+    })
+
+    it('maps card labels to selectedLabelIds', async () => {
+      const label = makeLabel({ id: 'lbl-99' })
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ labels: [label] })
+      await nextTick()
+
+      expect(ctx.result.selectedLabelIds.value).toEqual(['lbl-99'])
+    })
+
+    it('loads provenance when card changes while modal is open', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      mockBoardStore.fetchCardProvenance.mockClear()
+
+      // Change card (reset the loaded provenance card ID by changing to a new card)
+      ctx.cardRef.value = makeCard({ id: 'card-2' })
+      await nextTick()
+      await nextTick()
+
+      expect(mockBoardStore.fetchCardProvenance).toHaveBeenCalledWith('board-1', 'card-2')
+    })
+
+    it('does not load provenance when card changes while modal is closed', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = false
+      await nextTick()
+
+      mockBoardStore.fetchCardProvenance.mockClear()
+      ctx.cardRef.value = makeCard({ id: 'card-3' })
+      await nextTick()
+      await nextTick()
+
+      expect(mockBoardStore.fetchCardProvenance).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // isOpen watcher
+  // -------------------------------------------------------------------------
+
+  describe('isOpen watcher', () => {
+    it('fetches comments and provenance when modal opens', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+
+      // The isOpen watcher is async: it awaits fetchCardComments, then
+      // loadCaptureProvenance, then calls setEditingCard. We need to flush
+      // the microtask queue several times to let all awaits settle.
+      await nextTick()
+      await nextTick()
+      await nextTick()
+      await nextTick()
+
+      expect(mockBoardStore.fetchCardComments).toHaveBeenCalledWith('board-1', 'card-1')
+      expect(mockBoardStore.setEditingCard).toHaveBeenCalledWith('card-1')
+    })
+
+    it('resets comment and provenance state when modal closes', async () => {
+      const ctx = mountComposable()
+
+      // Open
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      // Set some state
+      ctx.result.newCommentContent.value = 'draft'
+      ctx.result.editingCommentId.value = 'c-1'
+      ctx.result.editingCommentContent.value = 'editing'
+      ctx.result.replyDraftByParent.value = { c1: 'reply' }
+
+      // Close
+      ctx.isOpenRef.value = false
+      await nextTick()
+
+      expect(ctx.result.newCommentContent.value).toBe('')
+      expect(ctx.result.editingCommentId.value).toBeNull()
+      expect(ctx.result.editingCommentContent.value).toBe('')
+      expect(ctx.result.replyDraftByParent.value).toEqual({})
+    })
+
+    it('clears editing card when closing if board store matches', async () => {
+      const ctx = mountComposable()
+      mockBoardStore.editingCardId = 'card-1'
+
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      mockBoardStore.setEditingCard.mockClear()
+      ctx.isOpenRef.value = false
+      await nextTick()
+
+      expect(mockBoardStore.setEditingCard).toHaveBeenCalledWith(null)
+    })
+
+    it('does not clear editing card when closing if board store has different card', async () => {
+      const ctx = mountComposable()
+      mockBoardStore.editingCardId = 'card-other'
+
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      mockBoardStore.setEditingCard.mockClear()
+      ctx.isOpenRef.value = false
+      await nextTick()
+
+      // setEditingCard should NOT be called with null (only the close-reset branch)
+      const nullCalls = mockBoardStore.setEditingCard.mock.calls.filter(
+        (args: unknown[]) => args[0] === null,
+      )
+      expect(nullCalls).toHaveLength(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Computed: formattedDueDate, isOverdue, isFormValid
+  // -------------------------------------------------------------------------
+
+  describe('formattedDueDate', () => {
+    it('returns "No due date" when card has no dueDate', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ dueDate: null })
+      await nextTick()
+
+      expect(ctx.result.formattedDueDate.value).toBe('No due date')
+    })
+
+    it('formats a valid due date', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ dueDate: '2025-12-31T00:00:00Z' })
+      await nextTick()
+
+      expect(ctx.result.formattedDueDate.value).toContain('2025')
+    })
+  })
+
+  describe('isOverdue', () => {
+    it('returns false when card has no dueDate', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ dueDate: null })
+      await nextTick()
+
+      expect(ctx.result.isOverdue.value).toBe(false)
+    })
+
+    it('returns true when due date is in the past', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ dueDate: '2020-01-01T00:00:00Z' })
+      await nextTick()
+
+      expect(ctx.result.isOverdue.value).toBe(true)
+    })
+
+    it('returns false when due date is in the future', async () => {
+      const ctx = mountComposable()
+      ctx.cardRef.value = makeCard({ dueDate: '2099-12-31T00:00:00Z' })
+      await nextTick()
+
+      expect(ctx.result.isOverdue.value).toBe(false)
+    })
+  })
+
+  describe('isFormValid', () => {
+    it('returns false when title is empty', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.title.value = '   '
+      expect(ctx.result.isFormValid.value).toBe(false)
+    })
+
+    it('returns false when blocked but blockReason is empty', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.title.value = 'Valid Title'
+      ctx.result.isBlocked.value = true
+      ctx.result.blockReason.value = ''
+      expect(ctx.result.isFormValid.value).toBe(false)
+    })
+
+    it('returns true when title is set and not blocked', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.title.value = 'Valid Title'
+      ctx.result.isBlocked.value = false
+      expect(ctx.result.isFormValid.value).toBe(true)
+    })
+
+    it('returns true when blocked with a reason provided', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.title.value = 'Valid Title'
+      ctx.result.isBlocked.value = true
+      ctx.result.blockReason.value = 'Waiting on API'
+      expect(ctx.result.isFormValid.value).toBe(true)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // deleteConfirmDescription
+  // -------------------------------------------------------------------------
+
+  describe('deleteConfirmDescription', () => {
+    it('includes the card title', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.deleteConfirmDescription.value).toContain('Test Card')
+      expect(ctx.result.deleteConfirmDescription.value).toContain('cannot be undone')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Comments computed
+  // -------------------------------------------------------------------------
+
+  describe('topLevelComments', () => {
+    it('filters out replies (comments with parentCommentId)', async () => {
+      const top = makeComment({ id: 'c-1', parentCommentId: null })
+      const reply = makeComment({ id: 'c-2', parentCommentId: 'c-1' })
+      mockBoardStore.getCardComments.mockReturnValue([top, reply])
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.topLevelComments.value).toHaveLength(1)
+      expect(ctx.result.topLevelComments.value[0]!.id).toBe('c-1')
+    })
+  })
+
+  describe('getReplies', () => {
+    it('returns only comments with matching parentCommentId', async () => {
+      const top = makeComment({ id: 'c-1', parentCommentId: null })
+      const reply1 = makeComment({ id: 'c-2', parentCommentId: 'c-1' })
+      const reply2 = makeComment({ id: 'c-3', parentCommentId: 'c-1' })
+      const other = makeComment({ id: 'c-4', parentCommentId: 'c-99' })
+      mockBoardStore.getCardComments.mockReturnValue([top, reply1, reply2, other])
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.getReplies('c-1')).toHaveLength(2)
+      expect(ctx.result.getReplies('c-99')).toHaveLength(1)
+      expect(ctx.result.getReplies('nonexistent')).toHaveLength(0)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // canEditComment
+  // -------------------------------------------------------------------------
+
+  describe('canEditComment', () => {
+    it('returns true when session user matches comment author', async () => {
+      mockSessionStore.userId = 'user-1'
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.canEditComment(makeComment({ authorUserId: 'user-1' }))).toBe(true)
+    })
+
+    it('returns false when session user differs from comment author', async () => {
+      mockSessionStore.userId = 'user-1'
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.canEditComment(makeComment({ authorUserId: 'user-other' }))).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // loadCaptureProvenance
+  // -------------------------------------------------------------------------
+
+  describe('loadCaptureProvenance (via open watcher)', () => {
+    it('sets capture provenance on success', async () => {
+      const provenance = {
+        cardId: 'card-1',
+        captureItemId: 'cap-1',
+        proposalId: 'prop-1',
+        proposalStatus: 'Applied' as const,
+        triageRunId: null,
+      }
+      mockBoardStore.fetchCardProvenance.mockResolvedValue(provenance)
+
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+      await nextTick()
+
+      expect(ctx.result.captureProvenance.value).toEqual(provenance)
+      expect(ctx.result.loadedCaptureProvenanceCardId.value).toBe('card-1')
+      expect(ctx.result.loadingCaptureProvenance.value).toBe(false)
+    })
+
+    it('sets error state when provenance fetch fails', async () => {
+      mockBoardStore.fetchCardProvenance.mockRejectedValue(new Error('Network error'))
+
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+      await nextTick()
+
+      expect(ctx.result.captureProvenance.value).toBeNull()
+      expect(ctx.result.captureProvenanceError.value).toBe('Unable to load capture provenance.')
+      expect(ctx.result.loadedCaptureProvenanceCardId.value).toBe('card-1')
+      expect(ctx.result.loadingCaptureProvenance.value).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // handleSave
+  // -------------------------------------------------------------------------
+
+  describe('handleSave', () => {
+    it('does nothing when form is invalid', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.title.value = ''
+      await ctx.result.handleSave()
+
+      expect(mockBoardStore.updateCard).not.toHaveBeenCalled()
+      expect(ctx.onUpdated).not.toHaveBeenCalled()
+    })
+
+    it('sends only changed fields to updateCard', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      // Modify only title
+      ctx.result.title.value = 'New Title'
+      await ctx.result.handleSave()
+
+      expect(mockBoardStore.updateCard).toHaveBeenCalledWith(
+        'board-1',
+        'card-1',
+        expect.objectContaining({
+          title: 'New Title',
+          description: null, // unchanged
+        }),
+      )
+      expect(ctx.onUpdated).toHaveBeenCalled()
+      expect(ctx.onClose).toHaveBeenCalled()
+    })
+
+    it('sends null dueDate when dueDate is empty string', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      ctx.result.dueDate.value = ''
+      await ctx.result.handleSave()
+
+      expect(mockBoardStore.updateCard).toHaveBeenCalledWith(
+        'board-1',
+        'card-1',
+        expect.objectContaining({
+          dueDate: null,
+        }),
+      )
+    })
+
+    it('sends ISO dueDate when dueDate is set', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      ctx.result.dueDate.value = '2026-06-01'
+      await ctx.result.handleSave()
+
+      const call = mockBoardStore.updateCard.mock.calls[0]!
+      expect(call[2].dueDate).toContain('2026-06-01')
+    })
+
+    it('sends isBlocked delta and blockReason when blocked', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      ctx.result.isBlocked.value = true
+      ctx.result.blockReason.value = 'Blocked reason'
+      await ctx.result.handleSave()
+
+      expect(mockBoardStore.updateCard).toHaveBeenCalledWith(
+        'board-1',
+        'card-1',
+        expect.objectContaining({
+          isBlocked: true,
+          blockReason: 'Blocked reason',
+        }),
+      )
+    })
+
+    it('sends null blockReason when not blocked', async () => {
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      ctx.result.isBlocked.value = false
+      await ctx.result.handleSave()
+
+      expect(mockBoardStore.updateCard).toHaveBeenCalledWith(
+        'board-1',
+        'card-1',
+        expect.objectContaining({
+          blockReason: null,
+        }),
+      )
+    })
+
+    it('handles updateCard failure gracefully', async () => {
+      mockBoardStore.updateCard.mockRejectedValue(new Error('Save failed'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const ctx = mountComposable()
+      ctx.isOpenRef.value = true
+      await nextTick()
+      await nextTick()
+
+      await ctx.result.handleSave()
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to update card:', expect.any(Error))
+      expect(ctx.onUpdated).not.toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Delete
+  // -------------------------------------------------------------------------
+
+  describe('delete operations', () => {
+    it('handleDeleteClick sets showDeleteConfirm', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.handleDeleteClick()
+      expect(ctx.result.showDeleteConfirm.value).toBe(true)
+    })
+
+    it('handleDeleteCancel clears showDeleteConfirm', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.handleDeleteClick()
+      ctx.result.handleDeleteCancel()
+      expect(ctx.result.showDeleteConfirm.value).toBe(false)
+    })
+
+    it('handleDeleteConfirm calls deleteCard and emits', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      await ctx.result.handleDeleteConfirm()
+
+      expect(mockBoardStore.deleteCard).toHaveBeenCalledWith('board-1', 'card-1')
+      expect(ctx.result.showDeleteConfirm.value).toBe(false)
+      expect(ctx.onUpdated).toHaveBeenCalled()
+      expect(ctx.onClose).toHaveBeenCalled()
+      expect(ctx.result.isDeleting.value).toBe(false)
+    })
+
+    it('handleDeleteConfirm does nothing when already deleting', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.isDeleting.value = true
+      await ctx.result.handleDeleteConfirm()
+
+      expect(mockBoardStore.deleteCard).not.toHaveBeenCalled()
+    })
+
+    it('handleDeleteConfirm handles error and resets isDeleting', async () => {
+      mockBoardStore.deleteCard.mockRejectedValue(new Error('Delete failed'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      await ctx.result.handleDeleteConfirm()
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to delete card:', expect.any(Error))
+      expect(ctx.result.isDeleting.value).toBe(false)
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Due date
+  // -------------------------------------------------------------------------
+
+  describe('clearDueDate', () => {
+    it('resets dueDate to empty string', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.dueDate.value).toBe('2025-12-31')
+      ctx.result.clearDueDate()
+      expect(ctx.result.dueDate.value).toBe('')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Comments
+  // -------------------------------------------------------------------------
+
+  describe('handleAddComment', () => {
+    it('creates a top-level comment when no parentCommentId', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.newCommentContent.value = 'New comment'
+      await ctx.result.handleAddComment()
+
+      expect(mockBoardStore.createCardComment).toHaveBeenCalledWith('board-1', 'card-1', {
+        content: 'New comment',
+        parentCommentId: null,
+      })
+      expect(ctx.result.newCommentContent.value).toBe('')
+    })
+
+    it('creates a reply when parentCommentId is provided', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.replyDraftByParent.value = { 'c-1': 'Reply text' }
+      await ctx.result.handleAddComment('c-1')
+
+      expect(mockBoardStore.createCardComment).toHaveBeenCalledWith('board-1', 'card-1', {
+        content: 'Reply text',
+        parentCommentId: 'c-1',
+      })
+      expect(ctx.result.replyDraftByParent.value['c-1']).toBe('')
+    })
+
+    it('does nothing when top-level content is empty', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.newCommentContent.value = '   '
+      await ctx.result.handleAddComment()
+
+      expect(mockBoardStore.createCardComment).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when reply content is empty', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.replyDraftByParent.value = { 'c-1': '   ' }
+      await ctx.result.handleAddComment('c-1')
+
+      expect(mockBoardStore.createCardComment).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when reply draft is missing (nullish coalescing)', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      // replyDraftByParent does not have 'c-1' key
+      ctx.result.replyDraftByParent.value = {}
+      await ctx.result.handleAddComment('c-1')
+
+      expect(mockBoardStore.createCardComment).not.toHaveBeenCalled()
+    })
+
+    it('handles createCardComment failure gracefully', async () => {
+      mockBoardStore.createCardComment.mockRejectedValue(new Error('fail'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.newCommentContent.value = 'comment'
+      await ctx.result.handleAddComment()
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to add comment:', expect.any(Error))
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('handleStartEditComment', () => {
+    it('sets editing state for an editable comment', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-1', content: 'Edit me' })
+      ctx.result.handleStartEditComment(comment)
+
+      expect(ctx.result.editingCommentId.value).toBe('c-1')
+      expect(ctx.result.editingCommentContent.value).toBe('Edit me')
+    })
+
+    it('does nothing when user cannot edit the comment', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-other' })
+      ctx.result.handleStartEditComment(comment)
+
+      expect(ctx.result.editingCommentId.value).toBeNull()
+    })
+
+    it('does nothing when comment is deleted', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-1', isDeleted: true })
+      ctx.result.handleStartEditComment(comment)
+
+      expect(ctx.result.editingCommentId.value).toBeNull()
+    })
+  })
+
+  describe('handleCancelEditComment', () => {
+    it('resets editing state', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.editingCommentId.value = 'c-1'
+      ctx.result.editingCommentContent.value = 'some content'
+
+      ctx.result.handleCancelEditComment()
+
+      expect(ctx.result.editingCommentId.value).toBeNull()
+      expect(ctx.result.editingCommentContent.value).toBe('')
+    })
+  })
+
+  describe('handleSaveEditComment', () => {
+    it('updates the comment and clears editing state', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.editingCommentContent.value = 'Updated content'
+      await ctx.result.handleSaveEditComment('c-1')
+
+      expect(mockBoardStore.updateCardComment).toHaveBeenCalledWith(
+        'board-1', 'card-1', 'c-1', { content: 'Updated content' },
+      )
+      expect(ctx.result.editingCommentId.value).toBeNull()
+    })
+
+    it('does nothing when editing content is empty', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.editingCommentContent.value = '   '
+      await ctx.result.handleSaveEditComment('c-1')
+
+      expect(mockBoardStore.updateCardComment).not.toHaveBeenCalled()
+    })
+
+    it('handles updateCardComment failure gracefully', async () => {
+      mockBoardStore.updateCardComment.mockRejectedValue(new Error('fail'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      ctx.result.editingCommentContent.value = 'content'
+      await ctx.result.handleSaveEditComment('c-1')
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to update comment:', expect.any(Error))
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe('handleDeleteComment', () => {
+    it('deletes the comment when user confirms', async () => {
+      vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-1' })
+      await ctx.result.handleDeleteComment(comment)
+
+      expect(mockBoardStore.deleteCardComment).toHaveBeenCalledWith('board-1', 'card-1', 'c-1')
+    })
+
+    it('does nothing when user is not the author', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-other' })
+      await ctx.result.handleDeleteComment(comment)
+
+      expect(mockBoardStore.deleteCardComment).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when user cancels confirmation', async () => {
+      vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-1' })
+      await ctx.result.handleDeleteComment(comment)
+
+      expect(mockBoardStore.deleteCardComment).not.toHaveBeenCalled()
+    })
+
+    it('handles deleteCardComment failure gracefully', async () => {
+      vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
+      mockBoardStore.deleteCardComment.mockRejectedValue(new Error('fail'))
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      const comment = makeComment({ id: 'c-1', authorUserId: 'user-1' })
+      await ctx.result.handleDeleteComment(comment)
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to delete comment:', expect.any(Error))
+      consoleSpy.mockRestore()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Provenance links
+  // -------------------------------------------------------------------------
+
+  describe('captureHref / proposalHref', () => {
+    it('generates correct capture href', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.captureHref('cap-1')).toBe(
+        '/workspace/inbox?boardId=board-1#capture-cap-1',
+      )
+    })
+
+    it('generates correct proposal href', async () => {
+      const ctx = mountComposable()
+      await nextTick()
+
+      expect(ctx.result.proposalHref('prop-1')).toBe(
+        '/workspace/review?boardId=board-1#proposal-prop-1',
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // onBeforeUnmount cleanup
+  // -------------------------------------------------------------------------
+
+  describe('onBeforeUnmount', () => {
+    it('clears editing card when it matches the current card', async () => {
+      mockBoardStore.editingCardId = 'card-1'
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      mockBoardStore.setEditingCard.mockClear()
+      ctx.wrapper.unmount()
+
+      expect(mockBoardStore.setEditingCard).toHaveBeenCalledWith(null)
+    })
+
+    it('does not clear editing card when it does not match', async () => {
+      mockBoardStore.editingCardId = 'card-other'
+
+      const ctx = mountComposable()
+      await nextTick()
+
+      mockBoardStore.setEditingCard.mockClear()
+      ctx.wrapper.unmount()
+
+      const nullCalls = mockBoardStore.setEditingCard.mock.calls.filter(
+        (args: unknown[]) => args[0] === null,
+      )
+      expect(nullCalls).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Extract all business logic from `CardModal.vue` (681 lines) into a `useCardModal` composable (`src/composables/useCardModal.ts`)
- Create six sub-components in `src/components/board/card-modal/`:
  - `CardModalHeader.vue` -- title and close button
  - `CardModalForm.vue` -- title, description, due date, blocked status fields
  - `CardModalLabels.vue` -- label checkbox selection with color swatches
  - `CardModalComments.vue` -- threaded comments with replies, editing, and deletion
  - `CardModalMetadata.vue` -- timestamps and capture provenance display
  - `CardModalActions.vue` -- delete, cancel, and save footer buttons
- Rewrite `CardModal.vue` as a 190-line thin shell (down from 681 lines) that composes the sub-components
- Add barrel export (`card-modal/index.ts`) following the existing pattern in `components/inbox/`
- No changes needed to `ColumnLane.vue` -- CardModal's public API (props and events) is unchanged

## Test plan

- [x] All 2607 existing unit tests pass without modification
- [x] `npm run typecheck` passes cleanly
- [x] `npm run build` succeeds
- [x] `npm run lint` introduces no new warnings or errors
- [x] CardModal's props/events interface unchanged -- ColumnLane.vue requires zero changes
- [ ] Manual smoke test: open a card modal, edit fields, save, verify provenance and comments render

Closes #954