### PR TITLE
Expand virtual scrolling to ReviewView and NotificationInboxView

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/NotificationInboxView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/NotificationInboxView.spec.ts
@@ -3,6 +3,39 @@ import { mount } from '@vue/test-utils'
 import { reactive } from 'vue'
 import NotificationInboxView from '../../views/NotificationInboxView.vue'
 
+const vueHelpers = vi.hoisted(async () => {
+  const { computed, ref, shallowRef } = await import('vue')
+  return { computed, ref, shallowRef }
+})
+
+vi.mock('../../composables/useVirtualList', async () => {
+  const { computed, ref, shallowRef } = await vueHelpers
+  return {
+    useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
+      const getCount = typeof options.count === 'function'
+        ? options.count
+        : () => options.count.value
+      return {
+        parentRef: ref(null),
+        virtualItemEls: shallowRef([]),
+        virtualRows: computed(() =>
+          Array.from({ length: getCount() }, (_, i) => ({
+            key: i,
+            index: i,
+            start: i * options.estimateSize,
+            end: (i + 1) * options.estimateSize,
+            size: options.estimateSize,
+            lane: 0,
+          })),
+        ),
+        totalSize: computed(() => getCount() * options.estimateSize),
+        translateY: computed(() => 0),
+        scrollToIndex: vi.fn(),
+      }
+    },
+  }
+})
+
 const routerMocks = vi.hoisted(() => ({
   push: vi.fn(),
 }))

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.coverage.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.coverage.spec.ts
@@ -4,6 +4,39 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import type { Proposal } from '../../types/automation'
 import ReviewView from '../../views/ReviewView.vue'
 
+const vueHelpers = vi.hoisted(async () => {
+  const { computed, ref, shallowRef } = await import('vue')
+  return { computed, ref, shallowRef }
+})
+
+vi.mock('../../composables/useVirtualList', async () => {
+  const { computed, ref, shallowRef } = await vueHelpers
+  return {
+    useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
+      const getCount = typeof options.count === 'function'
+        ? options.count
+        : () => options.count.value
+      return {
+        parentRef: ref(null),
+        virtualItemEls: shallowRef([]),
+        virtualRows: computed(() =>
+          Array.from({ length: getCount() }, (_, i) => ({
+            key: i,
+            index: i,
+            start: i * options.estimateSize,
+            end: (i + 1) * options.estimateSize,
+            size: options.estimateSize,
+            lane: 0,
+          })),
+        ),
+        totalSize: computed(() => getCount() * options.estimateSize),
+        translateY: computed(() => 0),
+        scrollToIndex: vi.fn(),
+      }
+    },
+  }
+})
+
 const mocks = vi.hoisted(() => ({
   getProposals: vi.fn(),
   getProposal: vi.fn(),

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
@@ -4,6 +4,39 @@ import { createMemoryHistory, createRouter } from 'vue-router'
 import type { Proposal } from '../../types/automation'
 import ReviewView from '../../views/ReviewView.vue'
 
+const vueHelpers = vi.hoisted(async () => {
+  const { computed, ref, shallowRef } = await import('vue')
+  return { computed, ref, shallowRef }
+})
+
+vi.mock('../../composables/useVirtualList', async () => {
+  const { computed, ref, shallowRef } = await vueHelpers
+  return {
+    useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
+      const getCount = typeof options.count === 'function'
+        ? options.count
+        : () => options.count.value
+      return {
+        parentRef: ref(null),
+        virtualItemEls: shallowRef([]),
+        virtualRows: computed(() =>
+          Array.from({ length: getCount() }, (_, i) => ({
+            key: i,
+            index: i,
+            start: i * options.estimateSize,
+            end: (i + 1) * options.estimateSize,
+            size: options.estimateSize,
+            lane: 0,
+          })),
+        ),
+        totalSize: computed(() => getCount() * options.estimateSize),
+        translateY: computed(() => 0),
+        scrollToIndex: vi.fn(),
+      }
+    },
+  }
+})
+
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
   let reject!: (reason?: unknown) => void

--- a/frontend/taskdeck-web/src/views/NotificationInboxView.vue
+++ b/frontend/taskdeck-web/src/views/NotificationInboxView.vue
@@ -11,6 +11,7 @@ import {
   type NotificationGroup,
   type TimeGroup,
 } from '../composables/useNotificationGrouping'
+import { useVirtualList } from '../composables/useVirtualList'
 import type { NotificationItem } from '../types/notifications'
 import { normalizeBoardIdQueryParam } from '../utils/navigation'
 
@@ -27,21 +28,89 @@ const activeBoardId = computed(() => normalizeBoardIdQueryParam(route.query.boar
 
 const grouped = computed<NotificationGroup[]>(() => groupNotifications(items.value))
 
-/** Distinct time headers in display order */
-const timeHeaders = computed<TimeGroup[]>(() => {
-  const seen = new Set<TimeGroup>()
-  const result: TimeGroup[] = []
-  for (const g of grouped.value) {
-    if (!seen.has(g.timeHeader)) {
-      seen.add(g.timeHeader)
-      result.push(g.timeHeader)
+/**
+ * Flatten the grouped notification structure into a single list of display rows.
+ * Each row is either a time header, a collapsed group summary, a collapse button,
+ * or an individual notification item.
+ */
+type FlatRow =
+  | { kind: 'time-header'; header: TimeGroup; key: string }
+  | { kind: 'collapsed-summary'; group: NotificationGroup; key: string }
+  | { kind: 'collapse-button'; group: NotificationGroup; key: string }
+  | { kind: 'notification'; item: NotificationItem; group: NotificationGroup; key: string }
+
+const flatRows = computed<FlatRow[]>(() => {
+  const rows: FlatRow[] = []
+  let lastHeader: TimeGroup | null = null
+
+  for (const group of grouped.value) {
+    // Insert a time header row when the time section changes
+    if (group.timeHeader !== lastHeader) {
+      rows.push({ kind: 'time-header', header: group.timeHeader, key: `header-${group.timeHeader}` })
+      lastHeader = group.timeHeader
+    }
+
+    if (group.isCollapsed && !expandedGroups.value.has(group.key)) {
+      // Collapsed group: show a single summary row
+      rows.push({ kind: 'collapsed-summary', group, key: `collapsed-${group.key}` })
+    } else {
+      // Expanded group or single-item group
+      if (group.isCollapsed) {
+        // Add a collapse button row before the expanded items
+        rows.push({ kind: 'collapse-button', group, key: `collapse-btn-${group.key}` })
+      }
+      for (const item of group.items) {
+        rows.push({ kind: 'notification', item, group, key: `item-${item.id}` })
+      }
     }
   }
-  return result
+
+  return rows
 })
 
-function groupsForHeader(header: TimeGroup): NotificationGroup[] {
-  return grouped.value.filter((g) => g.timeHeader === header)
+const _vl = useVirtualList({
+  count: computed(() => flatRows.value.length),
+  estimateSize: 100,
+  overscan: 5,
+})
+
+// vue-tsc >=3.2.6 does not count ref="name" in templates as a script read;
+// these refs are intentionally bound via template ref attributes.
+// @ts-expect-error TS6133
+const notifParentRef = _vl.parentRef
+// @ts-expect-error TS6133
+const notifVirtualItemEls = _vl.virtualItemEls
+const notifVirtualRows = _vl.virtualRows
+const notifTotalSize = _vl.totalSize
+const notifTranslateY = _vl.translateY
+
+function handleNotifKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    const first = notifVirtualRows.value[0]
+    const current = first?.index ?? 0
+    const next = Math.min(current + 1, flatRows.value.length - 1)
+    _vl.scrollToIndex(next)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    const first = notifVirtualRows.value[0]
+    const current = first?.index ?? 0
+    const prev = Math.max(current - 1, 0)
+    _vl.scrollToIndex(prev)
+  }
+}
+
+/** Accessor helpers to simplify template type narrowing for flat rows. */
+function rowHeader(index: number): TimeGroup {
+  return (flatRows.value[index] as { kind: 'time-header'; header: TimeGroup }).header
+}
+
+function rowGroup(index: number): NotificationGroup {
+  return (flatRows.value[index] as { kind: 'collapsed-summary' | 'collapse-button'; group: NotificationGroup }).group
+}
+
+function rowItem(index: number): NotificationItem {
+  return (flatRows.value[index] as { kind: 'notification'; item: NotificationItem }).item
 }
 
 function formatCadence(value: number | string): string {
@@ -173,100 +242,130 @@ watch([unreadOnly, activeBoardId], () => {
     <div v-if="notifications.loading" class="td-placeholder">Loading notifications...</div>
     <div v-else-if="items.length === 0" class="td-placeholder">No notifications found.</div>
 
-    <template v-else>
-      <section v-for="header in timeHeaders" :key="header" class="mb-6">
-        <h2 class="text-sm font-semibold uppercase tracking-wide text-[color:var(--td-text-tertiary)] mb-3">
-          {{ header }}
-        </h2>
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- virtual scrollable list with keyboard handler -->
+    <div
+      v-else
+      ref="notifParentRef"
+      class="td-notif-virtual"
+      tabindex="0"
+      @keydown="handleNotifKeydown"
+    >
+      <div
+        role="presentation"
+        :style="{ height: `${notifTotalSize}px`, width: '100%', position: 'relative' }"
+      >
+        <div
+          role="presentation"
+          :style="{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${notifTranslateY}px)`,
+          }"
+        >
+          <div
+            v-for="virtualRow in notifVirtualRows"
+            :key="String(virtualRow.key)"
+            :data-index="virtualRow.index"
+            ref="notifVirtualItemEls"
+            role="presentation"
+          >
+            <template v-if="flatRows[virtualRow.index]">
+              <!-- Time header row -->
+              <h2
+                v-if="flatRows[virtualRow.index]!.kind === 'time-header'"
+                class="text-sm font-semibold uppercase tracking-wide text-[color:var(--td-text-tertiary)] mb-3 mt-4"
+              >
+                {{ rowHeader(virtualRow.index) }}
+              </h2>
 
-        <ul class="flex flex-col gap-3 list-none m-0 p-0">
-          <template v-for="group in groupsForHeader(header)" :key="group.key">
-            <!-- Collapsed group summary -->
-            <li v-if="group.isCollapsed && !expandedGroups.has(group.key)">
+              <!-- Collapsed group summary -->
               <button
-                class="w-full text-left rounded-lg border border-[color:var(--td-border-default)] bg-[color:var(--td-surface-primary)] p-4 hover:bg-[color:var(--td-surface-secondary)] transition-colors"
-                :class="typeBorderClass(group.items[0].type)"
-                @click="toggleGroupExpand(group.key)"
+                v-else-if="flatRows[virtualRow.index]!.kind === 'collapsed-summary'"
+                class="w-full text-left rounded-lg border border-[color:var(--td-border-default)] bg-[color:var(--td-surface-primary)] p-4 hover:bg-[color:var(--td-surface-secondary)] transition-colors mb-3"
+                :class="typeBorderClass(rowGroup(virtualRow.index).items[0].type)"
+                @click="toggleGroupExpand(rowGroup(virtualRow.index).key)"
               >
                 <div class="flex items-center gap-3">
                   <span
                     class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-                    :class="typeBadgeClass(group.items[0].type)"
+                    :class="typeBadgeClass(rowGroup(virtualRow.index).items[0].type)"
                   >
-                    {{ typeLabel(group.items[0].type) }}
+                    {{ typeLabel(rowGroup(virtualRow.index).items[0].type) }}
                   </span>
                   <span class="font-medium text-[color:var(--td-text-primary)]">
-                    {{ group.summaryLabel }}
+                    {{ rowGroup(virtualRow.index).summaryLabel }}
                   </span>
                   <span class="text-xs text-[color:var(--td-text-tertiary)] ml-auto">
                     Click to expand
                   </span>
                 </div>
               </button>
-            </li>
 
-            <!-- Expanded group or single item -->
-            <template v-else>
               <!-- Collapse button for expanded groups -->
-              <li v-if="group.isCollapsed" class="flex items-center gap-2 mb-1">
+              <div
+                v-else-if="flatRows[virtualRow.index]!.kind === 'collapse-button'"
+                class="flex items-center gap-2 mb-1"
+              >
                 <button
                   class="text-xs text-[color:var(--td-color-primary)] hover:underline"
-                  @click="toggleGroupExpand(group.key)"
+                  @click="toggleGroupExpand(rowGroup(virtualRow.index).key)"
                 >
-                  Collapse {{ group.items.length }} {{ typeLabel(group.items[0].type).toLowerCase() }} notifications
+                  Collapse {{ rowGroup(virtualRow.index).items.length }} {{ typeLabel(rowGroup(virtualRow.index).items[0].type).toLowerCase() }} notifications
                 </button>
-              </li>
+              </div>
 
-              <li
-                v-for="item in group.items"
-                :key="item.id"
-                class="td-notification-row flex justify-between gap-4 items-start rounded-lg border border-[color:var(--td-border-default)] bg-[color:var(--td-surface-primary)] p-4"
+              <!-- Individual notification item -->
+              <div
+                v-else-if="flatRows[virtualRow.index]!.kind === 'notification'"
+                class="td-notification-row flex justify-between gap-4 items-start rounded-lg border border-[color:var(--td-border-default)] bg-[color:var(--td-surface-primary)] p-4 mb-3"
                 :class="[
-                  typeBorderClass(item.type),
-                  { 'border-[color:var(--td-color-primary)]': !item.isRead },
+                  typeBorderClass(rowItem(virtualRow.index).type),
+                  { 'border-[color:var(--td-color-primary)]': !rowItem(virtualRow.index).isRead },
                 ]"
               >
                 <div class="flex flex-col gap-2">
                   <div class="flex items-center gap-2">
                     <span
                       class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium"
-                      :class="typeBadgeClass(item.type)"
+                      :class="typeBadgeClass(rowItem(virtualRow.index).type)"
                     >
-                      {{ typeLabel(item.type) }}
+                      {{ typeLabel(rowItem(virtualRow.index).type) }}
                     </span>
                     <span class="font-semibold text-[color:var(--td-text-primary)]">
-                      {{ item.title }}
+                      {{ rowItem(virtualRow.index).title }}
                     </span>
                   </div>
-                  <div class="text-[color:var(--td-text-secondary)]">{{ item.message }}</div>
+                  <div class="text-[color:var(--td-text-secondary)]">{{ rowItem(virtualRow.index).message }}</div>
                   <div class="flex flex-wrap gap-3 text-sm text-[color:var(--td-text-tertiary)]">
-                    <span v-if="item.boardId">Board-linked</span>
-                    <span>{{ formatCadence(item.cadence) }}</span>
-                    <span>{{ new Date(item.createdAt).toLocaleString() }}</span>
+                    <span v-if="rowItem(virtualRow.index).boardId">Board-linked</span>
+                    <span>{{ formatCadence(rowItem(virtualRow.index).cadence) }}</span>
+                    <span>{{ new Date(rowItem(virtualRow.index).createdAt).toLocaleString() }}</span>
                   </div>
                 </div>
                 <div class="flex flex-wrap justify-end gap-2">
                   <button
-                    v-if="destinationLabel(item)"
+                    v-if="destinationLabel(rowItem(virtualRow.index))"
                     class="td-btn td-btn--secondary"
-                    @click="openNotificationDestination(item)"
+                    @click="openNotificationDestination(rowItem(virtualRow.index))"
                   >
-                    {{ destinationLabel(item) }}
+                    {{ destinationLabel(rowItem(virtualRow.index)) }}
                   </button>
                   <button
-                    v-if="!item.isRead"
+                    v-if="!rowItem(virtualRow.index).isRead"
                     class="td-btn td-btn--primary"
-                    @click="markAsRead(item.id)"
+                    @click="markAsRead(rowItem(virtualRow.index).id)"
                   >
                     Mark read
                   </button>
                 </div>
-              </li>
+              </div>
             </template>
-          </template>
-        </ul>
-      </section>
-    </template>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -303,5 +402,16 @@ watch([unreadOnly, activeBoardId], () => {
   background: var(--td-surface-tertiary);
   color: var(--td-text-primary);
   border: 1px solid var(--td-border-default);
+}
+
+.td-notif-virtual {
+  max-height: 70vh;
+  overflow-y: auto;
+  contain: strict;
+  outline: none;
+}
+
+.td-notif-virtual:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(255, 77, 77, 0.35);
 }
 </style>

--- a/frontend/taskdeck-web/src/views/NotificationInboxView.vue
+++ b/frontend/taskdeck-web/src/views/NotificationInboxView.vue
@@ -84,33 +84,40 @@ const notifVirtualRows = _vl.virtualRows
 const notifTotalSize = _vl.totalSize
 const notifTranslateY = _vl.translateY
 
+const activeNotifIndex = ref(0)
+
 function handleNotifKeydown(event: KeyboardEvent) {
+  if (flatRows.value.length === 0) return
   if (event.key === 'ArrowDown') {
     event.preventDefault()
-    const first = notifVirtualRows.value[0]
-    const current = first?.index ?? 0
-    const next = Math.min(current + 1, flatRows.value.length - 1)
+    const next = Math.min(activeNotifIndex.value + 1, flatRows.value.length - 1)
+    activeNotifIndex.value = next
     _vl.scrollToIndex(next)
   } else if (event.key === 'ArrowUp') {
     event.preventDefault()
-    const first = notifVirtualRows.value[0]
-    const current = first?.index ?? 0
-    const prev = Math.max(current - 1, 0)
+    const prev = Math.max(activeNotifIndex.value - 1, 0)
+    activeNotifIndex.value = prev
     _vl.scrollToIndex(prev)
   }
 }
 
 /** Accessor helpers to simplify template type narrowing for flat rows. */
 function rowHeader(index: number): TimeGroup {
-  return (flatRows.value[index] as { kind: 'time-header'; header: TimeGroup }).header
+  const row = flatRows.value[index]
+  if (row && row.kind === 'time-header') return row.header
+  return '' as TimeGroup
 }
 
 function rowGroup(index: number): NotificationGroup {
-  return (flatRows.value[index] as { kind: 'collapsed-summary' | 'collapse-button'; group: NotificationGroup }).group
+  const row = flatRows.value[index]
+  if (row && (row.kind === 'collapsed-summary' || row.kind === 'collapse-button')) return row.group
+  return { key: '', timeHeader: '' as TimeGroup, isCollapsed: false, summaryLabel: '', items: [] } as unknown as NotificationGroup
 }
 
 function rowItem(index: number): NotificationItem {
-  return (flatRows.value[index] as { kind: 'notification'; item: NotificationItem }).item
+  const row = flatRows.value[index]
+  if (row && row.kind === 'notification') return row.item
+  return {} as NotificationItem
 }
 
 function formatCadence(value: number | string): string {

--- a/frontend/taskdeck-web/src/views/NotificationInboxView.vue
+++ b/frontend/taskdeck-web/src/views/NotificationInboxView.vue
@@ -414,7 +414,7 @@ watch([unreadOnly, activeBoardId], () => {
 .td-notif-virtual {
   max-height: 70vh;
   overflow-y: auto;
-  contain: strict;
+  contain: layout paint;
   outline: none;
 }
 

--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
 import ReviewHeader from '../components/review/ReviewHeader.vue'
@@ -64,11 +64,8 @@ const reviewVirtualRows = _vl.virtualRows
 const reviewTotalSize = _vl.totalSize
 const reviewTranslateY = _vl.translateY
 
-/** Active keyboard index for ArrowUp/ArrowDown navigation. */
-const activeReviewIndex = computed(() => {
-  if (reviewVirtualRows.value.length === 0) return -1
-  return reviewVirtualRows.value[0]?.index ?? -1
-})
+/** Tracked keyboard cursor for ArrowUp/ArrowDown navigation. */
+const activeReviewIndex = ref(0)
 
 const route = useRoute()
 
@@ -104,15 +101,16 @@ watch(
 )
 
 function handleReviewKeydown(event: KeyboardEvent) {
+  if (visibleProposals.value.length === 0) return
   if (event.key === 'ArrowDown') {
     event.preventDefault()
-    const current = activeReviewIndex.value
-    const next = Math.min(current + 1, visibleProposals.value.length - 1)
+    const next = Math.min(activeReviewIndex.value + 1, visibleProposals.value.length - 1)
+    activeReviewIndex.value = next
     _vl.scrollToIndex(next)
   } else if (event.key === 'ArrowUp') {
     event.preventDefault()
-    const current = activeReviewIndex.value
-    const prev = Math.max(current - 1, 0)
+    const prev = Math.max(activeReviewIndex.value - 1, 0)
+    activeReviewIndex.value = prev
     _vl.scrollToIndex(prev)
   }
 }

--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -88,6 +88,7 @@ function scrollVirtualizerToHashProposal() {
   const index = visibleProposals.value.findIndex((p) => p.id === proposalId)
   if (index >= 0) {
     _vl.scrollToIndex(index)
+    activeReviewIndex.value = index
   }
 }
 
@@ -195,7 +196,7 @@ onUnmounted(() => {
         >
           <div
             v-for="virtualRow in reviewVirtualRows"
-            :key="String(virtualRow.key)"
+            :key="visibleProposals[virtualRow.index]?.id ?? String(virtualRow.key)"
             :data-index="virtualRow.index"
             ref="reviewVirtualItemEls"
             role="presentation"

--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
 import ReviewHeader from '../components/review/ReviewHeader.vue'
 import ReviewSummaryCards from '../components/review/ReviewSummaryCards.vue'
@@ -7,6 +7,7 @@ import ReviewEmptyState from '../components/review/ReviewEmptyState.vue'
 import ReviewProposalCard from '../components/review/ReviewProposalCard.vue'
 import { useReviewProposals } from '../composables/useReviewProposals'
 import { useReviewActions } from '../composables/useReviewActions'
+import { useVirtualList } from '../composables/useVirtualList'
 
 const {
   proposals,
@@ -45,6 +46,42 @@ const {
   handleDismissProposal,
   handleDismissApplied,
 } = useReviewActions(proposals, dismissableProposalIds, loadProposals)
+
+const _vl = useVirtualList({
+  count: computed(() => visibleProposals.value.length),
+  estimateSize: 220,
+  overscan: 3,
+})
+
+// vue-tsc >=3.2.6 does not count ref="name" in templates as a script read;
+// these refs are intentionally bound via template ref attributes.
+// @ts-expect-error TS6133
+const reviewParentRef = _vl.parentRef
+// @ts-expect-error TS6133
+const reviewVirtualItemEls = _vl.virtualItemEls
+const reviewVirtualRows = _vl.virtualRows
+const reviewTotalSize = _vl.totalSize
+const reviewTranslateY = _vl.translateY
+
+/** Active keyboard index for ArrowUp/ArrowDown navigation. */
+const activeReviewIndex = computed(() => {
+  if (reviewVirtualRows.value.length === 0) return -1
+  return reviewVirtualRows.value[0]?.index ?? -1
+})
+
+function handleReviewKeydown(event: KeyboardEvent) {
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    const current = activeReviewIndex.value
+    const next = Math.min(current + 1, visibleProposals.value.length - 1)
+    _vl.scrollToIndex(next)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    const current = activeReviewIndex.value
+    const prev = Math.max(current - 1, 0)
+    _vl.scrollToIndex(prev)
+  }
+}
 
 onMounted(() => {
   void loadBoardOptions()
@@ -101,24 +138,55 @@ onUnmounted(() => {
       @navigate="openRoute"
     />
 
-    <section v-else class="td-review__list" aria-label="Proposals awaiting review">
-      <ReviewProposalCard
-        v-for="proposal in visibleProposals"
-        :key="proposal.id"
-        :proposal="proposal"
-        :is-expired="isProposalExpired(proposal)"
-        :is-busy="proposalActionBusyId === proposal.id"
-        :selected-diff-proposal-id="selectedDiffProposalId"
-        :selected-diff="selectedDiff"
-        :capture-href="captureHrefForProposal(proposal)"
-        :proposal-href="proposalHref(proposal)"
-        @approve="handleApproveProposal"
-        @reject="handleRejectProposal"
-        @execute="handleExecuteProposal"
-        @toggle-diff="handleToggleDiff"
-        @dismiss="handleDismissProposal"
-        @open-board="openBoard"
-      />
+    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- scrollable virtual list with keyboard handler -->
+    <section
+      v-else
+      ref="reviewParentRef"
+      class="td-review__list td-review__list--virtual"
+      aria-label="Proposals awaiting review"
+      tabindex="0"
+      @keydown="handleReviewKeydown"
+    >
+      <div
+        role="presentation"
+        :style="{ height: `${reviewTotalSize}px`, width: '100%', position: 'relative' }"
+      >
+        <div
+          role="presentation"
+          :style="{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${reviewTranslateY}px)`,
+          }"
+        >
+          <div
+            v-for="virtualRow in reviewVirtualRows"
+            :key="String(virtualRow.key)"
+            :data-index="virtualRow.index"
+            ref="reviewVirtualItemEls"
+            role="presentation"
+          >
+            <ReviewProposalCard
+              v-if="visibleProposals[virtualRow.index]"
+              :proposal="visibleProposals[virtualRow.index]!"
+              :is-expired="isProposalExpired(visibleProposals[virtualRow.index]!)"
+              :is-busy="proposalActionBusyId === visibleProposals[virtualRow.index]!.id"
+              :selected-diff-proposal-id="selectedDiffProposalId"
+              :selected-diff="selectedDiff"
+              :capture-href="captureHrefForProposal(visibleProposals[virtualRow.index]!)"
+              :proposal-href="proposalHref(visibleProposals[virtualRow.index]!)"
+              @approve="handleApproveProposal"
+              @reject="handleRejectProposal"
+              @execute="handleExecuteProposal"
+              @toggle-diff="handleToggleDiff"
+              @dismiss="handleDismissProposal"
+              @open-board="openBoard"
+            />
+          </div>
+        </div>
+      </div>
     </section>
   </div>
 </template>
@@ -138,6 +206,17 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--td-space-3);
+}
+
+.td-review__list--virtual {
+  max-height: 80vh;
+  overflow-y: auto;
+  contain: strict;
+  outline: none;
+}
+
+.td-review__list--virtual:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(255, 77, 77, 0.35);
 }
 
 @media (max-width: 640px) {

--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -99,6 +99,7 @@ watch(
     await nextTick()
     scrollVirtualizerToHashProposal()
   },
+  { flush: 'post' },
 )
 
 function handleReviewKeydown(event: KeyboardEvent) {
@@ -244,7 +245,7 @@ onUnmounted(() => {
 .td-review__list--virtual {
   max-height: 80vh;
   overflow-y: auto;
-  contain: strict;
+  contain: layout paint;
   outline: none;
 }
 

--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
 import ReviewHeader from '../components/review/ReviewHeader.vue'
 import ReviewSummaryCards from '../components/review/ReviewSummaryCards.vue'
@@ -68,6 +69,39 @@ const activeReviewIndex = computed(() => {
   if (reviewVirtualRows.value.length === 0) return -1
   return reviewVirtualRows.value[0]?.index ?? -1
 })
+
+const route = useRoute()
+
+/**
+ * Scroll the virtualizer to the proposal targeted by the URL hash.
+ * This ensures the targeted proposal is rendered in the virtual window
+ * before the composable's scrollToProposalFromHash tries getElementById.
+ */
+function scrollVirtualizerToHashProposal() {
+  const hash = route.hash
+  if (!hash.startsWith('#proposal-')) return
+  const rawId = hash.slice('#proposal-'.length).trim()
+  if (!rawId) return
+  let proposalId: string
+  try {
+    proposalId = decodeURIComponent(rawId)
+  } catch {
+    return
+  }
+  const index = visibleProposals.value.findIndex((p) => p.id === proposalId)
+  if (index >= 0) {
+    _vl.scrollToIndex(index)
+  }
+}
+
+watch(
+  () => [route.hash, visibleProposals.value.length] as const,
+  async () => {
+    scrollVirtualizerToHashProposal()
+    await nextTick()
+    scrollVirtualizerToHashProposal()
+  },
+)
 
 function handleReviewKeydown(event: KeyboardEvent) {
   if (event.key === 'ArrowDown') {


### PR DESCRIPTION
## Summary
- Add virtual scrolling (`useVirtualList` / `@tanstack/vue-virtual`) to the **ReviewView** proposal list, replacing the plain `v-for` that rendered all proposals at once (up to 200)
- Add virtual scrolling to the **NotificationInboxView**, flattening the grouped notification structure (time headers, collapsed summaries, individual items) into a single virtualized flat list
- Add `useVirtualList` test mocks to `ReviewView.spec.ts`, `ReviewView.coverage.spec.ts`, and `NotificationInboxView.spec.ts` to ensure headless tests render all items (happy-dom has 0 container dimensions)
- Both views gain ArrowUp/ArrowDown keyboard navigation via `scrollToIndex`

## Implementation details
- **ReviewView**: Wraps the `<section>` containing `ReviewProposalCard` components in a virtual scroll container with `estimateSize: 220px` and `overscan: 3`
- **NotificationInboxView**: Computes a `FlatRow[]` discriminated union from the grouped notification structure, where each row is a `time-header`, `collapsed-summary`, `collapse-button`, or `notification` item. Helper functions (`rowHeader`, `rowGroup`, `rowItem`) simplify template type narrowing
- Both follow the existing pattern from `InboxListPanel.vue` and `ActivityResults.vue`

## Test plan
- [x] `npm run typecheck` passes
- [x] All 2607 frontend unit tests pass (`npx vitest --run`)
- [x] `npm run build` succeeds
- [ ] Manual verification: ReviewView renders proposals correctly with scrolling
- [ ] Manual verification: NotificationInboxView renders grouped/collapsed notifications correctly
- [ ] Verify keyboard navigation (ArrowUp/ArrowDown) works in both views

Closes #959