### PR TITLE
RFAI-04: Proposal revision data model and compiler contract

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -47,6 +47,7 @@ public static class ApplicationServiceRegistration
         services.AddScoped<HistoryService>();
         services.AddScoped<IHistoryService>(sp => sp.GetRequiredService<HistoryService>());
         services.AddScoped<IAutomationProposalService, AutomationProposalService>();
+        services.AddScoped<IProposalRevisionService, ProposalRevisionService>();
         services.AddScoped<IAutomationPolicyEngine, AutomationPolicyEngine>();
         services.AddScoped<IAutomationPlannerService, AutomationPlannerService>();
         services.AddScoped<IAutomationExecutorService, AutomationExecutorService>();

--- a/backend/src/Taskdeck.Api/Extensions/McpApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/McpApplicationServiceRegistration.cs
@@ -31,6 +31,7 @@ public static class McpApplicationServiceRegistration
         services.AddScoped<AutomationProposalService>();
         services.AddScoped<IAutomationProposalService>(
             sp => sp.GetRequiredService<AutomationProposalService>());
+        services.AddScoped<IProposalRevisionService, ProposalRevisionService>();
         services.AddScoped<CaptureService>();
         services.AddScoped<ICaptureService>(
             sp => sp.GetRequiredService<CaptureService>());

--- a/backend/src/Taskdeck.Application/DTOs/ProposalRevisionDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/ProposalRevisionDtos.cs
@@ -6,7 +6,7 @@ public record ProposalRevisionDto(
     int RevisionNumber,
     Guid EditorUserId,
     string RevisedPayload,
-    DateTime RevisedAt,
+    DateTimeOffset RevisedAt,
     string Reason,
     DateTimeOffset CreatedAt
 );
@@ -23,6 +23,6 @@ public record ProposalOutcomeDto(
     Guid ProposalId,
     string OutcomeType,
     Guid DecidedByUserId,
-    DateTime DecidedAt,
+    DateTimeOffset DecidedAt,
     DateTimeOffset CreatedAt
 );

--- a/backend/src/Taskdeck.Application/DTOs/ProposalRevisionDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/ProposalRevisionDtos.cs
@@ -1,0 +1,28 @@
+namespace Taskdeck.Application.DTOs;
+
+public record ProposalRevisionDto(
+    Guid Id,
+    Guid ProposalId,
+    int RevisionNumber,
+    Guid EditorUserId,
+    string RevisedPayload,
+    DateTime RevisedAt,
+    string Reason,
+    DateTimeOffset CreatedAt
+);
+
+public record CreateProposalRevisionDto(
+    Guid ProposalId,
+    Guid EditorUserId,
+    string RevisedPayload,
+    string Reason
+);
+
+public record ProposalOutcomeDto(
+    Guid Id,
+    Guid ProposalId,
+    string OutcomeType,
+    Guid DecidedByUserId,
+    DateTime DecidedAt,
+    DateTimeOffset CreatedAt
+);

--- a/backend/src/Taskdeck.Application/Interfaces/IProposalRevisionRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IProposalRevisionRepository.cs
@@ -1,0 +1,21 @@
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Application.Interfaces;
+
+public interface IProposalRevisionRepository : IRepository<ProposalRevision>
+{
+    /// <summary>
+    /// Gets all revisions for a proposal, ordered by revision number ascending.
+    /// </summary>
+    Task<IReadOnlyList<ProposalRevision>> GetByProposalIdAsync(Guid proposalId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the latest (highest revision number) revision for a proposal, or null if none exist.
+    /// </summary>
+    Task<ProposalRevision?> GetLatestByProposalIdAsync(Guid proposalId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the next revision number for a proposal (max existing + 1, or 1 if none exist).
+    /// </summary>
+    Task<int> GetNextRevisionNumberAsync(Guid proposalId, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Interfaces/IUnitOfWork.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IUnitOfWork.cs
@@ -33,6 +33,7 @@ public interface IUnitOfWork
     IIntegrationConnectorRepository IntegrationConnectors { get; }
     IConnectorEventRepository ConnectorEvents { get; }
     IConnectorCredentialRepository ConnectorCredentials { get; }
+    IProposalRevisionRepository ProposalRevisions { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     Task BeginTransactionAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Services/IProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/IProposalRevisionService.cs
@@ -1,0 +1,24 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Common;
+
+namespace Taskdeck.Application.Services;
+
+public interface IProposalRevisionService
+{
+    /// <summary>
+    /// Creates a new revision for a proposal. The proposal must be in PendingReview status.
+    /// Revision numbers are auto-assigned (monotonically increasing).
+    /// </summary>
+    Task<Result<ProposalRevisionDto>> CreateRevisionAsync(CreateProposalRevisionDto dto, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all revisions for a proposal, ordered by revision number ascending.
+    /// </summary>
+    Task<Result<IReadOnlyList<ProposalRevisionDto>>> GetRevisionsForProposalAsync(Guid proposalId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the latest revision for a proposal, or null if no revisions exist.
+    /// When no revisions exist, the original proposal payload is the effective payload.
+    /// </summary>
+    Task<Result<ProposalRevisionDto?>> GetLatestRevisionAsync(Guid proposalId, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
@@ -51,6 +51,16 @@ public class ProposalRevisionService : IProposalRevisionService
         }
     }
 
+    // NOTE: There is a narrow race window between GetNextRevisionNumberAsync and
+    // SaveChangesAsync. If two concurrent callers both read the same next revision
+    // number, the DB unique constraint on (ProposalId, RevisionNumber) will reject
+    // one of them. The UnitOfWork surfaces DbUpdateConcurrencyException as a
+    // DomainException(Conflict), which is caught above. The unique constraint
+    // violation (DbUpdateException) will propagate as a 500 until the UnitOfWork
+    // is extended with a recovery handler for ProposalRevision conflicts.
+    // This is acceptable for now: the data model is safe, and the race is extremely
+    // narrow in a single-user local-first context.
+
     public async Task<Result<IReadOnlyList<ProposalRevisionDto>>> GetRevisionsForProposalAsync(
         Guid proposalId,
         CancellationToken cancellationToken = default)
@@ -62,8 +72,8 @@ public class ProposalRevisionService : IProposalRevisionService
         var revisions = await _unitOfWork.ProposalRevisions
             .GetByProposalIdAsync(proposalId, cancellationToken);
 
-        var dtos = revisions.Select(MapToDto).ToList() as IReadOnlyList<ProposalRevisionDto>;
-        return Result.Success(dtos);
+        var dtos = revisions.Select(MapToDto).ToList();
+        return Result.Success<IReadOnlyList<ProposalRevisionDto>>(dtos);
     }
 
     public async Task<Result<ProposalRevisionDto?>> GetLatestRevisionAsync(

--- a/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
@@ -53,13 +53,9 @@ public class ProposalRevisionService : IProposalRevisionService
 
     // NOTE: There is a narrow race window between GetNextRevisionNumberAsync and
     // SaveChangesAsync. If two concurrent callers both read the same next revision
-    // number, the DB unique constraint on (ProposalId, RevisionNumber) will reject
-    // one of them. The UnitOfWork surfaces DbUpdateConcurrencyException as a
-    // DomainException(Conflict), which is caught above. The unique constraint
-    // violation (DbUpdateException) will propagate as a 500 until the UnitOfWork
-    // is extended with a recovery handler for ProposalRevision conflicts.
-    // This is acceptable for now: the data model is safe, and the race is extremely
-    // narrow in a single-user local-first context.
+    // number, the DB unique constraint on (ProposalId, RevisionNumber) rejects one
+    // write and UnitOfWork maps that persistence collision to DomainException(Conflict),
+    // which is caught above and returned as a non-500 retryable result.
 
     public async Task<Result<IReadOnlyList<ProposalRevisionDto>>> GetRevisionsForProposalAsync(
         Guid proposalId,

--- a/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
@@ -1,0 +1,95 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+public class ProposalRevisionService : IProposalRevisionService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ProposalRevisionService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<ProposalRevisionDto>> CreateRevisionAsync(
+        CreateProposalRevisionDto dto,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(dto.ProposalId, cancellationToken);
+            if (proposal == null)
+                return Result.Failure<ProposalRevisionDto>(ErrorCodes.NotFound, "Proposal not found");
+
+            if (proposal.Status != ProposalStatus.PendingReview)
+                return Result.Failure<ProposalRevisionDto>(
+                    ErrorCodes.InvalidOperation,
+                    $"Cannot create revision for proposal in status {proposal.Status}");
+
+            var nextRevisionNumber = await _unitOfWork.ProposalRevisions
+                .GetNextRevisionNumberAsync(dto.ProposalId, cancellationToken);
+
+            var revision = new ProposalRevision(
+                dto.ProposalId,
+                nextRevisionNumber,
+                dto.EditorUserId,
+                dto.RevisedPayload,
+                dto.Reason);
+
+            await _unitOfWork.ProposalRevisions.AddAsync(revision, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(MapToDto(revision));
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<ProposalRevisionDto>(ex.ErrorCode, ex.Message);
+        }
+    }
+
+    public async Task<Result<IReadOnlyList<ProposalRevisionDto>>> GetRevisionsForProposalAsync(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(proposalId, cancellationToken);
+        if (proposal == null)
+            return Result.Failure<IReadOnlyList<ProposalRevisionDto>>(ErrorCodes.NotFound, "Proposal not found");
+
+        var revisions = await _unitOfWork.ProposalRevisions
+            .GetByProposalIdAsync(proposalId, cancellationToken);
+
+        var dtos = revisions.Select(MapToDto).ToList() as IReadOnlyList<ProposalRevisionDto>;
+        return Result.Success(dtos);
+    }
+
+    public async Task<Result<ProposalRevisionDto?>> GetLatestRevisionAsync(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(proposalId, cancellationToken);
+        if (proposal == null)
+            return Result.Failure<ProposalRevisionDto?>(ErrorCodes.NotFound, "Proposal not found");
+
+        var latest = await _unitOfWork.ProposalRevisions
+            .GetLatestByProposalIdAsync(proposalId, cancellationToken);
+
+        return Result.Success(latest != null ? MapToDto(latest) : (ProposalRevisionDto?)null);
+    }
+
+    private static ProposalRevisionDto MapToDto(ProposalRevision revision)
+    {
+        return new ProposalRevisionDto(
+            revision.Id,
+            revision.ProposalId,
+            revision.RevisionNumber,
+            revision.EditorUserId,
+            revision.RevisedPayload,
+            revision.RevisedAt,
+            revision.Reason,
+            revision.CreatedAt);
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/AutomationProposal.cs
+++ b/backend/src/Taskdeck.Domain/Entities/AutomationProposal.cs
@@ -24,6 +24,12 @@ public class AutomationProposal : Entity
     private readonly List<AutomationProposalOperation> _operations = new();
     public IReadOnlyList<AutomationProposalOperation> Operations => _operations.AsReadOnly();
 
+    private readonly List<ProposalRevision> _revisions = new();
+    public IReadOnlyList<ProposalRevision> Revisions => _revisions.AsReadOnly();
+
+    private readonly List<ProposalOutcome> _outcomes = new();
+    public IReadOnlyList<ProposalOutcome> Outcomes => _outcomes.AsReadOnly();
+
     private AutomationProposal() { } // EF Core
 
     public AutomationProposal(

--- a/backend/src/Taskdeck.Domain/Entities/CompilerValidationResult.cs
+++ b/backend/src/Taskdeck.Domain/Entities/CompilerValidationResult.cs
@@ -1,0 +1,62 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Result of compiling/validating a proposal's operations.
+/// Immutable after creation.
+/// </summary>
+public sealed class CompilerValidationResult
+{
+    public bool IsValid { get; }
+    public IReadOnlyList<OperationRisk> Risks { get; }
+    public IReadOnlyList<UnsupportedOperationFailure> Failures { get; }
+
+    private CompilerValidationResult(
+        bool isValid,
+        IReadOnlyList<OperationRisk> risks,
+        IReadOnlyList<UnsupportedOperationFailure> failures)
+    {
+        IsValid = isValid;
+        Risks = risks;
+        Failures = failures;
+    }
+
+    /// <summary>
+    /// Creates a successful validation result with optional risk warnings.
+    /// </summary>
+    public static CompilerValidationResult Success(IReadOnlyList<OperationRisk>? risks = null)
+    {
+        return new CompilerValidationResult(
+            true,
+            risks ?? Array.Empty<OperationRisk>(),
+            Array.Empty<UnsupportedOperationFailure>());
+    }
+
+    /// <summary>
+    /// Creates a failed validation result with failures and optional risk warnings.
+    /// </summary>
+    public static CompilerValidationResult Failure(
+        IReadOnlyList<UnsupportedOperationFailure> failures,
+        IReadOnlyList<OperationRisk>? risks = null)
+    {
+        if (failures == null || failures.Count == 0)
+            throw new ArgumentException("Failures must not be empty for a failed result.", nameof(failures));
+
+        return new CompilerValidationResult(
+            false,
+            risks ?? Array.Empty<OperationRisk>(),
+            failures);
+    }
+
+    /// <summary>
+    /// The aggregate risk level: the highest risk among all assessed risks,
+    /// or Low if no risks are present.
+    /// </summary>
+    public RiskLevel AggregateRiskLevel
+    {
+        get
+        {
+            if (Risks.Count == 0) return RiskLevel.Low;
+            return Risks.Max(r => r.Level);
+        }
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/IProposalCompiler.cs
+++ b/backend/src/Taskdeck.Domain/Entities/IProposalCompiler.cs
@@ -1,0 +1,20 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Typed compiler contract for validating and compiling proposal operations.
+/// Implementations are responsible for checking whether operations are supported,
+/// assessing risk, and producing a validation result.
+/// </summary>
+public interface IProposalCompiler
+{
+    /// <summary>
+    /// Validates the given proposal operations and returns a structured result
+    /// indicating whether they can be compiled, any risks, and any unsupported operations.
+    /// </summary>
+    /// <param name="operations">The operations to validate.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A compiler validation result with risks and/or failures.</returns>
+    Task<CompilerValidationResult> ValidateAsync(
+        IReadOnlyList<AutomationProposalOperation> operations,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Domain/Entities/OperationRisk.cs
+++ b/backend/src/Taskdeck.Domain/Entities/OperationRisk.cs
@@ -1,0 +1,33 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Value object representing a risk assessment for a proposal operation.
+/// Immutable after creation.
+/// </summary>
+public sealed class OperationRisk : IEquatable<OperationRisk>
+{
+    public RiskLevel Level { get; }
+    public string Reason { get; }
+
+    public OperationRisk(RiskLevel level, string reason)
+    {
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("Risk reason cannot be empty.", nameof(reason));
+
+        Level = level;
+        Reason = reason;
+    }
+
+    public bool Equals(OperationRisk? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Level == other.Level && Reason == other.Reason;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as OperationRisk);
+
+    public override int GetHashCode() => HashCode.Combine(Level, Reason);
+
+    public override string ToString() => $"{Level}: {Reason}";
+}

--- a/backend/src/Taskdeck.Domain/Entities/OutcomeType.cs
+++ b/backend/src/Taskdeck.Domain/Entities/OutcomeType.cs
@@ -1,0 +1,20 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Represents the decision outcome for an automation proposal.
+/// Content-free: captures what happened, not why.
+/// </summary>
+public enum OutcomeType
+{
+    /// <summary>Proposal approved without edits.</summary>
+    Approved,
+
+    /// <summary>Proposal edited then approved (revision chain exists).</summary>
+    EditedThenApproved,
+
+    /// <summary>Proposal explicitly rejected by user.</summary>
+    Rejected,
+
+    /// <summary>Proposal ignored (expired without decision).</summary>
+    Ignored
+}

--- a/backend/src/Taskdeck.Domain/Entities/ProposalOutcome.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ProposalOutcome.cs
@@ -1,0 +1,47 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Records a decision event for an automation proposal.
+/// Content-free: captures the outcome type and who decided, not business rationale.
+/// Immutable after creation.
+/// </summary>
+public class ProposalOutcome : Entity
+{
+    /// <summary>FK to the AutomationProposal this outcome applies to.</summary>
+    public Guid ProposalId { get; private set; }
+
+    /// <summary>The type of decision outcome.</summary>
+    public OutcomeType OutcomeType { get; private set; }
+
+    /// <summary>The user who made the decision.</summary>
+    public Guid DecidedByUserId { get; private set; }
+
+    /// <summary>When the decision was recorded (UTC).</summary>
+    public DateTime DecidedAt { get; private set; }
+
+    // Navigation
+    public AutomationProposal Proposal { get; private set; } = null!;
+
+    private ProposalOutcome() { } // EF Core
+
+    public ProposalOutcome(
+        Guid proposalId,
+        OutcomeType outcomeType,
+        Guid decidedByUserId)
+    {
+        if (proposalId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "ProposalId cannot be empty");
+        if (decidedByUserId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "DecidedByUserId cannot be empty");
+        if (!Enum.IsDefined(typeof(OutcomeType), outcomeType))
+            throw new DomainException(ErrorCodes.ValidationError, $"Invalid OutcomeType: {outcomeType}");
+
+        ProposalId = proposalId;
+        OutcomeType = outcomeType;
+        DecidedByUserId = decidedByUserId;
+        DecidedAt = DateTime.UtcNow;
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/ProposalOutcome.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ProposalOutcome.cs
@@ -20,7 +20,7 @@ public class ProposalOutcome : Entity
     public Guid DecidedByUserId { get; private set; }
 
     /// <summary>When the decision was recorded (UTC).</summary>
-    public DateTime DecidedAt { get; private set; }
+    public DateTimeOffset DecidedAt { get; private set; }
 
     // Navigation
     public AutomationProposal Proposal { get; private set; } = null!;
@@ -42,6 +42,6 @@ public class ProposalOutcome : Entity
         ProposalId = proposalId;
         OutcomeType = outcomeType;
         DecidedByUserId = decidedByUserId;
-        DecidedAt = DateTime.UtcNow;
+        DecidedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/backend/src/Taskdeck.Domain/Entities/ProposalRevision.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ProposalRevision.cs
@@ -27,7 +27,7 @@ public class ProposalRevision : Entity
     public string RevisedPayload { get; private set; } = string.Empty;
 
     /// <summary>Timestamp when the revision was created (UTC).</summary>
-    public DateTime RevisedAt { get; private set; }
+    public DateTimeOffset RevisedAt { get; private set; }
 
     /// <summary>Human-readable reason for the revision (e.g., "Updated card title").</summary>
     public string Reason { get; private set; } = string.Empty;
@@ -62,6 +62,6 @@ public class ProposalRevision : Entity
         EditorUserId = editorUserId;
         RevisedPayload = revisedPayload;
         Reason = reason;
-        RevisedAt = DateTime.UtcNow;
+        RevisedAt = DateTimeOffset.UtcNow;
     }
 }

--- a/backend/src/Taskdeck.Domain/Entities/ProposalRevision.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ProposalRevision.cs
@@ -1,0 +1,67 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Immutable revision of an automation proposal. Revisions never destructively
+/// overwrite the original proposal payload; they form a chronological chain.
+/// Each revision captures: who edited, what the revised payload is, why, and when.
+/// </summary>
+public class ProposalRevision : Entity
+{
+    /// <summary>FK to the original AutomationProposal.</summary>
+    public Guid ProposalId { get; private set; }
+
+    /// <summary>Monotonically increasing revision number (1-based).</summary>
+    public int RevisionNumber { get; private set; }
+
+    /// <summary>The user who created this revision.</summary>
+    public Guid EditorUserId { get; private set; }
+
+    /// <summary>
+    /// The revised proposal payload as JSON. This is the full snapshot of the
+    /// edited operations, not a diff. The original proposal payload is preserved
+    /// on the AutomationProposal entity itself.
+    /// </summary>
+    public string RevisedPayload { get; private set; } = string.Empty;
+
+    /// <summary>Timestamp when the revision was created (UTC).</summary>
+    public DateTime RevisedAt { get; private set; }
+
+    /// <summary>Human-readable reason for the revision (e.g., "Updated card title").</summary>
+    public string Reason { get; private set; } = string.Empty;
+
+    // Navigation
+    public AutomationProposal Proposal { get; private set; } = null!;
+
+    private ProposalRevision() { } // EF Core
+
+    public ProposalRevision(
+        Guid proposalId,
+        int revisionNumber,
+        Guid editorUserId,
+        string revisedPayload,
+        string reason)
+    {
+        if (proposalId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "ProposalId cannot be empty");
+        if (revisionNumber < 1)
+            throw new DomainException(ErrorCodes.ValidationError, "RevisionNumber must be at least 1");
+        if (editorUserId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "EditorUserId cannot be empty");
+        if (string.IsNullOrWhiteSpace(revisedPayload))
+            throw new DomainException(ErrorCodes.ValidationError, "RevisedPayload cannot be empty");
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new DomainException(ErrorCodes.ValidationError, "Reason cannot be empty");
+        if (reason.Length > 500)
+            throw new DomainException(ErrorCodes.ValidationError, "Reason cannot exceed 500 characters");
+
+        ProposalId = proposalId;
+        RevisionNumber = revisionNumber;
+        EditorUserId = editorUserId;
+        RevisedPayload = revisedPayload;
+        Reason = reason;
+        RevisedAt = DateTime.UtcNow;
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/UnsupportedOperationFailure.cs
+++ b/backend/src/Taskdeck.Domain/Entities/UnsupportedOperationFailure.cs
@@ -1,0 +1,46 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Structured failure for an operation that the compiler cannot process.
+/// Immutable after creation.
+/// </summary>
+public sealed class UnsupportedOperationFailure : IEquatable<UnsupportedOperationFailure>
+{
+    /// <summary>The action type that is unsupported.</summary>
+    public string ActionType { get; }
+
+    /// <summary>The target type the operation references.</summary>
+    public string TargetType { get; }
+
+    /// <summary>Human-readable reason why this operation is unsupported.</summary>
+    public string Reason { get; }
+
+    public UnsupportedOperationFailure(string actionType, string targetType, string reason)
+    {
+        if (string.IsNullOrWhiteSpace(actionType))
+            throw new ArgumentException("ActionType cannot be empty.", nameof(actionType));
+        if (string.IsNullOrWhiteSpace(targetType))
+            throw new ArgumentException("TargetType cannot be empty.", nameof(targetType));
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("Reason cannot be empty.", nameof(reason));
+
+        ActionType = actionType;
+        TargetType = targetType;
+        Reason = reason;
+    }
+
+    public bool Equals(UnsupportedOperationFailure? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return ActionType == other.ActionType
+            && TargetType == other.TargetType
+            && Reason == other.Reason;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as UnsupportedOperationFailure);
+
+    public override int GetHashCode() => HashCode.Combine(ActionType, TargetType, Reason);
+
+    public override string ToString() => $"Unsupported: {ActionType} on {TargetType} - {Reason}";
+}

--- a/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
@@ -70,6 +70,7 @@ public static class DependencyInjection
         services.AddScoped<IIntegrationConnectorRepository, IntegrationConnectorRepository>();
         services.AddScoped<IConnectorEventRepository, ConnectorEventRepository>();
         services.AddScoped<IConnectorCredentialRepository, ConnectorCredentialRepository>();
+        services.AddScoped<IProposalRevisionRepository, ProposalRevisionRepository>();
         services.AddScoped<IKnowledgeSearchService, Taskdeck.Infrastructure.Services.KnowledgeFtsSearchService>();
 
         // Credential encryption — requires a configured AES-256 key.

--- a/backend/src/Taskdeck.Infrastructure/Migrations/TaskdeckDbContextModelSnapshot.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/TaskdeckDbContextModelSnapshot.cs
@@ -1654,7 +1654,7 @@ namespace Taskdeck.Infrastructure.Migrations
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTime>("DecidedAt")
+                    b.Property<DateTimeOffset>("DecidedAt")
                         .HasColumnType("TEXT");
 
                     b.Property<Guid>("DecidedByUserId")
@@ -1697,7 +1697,7 @@ namespace Taskdeck.Infrastructure.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTime>("RevisedAt")
+                    b.Property<DateTimeOffset>("RevisedAt")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("RevisedPayload")

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/AutomationProposalConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/AutomationProposalConfiguration.cs
@@ -74,6 +74,16 @@ public class AutomationProposalConfiguration : IEntityTypeConfiguration<Automati
             .HasForeignKey(o => o.ProposalId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        builder.HasMany(ap => ap.Revisions)
+            .WithOne(r => r.Proposal)
+            .HasForeignKey(r => r.ProposalId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(ap => ap.Outcomes)
+            .WithOne(o => o.Proposal)
+            .HasForeignKey(o => o.ProposalId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         builder.HasIndex(ap => ap.Status);
         builder.HasIndex(ap => ap.RequestedByUserId);
         builder.HasIndex(ap => ap.BoardId);

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/ProposalOutcomeConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/ProposalOutcomeConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Infrastructure.Persistence.Configurations;
+
+public class ProposalOutcomeConfiguration : IEntityTypeConfiguration<ProposalOutcome>
+{
+    public void Configure(EntityTypeBuilder<ProposalOutcome> builder)
+    {
+        builder.ToTable("ProposalOutcomes");
+
+        builder.HasKey(po => po.Id);
+
+        builder.Property(po => po.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(po => po.ProposalId)
+            .IsRequired();
+
+        builder.Property(po => po.OutcomeType)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(po => po.DecidedByUserId)
+            .IsRequired();
+
+        builder.Property(po => po.DecidedAt)
+            .IsRequired();
+
+        builder.Property(po => po.CreatedAt)
+            .IsRequired();
+
+        builder.Property(po => po.UpdatedAt)
+            .IsRequired();
+
+        builder.HasIndex(po => po.ProposalId);
+        builder.HasIndex(po => po.DecidedByUserId);
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/ProposalRevisionConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/ProposalRevisionConfiguration.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Infrastructure.Persistence.Configurations;
+
+public class ProposalRevisionConfiguration : IEntityTypeConfiguration<ProposalRevision>
+{
+    public void Configure(EntityTypeBuilder<ProposalRevision> builder)
+    {
+        builder.ToTable("ProposalRevisions");
+
+        builder.HasKey(pr => pr.Id);
+
+        builder.Property(pr => pr.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(pr => pr.ProposalId)
+            .IsRequired();
+
+        builder.Property(pr => pr.RevisionNumber)
+            .IsRequired();
+
+        builder.Property(pr => pr.EditorUserId)
+            .IsRequired();
+
+        builder.Property(pr => pr.RevisedPayload)
+            .IsRequired();
+
+        builder.Property(pr => pr.RevisedAt)
+            .IsRequired();
+
+        builder.Property(pr => pr.Reason)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(pr => pr.CreatedAt)
+            .IsRequired();
+
+        builder.Property(pr => pr.UpdatedAt)
+            .IsRequired();
+
+        // Unique constraint: one revision number per proposal
+        builder.HasIndex(pr => new { pr.ProposalId, pr.RevisionNumber })
+            .IsUnique();
+
+        builder.HasIndex(pr => pr.ProposalId);
+        builder.HasIndex(pr => pr.EditorUserId);
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.Designer.cs
@@ -1657,7 +1657,7 @@ namespace Taskdeck.Infrastructure.Persistence.Migrations
                     b.Property<DateTimeOffset>("CreatedAt")
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTime>("DecidedAt")
+                    b.Property<DateTimeOffset>("DecidedAt")
                         .HasColumnType("TEXT");
 
                     b.Property<Guid>("DecidedByUserId")
@@ -1700,7 +1700,7 @@ namespace Taskdeck.Infrastructure.Persistence.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("TEXT");
 
-                    b.Property<DateTime>("RevisedAt")
+                    b.Property<DateTimeOffset>("RevisedAt")
                         .HasColumnType("TEXT");
 
                     b.Property<string>("RevisedPayload")

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.Designer.cs
@@ -2,17 +2,20 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Taskdeck.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace Taskdeck.Infrastructure.Migrations
+namespace Taskdeck.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(TaskdeckDbContext))]
-    partial class TaskdeckDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260425105642_AddProposalRevisionsAndOutcomes")]
+    partial class AddProposalRevisionsAndOutcomes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.26");

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Taskdeck.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProposalRevisionsAndOutcomes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProposalOutcomes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ProposalId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    OutcomeType = table.Column<int>(type: "INTEGER", nullable: false),
+                    DecidedByUserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    DecidedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProposalOutcomes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProposalOutcomes_AutomationProposals_ProposalId",
+                        column: x => x.ProposalId,
+                        principalTable: "AutomationProposals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ProposalRevisions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ProposalId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    RevisionNumber = table.Column<int>(type: "INTEGER", nullable: false),
+                    EditorUserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    RevisedPayload = table.Column<string>(type: "TEXT", nullable: false),
+                    RevisedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    Reason = table.Column<string>(type: "TEXT", maxLength: 500, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProposalRevisions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProposalRevisions_AutomationProposals_ProposalId",
+                        column: x => x.ProposalId,
+                        principalTable: "AutomationProposals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProposalOutcomes_DecidedByUserId",
+                table: "ProposalOutcomes",
+                column: "DecidedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProposalOutcomes_ProposalId",
+                table: "ProposalOutcomes",
+                column: "ProposalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProposalRevisions_EditorUserId",
+                table: "ProposalRevisions",
+                column: "EditorUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProposalRevisions_ProposalId",
+                table: "ProposalRevisions",
+                column: "ProposalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProposalRevisions_ProposalId_RevisionNumber",
+                table: "ProposalRevisions",
+                columns: new[] { "ProposalId", "RevisionNumber" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProposalOutcomes");
+
+            migrationBuilder.DropTable(
+                name: "ProposalRevisions");
+        }
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260425105642_AddProposalRevisionsAndOutcomes.cs
@@ -19,7 +19,7 @@ namespace Taskdeck.Infrastructure.Persistence.Migrations
                     ProposalId = table.Column<Guid>(type: "TEXT", nullable: false),
                     OutcomeType = table.Column<int>(type: "INTEGER", nullable: false),
                     DecidedByUserId = table.Column<Guid>(type: "TEXT", nullable: false),
-                    DecidedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DecidedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
                     CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
                     UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
                 },
@@ -43,7 +43,7 @@ namespace Taskdeck.Infrastructure.Persistence.Migrations
                     RevisionNumber = table.Column<int>(type: "INTEGER", nullable: false),
                     EditorUserId = table.Column<Guid>(type: "TEXT", nullable: false),
                     RevisedPayload = table.Column<string>(type: "TEXT", nullable: false),
-                    RevisedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    RevisedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
                     Reason = table.Column<string>(type: "TEXT", maxLength: 500, nullable: false),
                     CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
                     UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)

--- a/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckDbContext.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckDbContext.cs
@@ -45,6 +45,8 @@ public class TaskdeckDbContext : DbContext
     public DbSet<IntegrationConnector> IntegrationConnectors => Set<IntegrationConnector>();
     public DbSet<ConnectorEvent> ConnectorEvents => Set<ConnectorEvent>();
     public DbSet<ConnectorCredential> ConnectorCredentials => Set<ConnectorCredential>();
+    public DbSet<ProposalRevision> ProposalRevisions => Set<ProposalRevision>();
+    public DbSet<ProposalOutcome> ProposalOutcomes => Set<ProposalOutcome>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Taskdeck.Infrastructure/Repositories/ProposalRevisionRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/ProposalRevisionRepository.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Persistence;
+
+namespace Taskdeck.Infrastructure.Repositories;
+
+public class ProposalRevisionRepository : Repository<ProposalRevision>, IProposalRevisionRepository
+{
+    public ProposalRevisionRepository(TaskdeckDbContext context) : base(context)
+    {
+    }
+
+    public async Task<IReadOnlyList<ProposalRevision>> GetByProposalIdAsync(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .AsNoTracking()
+            .Where(r => r.ProposalId == proposalId)
+            .OrderBy(r => r.RevisionNumber)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<ProposalRevision?> GetLatestByProposalIdAsync(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .AsNoTracking()
+            .Where(r => r.ProposalId == proposalId)
+            .OrderByDescending(r => r.RevisionNumber)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<int> GetNextRevisionNumberAsync(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        var maxRevision = await _dbSet
+            .Where(r => r.ProposalId == proposalId)
+            .MaxAsync(r => (int?)r.RevisionNumber, cancellationToken);
+
+        return (maxRevision ?? 0) + 1;
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
@@ -44,7 +44,8 @@ public class UnitOfWork : IUnitOfWork
         IMfaCredentialRepository mfaCredentials,
         IIntegrationConnectorRepository integrationConnectors,
         IConnectorEventRepository connectorEvents,
-        IConnectorCredentialRepository connectorCredentials)
+        IConnectorCredentialRepository connectorCredentials,
+        IProposalRevisionRepository proposalRevisions)
     {
         _context = context;
         Boards = boards;
@@ -78,6 +79,7 @@ public class UnitOfWork : IUnitOfWork
         IntegrationConnectors = integrationConnectors;
         ConnectorEvents = connectorEvents;
         ConnectorCredentials = connectorCredentials;
+        ProposalRevisions = proposalRevisions;
     }
 
     public IBoardRepository Boards { get; }
@@ -111,6 +113,7 @@ public class UnitOfWork : IUnitOfWork
     public IIntegrationConnectorRepository IntegrationConnectors { get; }
     public IConnectorEventRepository ConnectorEvents { get; }
     public IConnectorCredentialRepository ConnectorCredentials { get; }
+    public IProposalRevisionRepository ProposalRevisions { get; }
 
     public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
@@ -128,6 +128,13 @@ public class UnitOfWork : IUnitOfWork
                 "Record was updated by another session. Refresh and retry your action.",
                 ex);
         }
+        catch (DbUpdateException ex) when (IsProposalRevisionUniqueViolation(ex))
+        {
+            throw new DomainException(
+                ErrorCodes.Conflict,
+                "Proposal revision was created by another session. Refresh and retry your edit.",
+                ex);
+        }
         catch (DbUpdateException ex) when (TryResolveRecoverableUniqueConflicts(ex))
         {
             return await _context.SaveChangesAsync(cancellationToken);
@@ -247,6 +254,19 @@ public class UnitOfWork : IUnitOfWork
             StringComparison.OrdinalIgnoreCase)
             || exception.InnerException.Message.Contains(
                 "IX_UserPreferences_UserId",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsProposalRevisionUniqueViolation(DbUpdateException exception)
+    {
+        if (exception.InnerException is null)
+            return false;
+
+        return exception.InnerException.Message.Contains(
+            "ProposalRevisions.ProposalId, ProposalRevisions.RevisionNumber",
+            StringComparison.OrdinalIgnoreCase)
+            || exception.InnerException.Message.Contains(
+                "IX_ProposalRevisions_ProposalId_RevisionNumber",
                 StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/ActiveUserValidationMiddlewareTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ActiveUserValidationMiddlewareTests.cs
@@ -306,6 +306,7 @@ public class ActiveUserValidationMiddlewareTests
         public IIntegrationConnectorRepository IntegrationConnectors => throw new NotImplementedException();
         public IConnectorEventRepository ConnectorEvents => throw new NotImplementedException();
         public IConnectorCredentialRepository ConnectorCredentials => throw new NotImplementedException();
+        public IProposalRevisionRepository ProposalRevisions => throw new NotImplementedException();
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/backend/tests/Taskdeck.Api.Tests/Concurrency/ProposalRevisionRaceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Concurrency/ProposalRevisionRaceTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Taskdeck.Infrastructure.Persistence;
+using Xunit;
+
+namespace Taskdeck.Api.Tests.Concurrency;
+
+public class ProposalRevisionRaceTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public ProposalRevisionRaceTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task SaveChangesAsync_DuplicateProposalRevisionNumber_ThrowsDomainConflict()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        var editorId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            editorId,
+            "Proposal revision race test",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString("N"),
+            Guid.NewGuid());
+
+        db.AutomationProposals.Add(proposal);
+        await db.SaveChangesAsync();
+
+        await unitOfWork.ProposalRevisions.AddAsync(new ProposalRevision(
+            proposal.Id,
+            1,
+            editorId,
+            """{"operations":[{"id":1}]}""",
+            "First edit"));
+        await unitOfWork.SaveChangesAsync();
+
+        await unitOfWork.ProposalRevisions.AddAsync(new ProposalRevision(
+            proposal.Id,
+            1,
+            editorId,
+            """{"operations":[{"id":2}]}""",
+            "Concurrent edit"));
+
+        var act = () => unitOfWork.SaveChangesAsync();
+
+        var assertion = await act.Should().ThrowAsync<DomainException>();
+        assertion.Which.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        assertion.Which.Message.Should().Contain("another session");
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -849,6 +849,7 @@ public class LlmQueueToProposalWorkerTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerReliabilityTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerReliabilityTests.cs
@@ -648,6 +648,7 @@ public class OutboundWebhookDeliveryWorkerReliabilityTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(0);

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
@@ -554,6 +554,7 @@ public class OutboundWebhookDeliveryWorkerTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookHmacDeliveryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookHmacDeliveryTests.cs
@@ -541,6 +541,7 @@ public class OutboundWebhookHmacDeliveryTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(0);

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
@@ -347,6 +347,7 @@ public class ProposalHousekeepingWorkerEdgeCaseTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
@@ -225,6 +225,7 @@ public class ProposalHousekeepingWorkerTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -601,6 +601,7 @@ public class WorkerResilienceTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task CommitTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -641,6 +642,7 @@ public class WorkerResilienceTests
         public IIntegrationConnectorRepository IntegrationConnectors => null!;
         public IConnectorEventRepository ConnectorEvents => null!;
         public IConnectorCredentialRepository ConnectorCredentials => null!;
+        public IProposalRevisionRepository ProposalRevisions => null!;
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task CommitTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class ProposalRevisionServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IAutomationProposalRepository> _proposals = new();
+    private readonly Mock<IProposalRevisionRepository> _revisions = new();
+    private readonly ProposalRevisionService _service;
+
+    public ProposalRevisionServiceTests()
+    {
+        _unitOfWork.SetupGet(unitOfWork => unitOfWork.AutomationProposals).Returns(_proposals.Object);
+        _unitOfWork.SetupGet(unitOfWork => unitOfWork.ProposalRevisions).Returns(_revisions.Object);
+
+        _service = new ProposalRevisionService(_unitOfWork.Object);
+    }
+
+    [Fact]
+    public async Task CreateRevisionAsync_ReturnsConflict_WhenSaveChangesDetectsRevisionNumberRace()
+    {
+        var proposal = CreatePendingProposal();
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            """{"operations":[]}""",
+            "Edited before approval");
+
+        _proposals
+            .Setup(repo => repo.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _revisions
+            .Setup(repo => repo.GetNextRevisionNumberAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _revisions
+            .Setup(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProposalRevision revision, CancellationToken _) => revision);
+        _unitOfWork
+            .Setup(unitOfWork => unitOfWork.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DomainException(
+                ErrorCodes.Conflict,
+                "Proposal revision was created by another session. Refresh and retry your edit."));
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("another session");
+    }
+
+    private static AutomationProposal CreatePendingProposal()
+    {
+        return new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Draft proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString("N"),
+            Guid.NewGuid());
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/CompilerValidationResultTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/CompilerValidationResultTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class CompilerValidationResultTests
+{
+    [Fact]
+    public void Success_WithNoRisks_ShouldBeValid()
+    {
+        var result = CompilerValidationResult.Success();
+
+        result.IsValid.Should().BeTrue();
+        result.Risks.Should().BeEmpty();
+        result.Failures.Should().BeEmpty();
+        result.AggregateRiskLevel.Should().Be(RiskLevel.Low);
+    }
+
+    [Fact]
+    public void Success_WithRisks_ShouldBeValidWithRiskWarnings()
+    {
+        var risks = new List<OperationRisk>
+        {
+            new(RiskLevel.Medium, "Moves card to Done column"),
+            new(RiskLevel.Low, "Updates card title")
+        };
+
+        var result = CompilerValidationResult.Success(risks);
+
+        result.IsValid.Should().BeTrue();
+        result.Risks.Should().HaveCount(2);
+        result.Failures.Should().BeEmpty();
+        result.AggregateRiskLevel.Should().Be(RiskLevel.Medium);
+    }
+
+    [Fact]
+    public void Failure_WithFailures_ShouldBeInvalid()
+    {
+        var failures = new List<UnsupportedOperationFailure>
+        {
+            new("delete_board", "board", "Board deletion is not supported via proposals")
+        };
+
+        var result = CompilerValidationResult.Failure(failures);
+
+        result.IsValid.Should().BeFalse();
+        result.Failures.Should().HaveCount(1);
+        result.Risks.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Failure_WithFailuresAndRisks_ShouldBeInvalidWithBoth()
+    {
+        var failures = new List<UnsupportedOperationFailure>
+        {
+            new("unknown_action", "card", "Unrecognized action type")
+        };
+        var risks = new List<OperationRisk>
+        {
+            new(RiskLevel.High, "Contains destructive operations")
+        };
+
+        var result = CompilerValidationResult.Failure(failures, risks);
+
+        result.IsValid.Should().BeFalse();
+        result.Failures.Should().HaveCount(1);
+        result.Risks.Should().HaveCount(1);
+        result.AggregateRiskLevel.Should().Be(RiskLevel.High);
+    }
+
+    [Fact]
+    public void Failure_ShouldThrow_WhenFailuresAreEmpty()
+    {
+        var act = () => CompilerValidationResult.Failure(
+            new List<UnsupportedOperationFailure>());
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Failures must not be empty for a failed result.*");
+    }
+
+    [Fact]
+    public void Failure_ShouldThrow_WhenFailuresAreNull()
+    {
+        var act = () => CompilerValidationResult.Failure(null!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AggregateRiskLevel_ShouldReturnHighestRisk()
+    {
+        var risks = new List<OperationRisk>
+        {
+            new(RiskLevel.Low, "Minor change"),
+            new(RiskLevel.Critical, "Deletes data"),
+            new(RiskLevel.Medium, "Moves multiple cards")
+        };
+
+        var result = CompilerValidationResult.Success(risks);
+
+        result.AggregateRiskLevel.Should().Be(RiskLevel.Critical);
+    }
+
+    [Fact]
+    public void AggregateRiskLevel_SingleRisk_ReturnsThatLevel()
+    {
+        var risks = new List<OperationRisk>
+        {
+            new(RiskLevel.High, "Bulk operation")
+        };
+
+        var result = CompilerValidationResult.Success(risks);
+
+        result.AggregateRiskLevel.Should().Be(RiskLevel.High);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/OperationRiskTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/OperationRiskTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class OperationRiskTests
+{
+    [Fact]
+    public void Constructor_ShouldCreateRisk_WithValidData()
+    {
+        var risk = new OperationRisk(RiskLevel.Medium, "Card will be moved to Done");
+
+        risk.Level.Should().Be(RiskLevel.Medium);
+        risk.Reason.Should().Be("Card will be moved to Done");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenReasonIsBlank(string reason)
+    {
+        var act = () => new OperationRisk(RiskLevel.Low, reason);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Risk reason cannot be empty.*");
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var risk1 = new OperationRisk(RiskLevel.High, "Destructive");
+        var risk2 = new OperationRisk(RiskLevel.High, "Destructive");
+
+        risk1.Should().Be(risk2);
+        risk1.Equals(risk2).Should().BeTrue();
+        (risk1.GetHashCode() == risk2.GetHashCode()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentLevel_ShouldNotBeEqual()
+    {
+        var risk1 = new OperationRisk(RiskLevel.Low, "Same reason");
+        var risk2 = new OperationRisk(RiskLevel.High, "Same reason");
+
+        risk1.Should().NotBe(risk2);
+    }
+
+    [Fact]
+    public void Equals_DifferentReason_ShouldNotBeEqual()
+    {
+        var risk1 = new OperationRisk(RiskLevel.Medium, "Reason A");
+        var risk2 = new OperationRisk(RiskLevel.Medium, "Reason B");
+
+        risk1.Should().NotBe(risk2);
+    }
+
+    [Fact]
+    public void Equals_Null_ShouldNotBeEqual()
+    {
+        var risk = new OperationRisk(RiskLevel.Low, "something");
+
+        risk.Equals(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToString_ShouldFormatCorrectly()
+    {
+        var risk = new OperationRisk(RiskLevel.Critical, "Data loss");
+
+        risk.ToString().Should().Be("Critical: Data loss");
+    }
+
+    [Theory]
+    [InlineData(RiskLevel.Low)]
+    [InlineData(RiskLevel.Medium)]
+    [InlineData(RiskLevel.High)]
+    [InlineData(RiskLevel.Critical)]
+    public void Constructor_ShouldAcceptAllRiskLevels(RiskLevel level)
+    {
+        var risk = new OperationRisk(level, "test reason");
+
+        risk.Level.Should().Be(level);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalOutcomeTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalOutcomeTests.cs
@@ -17,7 +17,7 @@ public class ProposalOutcomeTests
     [InlineData(OutcomeType.Ignored)]
     public void Constructor_ShouldCreateOutcome_ForEachValidOutcomeType(OutcomeType outcomeType)
     {
-        var before = DateTime.UtcNow;
+        var before = DateTimeOffset.UtcNow;
 
         var outcome = new ProposalOutcome(_proposalId, outcomeType, _decidedByUserId);
 
@@ -26,7 +26,7 @@ public class ProposalOutcomeTests
         outcome.OutcomeType.Should().Be(outcomeType);
         outcome.DecidedByUserId.Should().Be(_decidedByUserId);
         outcome.DecidedAt.Should().BeOnOrAfter(before);
-        outcome.DecidedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+        outcome.DecidedAt.Should().BeOnOrBefore(DateTimeOffset.UtcNow);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalOutcomeTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalOutcomeTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class ProposalOutcomeTests
+{
+    private readonly Guid _proposalId = Guid.NewGuid();
+    private readonly Guid _decidedByUserId = Guid.NewGuid();
+
+    [Theory]
+    [InlineData(OutcomeType.Approved)]
+    [InlineData(OutcomeType.EditedThenApproved)]
+    [InlineData(OutcomeType.Rejected)]
+    [InlineData(OutcomeType.Ignored)]
+    public void Constructor_ShouldCreateOutcome_ForEachValidOutcomeType(OutcomeType outcomeType)
+    {
+        var before = DateTime.UtcNow;
+
+        var outcome = new ProposalOutcome(_proposalId, outcomeType, _decidedByUserId);
+
+        outcome.Id.Should().NotBe(Guid.Empty);
+        outcome.ProposalId.Should().Be(_proposalId);
+        outcome.OutcomeType.Should().Be(outcomeType);
+        outcome.DecidedByUserId.Should().Be(_decidedByUserId);
+        outcome.DecidedAt.Should().BeOnOrAfter(before);
+        outcome.DecidedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenProposalIdIsEmpty()
+    {
+        var act = () => new ProposalOutcome(Guid.Empty, OutcomeType.Approved, _decidedByUserId);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("ProposalId cannot be empty");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenDecidedByUserIdIsEmpty()
+    {
+        var act = () => new ProposalOutcome(_proposalId, OutcomeType.Approved, Guid.Empty);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("DecidedByUserId cannot be empty");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenOutcomeTypeIsInvalid()
+    {
+        var act = () => new ProposalOutcome(_proposalId, (OutcomeType)999, _decidedByUserId);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Invalid OutcomeType: 999");
+    }
+
+    [Fact]
+    public void OutcomeType_Enum_HasExpectedValues()
+    {
+        // Verify the enum has exactly the expected members
+        var values = Enum.GetValues<OutcomeType>();
+        values.Should().HaveCount(4);
+        values.Should().Contain(OutcomeType.Approved);
+        values.Should().Contain(OutcomeType.EditedThenApproved);
+        values.Should().Contain(OutcomeType.Rejected);
+        values.Should().Contain(OutcomeType.Ignored);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalRevisionChainTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalRevisionChainTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+/// <summary>
+/// Tests for revision chain integrity: building ordered revision chains,
+/// latest revision resolution, and edge cases.
+/// </summary>
+public class ProposalRevisionChainTests
+{
+    private readonly Guid _proposalId = Guid.NewGuid();
+    private readonly Guid _editorUserId = Guid.NewGuid();
+
+    [Fact]
+    public void LatestRevision_NoRevisions_ReturnsNull()
+    {
+        // An empty revision list means the original proposal payload is authoritative.
+        var revisions = new List<ProposalRevision>();
+
+        var latest = revisions
+            .OrderByDescending(r => r.RevisionNumber)
+            .FirstOrDefault();
+
+        latest.Should().BeNull();
+    }
+
+    [Fact]
+    public void LatestRevision_SingleRevision_ReturnsThatRevision()
+    {
+        var revision = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{\"v1\": true}", "first edit");
+
+        var revisions = new List<ProposalRevision> { revision };
+
+        var latest = revisions
+            .OrderByDescending(r => r.RevisionNumber)
+            .First();
+
+        latest.Should().Be(revision);
+        latest.RevisionNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public void LatestRevision_ManyRevisions_ReturnsHighestRevisionNumber()
+    {
+        var rev1 = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{\"v1\": true}", "first edit");
+        var rev2 = new ProposalRevision(
+            _proposalId, 2, _editorUserId, "{\"v2\": true}", "second edit");
+        var rev3 = new ProposalRevision(
+            _proposalId, 3, _editorUserId, "{\"v3\": true}", "third edit");
+
+        var revisions = new List<ProposalRevision> { rev1, rev3, rev2 }; // intentionally unordered
+
+        var latest = revisions
+            .OrderByDescending(r => r.RevisionNumber)
+            .First();
+
+        latest.Should().Be(rev3);
+        latest.RevisionNumber.Should().Be(3);
+        latest.RevisedPayload.Should().Be("{\"v3\": true}");
+    }
+
+    [Fact]
+    public void RevisionChain_PreservesAllPriorPayloads()
+    {
+        var rev1 = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{\"title\": \"Draft\"}", "initial draft");
+        var rev2 = new ProposalRevision(
+            _proposalId, 2, _editorUserId, "{\"title\": \"Final\"}", "finalized title");
+
+        var revisions = new List<ProposalRevision> { rev1, rev2 };
+
+        // Both revisions retain their payloads -- nothing is overwritten
+        revisions[0].RevisedPayload.Should().Be("{\"title\": \"Draft\"}");
+        revisions[1].RevisedPayload.Should().Be("{\"title\": \"Final\"}");
+    }
+
+    [Fact]
+    public void RevisionChain_AllRevisionsReferenceTheSameProposal()
+    {
+        var rev1 = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{}", "edit 1");
+        var rev2 = new ProposalRevision(
+            _proposalId, 2, _editorUserId, "{}", "edit 2");
+        var rev3 = new ProposalRevision(
+            _proposalId, 3, _editorUserId, "{}", "edit 3");
+
+        var revisions = new List<ProposalRevision> { rev1, rev2, rev3 };
+
+        revisions.Should().AllSatisfy(r => r.ProposalId.Should().Be(_proposalId));
+    }
+
+    [Fact]
+    public void RevisionChain_DifferentEditors_TracksEditorPerRevision()
+    {
+        var editor1 = Guid.NewGuid();
+        var editor2 = Guid.NewGuid();
+
+        var rev1 = new ProposalRevision(
+            _proposalId, 1, editor1, "{\"by\": \"alice\"}", "alice's edit");
+        var rev2 = new ProposalRevision(
+            _proposalId, 2, editor2, "{\"by\": \"bob\"}", "bob's edit");
+
+        rev1.EditorUserId.Should().Be(editor1);
+        rev2.EditorUserId.Should().Be(editor2);
+    }
+
+    [Fact]
+    public void RevisionChain_OrderedByRevisionNumber_ReturnsChronologicalOrder()
+    {
+        var rev3 = new ProposalRevision(
+            _proposalId, 3, _editorUserId, "{\"seq\": 3}", "third");
+        var rev1 = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{\"seq\": 1}", "first");
+        var rev2 = new ProposalRevision(
+            _proposalId, 2, _editorUserId, "{\"seq\": 2}", "second");
+
+        var ordered = new List<ProposalRevision> { rev3, rev1, rev2 }
+            .OrderBy(r => r.RevisionNumber)
+            .ToList();
+
+        ordered[0].RevisionNumber.Should().Be(1);
+        ordered[1].RevisionNumber.Should().Be(2);
+        ordered[2].RevisionNumber.Should().Be(3);
+    }
+
+    [Fact]
+    public void RevisionChain_EachRevisionHasUniqueId()
+    {
+        var rev1 = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{}", "edit 1");
+        var rev2 = new ProposalRevision(
+            _proposalId, 2, _editorUserId, "{}", "edit 2");
+
+        rev1.Id.Should().NotBe(rev2.Id);
+        rev1.Id.Should().NotBe(Guid.Empty);
+        rev2.Id.Should().NotBe(Guid.Empty);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalRevisionTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalRevisionTests.cs
@@ -1,0 +1,154 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class ProposalRevisionTests
+{
+    private readonly Guid _proposalId = Guid.NewGuid();
+    private readonly Guid _editorUserId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ShouldCreateRevision_WithValidData()
+    {
+        // Arrange & Act
+        var before = DateTime.UtcNow;
+        var revision = new ProposalRevision(
+            _proposalId,
+            1,
+            _editorUserId,
+            "{\"operations\": []}",
+            "Updated card title");
+
+        // Assert
+        revision.Id.Should().NotBe(Guid.Empty);
+        revision.ProposalId.Should().Be(_proposalId);
+        revision.RevisionNumber.Should().Be(1);
+        revision.EditorUserId.Should().Be(_editorUserId);
+        revision.RevisedPayload.Should().Be("{\"operations\": []}");
+        revision.Reason.Should().Be("Updated card title");
+        revision.RevisedAt.Should().BeOnOrAfter(before);
+        revision.RevisedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenProposalIdIsEmpty()
+    {
+        var act = () => new ProposalRevision(
+            Guid.Empty, 1, _editorUserId, "{}", "reason");
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("ProposalId cannot be empty");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Constructor_ShouldThrow_WhenRevisionNumberIsLessThanOne(int revisionNumber)
+    {
+        var act = () => new ProposalRevision(
+            _proposalId, revisionNumber, _editorUserId, "{}", "reason");
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("RevisionNumber must be at least 1");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenEditorUserIdIsEmpty()
+    {
+        var act = () => new ProposalRevision(
+            _proposalId, 1, Guid.Empty, "{}", "reason");
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("EditorUserId cannot be empty");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenRevisedPayloadIsBlank(string payload)
+    {
+        var act = () => new ProposalRevision(
+            _proposalId, 1, _editorUserId, payload, "reason");
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("RevisedPayload cannot be empty");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenReasonIsBlank(string reason)
+    {
+        var act = () => new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{}", reason);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Reason cannot be empty");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenReasonExceedsMaxLength()
+    {
+        var longReason = new string('a', 501);
+
+        var act = () => new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{}", longReason);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Reason cannot exceed 500 characters");
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptReason_AtExactMaxLength()
+    {
+        var reason = new string('a', 500);
+
+        var revision = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{}", reason);
+
+        revision.Reason.Should().HaveLength(500);
+    }
+
+    [Fact]
+    public void Immutability_PropertiesAreReadOnly()
+    {
+        // Verify that properties have private setters (enforced by C# compiler)
+        // The entity uses private set throughout, confirming immutability after construction.
+        var revision = new ProposalRevision(
+            _proposalId, 1, _editorUserId, "{\"data\": true}", "initial edit");
+
+        // All properties should retain their construction values
+        revision.ProposalId.Should().Be(_proposalId);
+        revision.RevisionNumber.Should().Be(1);
+        revision.EditorUserId.Should().Be(_editorUserId);
+        revision.RevisedPayload.Should().Be("{\"data\": true}");
+        revision.Reason.Should().Be("initial edit");
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptHighRevisionNumbers()
+    {
+        var revision = new ProposalRevision(
+            _proposalId, 100, _editorUserId, "{}", "hundredth edit");
+
+        revision.RevisionNumber.Should().Be(100);
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptLargeJsonPayload()
+    {
+        var largePayload = "{\"operations\": [" + string.Join(",",
+            Enumerable.Range(0, 100).Select(i => $"{{\"seq\": {i}}}")) + "]}";
+
+        var revision = new ProposalRevision(
+            _proposalId, 1, _editorUserId, largePayload, "bulk edit");
+
+        revision.RevisedPayload.Should().Be(largePayload);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalRevisionTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalRevisionTests.cs
@@ -14,7 +14,7 @@ public class ProposalRevisionTests
     public void Constructor_ShouldCreateRevision_WithValidData()
     {
         // Arrange & Act
-        var before = DateTime.UtcNow;
+        var before = DateTimeOffset.UtcNow;
         var revision = new ProposalRevision(
             _proposalId,
             1,
@@ -30,7 +30,7 @@ public class ProposalRevisionTests
         revision.RevisedPayload.Should().Be("{\"operations\": []}");
         revision.Reason.Should().Be("Updated card title");
         revision.RevisedAt.Should().BeOnOrAfter(before);
-        revision.RevisedAt.Should().BeOnOrBefore(DateTime.UtcNow);
+        revision.RevisedAt.Should().BeOnOrBefore(DateTimeOffset.UtcNow);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/UnsupportedOperationFailureTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/UnsupportedOperationFailureTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class UnsupportedOperationFailureTests
+{
+    [Fact]
+    public void Constructor_ShouldCreateFailure_WithValidData()
+    {
+        var failure = new UnsupportedOperationFailure(
+            "delete_board", "board", "Board deletion is not supported");
+
+        failure.ActionType.Should().Be("delete_board");
+        failure.TargetType.Should().Be("board");
+        failure.Reason.Should().Be("Board deletion is not supported");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenActionTypeIsBlank(string actionType)
+    {
+        var act = () => new UnsupportedOperationFailure(actionType, "card", "reason");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("ActionType cannot be empty.*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenTargetTypeIsBlank(string targetType)
+    {
+        var act = () => new UnsupportedOperationFailure("create", targetType, "reason");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("TargetType cannot be empty.*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenReasonIsBlank(string reason)
+    {
+        var act = () => new UnsupportedOperationFailure("create", "card", reason);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Reason cannot be empty.*");
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var f1 = new UnsupportedOperationFailure("delete", "board", "not allowed");
+        var f2 = new UnsupportedOperationFailure("delete", "board", "not allowed");
+
+        f1.Should().Be(f2);
+        f1.Equals(f2).Should().BeTrue();
+        (f1.GetHashCode() == f2.GetHashCode()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentActionType_ShouldNotBeEqual()
+    {
+        var f1 = new UnsupportedOperationFailure("create", "board", "reason");
+        var f2 = new UnsupportedOperationFailure("delete", "board", "reason");
+
+        f1.Should().NotBe(f2);
+    }
+
+    [Fact]
+    public void Equals_DifferentTargetType_ShouldNotBeEqual()
+    {
+        var f1 = new UnsupportedOperationFailure("delete", "board", "reason");
+        var f2 = new UnsupportedOperationFailure("delete", "card", "reason");
+
+        f1.Should().NotBe(f2);
+    }
+
+    [Fact]
+    public void Equals_DifferentReason_ShouldNotBeEqual()
+    {
+        var f1 = new UnsupportedOperationFailure("delete", "board", "reason A");
+        var f2 = new UnsupportedOperationFailure("delete", "board", "reason B");
+
+        f1.Should().NotBe(f2);
+    }
+
+    [Fact]
+    public void Equals_Null_ShouldNotBeEqual()
+    {
+        var failure = new UnsupportedOperationFailure("delete", "board", "reason");
+
+        failure.Equals(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToString_ShouldFormatCorrectly()
+    {
+        var failure = new UnsupportedOperationFailure(
+            "merge", "column", "Column merge not supported");
+
+        failure.ToString().Should().Be("Unsupported: merge on column - Column merge not supported");
+    }
+}


### PR DESCRIPTION
## Summary

Foundational data model slice for #976 (RFAI-04: Typed ProposalCompiler and revision-backed edit-before-approve flow).

- **ProposalRevision entity**: Immutable revision of an automation proposal. References the original proposal via FK. Contains revision number (monotonic, 1-based), editor identity, revised payload (full JSON snapshot -- never destructively overwrites original), timestamp, and reason. Private setters enforce immutability after construction.
- **ProposalOutcome entity**: Records content-free decision events with OutcomeType enum (Approved, EditedThenApproved, Rejected, Ignored).
- **IProposalCompiler interface**: Typed compiler contract in Domain layer with CompilerValidationResult (success/failure with risk aggregation).
- **OperationRisk value object**: Immutable risk level + reason with value equality semantics.
- **UnsupportedOperationFailure**: Structured failure for operations the compiler cannot process.
- **Application layer**: IProposalRevisionRepository (with latest-revision and next-number queries), ProposalRevisionDtos, IProposalRevisionService with create/list/get-latest.
- **Infrastructure**: EF Core migration creating ProposalRevisions and ProposalOutcomes tables with FK to AutomationProposals, unique index on (ProposalId, RevisionNumber). ProposalRevisionRepository, EF configurations, DI registration, DbContext and UnitOfWork updates.
- **70 new domain tests**: ProposalRevision creation/immutability/validation, revision chain integrity (latest resolution, ordering, no-revisions case, many-revisions), ProposalOutcome and OutcomeType coverage, CompilerValidationResult success/failure/aggregation, OperationRisk and UnsupportedOperationFailure value object semantics.

### Key design decisions

1. **Revisions never overwrite**: Each revision stores a full JSON snapshot. The original proposal payload on AutomationProposal is preserved. Latest effective payload is resolved via `GetLatestByProposalIdAsync`.
2. **Immutability**: ProposalRevision and ProposalOutcome use private setters throughout. No mutation methods exist after construction.
3. **Revision chain integrity**: Unique DB constraint on (ProposalId, RevisionNumber) prevents orphaned or duplicate revisions. RevisionNumber is auto-assigned via `GetNextRevisionNumberAsync`.
4. **OutcomeType is content-free**: Captures what happened (Approved, EditedThenApproved, Rejected, Ignored), not why.

### What awaits upstream

- Compiler wiring (concrete IProposalCompiler implementations) awaits upstream merges
- Frontend review card editing (edit-before-approve UI) awaits this data model landing
- API endpoints for revision CRUD will follow in a subsequent slice

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors
- [x] `dotnet test backend/Taskdeck.sln -c Release -m:1` -- 5,130 tests pass (0 failures)
- [x] Domain tests cover all new entities, value objects, and edge cases (70 new tests)
- [x] All existing fake UnitOfWork implementations updated for new interface member
- [x] EF migration generates correct tables, FKs, and indices

Closes: contributes to #976