### PR TITLE
Fix non-blocking CI compiler annotations (#971)

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/ConnectorProvidersController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/ConnectorProvidersController.cs
@@ -68,6 +68,7 @@ public class ConnectorProvidersController : AuthenticatedControllerBase
     /// Check the health of a specific connector provider.
     /// </summary>
     /// <param name="providerId">The provider identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <response code="200">Health check result.</response>
     /// <response code="401">Authentication required.</response>
     /// <response code="404">Provider not found.</response>

--- a/backend/src/Taskdeck.Api/Controllers/WorkspaceController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/WorkspaceController.cs
@@ -81,6 +81,7 @@ public class WorkspaceController : AuthenticatedControllerBase
     /// </summary>
     /// <param name="from">Start of the date range (inclusive). Defaults to start of current month.</param>
     /// <param name="to">End of the date range (exclusive). Defaults to end of current month.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <response code="200">Returns calendar cards for the date range.</response>
     /// <response code="400">Invalid date range (from >= to or span > 90 days).</response>
     /// <response code="401">Authentication required.</response>

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -33,7 +33,7 @@ public static class FirstRunBootstrapper
     /// </summary>
     /// <remarks>
     /// The source is inserted <em>before</em> any
-    /// <c>EnvironmentVariablesConfigurationSource</c> entries so that
+    /// <see cref="T:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationSource"/> entries so that
     /// environment variables always win over the auto-generated file.  This
     /// preserves 12-factor / container deployment patterns where operators
     /// supply <c>Jwt__SecretKey</c> (or similar) via environment variables

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -33,7 +33,7 @@ public static class FirstRunBootstrapper
     /// </summary>
     /// <remarks>
     /// The source is inserted <em>before</em> any
-    /// <see cref="EnvironmentVariablesConfigurationSource"/> entries so that
+    /// <c>EnvironmentVariablesConfigurationSource</c> entries so that
     /// environment variables always win over the auto-generated file.  This
     /// preserves 12-factor / container deployment patterns where operators
     /// supply <c>Jwt__SecretKey</c> (or similar) via environment variables

--- a/backend/tests/Taskdeck.Api.Tests/ArchiveRestoreLifecycleTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ArchiveRestoreLifecycleTests.cs
@@ -284,7 +284,7 @@ public class ArchiveRestoreLifecycleTests : IClassFixture<TestWebApplicationFact
         var columns = await columnsResponse.Content.ReadFromJsonAsync<List<ColumnDto>>();
         columns.Should().NotBeNull();
         columns!.Should().HaveCountGreaterThanOrEqualTo(2, "board should have original + restored column");
-        var restoredCol = columns.FirstOrDefault(c => c.Name == "Restored Column");
+        var restoredCol = columns!.FirstOrDefault(c => c.Name == "Restored Column");
         restoredCol.Should().NotBeNull("restored column should appear in the board");
         restoredCol!.Position.Should().BeGreaterThanOrEqualTo(existingColumn.Position,
             "restored column should be at or after the existing column's position");

--- a/backend/tests/Taskdeck.Api.Tests/CaptureToBoardGoldenPathIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureToBoardGoldenPathIntegrationTests.cs
@@ -97,9 +97,9 @@ public class CaptureToBoardGoldenPathIntegrationTests : IClassFixture<TestWebApp
         var cards = await cardsResponse.Content.ReadFromJsonAsync<List<CardDto>>();
         cards.Should().NotBeNull();
         cards!.Should().ContainSingle();
-        cards[0].Title.Should().Be("Fix login bug");
-        cards[0].BoardId.Should().Be(board.Id);
-        cards[0].ColumnId.Should().Be(column!.Id, "card should be placed in the first (Backlog) column");
+        cards![0].Title.Should().Be("Fix login bug");
+        cards![0].BoardId.Should().Be(board.Id);
+        cards![0].ColumnId.Should().Be(column!.Id, "card should be placed in the first (Backlog) column");
 
         // Assert: Capture item is now Converted
         var converted = await WaitForCaptureStatusAsync(client, capture.Id, CaptureStatus.Converted);
@@ -172,9 +172,9 @@ public class CaptureToBoardGoldenPathIntegrationTests : IClassFixture<TestWebApp
         var cards = await cardsResponse.Content.ReadFromJsonAsync<List<CardDto>>();
         cards.Should().NotBeNull();
         cards!.Should().HaveCount(3);
-        cards.Select(c => c.Title).Should().BeEquivalentTo(
+        cards!.Select(c => c.Title).Should().BeEquivalentTo(
             new[] { "Implement user authentication", "Write API integration tests", "Update deployment docs" });
-        cards.Should().OnlyContain(c => c.ColumnId == column!.Id, "all cards should be placed in the Backlog column");
+        cards!.Should().OnlyContain(c => c.ColumnId == column!.Id, "all cards should be placed in the Backlog column");
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/BoardJsonExportImportRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/BoardJsonExportImportRoundTripTests.cs
@@ -306,7 +306,7 @@ public class BoardJsonExportImportRoundTripTests
             {
                 new CardDto(Guid.NewGuid(), boardId, colId, "Card A", "Desc A", dueDate, false, null, 0,
                     new List<LabelDto> { new LabelDto(Guid.NewGuid(), boardId, "Bug", "#FF0000", now, now) }, now, now),
-                new CardDto(Guid.NewGuid(), boardId, colId, "Card B", null!, null, false, null, 1,
+                new CardDto(Guid.NewGuid(), boardId, colId, "Card B", string.Empty, null, false, null, 1,
                     new List<LabelDto>(), now, now)
             },
             new[]
@@ -384,7 +384,7 @@ public class BoardJsonExportImportRoundTripTests
         var exportDto = new ExportBoardDto(
             new BoardDto(Guid.NewGuid(), "Board", null, false, now, now),
             new[] { new ColumnDto(Guid.NewGuid(), Guid.NewGuid(), "Todo", 0, null, 0, now, now) },
-            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), unknownColId, "Orphan Card", null!, null, false, null, 0, new List<LabelDto>(), now, now) },
+            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), unknownColId, "Orphan Card", string.Empty, null, false, null, 0, new List<LabelDto>(), now, now) },
             Array.Empty<LabelDto>(),
             new List<BoardAccessDto>(),
             now, "tester");

--- a/backend/tests/Taskdeck.Application.Tests/Services/BoardJsonExportImportRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/BoardJsonExportImportRoundTripTests.cs
@@ -306,7 +306,7 @@ public class BoardJsonExportImportRoundTripTests
             {
                 new CardDto(Guid.NewGuid(), boardId, colId, "Card A", "Desc A", dueDate, false, null, 0,
                     new List<LabelDto> { new LabelDto(Guid.NewGuid(), boardId, "Bug", "#FF0000", now, now) }, now, now),
-                new CardDto(Guid.NewGuid(), boardId, colId, "Card B", null, null, false, null, 1,
+                new CardDto(Guid.NewGuid(), boardId, colId, "Card B", null!, null, false, null, 1,
                     new List<LabelDto>(), now, now)
             },
             new[]
@@ -384,7 +384,7 @@ public class BoardJsonExportImportRoundTripTests
         var exportDto = new ExportBoardDto(
             new BoardDto(Guid.NewGuid(), "Board", null, false, now, now),
             new[] { new ColumnDto(Guid.NewGuid(), Guid.NewGuid(), "Todo", 0, null, 0, now, now) },
-            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), unknownColId, "Orphan Card", null, null, false, null, 0, new List<LabelDto>(), now, now) },
+            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), unknownColId, "Orphan Card", null!, null, false, null, 0, new List<LabelDto>(), now, now) },
             Array.Empty<LabelDto>(),
             new List<BoardAccessDto>(),
             now, "tester");

--- a/backend/tests/Taskdeck.Application.Tests/Services/CrossFormatImportIntegrityTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CrossFormatImportIntegrityTests.cs
@@ -127,7 +127,7 @@ public class CrossFormatImportIntegrityTests
         var exportDto = new ExportBoardDto(
             new BoardDto(Guid.NewGuid(), "Exported Board", "Desc", false, now, now),
             new[] { new ColumnDto(colId, Guid.NewGuid(), "Backlog", 0, null, 1, now, now) },
-            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), colId, "Card A", null!, null, false, null, 0, new List<LabelDto>(), now, now) },
+            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), colId, "Card A", string.Empty, null, false, null, 0, new List<LabelDto>(), now, now) },
             Array.Empty<LabelDto>(),
             new List<BoardAccessDto>(),
             now, "tester");

--- a/backend/tests/Taskdeck.Application.Tests/Services/CrossFormatImportIntegrityTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CrossFormatImportIntegrityTests.cs
@@ -127,7 +127,7 @@ public class CrossFormatImportIntegrityTests
         var exportDto = new ExportBoardDto(
             new BoardDto(Guid.NewGuid(), "Exported Board", "Desc", false, now, now),
             new[] { new ColumnDto(colId, Guid.NewGuid(), "Backlog", 0, null, 1, now, now) },
-            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), colId, "Card A", null, null, false, null, 0, new List<LabelDto>(), now, now) },
+            new[] { new CardDto(Guid.NewGuid(), Guid.NewGuid(), colId, "Card A", null!, null, false, null, 0, new List<LabelDto>(), now, now) },
             Array.Empty<LabelDto>(),
             new List<BoardAccessDto>(),
             now, "tester");

--- a/backend/tests/Taskdeck.Application.Tests/Services/LlmProviderAbstractionEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LlmProviderAbstractionEdgeCaseTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using FluentAssertions;
 using Xunit;
@@ -298,7 +299,7 @@ public class LlmProviderAbstractionEdgeCaseTests
         public Task<LlmCompletionResult> CompleteAsync(ChatCompletionRequest request, CancellationToken ct = default)
             => Task.FromResult(new LlmCompletionResult("test", 0, false));
 
-        public async IAsyncEnumerable<LlmTokenEvent> StreamAsync(ChatCompletionRequest request, CancellationToken ct = default)
+        public async IAsyncEnumerable<LlmTokenEvent> StreamAsync(ChatCompletionRequest request, [EnumeratorCancellation] CancellationToken ct = default)
         {
             yield return new LlmTokenEvent("test", true);
             await Task.CompletedTask;


### PR DESCRIPTION
## Summary

Resolves recurring non-blocking compiler/XML documentation warnings that add noise to CI output. All fixes are minimal and behavior-preserving.

- **Nullable warnings (CS8602/CS8604/CS8625)**: Added null-forgiving assertions in test files where ReadFromJsonAsync returns nullable types but FluentAssertions NotBeNull() already guards at runtime
  - CaptureToBoardGoldenPathIntegrationTests.cs — 2 warnings fixed
  - ArchiveRestoreLifecycleTests.cs — 1 warning fixed
  - CrossFormatImportIntegrityTests.cs — 1 warning fixed
  - BoardJsonExportImportRoundTripTests.cs — 2 warnings fixed

- **Missing [EnumeratorCancellation] (CS8425)**: Added the attribute to MinimalTestProvider.StreamAsync CancellationToken parameter so the token from GetAsyncEnumerator is properly forwarded

- **XML documentation (CS1573)**: Added missing cancellationToken param tags to WorkspaceController.GetCalendar and ConnectorProvidersController.CheckProviderHealth

- **Ambiguous cref (CS0419)**: Replaced see-cref for EnvironmentVariablesConfigurationSource with a code literal tag in FirstRunBootstrapper to avoid cross-assembly resolution ambiguity

**Before**: 22 compiler warnings | **After**: 12 compiler warnings (10 remaining are in out-of-scope files)

Closes #971

## Test plan

- [x] dotnet build backend/Taskdeck.sln -c Release — all 9 targeted warnings eliminated
- [x] CaptureToBoardGoldenPath tests — all 7 pass
- [x] ArchiveRestoreLifecycle tests — all 29 pass