### PR TITLE
FE-23: Expand loading skeleton consistency across views

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/BoardsListView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/BoardsListView.spec.ts
@@ -67,13 +67,14 @@ describe('BoardsListView', () => {
     expect(wrapper.text()).toContain('My Boards')
   })
 
-  it('shows loading spinner while boards are loading', async () => {
+  it('shows loading skeleton while boards are loading', async () => {
     mockBoardStore.loading = true
 
     const wrapper = mount(BoardsListView)
     await waitForUi()
 
     expect(wrapper.text()).toContain('Loading boards...')
+    expect(wrapper.find('.td-boards-skeleton').exists()).toBe(true)
   })
 
   it('shows error state when boardStore.error is set', async () => {

--- a/frontend/taskdeck-web/src/tests/views/MetricsView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/MetricsView.spec.ts
@@ -116,13 +116,13 @@ describe('MetricsView', () => {
     expect(wrapper.text()).toContain('Select a board above to view its metrics.')
   })
 
-  it('shows loading spinner when loading is true', async () => {
+  it('shows loading skeleton when loading is true', async () => {
     mockMetricsStore.loading = true
     const wrapper = mount(MetricsView)
     await waitForUi()
 
     expect(wrapper.text()).toContain('Loading metrics...')
-    expect(wrapper.find('.td-metrics__spinner').exists()).toBe(true)
+    expect(wrapper.find('.td-metrics__skeleton').exists()).toBe(true)
   })
 
   it('shows error state with retry button', async () => {

--- a/frontend/taskdeck-web/src/views/BoardView.vue
+++ b/frontend/taskdeck-web/src/views/BoardView.vue
@@ -14,6 +14,7 @@ import BoardCanvas from '../components/board/BoardCanvas.vue'
 import BoardDialogHost from '../components/board/BoardDialogHost.vue'
 import FilterPanel from '../components/board/FilterPanel.vue'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
+import { TdSkeleton } from '../components/ui'
 import type { BoardPresenceMember } from '../types/realtime'
 import type { CardFilters } from '../store/boardStore'
 import { isClientOnboardingDemoBoardName } from '../utils/boardDemo'
@@ -398,9 +399,26 @@ useKeyboardShortcuts([
     />
 
     <!-- Loading State -->
-    <div v-if="boardStore.loading && !boardStore.currentBoard" class="flex justify-center items-center py-12" aria-live="polite">
-      <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-container" role="status" aria-label="Loading board">
-        <span class="sr-only">Loading board...</span>
+    <div v-if="boardStore.loading && !boardStore.currentBoard" class="td-board-skeleton" aria-live="polite" role="status">
+      <span class="sr-only">Loading board...</span>
+      <div class="td-board-skeleton__toolbar">
+        <TdSkeleton width="200px" height="24px" />
+        <TdSkeleton width="300px" height="14px" />
+      </div>
+      <div class="td-board-skeleton__columns">
+        <div v-for="n in 4" :key="n" class="td-board-skeleton__column">
+          <TdSkeleton width="80%" height="16px" />
+          <div class="td-board-skeleton__cards">
+            <div v-for="m in (n % 2 === 0 ? 3 : 2)" :key="m" class="td-board-skeleton__card">
+              <TdSkeleton width="90%" height="14px" />
+              <TdSkeleton width="60%" height="10px" />
+              <div style="display: flex; gap: 0.5rem; margin-top: 0.25rem">
+                <TdSkeleton width="48px" height="18px" />
+                <TdSkeleton width="48px" height="18px" />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -452,6 +470,52 @@ useKeyboardShortcuts([
 </template>
 
 <style scoped>
+/* ── Board Skeleton ── */
+.td-board-skeleton {
+  padding: var(--td-space-6) var(--td-space-8);
+}
+
+.td-board-skeleton__toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-2);
+  margin-bottom: var(--td-space-6);
+}
+
+.td-board-skeleton__columns {
+  display: flex;
+  gap: var(--td-space-4);
+  overflow-x: auto;
+}
+
+.td-board-skeleton__column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-3);
+  min-width: 280px;
+  width: 280px;
+  padding: var(--td-space-4);
+  border-radius: var(--td-radius-lg);
+  background: var(--td-surface-container);
+  border: 0.5px solid var(--td-border-ghost);
+}
+
+.td-board-skeleton__cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-2);
+}
+
+.td-board-skeleton__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: var(--td-space-3);
+  border-radius: var(--td-radius-md);
+  background: var(--td-surface-container-high);
+  border: 0.5px solid var(--td-border-ghost);
+}
+
 /* ── Create Column Form — token-based ── */
 .td-column-form {
   margin-top: var(--td-space-5);

--- a/frontend/taskdeck-web/src/views/BoardsListView.vue
+++ b/frontend/taskdeck-web/src/views/BoardsListView.vue
@@ -2,6 +2,7 @@
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useBoardStore } from '../store/boardStore'
+import { TdSkeleton } from '../components/ui'
 
 const router = useRouter()
 const boardStore = useBoardStore()
@@ -81,9 +82,18 @@ function goToBoard(id: string) {
       </div>
 
       <!-- Loading State -->
-      <div v-if="boardStore.loading" class="text-center py-12">
-        <div class="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-primary-container"></div>
-        <p class="mt-4 text-on-surface/60">Loading boards...</p>
+      <div v-if="boardStore.loading" class="td-boards-skeleton" role="status" aria-live="polite">
+        <span class="sr-only">Loading boards...</span>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div v-for="n in 6" :key="n" class="td-boards-skeleton__card">
+            <TdSkeleton width="70%" height="20px" />
+            <TdSkeleton width="90%" height="12px" />
+            <TdSkeleton width="50%" height="12px" />
+            <div style="margin-top: auto; padding-top: 0.75rem">
+              <TdSkeleton width="120px" height="10px" />
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Error State -->
@@ -146,3 +156,16 @@ function goToBoard(id: string) {
     </div>
   </div>
 </template>
+
+<style scoped>
+.td-boards-skeleton__card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: var(--td-space-6);
+  border-radius: var(--td-radius-lg);
+  background: var(--td-surface-container-low);
+  border: 1px solid var(--td-border-ghost);
+  min-height: 140px;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/HomeView.vue
+++ b/frontend/taskdeck-web/src/views/HomeView.vue
@@ -2,6 +2,7 @@
 import { computed, onActivated, onMounted } from 'vue'
 import WorkspaceSetupModal from '../components/workspace/WorkspaceSetupModal.vue'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
+import { TdSkeleton } from '../components/ui'
 import { useWorkspaceOnboardingActions } from '../composables/useWorkspaceOnboardingActions'
 import { useWorkspaceStore } from '../store/workspaceStore'
 import { usePerformanceMark } from '../composables/usePerformanceMark'
@@ -154,8 +155,50 @@ onActivated(refreshHomeSummary)
       </template>
     </WorkspaceHelpCallout>
 
-    <div v-if="workspace.homeLoading" class="td-panel td-home__placeholder" aria-live="polite">
-      Loading your workspace summary...
+    <div v-if="workspace.homeLoading" class="td-home__skeleton" aria-live="polite" role="status">
+      <span class="sr-only">Loading your workspace summary...</span>
+      <div class="td-home__grid">
+        <!-- Needs attention skeleton -->
+        <div class="td-panel td-home-card">
+          <div class="td-home-card__header">
+            <TdSkeleton width="140px" height="16px" />
+            <TdSkeleton width="100px" height="20px" :rounded="false" />
+          </div>
+          <div class="td-home-card__stats">
+            <div v-for="n in 4" :key="n" class="td-home-card__stat">
+              <TdSkeleton width="40px" height="28px" />
+              <TdSkeleton width="80px" height="12px" />
+              <TdSkeleton width="100%" height="10px" />
+            </div>
+          </div>
+        </div>
+        <!-- Next step skeleton -->
+        <div class="td-panel td-home-card">
+          <div class="td-home-card__header">
+            <TdSkeleton width="100px" height="16px" />
+            <TdSkeleton width="90px" height="20px" :rounded="false" />
+          </div>
+          <div class="td-home-card__actions">
+            <div v-for="n in 2" :key="n" class="td-home__skeleton-action">
+              <TdSkeleton width="70%" height="14px" />
+              <TdSkeleton width="90%" height="10px" />
+            </div>
+          </div>
+        </div>
+        <!-- Boards skeleton -->
+        <div class="td-panel td-home-card">
+          <div class="td-home-card__header">
+            <TdSkeleton width="60px" height="16px" />
+            <TdSkeleton width="110px" height="20px" :rounded="false" />
+          </div>
+          <div class="td-home-card__board-list">
+            <div v-for="n in 3" :key="n" class="td-home__skeleton-board">
+              <TdSkeleton width="60%" height="14px" />
+              <TdSkeleton width="90%" height="10px" />
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div v-else-if="workspace.homeError" class="td-alert td-alert--error" role="alert">
@@ -353,9 +396,16 @@ onActivated(refreshHomeSummary)
   justify-content: flex-end;
 }
 
-/* ─── Placeholder / Loading ─── */
-.td-home__placeholder {
-  color: var(--td-text-tertiary);
+/* ─── Skeleton / Loading ─── */
+.td-home__skeleton-action,
+.td-home__skeleton-board {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: var(--td-space-3);
+  border-radius: var(--td-radius-md);
+  border: 0.5px solid var(--td-border-ghost);
+  background: var(--td-surface-container);
 }
 
 /* .td-panel, .td-section-title, .td-section-desc, .td-alert, .td-btn

--- a/frontend/taskdeck-web/src/views/MetricsView.vue
+++ b/frontend/taskdeck-web/src/views/MetricsView.vue
@@ -279,9 +279,15 @@ const maxWipCount = computed(() => {
       <section class="td-metrics__section td-metrics__forecast" aria-label="Completion forecast">
         <h2 class="td-metrics__section-title">Completion Forecast</h2>
 
-        <div v-if="forecastLoading" class="td-metrics__forecast-loading">
-          <div class="td-metrics__spinner td-metrics__spinner--sm" />
-          <span>Computing forecast...</span>
+        <div v-if="forecastLoading" class="td-metrics__forecast-loading" role="status">
+          <span class="sr-only">Computing forecast...</span>
+          <div class="td-metrics__forecast-grid">
+            <div v-for="n in 4" :key="n" class="td-metrics__card">
+              <TdSkeleton width="80px" height="12px" />
+              <TdSkeleton width="50px" height="24px" />
+              <TdSkeleton width="70px" height="10px" />
+            </div>
+          </div>
         </div>
 
         <div v-else-if="forecastError" class="td-metrics__forecast-error" role="alert">
@@ -799,16 +805,8 @@ const maxWipCount = computed(() => {
 
 .td-metrics__forecast-loading {
   display: flex;
-  align-items: center;
-  gap: var(--td-space-3);
-  color: var(--td-text-secondary);
-  font-size: var(--td-font-sm);
-}
-
-.td-metrics__spinner--sm {
-  width: 20px;
-  height: 20px;
-  border-width: 2px;
+  flex-direction: column;
+  gap: var(--td-space-4);
 }
 
 .td-metrics__forecast-error {

--- a/frontend/taskdeck-web/src/views/MetricsView.vue
+++ b/frontend/taskdeck-web/src/views/MetricsView.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useBoardStore } from '../store/boardStore'
 import { useMetricsStore } from '../store/metricsStore'
 import { useToastStore } from '../store/toastStore'
+import { TdSkeleton } from '../components/ui'
 import { metricsApi } from '../api/metricsApi'
 import { getErrorDisplay } from '../composables/useErrorMapper'
 import type { MetricsQuery, ForecastQuery } from '../types/metrics'
@@ -198,9 +199,34 @@ const maxWipCount = computed(() => {
     </section>
 
     <!-- Loading state -->
-    <div v-if="loading" class="td-metrics__state" role="status" aria-live="polite">
-      <div class="td-metrics__spinner" />
-      <p>Loading metrics...</p>
+    <div v-if="loading" class="td-metrics__skeleton" role="status" aria-live="polite">
+      <span class="sr-only">Loading metrics...</span>
+      <!-- Summary card skeletons -->
+      <div class="td-metrics__summary">
+        <div v-for="n in 4" :key="n" class="td-metrics__card">
+          <TdSkeleton width="100px" height="12px" />
+          <TdSkeleton width="60px" height="28px" />
+          <TdSkeleton width="80px" height="10px" />
+        </div>
+      </div>
+      <!-- Chart skeleton -->
+      <div class="td-metrics__section">
+        <TdSkeleton width="160px" height="18px" />
+        <div class="td-metrics__skeleton-chart">
+          <TdSkeleton width="100%" height="200px" />
+        </div>
+      </div>
+      <!-- WIP skeleton -->
+      <div class="td-metrics__section">
+        <TdSkeleton width="120px" height="18px" />
+        <div class="td-metrics__skeleton-rows">
+          <div v-for="n in 3" :key="n" class="td-metrics__skeleton-wip-row">
+            <TdSkeleton width="100px" height="14px" />
+            <TdSkeleton width="100%" height="24px" />
+            <TdSkeleton width="40px" height="14px" />
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Error state -->
@@ -547,17 +573,30 @@ const maxWipCount = computed(() => {
   font-weight: 600;
 }
 
-.td-metrics__spinner {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--td-border-ghost);
-  border-top-color: var(--td-color-ember);
-  border-radius: 50%;
-  animation: td-spin 0.8s linear infinite;
+.td-metrics__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-8);
 }
 
-@keyframes td-spin {
-  to { transform: rotate(360deg); }
+.td-metrics__skeleton-chart {
+  margin-top: var(--td-space-4);
+  border-radius: var(--td-radius-md);
+  overflow: hidden;
+}
+
+.td-metrics__skeleton-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-3);
+  margin-top: var(--td-space-4);
+}
+
+.td-metrics__skeleton-wip-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 60px;
+  align-items: center;
+  gap: var(--td-space-3);
 }
 
 /* Summary cards */

--- a/frontend/taskdeck-web/src/views/NotificationInboxView.vue
+++ b/frontend/taskdeck-web/src/views/NotificationInboxView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useNotificationStore } from '../store/notificationStore'
+import { TdSkeleton } from '../components/ui'
 import { getErrorDisplay } from '../composables/useErrorMapper'
 import {
   groupNotifications,
@@ -170,7 +171,23 @@ watch([unreadOnly, activeBoardId], () => {
       {{ inlineError }}
     </div>
 
-    <div v-if="notifications.loading" class="td-placeholder">Loading notifications...</div>
+    <div v-if="notifications.loading" class="td-notification-skeleton" role="status" aria-live="polite">
+      <span class="sr-only">Loading notifications...</span>
+      <div v-for="n in 4" :key="n" class="td-notification-skeleton__row">
+        <div style="display: flex; flex-direction: column; gap: 0.5rem; flex: 1">
+          <div style="display: flex; align-items: center; gap: 0.5rem">
+            <TdSkeleton width="60px" height="20px" />
+            <TdSkeleton width="200px" height="14px" />
+          </div>
+          <TdSkeleton width="80%" height="12px" />
+          <div style="display: flex; gap: 0.75rem">
+            <TdSkeleton width="70px" height="10px" />
+            <TdSkeleton width="100px" height="10px" />
+          </div>
+        </div>
+        <TdSkeleton width="80px" height="32px" />
+      </div>
+    </div>
     <div v-else-if="items.length === 0" class="td-placeholder">No notifications found.</div>
 
     <template v-else>
@@ -271,9 +288,22 @@ watch([unreadOnly, activeBoardId], () => {
 </template>
 
 <style scoped>
-.td-placeholder {
-  color: var(--td-text-secondary);
-  padding: var(--td-space-6) 0;
+.td-notification-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-3);
+  padding: var(--td-space-2) 0;
+}
+
+.td-notification-skeleton__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--td-space-4);
+  padding: var(--td-space-4);
+  border-radius: var(--td-radius-lg);
+  border: 1px solid var(--td-border-default);
+  background: var(--td-surface-primary);
 }
 
 .td-alert {

--- a/frontend/taskdeck-web/src/views/NotificationInboxView.vue
+++ b/frontend/taskdeck-web/src/views/NotificationInboxView.vue
@@ -188,7 +188,7 @@ watch([unreadOnly, activeBoardId], () => {
         <TdSkeleton width="80px" height="32px" />
       </div>
     </div>
-    <div v-else-if="items.length === 0" class="td-placeholder">No notifications found.</div>
+    <div v-else-if="items.length === 0" class="td-notification-empty">No notifications found.</div>
 
     <template v-else>
       <section v-for="header in timeHeaders" :key="header" class="mb-6">
@@ -293,6 +293,11 @@ watch([unreadOnly, activeBoardId], () => {
   flex-direction: column;
   gap: var(--td-space-3);
   padding: var(--td-space-2) 0;
+}
+
+.td-notification-empty {
+  color: var(--td-text-secondary);
+  padding: var(--td-space-6) 0;
 }
 
 .td-notification-skeleton__row {

--- a/frontend/taskdeck-web/src/views/ReviewView.vue
+++ b/frontend/taskdeck-web/src/views/ReviewView.vue
@@ -5,6 +5,7 @@ import ReviewHeader from '../components/review/ReviewHeader.vue'
 import ReviewSummaryCards from '../components/review/ReviewSummaryCards.vue'
 import ReviewEmptyState from '../components/review/ReviewEmptyState.vue'
 import ReviewProposalCard from '../components/review/ReviewProposalCard.vue'
+import { TdSkeleton } from '../components/ui'
 import { useReviewProposals } from '../composables/useReviewProposals'
 import { useReviewActions } from '../composables/useReviewActions'
 
@@ -91,8 +92,22 @@ onUnmounted(() => {
 
     <ReviewSummaryCards :cards="summaryCards" />
 
-    <div v-if="proposalsLoading" class="td-panel td-review__loading" aria-live="polite">
-      Loading proposals to review...
+    <div v-if="proposalsLoading" class="td-review__skeleton" aria-live="polite" role="status">
+      <span class="sr-only">Loading proposals to review...</span>
+      <div v-for="n in 3" :key="n" class="td-panel td-review__skeleton-card">
+        <div class="td-review__skeleton-header">
+          <TdSkeleton width="60px" height="20px" />
+          <TdSkeleton width="200px" height="16px" />
+          <TdSkeleton width="80px" height="14px" />
+        </div>
+        <TdSkeleton width="90%" height="14px" />
+        <TdSkeleton width="70%" height="14px" />
+        <div class="td-review__skeleton-actions">
+          <TdSkeleton width="90px" height="32px" />
+          <TdSkeleton width="80px" height="32px" />
+          <TdSkeleton width="70px" height="32px" />
+        </div>
+      </div>
     </div>
 
     <ReviewEmptyState
@@ -130,8 +145,28 @@ onUnmounted(() => {
   gap: var(--td-space-4);
 }
 
-.td-review__loading {
-  color: var(--td-text-secondary);
+.td-review__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-3);
+}
+
+.td-review__skeleton-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-3);
+}
+
+.td-review__skeleton-header {
+  display: flex;
+  align-items: center;
+  gap: var(--td-space-3);
+}
+
+.td-review__skeleton-actions {
+  display: flex;
+  gap: var(--td-space-2);
+  margin-top: var(--td-space-2);
 }
 
 .td-review__list {

--- a/frontend/taskdeck-web/src/views/TodayView.vue
+++ b/frontend/taskdeck-web/src/views/TodayView.vue
@@ -2,6 +2,7 @@
 import { computed, onActivated, onMounted, ref } from 'vue'
 import WorkspaceSetupModal from '../components/workspace/WorkspaceSetupModal.vue'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
+import { TdSkeleton } from '../components/ui'
 import { useWorkspaceOnboardingActions } from '../composables/useWorkspaceOnboardingActions'
 import { useWorkspaceStore } from '../store/workspaceStore'
 import type {
@@ -235,8 +236,34 @@ onActivated(refreshTodaySummary)
       </template>
     </WorkspaceHelpCallout>
 
-    <div v-if="workspace.todayLoading" class="td-panel td-today__placeholder" aria-live="polite">
-      Loading today's agenda...
+    <div v-if="workspace.todayLoading" class="td-today__skeleton" aria-live="polite" role="status">
+      <span class="sr-only">Loading today's agenda...</span>
+      <!-- Stats skeleton -->
+      <div class="td-today__stats">
+        <div v-for="n in 3" :key="n" class="td-panel td-today-stat">
+          <TdSkeleton width="80px" height="12px" />
+          <TdSkeleton width="50px" height="32px" />
+          <TdSkeleton width="100%" height="10px" />
+        </div>
+      </div>
+      <!-- Agenda skeleton -->
+      <div class="td-today__agenda-grid">
+        <div v-for="n in 3" :key="n" class="td-panel td-today-card td-today-card--neutral">
+          <div class="td-today__section-head">
+            <div style="display: flex; flex-direction: column; gap: 0.5rem; flex: 1">
+              <TdSkeleton width="120px" height="16px" />
+              <TdSkeleton width="90%" height="12px" />
+            </div>
+            <TdSkeleton width="28px" height="28px" circle />
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 0.5rem">
+            <div v-for="m in 2" :key="m" class="td-today__skeleton-item">
+              <TdSkeleton width="70%" height="14px" />
+              <TdSkeleton width="50%" height="10px" />
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div v-else-if="workspace.todayError" class="td-alert td-alert--error" role="alert">
@@ -456,8 +483,20 @@ onActivated(refreshTodaySummary)
 
 /* .td-panel, .td-section-title, .td-section-desc are global (src/style.css) */
 
-.td-today__placeholder {
-  color: var(--td-text-tertiary);
+.td-today__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--td-space-6);
+}
+
+.td-today__skeleton-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: var(--td-space-3);
+  border-radius: var(--td-radius-md);
+  border: 0.5px solid var(--td-border-ghost);
+  background: var(--td-surface-container-high);
 }
 
 /* ── Onboarding & Recommended sections ── */


### PR DESCRIPTION
## Summary

- Replace plain-text loading states and generic spinners with structured `TdSkeleton` layouts in 7 high-traffic views: HomeView, TodayView, BoardView, MetricsView, ReviewView, NotificationInboxView, and BoardsListView
- Each skeleton mimics the shape of the loaded content (stat tiles, card grids, board columns, proposal cards, notification rows) for a smoother perceived load
- Update MetricsView test to assert the new skeleton class instead of the removed spinner class

## Views Updated

| View | Before | After |
|------|--------|-------|
| HomeView | "Loading your workspace summary..." text | 3-card bento grid skeleton |
| TodayView | "Loading today's agenda..." text | Stats + agenda card skeletons |
| BoardView | Spinning border circle | 4-column board skeleton with cards |
| MetricsView | Animated spinner | Summary cards + chart + WIP row skeletons |
| ReviewView | "Loading proposals to review..." text | 3 proposal card skeletons |
| NotificationInboxView | "Loading notifications..." text | 4 notification row skeletons |
| BoardsListView | Spinning border circle | 6-card grid skeleton |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest --run` -- 2607/2607 tests pass (MetricsView test updated)
- [x] `npm run build` succeeds
- [ ] Manual verification: each view shows skeleton layout during loading instead of text/spinner

Closes #955