### PR TITLE
RFAI-02: IntentEnvelopeV1, IChatClient adapter, and schema spike

### DIFF
--- a/backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json
+++ b/backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://taskdeck.dev/schemas/proposal-batch.v1.schema.json",
+  "title": "Taskdeck Proposal Batch v1",
+  "description": "Schema for a batch of proposals generated from an IntentEnvelopeV1. Used for structured output from LLM providers and for validation of proposal payloads.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "envelopeId",
+    "summary",
+    "proposals"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version for format evolution."
+    },
+    "envelopeId": {
+      "type": "string",
+      "format": "uuid",
+      "description": "ID of the originating IntentEnvelopeV1."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "description": "Human-readable summary of the batch."
+    },
+    "proposals": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 50,
+      "items": {
+        "$ref": "#/$defs/proposal"
+      }
+    }
+  },
+  "$defs": {
+    "proposal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "summary",
+        "riskLevel",
+        "operations"
+      ],
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "description": "Human-readable summary of this proposal."
+        },
+        "riskLevel": {
+          "type": "string",
+          "enum": [
+            "Low",
+            "Medium",
+            "High",
+            "Critical"
+          ],
+          "description": "Risk classification for the proposal."
+        },
+        "sourceIntentLabel": {
+          "type": "string",
+          "maxLength": 500,
+          "description": "Label of the IntentCandidate that produced this proposal."
+        },
+        "operations": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/$defs/operation"
+          }
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operationType",
+        "payload"
+      ],
+      "properties": {
+        "operationType": {
+          "type": "string",
+          "enum": [
+            "CreateCard",
+            "UpdateCard",
+            "MoveCard",
+            "DeleteCard",
+            "CreateColumn",
+            "UpdateColumn",
+            "CreateLabel",
+            "AddLabel",
+            "RemoveLabel"
+          ],
+          "description": "The type of board mutation this operation represents."
+        },
+        "targetId": {
+          "type": "string",
+          "format": "uuid",
+          "description": "ID of the entity being operated on (null for creates)."
+        },
+        "payload": {
+          "type": "object",
+          "description": "Operation-specific payload. Shape varies by operationType.",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json
+++ b/backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json
@@ -64,7 +64,7 @@
           "description": "Risk classification for the proposal."
         },
         "sourceIntentLabel": {
-          "type": "string",
+          "type": ["string", "null"],
           "maxLength": 500,
           "description": "Label of the IntentCandidate that produced this proposal."
         },
@@ -102,7 +102,7 @@
           "description": "The type of board mutation this operation represents."
         },
         "targetId": {
-          "type": "string",
+          "type": ["string", "null"],
           "format": "uuid",
           "description": "ID of the entity being operated on (null for creates)."
         },

--- a/backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json
+++ b/backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json
@@ -81,6 +81,38 @@
     "operation": {
       "type": "object",
       "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "operationType"
+            ],
+            "properties": {
+              "operationType": {
+                "not": {
+                  "enum": [
+                    "CreateCard",
+                    "CreateColumn",
+                    "CreateLabel"
+                  ]
+                }
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "targetId"
+            ],
+            "properties": {
+              "targetId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "ID of the existing entity being operated on."
+              }
+            }
+          }
+        }
+      ],
       "required": [
         "operationType",
         "payload"

--- a/backend/src/Taskdeck.Application/Services/IIntentEnvelopeFactory.cs
+++ b/backend/src/Taskdeck.Application/Services/IIntentEnvelopeFactory.cs
@@ -1,0 +1,51 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Factory for creating <see cref="IntentEnvelopeV1"/> instances from
+/// different input surfaces (Capture, Chat). Implementations live in
+/// Infrastructure or Application depending on whether external dependencies
+/// are required.
+///
+/// This is a PARALLEL path alongside the existing capture/chat pipelines.
+/// It does not replace or modify existing behavior -- it produces envelopes
+/// that can be consumed by future pipeline stages.
+/// </summary>
+public interface IIntentEnvelopeFactory
+{
+    /// <summary>
+    /// Creates an envelope from a capture payload. The returned envelope
+    /// is in <see cref="EnvelopeStatus.Created"/> status with source blocks
+    /// pre-populated from the payload content.
+    /// </summary>
+    /// <param name="userId">The user who triggered the capture.</param>
+    /// <param name="rawContent">Raw text content from the capture input.</param>
+    /// <param name="captureItemId">Optional ID of the originating capture item for correlation.</param>
+    /// <param name="capturedAt">When the input was captured. Defaults to now.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A Result containing the created envelope, or an error.</returns>
+    Task<Result<IntentEnvelopeV1>> CreateFromCaptureAsync(
+        Guid userId,
+        string rawContent,
+        Guid? captureItemId = null,
+        DateTimeOffset? capturedAt = null,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates an envelope from a chat message. The returned envelope
+    /// is in <see cref="EnvelopeStatus.Created"/> status with source blocks
+    /// pre-populated from the message content.
+    /// </summary>
+    /// <param name="userId">The user who sent the message.</param>
+    /// <param name="rawContent">Raw text content from the chat message.</param>
+    /// <param name="sessionId">The chat session ID for correlation.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A Result containing the created envelope, or an error.</returns>
+    Task<Result<IntentEnvelopeV1>> CreateFromChatAsync(
+        Guid userId,
+        string rawContent,
+        Guid sessionId,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Domain/Entities/EvidenceLink.cs
+++ b/backend/src/Taskdeck.Domain/Entities/EvidenceLink.cs
@@ -41,7 +41,7 @@ public class EvidenceLink : Entity
             throw new DomainException(ErrorCodes.ValidationError, "IntentCandidateId cannot be empty");
         if (sourceSpanId == Guid.Empty)
             throw new DomainException(ErrorCodes.ValidationError, "SourceSpanId cannot be empty");
-        if (relevance < 0.0 || relevance > 1.0)
+        if (!double.IsFinite(relevance) || relevance < 0.0 || relevance > 1.0)
             throw new DomainException(ErrorCodes.ValidationError, "Relevance must be between 0.0 and 1.0");
         if (rationale is not null && rationale.Length > 500)
             throw new DomainException(ErrorCodes.ValidationError, "Rationale cannot exceed 500 characters");
@@ -54,7 +54,7 @@ public class EvidenceLink : Entity
 
     public void UpdateRelevance(double newRelevance)
     {
-        if (newRelevance < 0.0 || newRelevance > 1.0)
+        if (!double.IsFinite(newRelevance) || newRelevance < 0.0 || newRelevance > 1.0)
             throw new DomainException(ErrorCodes.ValidationError, "Relevance must be between 0.0 and 1.0");
 
         Relevance = newRelevance;

--- a/backend/src/Taskdeck.Domain/Entities/EvidenceLink.cs
+++ b/backend/src/Taskdeck.Domain/Entities/EvidenceLink.cs
@@ -1,0 +1,63 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Links an <see cref="IntentCandidate"/> to a <see cref="SourceSpan"/>
+/// that provides supporting evidence for that intent. Carries a relevance
+/// weight so the review UI can highlight the most important evidence first.
+/// </summary>
+public class EvidenceLink : Entity
+{
+    public Guid IntentCandidateId { get; private set; }
+    public Guid SourceSpanId { get; private set; }
+
+    /// <summary>
+    /// Relevance weight in the range [0.0, 1.0]. Higher values indicate
+    /// stronger evidence. Defaults to 1.0 (fully relevant).
+    /// </summary>
+    public double Relevance { get; private set; }
+
+    /// <summary>
+    /// Optional human-readable note explaining why this span supports
+    /// the linked intent (e.g. "contains deadline mention").
+    /// </summary>
+    public string? Rationale { get; private set; }
+
+    // Navigation
+    public IntentCandidate IntentCandidate { get; private set; } = null!;
+    public SourceSpan SourceSpan { get; private set; } = null!;
+
+    private EvidenceLink() { } // EF Core
+
+    public EvidenceLink(
+        Guid intentCandidateId,
+        Guid sourceSpanId,
+        double relevance = 1.0,
+        string? rationale = null)
+    {
+        if (intentCandidateId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "IntentCandidateId cannot be empty");
+        if (sourceSpanId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "SourceSpanId cannot be empty");
+        if (relevance < 0.0 || relevance > 1.0)
+            throw new DomainException(ErrorCodes.ValidationError, "Relevance must be between 0.0 and 1.0");
+        if (rationale is not null && rationale.Length > 500)
+            throw new DomainException(ErrorCodes.ValidationError, "Rationale cannot exceed 500 characters");
+
+        IntentCandidateId = intentCandidateId;
+        SourceSpanId = sourceSpanId;
+        Relevance = relevance;
+        Rationale = string.IsNullOrWhiteSpace(rationale) ? null : rationale.Trim();
+    }
+
+    public void UpdateRelevance(double newRelevance)
+    {
+        if (newRelevance < 0.0 || newRelevance > 1.0)
+            throw new DomainException(ErrorCodes.ValidationError, "Relevance must be between 0.0 and 1.0");
+
+        Relevance = newRelevance;
+        Touch();
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
@@ -56,7 +56,7 @@ public class IntentCandidate : Entity
             throw new DomainException(ErrorCodes.ValidationError, "Label cannot be empty");
         if (label.Length > 500)
             throw new DomainException(ErrorCodes.ValidationError, "Label cannot exceed 500 characters");
-        if (confidence < 0.0 || confidence > 1.0)
+        if (!double.IsFinite(confidence) || confidence < 0.0 || confidence > 1.0)
             throw new DomainException(ErrorCodes.ValidationError, "Confidence must be between 0.0 and 1.0");
         if (rank < 0)
             throw new DomainException(ErrorCodes.ValidationError, "Rank must be non-negative");
@@ -70,11 +70,20 @@ public class IntentCandidate : Entity
         ActionType = string.IsNullOrWhiteSpace(actionType) ? null : actionType.Trim();
     }
 
-    public void AddEvidenceLink(EvidenceLink link)
+    public void AddEvidenceLink(EvidenceLink link, SourceSpan sourceSpan)
     {
+        if (sourceSpan is null)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "SourceSpan is required when adding an EvidenceLink");
         if (link.IntentCandidateId != Id)
             throw new DomainException(ErrorCodes.ValidationError,
                 "EvidenceLink does not belong to this IntentCandidate");
+        if (link.SourceSpanId != sourceSpan.Id)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "EvidenceLink does not point to the provided SourceSpan");
+        if (sourceSpan.EnvelopeId != EnvelopeId)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "EvidenceLink source span does not belong to this IntentCandidate envelope");
 
         _evidenceLinks.Add(link);
         Touch();
@@ -82,7 +91,7 @@ public class IntentCandidate : Entity
 
     public void UpdateConfidence(double newConfidence)
     {
-        if (newConfidence < 0.0 || newConfidence > 1.0)
+        if (!double.IsFinite(newConfidence) || newConfidence < 0.0 || newConfidence > 1.0)
             throw new DomainException(ErrorCodes.ValidationError, "Confidence must be between 0.0 and 1.0");
 
         Confidence = newConfidence;

--- a/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
@@ -72,6 +72,9 @@ public class IntentCandidate : Entity
 
     public void AddEvidenceLink(EvidenceLink link, SourceSpan sourceSpan)
     {
+        if (link is null)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "EvidenceLink cannot be null");
         if (sourceSpan is null)
             throw new DomainException(ErrorCodes.ValidationError,
                 "SourceSpan is required when adding an EvidenceLink");

--- a/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
@@ -1,0 +1,87 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// An extracted intent from an <see cref="IntentEnvelopeV1"/>.
+/// Carries a human-readable label, optional structured action type, and a
+/// confidence score (0.0 -- 1.0). Linked to supporting evidence via
+/// <see cref="EvidenceLink"/>.
+/// </summary>
+public class IntentCandidate : Entity
+{
+    public Guid EnvelopeId { get; private set; }
+
+    /// <summary>
+    /// Human-readable label describing the intent, e.g. "Create card for API review".
+    /// </summary>
+    public string Label { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Machine-readable action type, e.g. "create-card", "update-column", "archive".
+    /// Null when the intent is purely informational.
+    /// </summary>
+    public string? ActionType { get; private set; }
+
+    /// <summary>
+    /// Confidence score in the range [0.0, 1.0].
+    /// </summary>
+    public double Confidence { get; private set; }
+
+    /// <summary>
+    /// Zero-based rank among sibling candidates in the same envelope.
+    /// Lower rank = higher priority.
+    /// </summary>
+    public int Rank { get; private set; }
+
+    private readonly List<EvidenceLink> _evidenceLinks = new();
+    public IReadOnlyList<EvidenceLink> EvidenceLinks => _evidenceLinks.AsReadOnly();
+
+    // Navigation
+    public IntentEnvelopeV1 Envelope { get; private set; } = null!;
+
+    private IntentCandidate() { } // EF Core
+
+    public IntentCandidate(
+        Guid envelopeId,
+        string label,
+        double confidence,
+        int rank,
+        string? actionType = null)
+    {
+        if (envelopeId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "EnvelopeId cannot be empty");
+        if (string.IsNullOrWhiteSpace(label))
+            throw new DomainException(ErrorCodes.ValidationError, "Label cannot be empty");
+        if (label.Length > 500)
+            throw new DomainException(ErrorCodes.ValidationError, "Label cannot exceed 500 characters");
+        if (confidence < 0.0 || confidence > 1.0)
+            throw new DomainException(ErrorCodes.ValidationError, "Confidence must be between 0.0 and 1.0");
+        if (rank < 0)
+            throw new DomainException(ErrorCodes.ValidationError, "Rank must be non-negative");
+        if (actionType is not null && actionType.Length > 100)
+            throw new DomainException(ErrorCodes.ValidationError, "ActionType cannot exceed 100 characters");
+
+        EnvelopeId = envelopeId;
+        Label = label;
+        Confidence = confidence;
+        Rank = rank;
+        ActionType = string.IsNullOrWhiteSpace(actionType) ? null : actionType.Trim();
+    }
+
+    public void AddEvidenceLink(EvidenceLink link)
+    {
+        _evidenceLinks.Add(link);
+        Touch();
+    }
+
+    public void UpdateConfidence(double newConfidence)
+    {
+        if (newConfidence < 0.0 || newConfidence > 1.0)
+            throw new DomainException(ErrorCodes.ValidationError, "Confidence must be between 0.0 and 1.0");
+
+        Confidence = newConfidence;
+        Touch();
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentCandidate.cs
@@ -72,6 +72,10 @@ public class IntentCandidate : Entity
 
     public void AddEvidenceLink(EvidenceLink link)
     {
+        if (link.IntentCandidateId != Id)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "EvidenceLink does not belong to this IntentCandidate");
+
         _evidenceLinks.Add(link);
         Touch();
     }

--- a/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
@@ -1,0 +1,173 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Version 1 of the intent envelope -- the versioned spine for the review-first
+/// AI pipeline. Wraps raw user input (<see cref="SourceBlock"/>s), extracted
+/// intents (<see cref="IntentCandidate"/>s), and the resulting
+/// <see cref="TaskdeckProposalBatch"/>.
+///
+/// Lifecycle: Created → Populated (blocks + intents) → Processed (batch sealed).
+/// </summary>
+public class IntentEnvelopeV1 : Entity
+{
+    /// <summary>
+    /// Schema version. Always 1 for this class. Future envelopes will
+    /// increment this, enabling consumers to handle format evolution.
+    /// </summary>
+    public int Version { get; private set; } = 1;
+
+    /// <summary>
+    /// Where the envelope originated: "capture", "chat", "import", etc.
+    /// </summary>
+    public string Source { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Timestamp when the raw input was captured (may differ from
+    /// <see cref="Entity.CreatedAt"/> if the envelope is created after
+    /// a processing delay).
+    /// </summary>
+    public DateTimeOffset CapturedAt { get; private set; }
+
+    /// <summary>
+    /// The raw, unprocessed content that was captured. Retained for
+    /// auditability and replay.
+    /// </summary>
+    public string RawContent { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Current processing status of the envelope.
+    /// </summary>
+    public EnvelopeStatus Status { get; private set; }
+
+    /// <summary>
+    /// The user who triggered the capture.
+    /// </summary>
+    public Guid UserId { get; private set; }
+
+    /// <summary>
+    /// Optional correlation ID linking to the originating capture item,
+    /// chat session, or other upstream entity.
+    /// </summary>
+    public string? CorrelationId { get; private set; }
+
+    private readonly List<SourceBlock> _sourceBlocks = new();
+    public IReadOnlyList<SourceBlock> SourceBlocks => _sourceBlocks.AsReadOnly();
+
+    private readonly List<IntentCandidate> _intentCandidates = new();
+    public IReadOnlyList<IntentCandidate> IntentCandidates => _intentCandidates.AsReadOnly();
+
+    private readonly List<TaskdeckProposalBatch> _batches = new();
+    public IReadOnlyList<TaskdeckProposalBatch> Batches => _batches.AsReadOnly();
+
+    private IntentEnvelopeV1() { } // EF Core
+
+    public IntentEnvelopeV1(
+        string source,
+        string rawContent,
+        Guid userId,
+        DateTimeOffset? capturedAt = null,
+        string? correlationId = null)
+    {
+        if (string.IsNullOrWhiteSpace(source))
+            throw new DomainException(ErrorCodes.ValidationError, "Source cannot be empty");
+        if (source.Length > 50)
+            throw new DomainException(ErrorCodes.ValidationError, "Source cannot exceed 50 characters");
+        if (string.IsNullOrWhiteSpace(rawContent))
+            throw new DomainException(ErrorCodes.ValidationError, "RawContent cannot be empty");
+        if (rawContent.Length > 100_000)
+            throw new DomainException(ErrorCodes.ValidationError, "RawContent cannot exceed 100000 characters");
+        if (userId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "UserId cannot be empty");
+
+        Source = source;
+        RawContent = rawContent;
+        UserId = userId;
+        CapturedAt = capturedAt ?? DateTimeOffset.UtcNow;
+        CorrelationId = string.IsNullOrWhiteSpace(correlationId) ? null : correlationId.Trim();
+        Status = EnvelopeStatus.Created;
+    }
+
+    public SourceBlock AddSourceBlock(
+        int position,
+        string content,
+        string sourceType,
+        string? sourceReferenceId = null)
+    {
+        if (Status != EnvelopeStatus.Created)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                "Cannot add source blocks after envelope processing has started");
+
+        var block = new SourceBlock(Id, position, content, sourceType, sourceReferenceId);
+        _sourceBlocks.Add(block);
+        Touch();
+        return block;
+    }
+
+    public IntentCandidate AddIntentCandidate(
+        string label,
+        double confidence,
+        int rank,
+        string? actionType = null)
+    {
+        if (Status == EnvelopeStatus.Processed || Status == EnvelopeStatus.Failed)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                $"Cannot add intent candidates when envelope is in status {Status}");
+
+        if (Status == EnvelopeStatus.Created)
+            Status = EnvelopeStatus.Extracting;
+
+        var candidate = new IntentCandidate(Id, label, confidence, rank, actionType);
+        _intentCandidates.Add(candidate);
+        Touch();
+        return candidate;
+    }
+
+    public TaskdeckProposalBatch CreateBatch(
+        Guid requestedByUserId,
+        string summary,
+        int schemaVersion = 1)
+    {
+        if (Status != EnvelopeStatus.Extracting)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                $"Cannot create batches when envelope is in status {Status}");
+
+        var batch = new TaskdeckProposalBatch(Id, requestedByUserId, summary, schemaVersion);
+        _batches.Add(batch);
+        Touch();
+        return batch;
+    }
+
+    public void MarkProcessed()
+    {
+        if (Status != EnvelopeStatus.Extracting)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                $"Cannot mark as processed when envelope is in status {Status}");
+        if (_intentCandidates.Count == 0)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "Cannot mark as processed without at least one intent candidate");
+
+        Status = EnvelopeStatus.Processed;
+        Touch();
+    }
+
+    public void MarkFailed(string? reason = null)
+    {
+        if (Status == EnvelopeStatus.Processed)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                "Cannot mark an already-processed envelope as failed");
+
+        Status = EnvelopeStatus.Failed;
+        Touch();
+    }
+}
+
+public enum EnvelopeStatus
+{
+    Created,
+    Extracting,
+    Processed,
+    Failed
+}

--- a/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
@@ -155,6 +155,12 @@ public class IntentEnvelopeV1 : Entity
         if (_intentCandidates.Count == 0)
             throw new DomainException(ErrorCodes.ValidationError,
                 "Cannot mark as processed without at least one intent candidate");
+        if (_batches.Count == 0)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "Cannot mark as processed without at least one proposal batch");
+        if (_batches.Any(batch => batch.Status != ProposalBatchStatus.Sealed))
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                "Cannot mark as processed until all proposal batches are sealed");
 
         Status = EnvelopeStatus.Processed;
         Touch();

--- a/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
@@ -122,10 +122,11 @@ public class IntentEnvelopeV1 : Entity
             throw new DomainException(ErrorCodes.InvalidOperation,
                 $"Cannot add intent candidates when envelope is in status {Status}");
 
+        var candidate = new IntentCandidate(Id, label, confidence, rank, actionType);
+
         if (Status == EnvelopeStatus.Created)
             Status = EnvelopeStatus.Extracting;
 
-        var candidate = new IntentCandidate(Id, label, confidence, rank, actionType);
         _intentCandidates.Add(candidate);
         Touch();
         return candidate;

--- a/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
@@ -158,13 +158,18 @@ public class IntentEnvelopeV1 : Entity
         if (_batches.Count == 0)
             throw new DomainException(ErrorCodes.ValidationError,
                 "Cannot mark as processed without at least one proposal batch");
-        if (_batches.Any(batch => batch.Status != ProposalBatchStatus.Sealed))
+        if (_batches.Any(batch => !IsReadyForProcessedEnvelope(batch.Status)))
             throw new DomainException(ErrorCodes.InvalidOperation,
-                "Cannot mark as processed until all proposal batches are sealed");
+                "Cannot mark as processed until all proposal batches are finalized");
 
         Status = EnvelopeStatus.Processed;
         Touch();
     }
+
+    private static bool IsReadyForProcessedEnvelope(ProposalBatchStatus status) =>
+        status is ProposalBatchStatus.Sealed
+            or ProposalBatchStatus.Completed
+            or ProposalBatchStatus.Discarded;
 
     public void MarkFailed(string? reason = null)
     {

--- a/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IntentEnvelopeV1.cs
@@ -53,6 +53,12 @@ public class IntentEnvelopeV1 : Entity
     /// </summary>
     public string? CorrelationId { get; private set; }
 
+    /// <summary>
+    /// Reason for failure when status is <see cref="EnvelopeStatus.Failed"/>.
+    /// Null when the envelope has not failed.
+    /// </summary>
+    public string? FailureReason { get; private set; }
+
     private readonly List<SourceBlock> _sourceBlocks = new();
     public IReadOnlyList<SourceBlock> SourceBlocks => _sourceBlocks.AsReadOnly();
 
@@ -160,6 +166,7 @@ public class IntentEnvelopeV1 : Entity
                 "Cannot mark an already-processed envelope as failed");
 
         Status = EnvelopeStatus.Failed;
+        FailureReason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim();
         Touch();
     }
 }

--- a/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
@@ -78,6 +78,11 @@ public class SourceBlock : Entity
             throw new DomainException(ErrorCodes.ValidationError,
                 $"EndOffset ({endOffset}) exceeds block content length ({Content.Length})");
 
+        var expectedSnippet = Content.Substring(startOffset, endOffset - startOffset);
+        if (snippetText != expectedSnippet)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "SnippetText must match the block content at the specified offsets");
+
         var span = new SourceSpan(Id, startOffset, endOffset, snippetText);
         _spans.Add(span);
         Touch();

--- a/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
@@ -71,6 +71,9 @@ public class SourceBlock : Entity
 
     public SourceSpan AddSpan(int startOffset, int endOffset, string snippetText)
     {
+        if (startOffset > Content.Length)
+            throw new DomainException(ErrorCodes.ValidationError,
+                $"StartOffset ({startOffset}) exceeds block content length ({Content.Length})");
         if (endOffset > Content.Length)
             throw new DomainException(ErrorCodes.ValidationError,
                 $"EndOffset ({endOffset}) exceeds block content length ({Content.Length})");

--- a/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
@@ -71,6 +71,12 @@ public class SourceBlock : Entity
 
     public SourceSpan AddSpan(int startOffset, int endOffset, string snippetText)
     {
+        if (startOffset < 0)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "StartOffset must be non-negative");
+        if (endOffset <= startOffset)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "EndOffset must be greater than StartOffset");
         if (startOffset > Content.Length)
             throw new DomainException(ErrorCodes.ValidationError,
                 $"StartOffset ({startOffset}) exceeds block content length ({Content.Length})");

--- a/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
@@ -1,0 +1,83 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// A discrete text block from a source (capture input, chat message, etc.)
+/// with position metadata. Blocks are contained within an
+/// <see cref="IntentEnvelopeV1"/> and may contain multiple
+/// <see cref="SourceSpan"/> ranges used as evidence.
+/// </summary>
+public class SourceBlock : Entity
+{
+    public Guid EnvelopeId { get; private set; }
+
+    /// <summary>
+    /// Zero-based index of this block within the envelope's ordered list.
+    /// </summary>
+    public int Position { get; private set; }
+
+    /// <summary>
+    /// The raw text content of this block.
+    /// </summary>
+    public string Content { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Identifies where this block came from, e.g. "capture", "chat", "paste".
+    /// </summary>
+    public string SourceType { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Optional reference to the originating entity (capture item ID, chat
+    /// message ID, etc.). Not a foreign key -- just a correlation hint.
+    /// </summary>
+    public string? SourceReferenceId { get; private set; }
+
+    private readonly List<SourceSpan> _spans = new();
+    public IReadOnlyList<SourceSpan> Spans => _spans.AsReadOnly();
+
+    // Navigation
+    public IntentEnvelopeV1 Envelope { get; private set; } = null!;
+
+    private SourceBlock() { } // EF Core
+
+    public SourceBlock(
+        Guid envelopeId,
+        int position,
+        string content,
+        string sourceType,
+        string? sourceReferenceId = null)
+    {
+        if (envelopeId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "EnvelopeId cannot be empty");
+        if (position < 0)
+            throw new DomainException(ErrorCodes.ValidationError, "Position must be non-negative");
+        if (string.IsNullOrWhiteSpace(content))
+            throw new DomainException(ErrorCodes.ValidationError, "Content cannot be empty");
+        if (content.Length > 50_000)
+            throw new DomainException(ErrorCodes.ValidationError, "Content cannot exceed 50000 characters");
+        if (string.IsNullOrWhiteSpace(sourceType))
+            throw new DomainException(ErrorCodes.ValidationError, "SourceType cannot be empty");
+        if (sourceType.Length > 50)
+            throw new DomainException(ErrorCodes.ValidationError, "SourceType cannot exceed 50 characters");
+
+        EnvelopeId = envelopeId;
+        Position = position;
+        Content = content;
+        SourceType = sourceType;
+        SourceReferenceId = string.IsNullOrWhiteSpace(sourceReferenceId) ? null : sourceReferenceId.Trim();
+    }
+
+    public SourceSpan AddSpan(int startOffset, int endOffset, string snippetText)
+    {
+        if (endOffset > Content.Length)
+            throw new DomainException(ErrorCodes.ValidationError,
+                $"EndOffset ({endOffset}) exceeds block content length ({Content.Length})");
+
+        var span = new SourceSpan(Id, startOffset, endOffset, snippetText);
+        _spans.Add(span);
+        Touch();
+        return span;
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceBlock.cs
@@ -89,7 +89,7 @@ public class SourceBlock : Entity
             throw new DomainException(ErrorCodes.ValidationError,
                 "SnippetText must match the block content at the specified offsets");
 
-        var span = new SourceSpan(Id, startOffset, endOffset, snippetText);
+        var span = new SourceSpan(Id, EnvelopeId, startOffset, endOffset, snippetText);
         _spans.Add(span);
         Touch();
         return span;

--- a/backend/src/Taskdeck.Domain/Entities/SourceSpan.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceSpan.cs
@@ -11,6 +11,7 @@ namespace Taskdeck.Domain.Entities;
 public class SourceSpan : Entity
 {
     public Guid SourceBlockId { get; private set; }
+    public Guid EnvelopeId { get; private set; }
     public int StartOffset { get; private set; }
     public int EndOffset { get; private set; }
 
@@ -28,12 +29,15 @@ public class SourceSpan : Entity
 
     public SourceSpan(
         Guid sourceBlockId,
+        Guid envelopeId,
         int startOffset,
         int endOffset,
         string snippetText)
     {
         if (sourceBlockId == Guid.Empty)
             throw new DomainException(ErrorCodes.ValidationError, "SourceBlockId cannot be empty");
+        if (envelopeId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "EnvelopeId cannot be empty");
         if (startOffset < 0)
             throw new DomainException(ErrorCodes.ValidationError, "StartOffset must be non-negative");
         if (endOffset < 0)
@@ -49,6 +53,7 @@ public class SourceSpan : Entity
                 $"SnippetText length ({snippetText.Length}) must match the span range ({endOffset - startOffset})");
 
         SourceBlockId = sourceBlockId;
+        EnvelopeId = envelopeId;
         StartOffset = startOffset;
         EndOffset = endOffset;
         SnippetText = snippetText;

--- a/backend/src/Taskdeck.Domain/Entities/SourceSpan.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceSpan.cs
@@ -1,0 +1,56 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// A character-level span within a <see cref="SourceBlock"/> that identifies a
+/// precise range of text. Used by <see cref="EvidenceLink"/> to point at the
+/// exact evidence supporting an <see cref="IntentCandidate"/>.
+/// </summary>
+public class SourceSpan : Entity
+{
+    public Guid SourceBlockId { get; private set; }
+    public int StartOffset { get; private set; }
+    public int EndOffset { get; private set; }
+
+    /// <summary>
+    /// Verbatim text captured from the span. Stored separately from the
+    /// offsets so the evidence remains readable even if the source is
+    /// truncated or compacted later.
+    /// </summary>
+    public string SnippetText { get; private set; } = string.Empty;
+
+    // Navigation
+    public SourceBlock SourceBlock { get; private set; } = null!;
+
+    private SourceSpan() { } // EF Core
+
+    public SourceSpan(
+        Guid sourceBlockId,
+        int startOffset,
+        int endOffset,
+        string snippetText)
+    {
+        if (sourceBlockId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "SourceBlockId cannot be empty");
+        if (startOffset < 0)
+            throw new DomainException(ErrorCodes.ValidationError, "StartOffset must be non-negative");
+        if (endOffset < 0)
+            throw new DomainException(ErrorCodes.ValidationError, "EndOffset must be non-negative");
+        if (endOffset <= startOffset)
+            throw new DomainException(ErrorCodes.ValidationError, "EndOffset must be greater than StartOffset");
+        if (string.IsNullOrEmpty(snippetText))
+            throw new DomainException(ErrorCodes.ValidationError, "SnippetText cannot be empty");
+        if (snippetText.Length > 2000)
+            throw new DomainException(ErrorCodes.ValidationError, "SnippetText cannot exceed 2000 characters");
+
+        SourceBlockId = sourceBlockId;
+        StartOffset = startOffset;
+        EndOffset = endOffset;
+        SnippetText = snippetText;
+    }
+
+    /// <summary>Length of the span in characters.</summary>
+    public int Length => EndOffset - StartOffset;
+}

--- a/backend/src/Taskdeck.Domain/Entities/SourceSpan.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SourceSpan.cs
@@ -44,6 +44,9 @@ public class SourceSpan : Entity
             throw new DomainException(ErrorCodes.ValidationError, "SnippetText cannot be empty");
         if (snippetText.Length > 2000)
             throw new DomainException(ErrorCodes.ValidationError, "SnippetText cannot exceed 2000 characters");
+        if (snippetText.Length != (endOffset - startOffset))
+            throw new DomainException(ErrorCodes.ValidationError,
+                $"SnippetText length ({snippetText.Length}) must match the span range ({endOffset - startOffset})");
 
         SourceBlockId = sourceBlockId;
         StartOffset = startOffset;

--- a/backend/src/Taskdeck.Domain/Entities/TaskdeckProposalBatch.cs
+++ b/backend/src/Taskdeck.Domain/Entities/TaskdeckProposalBatch.cs
@@ -1,0 +1,121 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// A batch of <see cref="AutomationProposal"/>s generated from a single
+/// <see cref="IntentEnvelopeV1"/>. Groups proposals for atomic review and
+/// provides traceability back to the originating envelope.
+/// </summary>
+public class TaskdeckProposalBatch : Entity
+{
+    public Guid EnvelopeId { get; private set; }
+    public Guid RequestedByUserId { get; private set; }
+    public ProposalBatchStatus Status { get; private set; }
+
+    /// <summary>
+    /// Human-readable summary of the batch, typically derived from the
+    /// envelope's top-ranked intent candidates.
+    /// </summary>
+    public string Summary { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The schema version used to generate this batch. Allows downstream
+    /// consumers to handle format evolution gracefully.
+    /// </summary>
+    public int SchemaVersion { get; private set; }
+
+    private readonly List<Guid> _proposalIds = new();
+
+    /// <summary>
+    /// IDs of the <see cref="AutomationProposal"/>s contained in this batch.
+    /// Stored as a flat list rather than navigation properties to avoid tight
+    /// coupling between the new intent pipeline and the existing proposal model.
+    /// </summary>
+    public IReadOnlyList<Guid> ProposalIds => _proposalIds.AsReadOnly();
+
+    // Navigation
+    public IntentEnvelopeV1 Envelope { get; private set; } = null!;
+
+    private TaskdeckProposalBatch() { } // EF Core
+
+    public TaskdeckProposalBatch(
+        Guid envelopeId,
+        Guid requestedByUserId,
+        string summary,
+        int schemaVersion = 1)
+    {
+        if (envelopeId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "EnvelopeId cannot be empty");
+        if (requestedByUserId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "RequestedByUserId cannot be empty");
+        if (string.IsNullOrWhiteSpace(summary))
+            throw new DomainException(ErrorCodes.ValidationError, "Summary cannot be empty");
+        if (summary.Length > 1000)
+            throw new DomainException(ErrorCodes.ValidationError, "Summary cannot exceed 1000 characters");
+        if (schemaVersion < 1)
+            throw new DomainException(ErrorCodes.ValidationError, "SchemaVersion must be at least 1");
+
+        EnvelopeId = envelopeId;
+        RequestedByUserId = requestedByUserId;
+        Summary = summary;
+        SchemaVersion = schemaVersion;
+        Status = ProposalBatchStatus.Draft;
+    }
+
+    public void AddProposalId(Guid proposalId)
+    {
+        if (proposalId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "ProposalId cannot be empty");
+        if (_proposalIds.Contains(proposalId))
+            throw new DomainException(ErrorCodes.Conflict, "ProposalId is already in this batch");
+        if (Status != ProposalBatchStatus.Draft)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                "Cannot add proposals after batch has been sealed");
+
+        _proposalIds.Add(proposalId);
+        Touch();
+    }
+
+    public void Seal()
+    {
+        if (Status != ProposalBatchStatus.Draft)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                $"Cannot seal batch in status {Status}");
+        if (_proposalIds.Count == 0)
+            throw new DomainException(ErrorCodes.ValidationError,
+                "Cannot seal an empty batch");
+
+        Status = ProposalBatchStatus.Sealed;
+        Touch();
+    }
+
+    public void Complete()
+    {
+        if (Status != ProposalBatchStatus.Sealed)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                $"Cannot complete batch in status {Status}");
+
+        Status = ProposalBatchStatus.Completed;
+        Touch();
+    }
+
+    public void Discard()
+    {
+        if (Status == ProposalBatchStatus.Completed)
+            throw new DomainException(ErrorCodes.InvalidOperation,
+                "Cannot discard a completed batch");
+
+        Status = ProposalBatchStatus.Discarded;
+        Touch();
+    }
+}
+
+public enum ProposalBatchStatus
+{
+    Draft,
+    Sealed,
+    Completed,
+    Discarded
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/EvidenceLinkTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/EvidenceLinkTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class EvidenceLinkTests
+{
+    private readonly Guid _intentCandidateId = Guid.NewGuid();
+    private readonly Guid _sourceSpanId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateLink_WithValidData()
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.8, "Contains deadline mention");
+
+        link.Id.Should().NotBe(Guid.Empty);
+        link.IntentCandidateId.Should().Be(_intentCandidateId);
+        link.SourceSpanId.Should().Be(_sourceSpanId);
+        link.Relevance.Should().Be(0.8);
+        link.Rationale.Should().Be("Contains deadline mention");
+    }
+
+    [Fact]
+    public void Constructor_ShouldDefaultRelevanceTo1()
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId);
+
+        link.Relevance.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptNullRationale()
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5);
+
+        link.Rationale.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyIntentCandidateId()
+    {
+        var act = () => new EvidenceLink(Guid.Empty, _sourceSpanId);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptySourceSpanId()
+    {
+        var act = () => new EvidenceLink(_intentCandidateId, Guid.Empty);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    [InlineData(-1.0)]
+    [InlineData(2.0)]
+    public void Constructor_ShouldRejectRelevanceOutOfRange(double relevance)
+    {
+        var act = () => new EvidenceLink(_intentCandidateId, _sourceSpanId, relevance);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    [InlineData(1.0)]
+    public void Constructor_ShouldAcceptRelevanceBoundaryValues(double relevance)
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, relevance);
+
+        link.Relevance.Should().Be(relevance);
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectRationaleExceeding500Characters()
+    {
+        var longRationale = new string('x', 501);
+        var act = () => new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5, longRationale);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldTrimRationale()
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5, "  some rationale  ");
+
+        link.Rationale.Should().Be("some rationale");
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetNullRationale_WhenWhitespace()
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5, "   ");
+
+        link.Rationale.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateRelevance_ShouldUpdateValue()
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5);
+
+        link.UpdateRelevance(0.9);
+
+        link.Relevance.Should().Be(0.9);
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    public void UpdateRelevance_ShouldRejectOutOfRange(double newRelevance)
+    {
+        var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5);
+
+        var act = () => link.UpdateRelevance(newRelevance);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/EvidenceLinkTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/EvidenceLinkTests.cs
@@ -61,6 +61,9 @@ public class EvidenceLinkTests
     [InlineData(1.01)]
     [InlineData(-1.0)]
     [InlineData(2.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
     public void Constructor_ShouldRejectRelevanceOutOfRange(double relevance)
     {
         var act = () => new EvidenceLink(_intentCandidateId, _sourceSpanId, relevance);
@@ -119,6 +122,9 @@ public class EvidenceLinkTests
     [Theory]
     [InlineData(-0.01)]
     [InlineData(1.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
     public void UpdateRelevance_ShouldRejectOutOfRange(double newRelevance)
     {
         var link = new EvidenceLink(_intentCandidateId, _sourceSpanId, 0.5);

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
@@ -1,0 +1,156 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class IntentCandidateTests
+{
+    private readonly Guid _envelopeId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateCandidate_WithValidData()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Create API review card", 0.85, 0, "create-card");
+
+        candidate.Id.Should().NotBe(Guid.Empty);
+        candidate.EnvelopeId.Should().Be(_envelopeId);
+        candidate.Label.Should().Be("Create API review card");
+        candidate.Confidence.Should().Be(0.85);
+        candidate.Rank.Should().Be(0);
+        candidate.ActionType.Should().Be("create-card");
+        candidate.EvidenceLinks.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptNullActionType()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Informational note", 0.5, 1);
+
+        candidate.ActionType.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyEnvelopeId()
+    {
+        var act = () => new IntentCandidate(Guid.Empty, "Label", 0.5, 0);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyLabel()
+    {
+        var act = () => new IntentCandidate(_envelopeId, "", 0.5, 0);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectLabelExceeding500Characters()
+    {
+        var longLabel = new string('x', 501);
+        var act = () => new IntentCandidate(_envelopeId, longLabel, 0.5, 0);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    [InlineData(-1.0)]
+    [InlineData(2.0)]
+    public void Constructor_ShouldRejectConfidenceOutOfRange(double confidence)
+    {
+        var act = () => new IntentCandidate(_envelopeId, "Label", confidence, 0);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    [InlineData(1.0)]
+    public void Constructor_ShouldAcceptConfidenceBoundaryValues(double confidence)
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", confidence, 0);
+
+        candidate.Confidence.Should().Be(confidence);
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNegativeRank()
+    {
+        var act = () => new IntentCandidate(_envelopeId, "Label", 0.5, -1);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectActionTypeExceeding100Characters()
+    {
+        var longAction = new string('x', 101);
+        var act = () => new IntentCandidate(_envelopeId, "Label", 0.5, 0, longAction);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldTrimActionType()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0, "  create-card  ");
+
+        candidate.ActionType.Should().Be("create-card");
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetNullActionType_WhenWhitespace()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0, "   ");
+
+        candidate.ActionType.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateConfidence_ShouldUpdateValue()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+
+        candidate.UpdateConfidence(0.9);
+
+        candidate.Confidence.Should().Be(0.9);
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(1.01)]
+    public void UpdateConfidence_ShouldRejectOutOfRange(double newConfidence)
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+
+        var act = () => candidate.UpdateConfidence(newConfidence);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddEvidenceLink_ShouldAddLink()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+        var spanId = Guid.NewGuid();
+        var link = new EvidenceLink(candidate.Id, spanId, 0.8, "Key evidence");
+
+        candidate.AddEvidenceLink(link);
+
+        candidate.EvidenceLinks.Should().HaveCount(1);
+        candidate.EvidenceLinks[0].Should().Be(link);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
@@ -153,4 +153,17 @@ public class IntentCandidateTests
         candidate.EvidenceLinks.Should().HaveCount(1);
         candidate.EvidenceLinks[0].Should().Be(link);
     }
+
+    [Fact]
+    public void AddEvidenceLink_ShouldRejectLinkBelongingToDifferentCandidate()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+        var otherCandidateId = Guid.NewGuid();
+        var link = new EvidenceLink(otherCandidateId, Guid.NewGuid(), 0.8);
+
+        var act = () => candidate.AddEvidenceLink(link);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
@@ -177,6 +177,19 @@ public class IntentCandidateTests
     }
 
     [Fact]
+    public void AddEvidenceLink_ShouldRejectNullLink()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+        var block = new SourceBlock(_envelopeId, 0, "Key evidence text", "capture");
+        var span = block.AddSpan(0, 12, "Key evidence");
+
+        var act = () => candidate.AddEvidenceLink(null!, span);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
     public void AddEvidenceLink_ShouldRejectLinkPointingToDifferentSpan()
     {
         var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentCandidateTests.cs
@@ -64,6 +64,9 @@ public class IntentCandidateTests
     [InlineData(1.01)]
     [InlineData(-1.0)]
     [InlineData(2.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
     public void Constructor_ShouldRejectConfidenceOutOfRange(double confidence)
     {
         var act = () => new IntentCandidate(_envelopeId, "Label", confidence, 0);
@@ -131,6 +134,9 @@ public class IntentCandidateTests
     [Theory]
     [InlineData(-0.01)]
     [InlineData(1.01)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
     public void UpdateConfidence_ShouldRejectOutOfRange(double newConfidence)
     {
         var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
@@ -145,10 +151,11 @@ public class IntentCandidateTests
     public void AddEvidenceLink_ShouldAddLink()
     {
         var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
-        var spanId = Guid.NewGuid();
-        var link = new EvidenceLink(candidate.Id, spanId, 0.8, "Key evidence");
+        var block = new SourceBlock(_envelopeId, 0, "Key evidence text", "capture");
+        var span = block.AddSpan(0, 12, "Key evidence");
+        var link = new EvidenceLink(candidate.Id, span.Id, 0.8, "Key evidence");
 
-        candidate.AddEvidenceLink(link);
+        candidate.AddEvidenceLink(link, span);
 
         candidate.EvidenceLinks.Should().HaveCount(1);
         candidate.EvidenceLinks[0].Should().Be(link);
@@ -160,8 +167,38 @@ public class IntentCandidateTests
         var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
         var otherCandidateId = Guid.NewGuid();
         var link = new EvidenceLink(otherCandidateId, Guid.NewGuid(), 0.8);
+        var block = new SourceBlock(_envelopeId, 0, "Key evidence text", "capture");
+        var span = block.AddSpan(0, 12, "Key evidence");
 
-        var act = () => candidate.AddEvidenceLink(link);
+        var act = () => candidate.AddEvidenceLink(link, span);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddEvidenceLink_ShouldRejectLinkPointingToDifferentSpan()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+        var block = new SourceBlock(_envelopeId, 0, "Key evidence text", "capture");
+        var span = block.AddSpan(0, 12, "Key evidence");
+        var link = new EvidenceLink(candidate.Id, Guid.NewGuid(), 0.8);
+
+        var act = () => candidate.AddEvidenceLink(link, span);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddEvidenceLink_ShouldRejectSpanFromDifferentEnvelope()
+    {
+        var candidate = new IntentCandidate(_envelopeId, "Label", 0.5, 0);
+        var otherBlock = new SourceBlock(Guid.NewGuid(), 0, "Key evidence text", "capture");
+        var otherSpan = otherBlock.AddSpan(0, 12, "Key evidence");
+        var link = new EvidenceLink(candidate.Id, otherSpan.Id, 0.8);
+
+        var act = () => candidate.AddEvidenceLink(link, otherSpan);
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
@@ -1,0 +1,323 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class IntentEnvelopeV1Tests
+{
+    private readonly Guid _userId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateEnvelope_WithValidData()
+    {
+        var capturedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var envelope = new IntentEnvelopeV1("capture", "Fix the login bug", _userId, capturedAt, "corr-123");
+
+        envelope.Id.Should().NotBe(Guid.Empty);
+        envelope.Version.Should().Be(1);
+        envelope.Source.Should().Be("capture");
+        envelope.RawContent.Should().Be("Fix the login bug");
+        envelope.UserId.Should().Be(_userId);
+        envelope.CapturedAt.Should().Be(capturedAt);
+        envelope.CorrelationId.Should().Be("corr-123");
+        envelope.Status.Should().Be(EnvelopeStatus.Created);
+        envelope.SourceBlocks.Should().BeEmpty();
+        envelope.IntentCandidates.Should().BeEmpty();
+        envelope.Batches.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_ShouldDefaultCapturedAtToNow()
+    {
+        var before = DateTimeOffset.UtcNow;
+        var envelope = new IntentEnvelopeV1("chat", "Some input", _userId);
+        var after = DateTimeOffset.UtcNow;
+
+        envelope.CapturedAt.Should().BeOnOrAfter(before);
+        envelope.CapturedAt.Should().BeOnOrBefore(after);
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptySource()
+    {
+        var act = () => new IntentEnvelopeV1("", "content", _userId);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectSourceExceeding50Characters()
+    {
+        var longSource = new string('x', 51);
+        var act = () => new IntentEnvelopeV1(longSource, "content", _userId);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyRawContent()
+    {
+        var act = () => new IntentEnvelopeV1("capture", "", _userId);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectRawContentExceeding100000Characters()
+    {
+        var longContent = new string('x', 100_001);
+        var act = () => new IntentEnvelopeV1("capture", longContent, _userId);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyUserId()
+    {
+        var act = () => new IntentEnvelopeV1("capture", "content", Guid.Empty);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldTrimCorrelationId()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId, correlationId: "  corr-456  ");
+
+        envelope.CorrelationId.Should().Be("corr-456");
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetNullCorrelationId_WhenWhitespace()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId, correlationId: "   ");
+
+        envelope.CorrelationId.Should().BeNull();
+    }
+
+    // ── AddSourceBlock ────────────────────────────────────────────────
+
+    [Fact]
+    public void AddSourceBlock_ShouldAddBlock_WhenCreated()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "Fix the login bug", _userId);
+
+        var block = envelope.AddSourceBlock(0, "Fix the login bug", "capture");
+
+        block.Should().NotBeNull();
+        block.EnvelopeId.Should().Be(envelope.Id);
+        block.Position.Should().Be(0);
+        envelope.SourceBlocks.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddSourceBlock_ShouldRejectAfterExtracting()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("Some intent", 0.8, 0); // transitions to Extracting
+
+        var act = () => envelope.AddSourceBlock(0, "content", "capture");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    // ── AddIntentCandidate ────────────────────────────────────────────
+
+    [Fact]
+    public void AddIntentCandidate_ShouldTransitionToExtracting()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        envelope.AddIntentCandidate("Create card", 0.9, 0, "create-card");
+
+        envelope.Status.Should().Be(EnvelopeStatus.Extracting);
+        envelope.IntentCandidates.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddIntentCandidate_ShouldAllowMultipleCandidates()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        envelope.AddIntentCandidate("Create card", 0.9, 0, "create-card");
+        envelope.AddIntentCandidate("Update column", 0.7, 1, "update-column");
+
+        envelope.IntentCandidates.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void AddIntentCandidate_ShouldRejectAfterProcessed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+        envelope.MarkProcessed();
+
+        var act = () => envelope.AddIntentCandidate("another intent", 0.3, 1);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void AddIntentCandidate_ShouldRejectAfterFailed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.MarkFailed("something broke");
+
+        var act = () => envelope.AddIntentCandidate("intent", 0.5, 0);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    // ── CreateBatch ───────────────────────────────────────────────────
+
+    [Fact]
+    public void CreateBatch_ShouldCreateBatch_WhenExtracting()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+
+        var batch = envelope.CreateBatch(_userId, "Batch summary");
+
+        batch.Should().NotBeNull();
+        batch.EnvelopeId.Should().Be(envelope.Id);
+        envelope.Batches.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void CreateBatch_ShouldRejectWhenCreated()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        var act = () => envelope.CreateBatch(_userId, "Summary");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    // ── MarkProcessed ─────────────────────────────────────────────────
+
+    [Fact]
+    public void MarkProcessed_ShouldTransitionToProcessed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+
+        envelope.MarkProcessed();
+
+        envelope.Status.Should().Be(EnvelopeStatus.Processed);
+    }
+
+    [Fact]
+    public void MarkProcessed_ShouldRejectWithoutCandidates()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        // Must be in Extracting status -- but with no candidates we're still Created
+        // so this should fail on status check before reaching candidate check
+
+        var act = () => envelope.MarkProcessed();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void MarkProcessed_ShouldRejectWhenAlreadyProcessed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+        envelope.MarkProcessed();
+
+        var act = () => envelope.MarkProcessed();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    // ── MarkFailed ────────────────────────────────────────────────────
+
+    [Fact]
+    public void MarkFailed_ShouldTransitionToFailed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        envelope.MarkFailed("Processing error");
+
+        envelope.Status.Should().Be(EnvelopeStatus.Failed);
+    }
+
+    [Fact]
+    public void MarkFailed_ShouldRejectWhenAlreadyProcessed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+        envelope.MarkProcessed();
+
+        var act = () => envelope.MarkFailed("too late");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void MarkFailed_ShouldAllowFromExtractingStatus()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+
+        envelope.MarkFailed("extraction failed");
+
+        envelope.Status.Should().Be(EnvelopeStatus.Failed);
+    }
+
+    // ── Full lifecycle ────────────────────────────────────────────────
+
+    [Fact]
+    public void FullLifecycle_ShouldWorkEndToEnd()
+    {
+        // Create envelope
+        var envelope = new IntentEnvelopeV1("capture", "Fix login bug and add tests", _userId, correlationId: "cap-1");
+        envelope.Status.Should().Be(EnvelopeStatus.Created);
+
+        // Add source blocks
+        var block = envelope.AddSourceBlock(0, "Fix login bug and add tests", "capture", "cap-1");
+        var span = block.AddSpan(0, 13, "Fix login bug");
+
+        // Add intent candidates (transitions to Extracting)
+        var intent1 = envelope.AddIntentCandidate("Fix login bug", 0.95, 0, "create-card");
+        var intent2 = envelope.AddIntentCandidate("Add tests", 0.8, 1, "create-card");
+        envelope.Status.Should().Be(EnvelopeStatus.Extracting);
+
+        // Link evidence
+        var evidenceLink = new EvidenceLink(intent1.Id, span.Id, 0.95, "Direct mention");
+        intent1.AddEvidenceLink(evidenceLink);
+
+        // Create batch
+        var batch = envelope.CreateBatch(_userId, "Two cards from capture");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+
+        // Mark processed
+        envelope.MarkProcessed();
+        envelope.Status.Should().Be(EnvelopeStatus.Processed);
+
+        // Verify structure
+        envelope.SourceBlocks.Should().HaveCount(1);
+        envelope.IntentCandidates.Should().HaveCount(2);
+        envelope.Batches.Should().HaveCount(1);
+        block.Spans.Should().HaveCount(1);
+        intent1.EvidenceLinks.Should().HaveCount(1);
+        batch.ProposalIds.Should().HaveCount(2);
+        batch.Status.Should().Be(ProposalBatchStatus.Sealed);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
@@ -253,6 +253,36 @@ public class IntentEnvelopeV1Tests
         envelope.MarkFailed("Processing error");
 
         envelope.Status.Should().Be(EnvelopeStatus.Failed);
+        envelope.FailureReason.Should().Be("Processing error");
+    }
+
+    [Fact]
+    public void MarkFailed_ShouldStoreNullReason_WhenWhitespace()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        envelope.MarkFailed("   ");
+
+        envelope.Status.Should().Be(EnvelopeStatus.Failed);
+        envelope.FailureReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void MarkFailed_ShouldTrimReason()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        envelope.MarkFailed("  trimmed reason  ");
+
+        envelope.FailureReason.Should().Be("trimmed reason");
+    }
+
+    [Fact]
+    public void FailureReason_ShouldBeNull_WhenNotFailed()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        envelope.FailureReason.Should().BeNull();
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
@@ -402,7 +402,7 @@ public class IntentEnvelopeV1Tests
 
         // Link evidence
         var evidenceLink = new EvidenceLink(intent1.Id, span.Id, 0.95, "Direct mention");
-        intent1.AddEvidenceLink(evidenceLink);
+        intent1.AddEvidenceLink(evidenceLink, span);
 
         // Create batch
         var batch = envelope.CreateBatch(_userId, "Two cards from capture");

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
@@ -285,6 +285,23 @@ public class IntentEnvelopeV1Tests
     }
 
     [Fact]
+    public void MarkProcessed_ShouldAllowTerminalProposalBatches()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+        var completedBatch = CreateSealedBatch(envelope, _userId);
+        var discardedBatch = CreateSealedBatch(envelope, _userId);
+        completedBatch.Complete();
+        discardedBatch.Discard();
+
+        envelope.MarkProcessed();
+
+        envelope.Status.Should().Be(EnvelopeStatus.Processed);
+        completedBatch.Status.Should().Be(ProposalBatchStatus.Completed);
+        discardedBatch.Status.Should().Be(ProposalBatchStatus.Discarded);
+    }
+
+    [Fact]
     public void MarkProcessed_ShouldRejectWhenAlreadyProcessed()
     {
         var envelope = new IntentEnvelopeV1("capture", "content", _userId);

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
@@ -154,6 +154,21 @@ public class IntentEnvelopeV1Tests
     }
 
     [Fact]
+    public void AddIntentCandidate_ShouldNotTransitionStatus_WhenCandidateValidationFails()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+
+        // Attempt to add a candidate with an invalid label (empty)
+        var act = () => envelope.AddIntentCandidate("", 0.5, 0);
+
+        act.Should().Throw<DomainException>();
+        envelope.Status.Should().Be(EnvelopeStatus.Created,
+            "status must not change when candidate construction fails");
+        envelope.IntentCandidates.Should().BeEmpty(
+            "no candidate should be added when validation fails");
+    }
+
+    [Fact]
     public void AddIntentCandidate_ShouldRejectAfterProcessed()
     {
         var envelope = new IntentEnvelopeV1("capture", "content", _userId);

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/IntentEnvelopeV1Tests.cs
@@ -9,6 +9,14 @@ public class IntentEnvelopeV1Tests
 {
     private readonly Guid _userId = Guid.NewGuid();
 
+    private static TaskdeckProposalBatch CreateSealedBatch(IntentEnvelopeV1 envelope, Guid userId)
+    {
+        var batch = envelope.CreateBatch(userId, "Batch summary");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+        return batch;
+    }
+
     [Fact]
     public void Constructor_ShouldCreateEnvelope_WithValidData()
     {
@@ -173,6 +181,7 @@ public class IntentEnvelopeV1Tests
     {
         var envelope = new IntentEnvelopeV1("capture", "content", _userId);
         envelope.AddIntentCandidate("intent", 0.5, 0);
+        CreateSealedBatch(envelope, _userId);
         envelope.MarkProcessed();
 
         var act = () => envelope.AddIntentCandidate("another intent", 0.3, 1);
@@ -226,6 +235,7 @@ public class IntentEnvelopeV1Tests
     {
         var envelope = new IntentEnvelopeV1("capture", "content", _userId);
         envelope.AddIntentCandidate("intent", 0.5, 0);
+        CreateSealedBatch(envelope, _userId);
 
         envelope.MarkProcessed();
 
@@ -246,10 +256,40 @@ public class IntentEnvelopeV1Tests
     }
 
     [Fact]
+    public void MarkProcessed_ShouldRejectWithoutProposalBatch()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+
+        var act = () => envelope.MarkProcessed();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void MarkProcessed_ShouldRejectWhenAnyBatchIsDraft()
+    {
+        var envelope = new IntentEnvelopeV1("capture", "content", _userId);
+        envelope.AddIntentCandidate("intent", 0.5, 0);
+        var sealedBatch = CreateSealedBatch(envelope, _userId);
+        var draftBatch = envelope.CreateBatch(_userId, "Draft batch");
+
+        var act = () => envelope.MarkProcessed();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+        envelope.Status.Should().Be(EnvelopeStatus.Extracting);
+        sealedBatch.Status.Should().Be(ProposalBatchStatus.Sealed);
+        draftBatch.Status.Should().Be(ProposalBatchStatus.Draft);
+    }
+
+    [Fact]
     public void MarkProcessed_ShouldRejectWhenAlreadyProcessed()
     {
         var envelope = new IntentEnvelopeV1("capture", "content", _userId);
         envelope.AddIntentCandidate("intent", 0.5, 0);
+        CreateSealedBatch(envelope, _userId);
         envelope.MarkProcessed();
 
         var act = () => envelope.MarkProcessed();
@@ -305,6 +345,7 @@ public class IntentEnvelopeV1Tests
     {
         var envelope = new IntentEnvelopeV1("capture", "content", _userId);
         envelope.AddIntentCandidate("intent", 0.5, 0);
+        CreateSealedBatch(envelope, _userId);
         envelope.MarkProcessed();
 
         var act = () => envelope.MarkFailed("too late");

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalBatchSchemaRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalBatchSchemaRoundTripTests.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+/// <summary>
+/// Smoke tests validating that proposal batch JSON payloads survive
+/// serialization round-trips. These test the schema contract (matching
+/// proposal-batch.v1.schema.json) rather than domain entities directly.
+/// </summary>
+public class ProposalBatchSchemaRoundTripTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private record ProposalBatchDto(
+        int SchemaVersion,
+        string EnvelopeId,
+        string Summary,
+        List<ProposalDto> Proposals);
+
+    private record ProposalDto(
+        string Summary,
+        string RiskLevel,
+        string? SourceIntentLabel,
+        List<OperationDto> Operations);
+
+    private record OperationDto(
+        string OperationType,
+        string? TargetId,
+        JsonElement Payload);
+
+    private static ProposalBatchDto CreateMinimalBatch()
+    {
+        var payload = JsonSerializer.SerializeToElement(new { title = "Test card" }, JsonOptions);
+        return new ProposalBatchDto(
+            SchemaVersion: 1,
+            EnvelopeId: Guid.NewGuid().ToString(),
+            Summary: "Test batch",
+            Proposals: new List<ProposalDto>
+            {
+                new("Create test card", "Low", null, new List<OperationDto>
+                {
+                    new("CreateCard", null, payload)
+                })
+            });
+    }
+
+    [Fact]
+    public void Case01_MinimalBatch_ShouldRoundTrip()
+    {
+        var batch = CreateMinimalBatch();
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.SchemaVersion.Should().Be(1);
+        deserialized.Summary.Should().Be("Test batch");
+        deserialized.Proposals.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Case02_MultipleProposals_ShouldRoundTrip()
+    {
+        var payload = JsonSerializer.SerializeToElement(new { title = "Card" }, JsonOptions);
+        var batch = new ProposalBatchDto(
+            SchemaVersion: 1,
+            EnvelopeId: Guid.NewGuid().ToString(),
+            Summary: "Multi-proposal batch",
+            Proposals: new List<ProposalDto>
+            {
+                new("Create card A", "Low", "Intent A", new List<OperationDto>
+                {
+                    new("CreateCard", null, payload)
+                }),
+                new("Update card B", "Medium", "Intent B", new List<OperationDto>
+                {
+                    new("UpdateCard", Guid.NewGuid().ToString(), payload)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized!.Proposals.Should().HaveCount(2);
+        deserialized.Proposals[0].RiskLevel.Should().Be("Low");
+        deserialized.Proposals[1].RiskLevel.Should().Be("Medium");
+    }
+
+    [Fact]
+    public void Case03_AllRiskLevels_ShouldRoundTrip()
+    {
+        var riskLevels = new[] { "Low", "Medium", "High", "Critical" };
+        var payload = JsonSerializer.SerializeToElement(new { title = "X" }, JsonOptions);
+
+        foreach (var risk in riskLevels)
+        {
+            var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), $"Risk: {risk}",
+                new List<ProposalDto>
+                {
+                    new("Op", risk, null, new List<OperationDto>
+                    {
+                        new("CreateCard", null, payload)
+                    })
+                });
+
+            var json = JsonSerializer.Serialize(batch, JsonOptions);
+            var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+            deserialized!.Proposals[0].RiskLevel.Should().Be(risk);
+        }
+    }
+
+    [Fact]
+    public void Case04_AllOperationTypes_ShouldRoundTrip()
+    {
+        var opTypes = new[]
+        {
+            "CreateCard", "UpdateCard", "MoveCard", "DeleteCard",
+            "CreateColumn", "UpdateColumn", "CreateLabel", "AddLabel", "RemoveLabel"
+        };
+        var payload = JsonSerializer.SerializeToElement(new { data = "test" }, JsonOptions);
+
+        var operations = opTypes.Select(op => new OperationDto(op, Guid.NewGuid().ToString(), payload)).ToList();
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "All ops",
+            new List<ProposalDto> { new("All operations", "Low", null, operations) });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized!.Proposals[0].Operations.Should().HaveCount(opTypes.Length);
+        for (var i = 0; i < opTypes.Length; i++)
+            deserialized.Proposals[0].Operations[i].OperationType.Should().Be(opTypes[i]);
+    }
+
+    [Fact]
+    public void Case05_NullOptionalFields_ShouldRoundTrip()
+    {
+        var payload = JsonSerializer.SerializeToElement(new { title = "X" }, JsonOptions);
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "Nulls test",
+            new List<ProposalDto>
+            {
+                new("Op", "Low", null, new List<OperationDto>
+                {
+                    new("CreateCard", null, payload)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized!.Proposals[0].SourceIntentLabel.Should().BeNull();
+        deserialized.Proposals[0].Operations[0].TargetId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Case06_ComplexPayload_ShouldPreserveStructure()
+    {
+        var complexPayload = JsonSerializer.SerializeToElement(new
+        {
+            title = "Complex card",
+            description = "With nested data",
+            labels = new[] { "bug", "priority" },
+            metadata = new { priority = 1, estimate = 3.5 }
+        }, JsonOptions);
+
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "Complex payload",
+            new List<ProposalDto>
+            {
+                new("Create complex", "Medium", "Complex intent", new List<OperationDto>
+                {
+                    new("CreateCard", null, complexPayload)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        var payloadBack = deserialized!.Proposals[0].Operations[0].Payload;
+        payloadBack.GetProperty("title").GetString().Should().Be("Complex card");
+        payloadBack.GetProperty("labels").GetArrayLength().Should().Be(2);
+        payloadBack.GetProperty("metadata").GetProperty("priority").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public void Case07_UuidFormatPreserved()
+    {
+        var envelopeId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        var payload = JsonSerializer.SerializeToElement(new { x = 1 }, JsonOptions);
+
+        var batch = new ProposalBatchDto(1, envelopeId.ToString(), "UUID test",
+            new List<ProposalDto>
+            {
+                new("Op", "Low", null, new List<OperationDto>
+                {
+                    new("UpdateCard", targetId.ToString(), payload)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        Guid.Parse(deserialized!.EnvelopeId).Should().Be(envelopeId);
+        Guid.Parse(deserialized.Proposals[0].Operations[0].TargetId!).Should().Be(targetId);
+    }
+
+    [Fact]
+    public void Case08_LongSummary_ShouldRoundTrip()
+    {
+        var longSummary = new string('A', 1000);
+        var payload = JsonSerializer.SerializeToElement(new { x = 1 }, JsonOptions);
+
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), longSummary,
+            new List<ProposalDto>
+            {
+                new(new string('B', 500), "High", new string('C', 500), new List<OperationDto>
+                {
+                    new("CreateCard", null, payload)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized!.Summary.Length.Should().Be(1000);
+        deserialized.Proposals[0].Summary.Length.Should().Be(500);
+        deserialized.Proposals[0].SourceIntentLabel!.Length.Should().Be(500);
+    }
+
+    [Fact]
+    public void Case09_MultipleOperationsPerProposal_ShouldRoundTrip()
+    {
+        var payload1 = JsonSerializer.SerializeToElement(new { title = "Card A" }, JsonOptions);
+        var payload2 = JsonSerializer.SerializeToElement(new { labelName = "urgent" }, JsonOptions);
+        var payload3 = JsonSerializer.SerializeToElement(new { columnId = Guid.NewGuid() }, JsonOptions);
+
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "Multi-op",
+            new List<ProposalDto>
+            {
+                new("Multiple ops", "Medium", null, new List<OperationDto>
+                {
+                    new("CreateCard", null, payload1),
+                    new("AddLabel", Guid.NewGuid().ToString(), payload2),
+                    new("MoveCard", Guid.NewGuid().ToString(), payload3)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized!.Proposals[0].Operations.Should().HaveCount(3);
+        deserialized.Proposals[0].Operations[0].OperationType.Should().Be("CreateCard");
+        deserialized.Proposals[0].Operations[1].OperationType.Should().Be("AddLabel");
+        deserialized.Proposals[0].Operations[2].OperationType.Should().Be("MoveCard");
+    }
+
+    [Fact]
+    public void Case10_EmptyPayload_ShouldRoundTrip()
+    {
+        var emptyPayload = JsonSerializer.SerializeToElement(new { }, JsonOptions);
+
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "Empty payload test",
+            new List<ProposalDto>
+            {
+                new("Delete op", "Critical", null, new List<OperationDto>
+                {
+                    new("DeleteCard", Guid.NewGuid().ToString(), emptyPayload)
+                })
+            });
+
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
+
+        deserialized!.Proposals[0].Operations[0].Payload.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalBatchSchemaRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalBatchSchemaRoundTripTests.cs
@@ -99,6 +99,32 @@ public class ProposalBatchSchemaRoundTripTests
         if (schema.TryGetProperty("$ref", out var reference))
             schema = ResolveReference(rootSchema, reference.GetString()!);
 
+        if (schema.TryGetProperty("not", out var notSchema))
+        {
+            var notErrors = new List<string>();
+            ValidateElement(value, notSchema, rootSchema, path, notErrors);
+            if (notErrors.Count == 0)
+            {
+                errors.Add($"{path}: value matched disallowed schema");
+                return;
+            }
+        }
+
+        if (schema.TryGetProperty("allOf", out var allOf))
+        {
+            foreach (var nestedSchema in allOf.EnumerateArray())
+                ValidateElement(value, nestedSchema, rootSchema, path, errors);
+        }
+
+        if (schema.TryGetProperty("if", out var ifSchema) &&
+            schema.TryGetProperty("then", out var thenSchema))
+        {
+            var ifErrors = new List<string>();
+            ValidateElement(value, ifSchema, rootSchema, path, ifErrors);
+            if (ifErrors.Count == 0)
+                ValidateElement(value, thenSchema, rootSchema, path, errors);
+        }
+
         if (schema.TryGetProperty("type", out var type) && !MatchesType(value, type))
         {
             errors.Add($"{path}: expected type {type.GetRawText()}, found {value.ValueKind}");
@@ -464,6 +490,31 @@ public class ProposalBatchSchemaRoundTripTests
                 new("Op", "Severe", null, new List<OperationDto>
                 {
                     new("CreateCard", null, payload)
+                })
+            });
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+
+        var act = () => ValidateAgainstProposalBatchSchema(json);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    [Theory]
+    [InlineData("UpdateCard")]
+    [InlineData("MoveCard")]
+    [InlineData("DeleteCard")]
+    [InlineData("UpdateColumn")]
+    [InlineData("AddLabel")]
+    [InlineData("RemoveLabel")]
+    public void NonCreateOperation_ShouldFailSchemaValidation_WhenTargetIdIsMissingOrNull(string operationType)
+    {
+        var payload = JsonSerializer.SerializeToElement(new { title = "X" }, JsonOptions);
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "Missing target",
+            new List<ProposalDto>
+            {
+                new("Op", "Low", null, new List<OperationDto>
+                {
+                    new(operationType, null, payload)
                 })
             });
         var json = JsonSerializer.Serialize(batch, JsonOptions);

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalBatchSchemaRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalBatchSchemaRoundTripTests.cs
@@ -17,6 +17,9 @@ public class ProposalBatchSchemaRoundTripTests
         WriteIndented = false
     };
 
+    private static readonly Lazy<JsonDocument> Schema = new(() =>
+        JsonDocument.Parse(File.ReadAllText(FindSchemaPath())));
+
     private record ProposalBatchDto(
         int SchemaVersion,
         string EnvelopeId,
@@ -50,12 +53,183 @@ public class ProposalBatchSchemaRoundTripTests
             });
     }
 
+    private static string SerializeAndValidate(ProposalBatchDto batch)
+    {
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        ValidateAgainstProposalBatchSchema(json);
+        return json;
+    }
+
+    private static void ValidateAgainstProposalBatchSchema(string json)
+    {
+        using var payload = JsonDocument.Parse(json);
+        var errors = new List<string>();
+        ValidateElement(payload.RootElement, Schema.Value.RootElement, Schema.Value.RootElement, "$", errors);
+        errors.Should().BeEmpty("payload should satisfy proposal-batch.v1.schema.json");
+    }
+
+    private static string FindSchemaPath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(
+                directory.FullName,
+                "backend",
+                "src",
+                "Taskdeck.Application",
+                "Schemas",
+                "proposal-batch.v1.schema.json");
+            if (File.Exists(candidate))
+                return candidate;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate proposal-batch.v1.schema.json.");
+    }
+
+    private static void ValidateElement(
+        JsonElement value,
+        JsonElement schema,
+        JsonElement rootSchema,
+        string path,
+        List<string> errors)
+    {
+        if (schema.TryGetProperty("$ref", out var reference))
+            schema = ResolveReference(rootSchema, reference.GetString()!);
+
+        if (schema.TryGetProperty("type", out var type) && !MatchesType(value, type))
+        {
+            errors.Add($"{path}: expected type {type.GetRawText()}, found {value.ValueKind}");
+            return;
+        }
+
+        if (schema.TryGetProperty("const", out var constant) && !JsonElementEquals(value, constant))
+            errors.Add($"{path}: value does not match const {constant.GetRawText()}");
+
+        if (schema.TryGetProperty("enum", out var enumValues) &&
+            !enumValues.EnumerateArray().Any(candidate => JsonElementEquals(value, candidate)))
+            errors.Add($"{path}: value is not in enum {enumValues.GetRawText()}");
+
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.Object:
+                ValidateObject(value, schema, rootSchema, path, errors);
+                break;
+            case JsonValueKind.Array:
+                ValidateArray(value, schema, rootSchema, path, errors);
+                break;
+            case JsonValueKind.String:
+                ValidateString(value, schema, path, errors);
+                break;
+        }
+    }
+
+    private static void ValidateObject(
+        JsonElement value,
+        JsonElement schema,
+        JsonElement rootSchema,
+        string path,
+        List<string> errors)
+    {
+        if (schema.TryGetProperty("required", out var required))
+        {
+            foreach (var property in required.EnumerateArray().Select(p => p.GetString()!))
+            {
+                if (!value.TryGetProperty(property, out _))
+                    errors.Add($"{path}: missing required property {property}");
+            }
+        }
+
+        var properties = schema.TryGetProperty("properties", out var declaredProperties)
+            ? declaredProperties
+            : default;
+        var hasProperties = properties.ValueKind == JsonValueKind.Object;
+        var allowAdditional = !schema.TryGetProperty("additionalProperties", out var additionalProperties)
+            || additionalProperties.ValueKind != JsonValueKind.False;
+
+        foreach (var property in value.EnumerateObject())
+        {
+            if (hasProperties && properties.TryGetProperty(property.Name, out var propertySchema))
+            {
+                ValidateElement(property.Value, propertySchema, rootSchema, $"{path}.{property.Name}", errors);
+            }
+            else if (!allowAdditional)
+            {
+                errors.Add($"{path}: unexpected property {property.Name}");
+            }
+        }
+    }
+
+    private static void ValidateArray(
+        JsonElement value,
+        JsonElement schema,
+        JsonElement rootSchema,
+        string path,
+        List<string> errors)
+    {
+        var count = value.GetArrayLength();
+        if (schema.TryGetProperty("minItems", out var minItems) && count < minItems.GetInt32())
+            errors.Add($"{path}: expected at least {minItems.GetInt32()} items");
+        if (schema.TryGetProperty("maxItems", out var maxItems) && count > maxItems.GetInt32())
+            errors.Add($"{path}: expected at most {maxItems.GetInt32()} items");
+
+        if (!schema.TryGetProperty("items", out var itemSchema))
+            return;
+
+        var index = 0;
+        foreach (var item in value.EnumerateArray())
+            ValidateElement(item, itemSchema, rootSchema, $"{path}[{index++}]", errors);
+    }
+
+    private static void ValidateString(JsonElement value, JsonElement schema, string path, List<string> errors)
+    {
+        var text = value.GetString() ?? string.Empty;
+        if (schema.TryGetProperty("minLength", out var minLength) && text.Length < minLength.GetInt32())
+            errors.Add($"{path}: string is shorter than {minLength.GetInt32()}");
+        if (schema.TryGetProperty("maxLength", out var maxLength) && text.Length > maxLength.GetInt32())
+            errors.Add($"{path}: string is longer than {maxLength.GetInt32()}");
+        if (schema.TryGetProperty("format", out var format) &&
+            format.GetString() == "uuid" &&
+            !Guid.TryParse(text, out _))
+            errors.Add($"{path}: string is not a uuid");
+    }
+
+    private static JsonElement ResolveReference(JsonElement rootSchema, string reference)
+    {
+        var current = rootSchema;
+        foreach (var segment in reference.TrimStart('#').Split('/', StringSplitOptions.RemoveEmptyEntries))
+            current = current.GetProperty(segment);
+
+        return current;
+    }
+
+    private static bool MatchesType(JsonElement value, JsonElement type)
+    {
+        if (type.ValueKind == JsonValueKind.Array)
+            return type.EnumerateArray().Any(candidate => MatchesType(value, candidate));
+
+        return type.GetString() switch
+        {
+            "array" => value.ValueKind == JsonValueKind.Array,
+            "integer" => value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out _),
+            "null" => value.ValueKind == JsonValueKind.Null,
+            "object" => value.ValueKind == JsonValueKind.Object,
+            "string" => value.ValueKind == JsonValueKind.String,
+            _ => true
+        };
+    }
+
+    private static bool JsonElementEquals(JsonElement left, JsonElement right) =>
+        left.ValueKind == right.ValueKind && left.GetRawText() == right.GetRawText();
+
     [Fact]
     public void Case01_MinimalBatch_ShouldRoundTrip()
     {
         var batch = CreateMinimalBatch();
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized.Should().NotBeNull();
@@ -84,7 +258,7 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized!.Proposals.Should().HaveCount(2);
@@ -109,7 +283,7 @@ public class ProposalBatchSchemaRoundTripTests
                     })
                 });
 
-            var json = JsonSerializer.Serialize(batch, JsonOptions);
+            var json = SerializeAndValidate(batch);
             var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
             deserialized!.Proposals[0].RiskLevel.Should().Be(risk);
@@ -130,7 +304,7 @@ public class ProposalBatchSchemaRoundTripTests
         var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "All ops",
             new List<ProposalDto> { new("All operations", "Low", null, operations) });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized!.Proposals[0].Operations.Should().HaveCount(opTypes.Length);
@@ -151,7 +325,7 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized!.Proposals[0].SourceIntentLabel.Should().BeNull();
@@ -178,7 +352,7 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         var payloadBack = deserialized!.Proposals[0].Operations[0].Payload;
@@ -203,7 +377,7 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         Guid.Parse(deserialized!.EnvelopeId).Should().Be(envelopeId);
@@ -225,7 +399,7 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized!.Summary.Length.Should().Be(1000);
@@ -251,7 +425,7 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized!.Proposals[0].Operations.Should().HaveCount(3);
@@ -274,9 +448,28 @@ public class ProposalBatchSchemaRoundTripTests
                 })
             });
 
-        var json = JsonSerializer.Serialize(batch, JsonOptions);
+        var json = SerializeAndValidate(batch);
         var deserialized = JsonSerializer.Deserialize<ProposalBatchDto>(json, JsonOptions);
 
         deserialized!.Proposals[0].Operations[0].Payload.ValueKind.Should().Be(JsonValueKind.Object);
+    }
+
+    [Fact]
+    public void InvalidRiskLevel_ShouldFailSchemaValidation()
+    {
+        var payload = JsonSerializer.SerializeToElement(new { title = "X" }, JsonOptions);
+        var batch = new ProposalBatchDto(1, Guid.NewGuid().ToString(), "Invalid risk",
+            new List<ProposalDto>
+            {
+                new("Op", "Severe", null, new List<OperationDto>
+                {
+                    new("CreateCard", null, payload)
+                })
+            });
+        var json = JsonSerializer.Serialize(batch, JsonOptions);
+
+        var act = () => ValidateAgainstProposalBatchSchema(json);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>();
     }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
@@ -162,4 +162,26 @@ public class SourceBlockTests
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
     }
+
+    [Fact]
+    public void AddSpan_ShouldRejectNegativeStartOffset()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Hello, world!", "capture");
+
+        var act = () => block.AddSpan(-1, 5, "Hello");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddSpan_ShouldRejectEndOffsetNotGreaterThanStartOffset()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Hello, world!", "capture");
+
+        var act = () => block.AddSpan(5, 5, "");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
@@ -113,6 +113,7 @@ public class SourceBlockTests
 
         span.Should().NotBeNull();
         span.SourceBlockId.Should().Be(block.Id);
+        span.EnvelopeId.Should().Be(_envelopeId);
         span.StartOffset.Should().Be(0);
         span.EndOffset.Should().Be(5);
         span.SnippetText.Should().Be("Hello");

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
@@ -131,6 +131,17 @@ public class SourceBlockTests
     }
 
     [Fact]
+    public void AddSpan_ShouldRejectStartOffsetBeyondContentLength()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Short", "capture");
+
+        var act = () => block.AddSpan(100, 200, "x");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
     public void AddSpan_ShouldAllowMultipleSpans()
     {
         var block = new SourceBlock(_envelopeId, 0, "Hello, world! Goodbye.", "capture");

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
@@ -151,4 +151,15 @@ public class SourceBlockTests
 
         block.Spans.Should().HaveCount(2);
     }
+
+    [Fact]
+    public void AddSpan_ShouldRejectSnippetNotMatchingContent()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Hello, world!", "capture");
+
+        var act = () => block.AddSpan(0, 5, "Wrong");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceBlockTests.cs
@@ -1,0 +1,143 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class SourceBlockTests
+{
+    private readonly Guid _envelopeId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateBlock_WithValidData()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Some text content", "capture", "ref-123");
+
+        block.Id.Should().NotBe(Guid.Empty);
+        block.EnvelopeId.Should().Be(_envelopeId);
+        block.Position.Should().Be(0);
+        block.Content.Should().Be("Some text content");
+        block.SourceType.Should().Be("capture");
+        block.SourceReferenceId.Should().Be("ref-123");
+        block.Spans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyEnvelopeId()
+    {
+        var act = () => new SourceBlock(Guid.Empty, 0, "content", "capture");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNegativePosition()
+    {
+        var act = () => new SourceBlock(_envelopeId, -1, "content", "capture");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyContent()
+    {
+        var act = () => new SourceBlock(_envelopeId, 0, "", "capture");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectWhitespaceContent()
+    {
+        var act = () => new SourceBlock(_envelopeId, 0, "   ", "capture");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectContentExceeding50000Characters()
+    {
+        var longContent = new string('x', 50_001);
+        var act = () => new SourceBlock(_envelopeId, 0, longContent, "capture");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptySourceType()
+    {
+        var act = () => new SourceBlock(_envelopeId, 0, "content", "");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectSourceTypeExceeding50Characters()
+    {
+        var longType = new string('x', 51);
+        var act = () => new SourceBlock(_envelopeId, 0, "content", longType);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldTrimSourceReferenceId()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "content", "capture", "  ref-456  ");
+
+        block.SourceReferenceId.Should().Be("ref-456");
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetNullSourceReferenceId_WhenWhitespace()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "content", "capture", "   ");
+
+        block.SourceReferenceId.Should().BeNull();
+    }
+
+    [Fact]
+    public void AddSpan_ShouldCreateAndReturnSpan()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Hello, world!", "capture");
+
+        var span = block.AddSpan(0, 5, "Hello");
+
+        span.Should().NotBeNull();
+        span.SourceBlockId.Should().Be(block.Id);
+        span.StartOffset.Should().Be(0);
+        span.EndOffset.Should().Be(5);
+        span.SnippetText.Should().Be("Hello");
+        block.Spans.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void AddSpan_ShouldRejectEndOffsetBeyondContentLength()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Short", "capture");
+
+        var act = () => block.AddSpan(0, 100, "Short");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddSpan_ShouldAllowMultipleSpans()
+    {
+        var block = new SourceBlock(_envelopeId, 0, "Hello, world! Goodbye.", "capture");
+
+        block.AddSpan(0, 5, "Hello");
+        block.AddSpan(7, 12, "world");
+
+        block.Spans.Should().HaveCount(2);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceSpanTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceSpanTests.cs
@@ -106,8 +106,17 @@ public class SourceSpanTests
     public void Constructor_ShouldAcceptBoundarySnippetLength()
     {
         var snippet = new string('a', 2000);
-        var span = new SourceSpan(_sourceBlockId, 0, 100, snippet);
+        var span = new SourceSpan(_sourceBlockId, 0, 2000, snippet);
 
         span.SnippetText.Length.Should().Be(2000);
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectSnippetLengthMismatchingSpanRange()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, 0, 10, "short");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
     }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceSpanTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceSpanTests.cs
@@ -8,14 +8,16 @@ namespace Taskdeck.Domain.Tests.Entities;
 public class SourceSpanTests
 {
     private readonly Guid _sourceBlockId = Guid.NewGuid();
+    private readonly Guid _envelopeId = Guid.NewGuid();
 
     [Fact]
     public void Constructor_ShouldCreateSpan_WithValidData()
     {
-        var span = new SourceSpan(_sourceBlockId, 0, 10, "hello world".Substring(0, 10));
+        var span = new SourceSpan(_sourceBlockId, _envelopeId, 0, 10, "hello world".Substring(0, 10));
 
         span.Id.Should().NotBe(Guid.Empty);
         span.SourceBlockId.Should().Be(_sourceBlockId);
+        span.EnvelopeId.Should().Be(_envelopeId);
         span.StartOffset.Should().Be(0);
         span.EndOffset.Should().Be(10);
         span.SnippetText.Should().Be("hello worl");
@@ -24,7 +26,16 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectEmptySourceBlockId()
     {
-        var act = () => new SourceSpan(Guid.Empty, 0, 10, "snippet");
+        var act = () => new SourceSpan(Guid.Empty, _envelopeId, 0, 10, "snippet");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyEnvelopeId()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, Guid.Empty, 0, 10, "snippet");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -33,7 +44,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectNegativeStartOffset()
     {
-        var act = () => new SourceSpan(_sourceBlockId, -1, 10, "snippet");
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, -1, 10, "snippet");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -42,7 +53,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectNegativeEndOffset()
     {
-        var act = () => new SourceSpan(_sourceBlockId, 0, -1, "snippet");
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 0, -1, "snippet");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -51,7 +62,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectEndOffsetEqualToStartOffset()
     {
-        var act = () => new SourceSpan(_sourceBlockId, 5, 5, "snippet");
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 5, 5, "snippet");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -60,7 +71,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectEndOffsetLessThanStartOffset()
     {
-        var act = () => new SourceSpan(_sourceBlockId, 10, 5, "snippet");
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 10, 5, "snippet");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -69,7 +80,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectEmptySnippetText()
     {
-        var act = () => new SourceSpan(_sourceBlockId, 0, 10, "");
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 0, 10, "");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -78,7 +89,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectNullSnippetText()
     {
-        var act = () => new SourceSpan(_sourceBlockId, 0, 10, null!);
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 0, 10, null!);
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -88,7 +99,7 @@ public class SourceSpanTests
     public void Constructor_ShouldRejectSnippetTextExceeding2000Characters()
     {
         var longSnippet = new string('x', 2001);
-        var act = () => new SourceSpan(_sourceBlockId, 0, 10, longSnippet);
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 0, 10, longSnippet);
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");
@@ -97,7 +108,7 @@ public class SourceSpanTests
     [Fact]
     public void Length_ShouldReturnDifferenceBetweenEndAndStartOffset()
     {
-        var span = new SourceSpan(_sourceBlockId, 5, 15, "ten chars!");
+        var span = new SourceSpan(_sourceBlockId, _envelopeId, 5, 15, "ten chars!");
 
         span.Length.Should().Be(10);
     }
@@ -106,7 +117,7 @@ public class SourceSpanTests
     public void Constructor_ShouldAcceptBoundarySnippetLength()
     {
         var snippet = new string('a', 2000);
-        var span = new SourceSpan(_sourceBlockId, 0, 2000, snippet);
+        var span = new SourceSpan(_sourceBlockId, _envelopeId, 0, 2000, snippet);
 
         span.SnippetText.Length.Should().Be(2000);
     }
@@ -114,7 +125,7 @@ public class SourceSpanTests
     [Fact]
     public void Constructor_ShouldRejectSnippetLengthMismatchingSpanRange()
     {
-        var act = () => new SourceSpan(_sourceBlockId, 0, 10, "short");
+        var act = () => new SourceSpan(_sourceBlockId, _envelopeId, 0, 10, "short");
 
         act.Should().Throw<DomainException>()
             .Which.ErrorCode.Should().Be("ValidationError");

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SourceSpanTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SourceSpanTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class SourceSpanTests
+{
+    private readonly Guid _sourceBlockId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateSpan_WithValidData()
+    {
+        var span = new SourceSpan(_sourceBlockId, 0, 10, "hello world".Substring(0, 10));
+
+        span.Id.Should().NotBe(Guid.Empty);
+        span.SourceBlockId.Should().Be(_sourceBlockId);
+        span.StartOffset.Should().Be(0);
+        span.EndOffset.Should().Be(10);
+        span.SnippetText.Should().Be("hello worl");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptySourceBlockId()
+    {
+        var act = () => new SourceSpan(Guid.Empty, 0, 10, "snippet");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNegativeStartOffset()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, -1, 10, "snippet");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNegativeEndOffset()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, 0, -1, "snippet");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEndOffsetEqualToStartOffset()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, 5, 5, "snippet");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEndOffsetLessThanStartOffset()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, 10, 5, "snippet");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptySnippetText()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, 0, 10, "");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectNullSnippetText()
+    {
+        var act = () => new SourceSpan(_sourceBlockId, 0, 10, null!);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectSnippetTextExceeding2000Characters()
+    {
+        var longSnippet = new string('x', 2001);
+        var act = () => new SourceSpan(_sourceBlockId, 0, 10, longSnippet);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Length_ShouldReturnDifferenceBetweenEndAndStartOffset()
+    {
+        var span = new SourceSpan(_sourceBlockId, 5, 15, "ten chars!");
+
+        span.Length.Should().Be(10);
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptBoundarySnippetLength()
+    {
+        var snippet = new string('a', 2000);
+        var span = new SourceSpan(_sourceBlockId, 0, 100, snippet);
+
+        span.SnippetText.Length.Should().Be(2000);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/TaskdeckProposalBatchTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/TaskdeckProposalBatchTests.cs
@@ -1,0 +1,214 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class TaskdeckProposalBatchTests
+{
+    private readonly Guid _envelopeId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateBatch_WithValidData()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Create two cards from meeting notes");
+
+        batch.Id.Should().NotBe(Guid.Empty);
+        batch.EnvelopeId.Should().Be(_envelopeId);
+        batch.RequestedByUserId.Should().Be(_userId);
+        batch.Summary.Should().Be("Create two cards from meeting notes");
+        batch.SchemaVersion.Should().Be(1);
+        batch.Status.Should().Be(ProposalBatchStatus.Draft);
+        batch.ProposalIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyEnvelopeId()
+    {
+        var act = () => new TaskdeckProposalBatch(Guid.Empty, _userId, "Summary");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptyUserId()
+    {
+        var act = () => new TaskdeckProposalBatch(_envelopeId, Guid.Empty, "Summary");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectEmptySummary()
+    {
+        var act = () => new TaskdeckProposalBatch(_envelopeId, _userId, "");
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectSummaryExceeding1000Characters()
+    {
+        var longSummary = new string('x', 1001);
+        var act = () => new TaskdeckProposalBatch(_envelopeId, _userId, longSummary);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Constructor_ShouldRejectSchemaVersionLessThan1()
+    {
+        var act = () => new TaskdeckProposalBatch(_envelopeId, _userId, "Summary", schemaVersion: 0);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddProposalId_ShouldAddId()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        var proposalId = Guid.NewGuid();
+
+        batch.AddProposalId(proposalId);
+
+        batch.ProposalIds.Should().ContainSingle().Which.Should().Be(proposalId);
+    }
+
+    [Fact]
+    public void AddProposalId_ShouldRejectEmptyId()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+
+        var act = () => batch.AddProposalId(Guid.Empty);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void AddProposalId_ShouldRejectDuplicateId()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        var proposalId = Guid.NewGuid();
+        batch.AddProposalId(proposalId);
+
+        var act = () => batch.AddProposalId(proposalId);
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("Conflict");
+    }
+
+    [Fact]
+    public void AddProposalId_ShouldRejectWhenSealed()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+
+        var act = () => batch.AddProposalId(Guid.NewGuid());
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void Seal_ShouldTransitionToSealed()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        batch.AddProposalId(Guid.NewGuid());
+
+        batch.Seal();
+
+        batch.Status.Should().Be(ProposalBatchStatus.Sealed);
+    }
+
+    [Fact]
+    public void Seal_ShouldRejectEmptyBatch()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+
+        var act = () => batch.Seal();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("ValidationError");
+    }
+
+    [Fact]
+    public void Seal_ShouldRejectWhenAlreadySealed()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+
+        var act = () => batch.Seal();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void Complete_ShouldTransitionToCompleted()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+
+        batch.Complete();
+
+        batch.Status.Should().Be(ProposalBatchStatus.Completed);
+    }
+
+    [Fact]
+    public void Complete_ShouldRejectWhenNotSealed()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+
+        var act = () => batch.Complete();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void Discard_ShouldTransitionToDiscarded()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+
+        batch.Discard();
+
+        batch.Status.Should().Be(ProposalBatchStatus.Discarded);
+    }
+
+    [Fact]
+    public void Discard_ShouldRejectWhenCompleted()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+        batch.Complete();
+
+        var act = () => batch.Discard();
+
+        act.Should().Throw<DomainException>()
+            .Which.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public void Discard_ShouldAllowFromSealedStatus()
+    {
+        var batch = new TaskdeckProposalBatch(_envelopeId, _userId, "Summary");
+        batch.AddProposalId(Guid.NewGuid());
+        batch.Seal();
+
+        batch.Discard();
+
+        batch.Status.Should().Be(ProposalBatchStatus.Discarded);
+    }
+}

--- a/docs/spikes/SPIKE_974_ICHATCLIENT.md
+++ b/docs/spikes/SPIKE_974_ICHATCLIENT.md
@@ -1,0 +1,106 @@
+# SPIKE 974: IChatClient Compatibility with .NET 8
+
+**Issue**: #974 (RFAI-02)
+**Date**: 2026-04-25
+**Status**: Complete
+
+## Question
+
+Is `Microsoft.Extensions.AI.IChatClient` compatible with .NET 8, and can it
+be used behind Taskdeck's existing `ILlmProvider` abstraction?
+
+## Findings
+
+### Package Compatibility
+
+`Microsoft.Extensions.AI` targets `netstandard2.0` and is **fully compatible
+with .NET 8**. The package has been stable since late 2024 / early 2025 and is
+the official Microsoft abstraction for LLM provider interoperability.
+
+Key packages:
+- `Microsoft.Extensions.AI.Abstractions` -- defines `IChatClient`, `ChatMessage`, `ChatOptions`, etc.
+- `Microsoft.Extensions.AI` -- middleware pipeline builder and caching/telemetry middleware.
+- `Microsoft.Extensions.AI.OpenAI` -- OpenAI/Azure OpenAI adapter implementing `IChatClient`.
+
+All packages are available on NuGet and target `netstandard2.0`, meaning they
+work on .NET 8, .NET 9, and .NET Framework 4.6.2+.
+
+### IChatClient Surface Area
+
+```csharp
+public interface IChatClient : IDisposable
+{
+    Task<ChatCompletion> CompleteAsync(
+        IList<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<StreamingChatCompletionUpdate> CompleteStreamingAsync(
+        IList<ChatMessage> chatMessages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    ChatClientMetadata Metadata { get; }
+
+    TService? GetService<TService>(object? key = null);
+}
+```
+
+This maps cleanly onto Taskdeck's existing `ILlmProvider`:
+
+| `ILlmProvider` method | `IChatClient` equivalent |
+|---|---|
+| `CompleteAsync` | `CompleteAsync` |
+| `StreamAsync` | `CompleteStreamingAsync` |
+| `GetHealthAsync` | `Metadata` + try/catch probe |
+| `CompleteWithToolsAsync` | `CompleteAsync` with `ChatOptions.Tools` |
+
+### Adapter Feasibility
+
+A thin adapter implementing `ILlmProvider` by delegating to `IChatClient` is
+straightforward:
+
+1. **Message mapping**: Taskdeck's `ChatCompletionMessage(Role, Content)` maps
+   to `ChatMessage(ChatRole, string)` with no data loss.
+2. **Streaming**: `IAsyncEnumerable<StreamingChatCompletionUpdate>` yields
+   token-level events compatible with `LlmTokenEvent`.
+3. **Tool calling**: `ChatOptions.Tools` accepts `AIFunction` definitions;
+   tool results come back as `FunctionResultContent` in follow-up messages.
+4. **Health**: No direct health endpoint; implement via a lightweight probe
+   completion or expose `Metadata.ProviderUri`.
+
+### Risks and Considerations
+
+1. **Dependency footprint**: Adding `Microsoft.Extensions.AI` pulls in a small
+   dependency tree. Acceptable for Infrastructure; must NOT leak into Domain.
+2. **Version churn**: The package is pre-1.0 (preview/RC) as of early 2025.
+   Pin to a specific version and wrap behind `ILlmProvider` to isolate churn.
+3. **Semantic Kernel overlap**: IChatClient is the lower-level abstraction
+   that Semantic Kernel builds on. Per ADR-0018, Taskdeck uses custom
+   tool-calling over Semantic Kernel, so IChatClient is the right layer.
+4. **No breaking change**: The adapter sits behind `ILlmProvider`, so existing
+   Mock/OpenAI/Gemini providers remain untouched. IChatClient becomes an
+   additional provider option, not a replacement.
+
+### Recommended Approach
+
+1. Add `Microsoft.Extensions.AI.Abstractions` to `Taskdeck.Infrastructure.csproj`.
+2. Create `ChatClientLlmProvider : ILlmProvider` in Infrastructure that
+   delegates to an injected `IChatClient`.
+3. Register via DI config gate (e.g., `LlmProvider:Type = "ChatClient"`).
+4. Keep the existing OpenAI/Gemini/Mock providers as-is -- they remain the
+   default path.
+
+### Schema / Structured Output
+
+`IChatClient` supports structured output via `ChatOptions.ResponseFormat`
+using `ChatResponseFormatJson` with an optional JSON schema. This aligns with
+the schema spike (see `TaskdeckProposalBatch` JSON schema in
+`backend/src/Taskdeck.Application/Schemas/`).
+
+## Decision
+
+**IChatClient is compatible and recommended as a future provider adapter.**
+Implementation deferred to RFAI-03 or a follow-up issue. The adapter should
+live in `Taskdeck.Infrastructure` behind `ILlmProvider` with a config gate.
+Do NOT replace existing providers -- add as a parallel option.


### PR DESCRIPTION
## Summary

Implements the versioned intent spine for the review-first AI pipeline (#974):

- **6 domain entities**: `IntentEnvelopeV1`, `SourceBlock`, `SourceSpan`, `IntentCandidate`, `EvidenceLink`, `TaskdeckProposalBatch` -- all following existing Entity pattern with private setters, validation via DomainException, and proper lifecycle state machines
- **Application interface**: `IIntentEnvelopeFactory` for creating envelopes from Capture and Chat input as a PARALLEL path (no existing behavior modified)
- **IChatClient spike**: Documented in `docs/spikes/SPIKE_974_ICHATCLIENT.md` -- `Microsoft.Extensions.AI` targets netstandard2.0 and is fully compatible with .NET 8. Thin adapter behind `ILlmProvider` is feasible; deferred to follow-up
- **Schema spike**: `System.Text.Json.Schema.JsonSchemaExporter` requires .NET 9+; handwritten JSON schema at `backend/src/Taskdeck.Application/Schemas/proposal-batch.v1.schema.json`
- **114 new tests**: Unit tests for all 6 entities + 10 schema round-trip smoke tests

## Architecture

```
IntentEnvelopeV1 (spine)
  |-- SourceBlock[] (text blocks with position)
  |     |-- SourceSpan[] (character-level ranges)
  |
  |-- IntentCandidate[] (extracted intents with confidence)
  |     |-- EvidenceLink[] --> SourceSpan (evidence mapping)
  |
  |-- TaskdeckProposalBatch[] (grouped proposals)
```

Lifecycle: Created -> Extracting (first intent added) -> Processed (marked done)

## Key Design Decisions

- Domain entities are pure (no Infrastructure dependencies) -- GP-01 compliant
- Review-first safety preserved -- GP-06: envelopes produce proposals, never direct mutations
- IIntentEnvelopeFactory is a PARALLEL path alongside existing Capture/Chat pipelines
- No Semantic Kernel or Microsoft Agent Framework introduced (per issue requirements)
- TaskdeckProposalBatch stores proposal IDs as flat list to avoid tight coupling with existing AutomationProposal model

## Test Plan

- [x] All 6 domain entities have constructor validation tests
- [x] State machine transitions tested (valid + invalid)
- [x] Boundary value testing for confidence (0.0, 0.5, 1.0), lengths, offsets
- [x] Full lifecycle integration test (envelope -> blocks -> intents -> evidence -> batch -> processed)
- [x] 10 schema round-trip smoke tests covering all operation types, risk levels, complex payloads, UUID preservation
- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors
- [x] `dotnet test` domain tests -- 1076 total (114 new), all pass

Closes #974