### PR TITLE
PAPER-01 · Paper & Graphite tokens, theme store, styleguide

### DIFF
--- a/frontend/taskdeck-web/src/App.vue
+++ b/frontend/taskdeck-web/src/App.vue
@@ -16,6 +16,8 @@ const featureFlags = useFeatureFlagStore()
 const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
 
+paperTheme.apply()
+
 const showShell = computed(() => {
   return route.meta.requiresShell === true
 })
@@ -23,7 +25,6 @@ const showShell = computed(() => {
 onMounted(() => {
   session.restoreSession()
   featureFlags.restore()
-  paperTheme.apply()
 })
 
 watch(

--- a/frontend/taskdeck-web/src/App.vue
+++ b/frontend/taskdeck-web/src/App.vue
@@ -8,11 +8,13 @@ import ErrorBoundary from './components/ErrorBoundary.vue'
 import { useSessionStore } from './store/sessionStore'
 import { useFeatureFlagStore } from './store/featureFlagStore'
 import { useWorkspaceStore } from './store/workspaceStore'
+import { usePaperThemeStore } from './store/paperThemeStore'
 
 const route = useRoute()
 const session = useSessionStore()
 const featureFlags = useFeatureFlagStore()
 const workspace = useWorkspaceStore()
+const paperTheme = usePaperThemeStore()
 
 const showShell = computed(() => {
   return route.meta.requiresShell === true
@@ -21,6 +23,7 @@ const showShell = computed(() => {
 onMounted(() => {
   session.restoreSession()
   featureFlags.restore()
+  paperTheme.apply()
 })
 
 watch(

--- a/frontend/taskdeck-web/src/main.ts
+++ b/frontend/taskdeck-web/src/main.ts
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
 import './style.css'
+import './paper-tokens.css'
 import {
   installVueErrorHandler,
   installWindowErrorListeners,

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -7,10 +7,9 @@
    remain canonical until Paper is promoted by paperThemeStore.
    ========================================================= */
 
-/* Fonts: self-host in production. We import via Google Fonts during
-   the foundation slice; PAPER-01 follow-up replaces with @font-face
-   pointing at /public/fonts/*.woff2 with font-display: swap. */
-@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,300;1,9..144,400&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+/* Paper references preferred local font names first and falls back to system
+   families. External font imports are intentionally avoided so production CSP
+   can keep style-src locked to self. */
 
 .paper {
   /* --- Substrate --- */
@@ -328,7 +327,7 @@
 .paper .pbtn-primary, .paper-night .pbtn-primary {
   background: var(--ink-deep); color: var(--paper-card); border-color: var(--ink-deep);
 }
-.paper .pbtn-primary:hover, .paper-night .pbtn-primary:hover { background: #000; border-color: #000; }
+.paper .pbtn-primary:hover, .paper-night .pbtn-primary:hover { background: var(--ink); border-color: var(--ink); }
 .paper .pbtn-ember, .paper-night .pbtn-ember {
   background: var(--ember); color: #fbf2e8; border-color: var(--ember-deep);
   box-shadow: inset 0 1px 0 #ffffff20, 0 1px 0 var(--ember-deep);

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -1,0 +1,430 @@
+/* =========================================================
+   Paper & Graphite — Ember Edition · Tokens
+   Mirror of design_handoff_taskdeck_paper/paper/tokens.css.
+
+   Scope: Paper variables are scoped under `.paper` / `.paper-night`.
+   They DO NOT apply at :root, so existing Obsidian (`--td-*`) tokens
+   remain canonical until Paper is promoted by paperThemeStore.
+   ========================================================= */
+
+/* Fonts: self-host in production. We import via Google Fonts during
+   the foundation slice; PAPER-01 follow-up replaces with @font-face
+   pointing at /public/fonts/*.woff2 with font-display: swap. */
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;0,9..144,600;1,9..144,300;1,9..144,400&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+.paper {
+  /* --- Substrate --- */
+  --paper:        #f3eee5;
+  --paper-2:      #ebe5d8;
+  --paper-card:   #fbf7ee;
+  --paper-edge:   #e3dac8;
+  --line:         #d8d0bf;
+  --line-soft:    #e3dcc9;
+  --rule:         #1a181410;
+
+  /* --- Ink ladder --- */
+  --ink:          #1a1814;
+  --ink-deep:     #0a0908;
+  --ink-2:        #3a352d;
+  --mute:         #6c6557;
+  --faint:        #a39c8b;
+  --whisper:      #c2bba8;
+
+  /* --- Ember --- */
+  --ember:        #a8421f;
+  --ember-deep:   #7a2e15;
+  --ember-bloom:  #a8421f1a;
+  --ember-tint:   #f0d9c8;
+  --ember-ink:    #6e2810;
+
+  /* --- Earth-tone semantics --- */
+  --applied:      #4a6b3f;
+  --applied-tint: #d8e0ce;
+  --overdue:      #8c4a26;
+  --overdue-tint: #ecd9c4;
+  --awaits:       #6c6557;
+
+  /* --- Type --- */
+  --serif:  'Fraunces', 'Iowan Old Style', 'Charter', Georgia, serif;
+  --sans:   'Inter', -apple-system, system-ui, sans-serif;
+  --mono:   'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* --- Scale --- */
+  --t-xs:  10.5px;
+  --t-sm:  12px;
+  --t-md:  13.5px;
+  --t-bd:  15px;
+  --t-lg:  18px;
+  --t-h3:  22px;
+  --t-h2:  32px;
+  --t-h1:  44px;
+  --t-display: 64px;
+
+  /* --- Spacing & radius --- */
+  --r-0: 0px;
+  --r-1: 2px;
+  --r-2: 4px;
+  --r-3: 6px;
+  --s-1: 4px; --s-2: 8px; --s-3: 12px; --s-4: 16px;
+  --s-5: 20px; --s-6: 24px; --s-8: 32px; --s-10: 40px; --s-12: 56px;
+
+  /* --- Shadows --- */
+  --shadow-card:   0 1px 0 var(--line), 0 .5px 0 #1a18140d;
+  --shadow-lift:   0 .5px 0 #1a18140f, 0 6px 14px -8px #1a181430, 0 1.5px 0 var(--line);
+  --shadow-stamp:  0 2px 0 var(--line);
+  --shadow-press:  inset 0 1px 0 #1a181410;
+
+  /* --- Motion --- */
+  --ease-paper: cubic-bezier(.2, .65, .25, 1);
+  --ease-press: cubic-bezier(.4, 0, .15, 1);
+  --d-quick: 140ms;
+  --d-base:  240ms;
+  --d-press: 320ms;
+  --d-amb:   880ms;
+
+  /* --- Narrow scaling (PAPER-11 hook) --- */
+  --paper-scale: 1;
+
+  color-scheme: light;
+}
+
+.paper-night {
+  --paper:        #14110d;
+  --paper-2:      #100d0a;
+  --paper-card:   #1c1813;
+  --paper-edge:   #20180e;
+  --line:         #2a241c;
+  --line-soft:    #221c14;
+  --rule:         #ffffff0a;
+
+  --ink:          #ece4d3;
+  --ink-deep:     #fbf3df;
+  --ink-2:        #c8bfa9;
+  --mute:         #9a8f7a;
+  --faint:        #685e4c;
+  --whisper:      #3e362a;
+
+  --ember:        #d96a3e;
+  --ember-deep:   #b54e26;
+  --ember-bloom:  #d96a3e22;
+  --ember-tint:   #2d1a12;
+  --ember-ink:    #ffb38c;
+
+  --applied:      #8aae72;
+  --applied-tint: #1d2417;
+  --overdue:      #d09257;
+  --overdue-tint: #2a1f12;
+
+  --serif:  'Fraunces', 'Iowan Old Style', 'Charter', Georgia, serif;
+  --sans:   'Inter', -apple-system, system-ui, sans-serif;
+  --mono:   'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  --shadow-card:  0 1px 0 #00000060, inset 0 1px 0 #ffffff04;
+  --shadow-lift:  0 8px 22px -10px #00000080, 0 1.5px 0 var(--line), inset 0 1px 0 #ffffff05;
+  --shadow-stamp: 0 2px 0 var(--line);
+  --shadow-press: inset 0 1px 0 #00000040;
+
+  color-scheme: dark;
+}
+
+/* =========================================================
+   Paper substrate — fiber texture (light + night)
+   ========================================================= */
+.paper {
+  background-color: var(--paper);
+  background-image:
+    repeating-linear-gradient(91deg,
+      transparent 0 47px,
+      #1a181408 47px 48px,
+      transparent 48px 113px),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.6' numOctaves='1' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 .1   0 0 0 0 .09   0 0 0 0 .08   0 0 0 .035 0'/></filter><rect width='240' height='240' filter='url(%23n)'/></svg>");
+  background-blend-mode: multiply, normal;
+}
+.paper-night {
+  background-color: var(--paper);
+  background-image:
+    repeating-linear-gradient(91deg,
+      transparent 0 47px,
+      #ffffff05 47px 48px,
+      transparent 48px 113px),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.6' numOctaves='1' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1   0 0 0 0 .96   0 0 0 0 .85   0 0 0 .03 0'/></filter><rect width='240' height='240' filter='url(%23n)'/></svg>");
+  background-blend-mode: screen, normal;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .paper, .paper-night {
+    background-image: none;
+  }
+}
+
+/* =========================================================
+   Type primitives — only active when a Paper class is set
+   ========================================================= */
+.paper, .paper-night {
+  font-family: var(--sans);
+  color: var(--ink);
+  font-size: calc(var(--t-md) * var(--paper-scale, 1));
+  line-height: 1.5;
+  font-feature-settings: "ss01", "cv11", "kern", "liga";
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+.paper .tk-display, .paper-night .tk-display {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: calc(var(--t-display) * var(--paper-scale, 1));
+  line-height: 1.02;
+  letter-spacing: -.022em;
+  font-variation-settings: "opsz" 144;
+  color: var(--ink-deep);
+}
+.paper .tk-display em, .paper-night .tk-display em {
+  font-style: italic; font-weight: 400; color: var(--ember);
+  font-variation-settings: "opsz" 144;
+}
+.paper .tk-h1, .paper-night .tk-h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: calc(var(--t-h1) * var(--paper-scale, 1));
+  line-height: 1.04; letter-spacing: -.018em; color: var(--ink-deep);
+  font-variation-settings: "opsz" 96;
+}
+.paper .tk-h1 em, .paper-night .tk-h1 em { font-style: italic; color: var(--ember); }
+.paper .tk-h2, .paper-night .tk-h2 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: calc(var(--t-h2) * var(--paper-scale, 1));
+  line-height: 1.08; letter-spacing: -.014em; color: var(--ink-deep);
+  font-variation-settings: "opsz" 48;
+}
+.paper .tk-h2 em, .paper-night .tk-h2 em { font-style: italic; color: var(--ember); }
+.paper .tk-h3, .paper-night .tk-h3 {
+  font-family: var(--serif); font-weight: 500;
+  font-size: calc(var(--t-h3) * var(--paper-scale, 1));
+  line-height: 1.18; letter-spacing: -.008em; color: var(--ink-deep);
+  font-variation-settings: "opsz" 24;
+}
+.paper .tk-lede, .paper-night .tk-lede {
+  font-family: var(--sans);
+  font-size: calc(var(--t-bd) * var(--paper-scale, 1));
+  color: var(--ink-2); line-height: 1.55; max-width: 64ch;
+}
+.paper .tk-body, .paper-night .tk-body {
+  font-family: var(--sans);
+  font-size: calc(var(--t-md) * var(--paper-scale, 1));
+  color: var(--ink); line-height: 1.55;
+}
+.paper .tk-meta, .paper-night .tk-meta {
+  font-family: var(--mono); font-size: var(--t-xs); color: var(--mute);
+  letter-spacing: .04em;
+}
+.paper .tk-eyebrow, .paper-night .tk-eyebrow {
+  font-family: var(--mono); font-size: 10px; color: var(--mute);
+  letter-spacing: .22em; text-transform: uppercase; font-weight: 500;
+}
+.paper .tk-num, .paper-night .tk-num {
+  font-family: var(--mono); font-feature-settings: "tnum" 1, "ss01";
+}
+.paper .tk-serial, .paper-night .tk-serial {
+  font-family: var(--mono); font-size: 10.5px; color: var(--faint);
+  letter-spacing: .04em;
+}
+.paper .tk-ink-italic, .paper-night .tk-ink-italic {
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  color: var(--ember);
+}
+
+/* =========================================================
+   Hairlines, rules, stamps
+   ========================================================= */
+.paper .hr-line, .paper-night .hr-line { height: 1px; background: var(--line); border: 0; margin: 0; }
+.paper .hr-soft, .paper-night .hr-soft { height: 1px; background: var(--line-soft); border: 0; margin: 0; }
+.paper .hr-double, .paper-night .hr-double { height: 4px; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); background: transparent; margin: 0; }
+
+.paper .rule-ledger, .paper-night .rule-ledger {
+  background-image: repeating-linear-gradient(180deg, transparent 0 27px, var(--rule) 27px 28px);
+}
+
+/* Round embossed stamp */
+.paper .stamp, .paper-night .stamp {
+  display: inline-flex; flex-direction: column; align-items: center; justify-content: center; text-align: center;
+  border: 1.5px solid currentColor; border-radius: 50%;
+  font-family: var(--sans); font-weight: 500; font-size: 9px; letter-spacing: .22em; text-transform: uppercase;
+  color: var(--ink-deep);
+  width: 84px; height: 84px;
+  position: relative;
+  filter: contrast(1.04);
+}
+.paper .stamp.ember, .paper-night .stamp.ember { color: var(--ember); }
+.paper .stamp.applied, .paper-night .stamp.applied { color: var(--applied); }
+.paper .stamp.overdue, .paper-night .stamp.overdue { color: var(--overdue); }
+.paper .stamp b, .paper-night .stamp b {
+  font-family: var(--serif); font-weight: 400; font-style: italic;
+  font-size: 13px; letter-spacing: .03em; text-transform: none;
+  display: block; margin-top: 2px; line-height: 1;
+}
+.paper .stamp .stamp-num, .paper-night .stamp .stamp-num {
+  font-size: 8px; letter-spacing: .14em; color: currentColor; opacity: .7; margin-top: 4px;
+}
+
+.paper .letterpress { text-shadow: 0 1px 0 #ffffffa0, 0 -.5px 0 #1a18141a; }
+.paper-night .letterpress { text-shadow: 0 1px 0 #00000080, 0 -.5px 0 #ffffff10; }
+
+.paper .tagstamp, .paper-night .tagstamp {
+  display: inline-block; padding: 3px 8px 2px;
+  border: 1px solid currentColor; border-radius: 1px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: .22em; text-transform: uppercase; font-weight: 600;
+  line-height: 1;
+}
+
+/* =========================================================
+   Surfaces
+   ========================================================= */
+.paper .surface, .paper-night .surface { background: var(--paper); }
+.paper .card, .paper-night .card {
+  background: var(--paper-card);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  box-shadow: var(--shadow-card);
+}
+.paper .card-lift, .paper-night .card-lift {
+  background: var(--paper-card);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  box-shadow: var(--shadow-lift);
+}
+.paper .well, .paper-night .well {
+  background: var(--paper-2);
+  border: 1px solid var(--line-soft);
+  border-radius: var(--r-2);
+  box-shadow: var(--shadow-press);
+}
+.paper .halo-ember, .paper-night .halo-ember {
+  box-shadow:
+    0 0 0 1px var(--ember),
+    0 0 0 6px var(--ember-bloom),
+    0 8px 24px -10px #a8421f30,
+    0 1px 0 var(--line);
+}
+
+/* =========================================================
+   Buttons / chips
+   ========================================================= */
+.paper .pbtn, .paper-night .pbtn {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px;
+  background: var(--paper-card);
+  border: 1px solid var(--line);
+  border-radius: var(--r-2);
+  font-family: var(--sans); font-size: var(--t-sm); font-weight: 500;
+  color: var(--ink);
+  cursor: pointer;
+  transition:
+    transform var(--d-quick) var(--ease-press),
+    background var(--d-quick) var(--ease-paper),
+    border-color var(--d-quick) var(--ease-paper);
+}
+.paper .pbtn:hover, .paper-night .pbtn:hover { background: var(--paper); border-color: var(--ink-2); }
+.paper .pbtn:active, .paper-night .pbtn:active { transform: translateY(1px); }
+.paper .pbtn-primary, .paper-night .pbtn-primary {
+  background: var(--ink-deep); color: var(--paper-card); border-color: var(--ink-deep);
+}
+.paper .pbtn-primary:hover, .paper-night .pbtn-primary:hover { background: #000; border-color: #000; }
+.paper .pbtn-ember, .paper-night .pbtn-ember {
+  background: var(--ember); color: #fbf2e8; border-color: var(--ember-deep);
+  box-shadow: inset 0 1px 0 #ffffff20, 0 1px 0 var(--ember-deep);
+}
+.paper .pbtn-ember:hover, .paper-night .pbtn-ember:hover { background: var(--ember-deep); }
+.paper .pbtn-ghost, .paper-night .pbtn-ghost { background: transparent; border-color: transparent; }
+.paper .pbtn-ghost:hover, .paper-night .pbtn-ghost:hover { background: var(--paper-2); }
+
+.paper .pkbd, .paper-night .pkbd {
+  display: inline-grid; place-items: center;
+  min-width: 18px; padding: 1px 5px;
+  font-family: var(--mono); font-size: 10px; color: var(--mute);
+  background: var(--paper-card);
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  letter-spacing: .04em;
+}
+.paper .pkbd-light, .paper-night .pkbd-light {
+  background: transparent; border-color: var(--whisper); color: var(--faint);
+}
+
+/* =========================================================
+   Hairline icons
+   ========================================================= */
+.paper .hl-icon, .paper-night .hl-icon {
+  width: 14px; height: 14px; stroke: currentColor; fill: none;
+  stroke-width: 1; stroke-linecap: round; stroke-linejoin: round; flex: none;
+}
+.paper .hl-icon-md, .paper-night .hl-icon-md { width: 16px; height: 16px; }
+.paper .hl-icon-lg, .paper-night .hl-icon-lg { width: 20px; height: 20px; }
+
+/* =========================================================
+   Status pills
+   ========================================================= */
+.paper .pstatus, .paper-night .pstatus {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 10px; letter-spacing: .14em; text-transform: uppercase;
+  color: var(--mute);
+}
+.paper .pstatus::before, .paper-night .pstatus::before {
+  content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex: none;
+}
+.paper .pstatus.proposed, .paper-night .pstatus.proposed { color: var(--ember); }
+.paper .pstatus.applied,  .paper-night .pstatus.applied  { color: var(--applied); }
+.paper .pstatus.overdue,  .paper-night .pstatus.overdue  { color: var(--overdue); }
+.paper .pstatus.draft,    .paper-night .pstatus.draft    { color: var(--mute); }
+.paper .pstatus.live,     .paper-night .pstatus.live     { color: var(--applied); }
+.paper .pstatus.live::before, .paper-night .pstatus.live::before {
+  animation: paper-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes paper-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: .4; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .paper .pstatus.live::before, .paper-night .pstatus.live::before {
+    animation: none;
+  }
+}
+
+/* =========================================================
+   Diff strips — Review
+   ========================================================= */
+.paper .diff-add, .paper-night .diff-add {
+  background: linear-gradient(90deg, var(--applied-tint) 0%, transparent 100%);
+  border-left: 2px solid var(--applied);
+  padding: 6px 10px;
+}
+.paper .diff-rem, .paper-night .diff-rem {
+  background: linear-gradient(90deg, var(--ember-tint) 0%, transparent 100%);
+  border-left: 2px solid var(--ember);
+  padding: 6px 10px;
+  text-decoration: line-through;
+  text-decoration-color: var(--ember);
+  text-decoration-thickness: 1px;
+}
+
+/* =========================================================
+   Erasing dotted underline — reversibility countdown
+   ========================================================= */
+.paper .erase-line, .paper-night .erase-line {
+  background-image: linear-gradient(90deg, var(--ember) 50%, transparent 50%);
+  background-size: 6px 1px;
+  background-repeat: repeat-x;
+  background-position: 0 100%;
+  padding-bottom: 4px;
+}
+
+/* =========================================================
+   Focus rings — Paper substitutes browser default
+   ========================================================= */
+.paper :focus-visible, .paper-night :focus-visible {
+  outline: 2px solid var(--ember);
+  outline-offset: 1px;
+  border-radius: var(--r-1);
+}

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -136,8 +136,10 @@
       transparent 0 47px,
       #1a181408 47px 48px,
       transparent 48px 113px),
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.6' numOctaves='1' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 .1   0 0 0 0 .09   0 0 0 0 .08   0 0 0 .035 0'/></filter><rect width='240' height='240' filter='url(%23n)'/></svg>");
+    radial-gradient(circle at 24px 32px, #1a181406 0 1px, transparent 1px 100%),
+    radial-gradient(circle at 160px 96px, #1a181405 0 1px, transparent 1px 100%);
   background-blend-mode: multiply, normal;
+  background-size: auto, 240px 240px, 240px 240px;
 }
 .paper-night {
   background-color: var(--paper);
@@ -146,8 +148,10 @@
       transparent 0 47px,
       #ffffff05 47px 48px,
       transparent 48px 113px),
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='240' height='240'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.6' numOctaves='1' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1   0 0 0 0 .96   0 0 0 0 .85   0 0 0 .03 0'/></filter><rect width='240' height='240' filter='url(%23n)'/></svg>");
+    radial-gradient(circle at 24px 32px, #ffffff05 0 1px, transparent 1px 100%),
+    radial-gradient(circle at 160px 96px, #ffffff04 0 1px, transparent 1px 100%);
   background-blend-mode: screen, normal;
+  background-size: auto, 240px 240px, 240px 240px;
 }
 
 @media (prefers-reduced-transparency: reduce) {

--- a/frontend/taskdeck-web/src/router/index.ts
+++ b/frontend/taskdeck-web/src/router/index.ts
@@ -45,6 +45,7 @@ const AgentsView = () => import('../views/AgentsView.vue')
 const AgentRunsView = () => import('../views/AgentRunsView.vue')
 const AgentRunDetailView = () => import('../views/AgentRunDetailView.vue')
 const ApiKeySettingsView = () => import('../views/ApiKeySettingsView.vue')
+const PaperStyleGuideView = () => import('../views/PaperStyleGuideView.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -60,6 +61,15 @@ const router = createRouter({
       path: '/register',
       name: 'register',
       component: RegisterView,
+      meta: { public: true },
+    },
+
+    // Paper styleguide — design surface for the Paper & Graphite overhaul.
+    // Public so QA can hit it directly; renders no user data.
+    {
+      path: '/styleguide/paper',
+      name: 'styleguide-paper',
+      component: PaperStyleGuideView,
       meta: { public: true },
     },
 

--- a/frontend/taskdeck-web/src/store/paperThemeStore.ts
+++ b/frontend/taskdeck-web/src/store/paperThemeStore.ts
@@ -74,7 +74,7 @@ export const usePaperThemeStore = defineStore('paperTheme', {
      * Also wires the prefers-color-scheme listener when in auto mode.
      */
     apply() {
-      applyBodyClass(this.activeClass)
+      applyBodyClass(resolveBodyClass(this.mode))
       this._wireAutoListener()
     },
     setMode(mode: PaperMode) {

--- a/frontend/taskdeck-web/src/store/paperThemeStore.ts
+++ b/frontend/taskdeck-web/src/store/paperThemeStore.ts
@@ -54,6 +54,7 @@ function applyBodyClass(klass: 'paper' | 'paper-night' | null) {
 // time; the store action below tears down the previous one before wiring a
 // new one.
 let mediaListener: ((ev: MediaQueryListEvent) => void) | null = null
+let mediaQueryList: MediaQueryList | null = null
 
 export const usePaperThemeStore = defineStore('paperTheme', {
   state: () => ({
@@ -103,13 +104,14 @@ export const usePaperThemeStore = defineStore('paperTheme', {
     },
     _wireAutoListener() {
       if (typeof window === 'undefined' || !window.matchMedia) return
-      const mq = window.matchMedia('(prefers-color-scheme: dark)')
       // Tear down the previously-registered listener if any
-      if (mediaListener) {
-        mq.removeEventListener?.('change', mediaListener)
+      if (mediaQueryList && mediaListener) {
+        mediaQueryList.removeEventListener?.('change', mediaListener)
         mediaListener = null
+        mediaQueryList = null
       }
       if (this.mode !== 'auto') return
+      const mq = window.matchMedia('(prefers-color-scheme: dark)')
       // Note: re-resolve from `this.mode` directly rather than the
       // `activeClass` getter — the getter is memoized via Pinia/Vue reactivity
       // and prefersDark() is not a reactive dependency, so it would return a
@@ -118,6 +120,7 @@ export const usePaperThemeStore = defineStore('paperTheme', {
       const listener = () => applyBodyClass(resolveBodyClass(this.mode))
       mq.addEventListener?.('change', listener)
       mediaListener = listener
+      mediaQueryList = mq
     },
   },
 })

--- a/frontend/taskdeck-web/src/store/paperThemeStore.ts
+++ b/frontend/taskdeck-web/src/store/paperThemeStore.ts
@@ -1,0 +1,118 @@
+import { defineStore } from 'pinia'
+
+export type PaperMode = 'off' | 'paper' | 'paper-night' | 'auto'
+
+const STORAGE_KEY = 'td.paper.mode'
+
+const VALID_MODES: ReadonlyArray<PaperMode> = ['off', 'paper', 'paper-night', 'auto']
+
+function readStoredMode(): PaperMode {
+  if (typeof window === 'undefined') return 'off'
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw && (VALID_MODES as readonly string[]).includes(raw)) {
+      return raw as PaperMode
+    }
+  } catch {
+    // localStorage may throw in private mode; fall through to default
+  }
+  return 'off'
+}
+
+function prefersDark(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) return false
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+/**
+ * Resolve a mode value to the actual class that should sit on <body>.
+ * `auto` flips with prefers-color-scheme; `off` returns null (no class).
+ */
+export function resolveBodyClass(mode: PaperMode): 'paper' | 'paper-night' | null {
+  switch (mode) {
+    case 'off':
+      return null
+    case 'paper':
+      return 'paper'
+    case 'paper-night':
+      return 'paper-night'
+    case 'auto':
+      return prefersDark() ? 'paper-night' : 'paper'
+  }
+}
+
+function applyBodyClass(klass: 'paper' | 'paper-night' | null) {
+  if (typeof document === 'undefined') return
+  const body = document.body
+  body.classList.remove('paper', 'paper-night')
+  if (klass) body.classList.add(klass)
+}
+
+export const usePaperThemeStore = defineStore('paperTheme', {
+  state: () => ({
+    mode: readStoredMode() as PaperMode,
+    // Tracks the prefers-color-scheme listener so we can clean up
+    _mediaListener: null as ((ev: MediaQueryListEvent) => void) | null,
+  }),
+  getters: {
+    isOn(state): boolean {
+      return state.mode !== 'off'
+    },
+    activeClass(state): 'paper' | 'paper-night' | null {
+      return resolveBodyClass(state.mode)
+    },
+  },
+  actions: {
+    /**
+     * Apply current mode to <body>. Idempotent.
+     * Also wires the prefers-color-scheme listener when in auto mode.
+     */
+    apply() {
+      applyBodyClass(this.activeClass)
+      this._wireAutoListener()
+    },
+    setMode(mode: PaperMode) {
+      this.mode = mode
+      try {
+        if (typeof window !== 'undefined') {
+          window.localStorage.setItem(STORAGE_KEY, mode)
+        }
+      } catch {
+        // ignore quota / private mode failures
+      }
+      this.apply()
+    },
+    toggleNight() {
+      // Quick toggle between light and night when Paper is on.
+      // Off/auto round-trip through paper.
+      if (this.mode === 'paper') this.setMode('paper-night')
+      else if (this.mode === 'paper-night') this.setMode('paper')
+      else this.setMode('paper')
+    },
+    enable() {
+      if (this.mode === 'off') this.setMode('paper')
+      else this.apply()
+    },
+    disable() {
+      this.setMode('off')
+    },
+    _wireAutoListener() {
+      if (typeof window === 'undefined' || !window.matchMedia) return
+      const mq = window.matchMedia('(prefers-color-scheme: dark)')
+      // Tear down previous listener if any
+      if (this._mediaListener) {
+        mq.removeEventListener?.('change', this._mediaListener)
+        this._mediaListener = null
+      }
+      if (this.mode !== 'auto') return
+      // Note: re-resolve from `this.mode` directly rather than the
+      // `activeClass` getter — the getter is memoized via Pinia/Vue reactivity
+      // and prefersDark() is not a reactive dependency, so it would return a
+      // stale value when the OS toggles its color scheme without the mode
+      // string itself changing.
+      const listener = () => applyBodyClass(resolveBodyClass(this.mode))
+      mq.addEventListener?.('change', listener)
+      this._mediaListener = listener
+    },
+  },
+})

--- a/frontend/taskdeck-web/src/store/paperThemeStore.ts
+++ b/frontend/taskdeck-web/src/store/paperThemeStore.ts
@@ -48,11 +48,16 @@ function applyBodyClass(klass: 'paper' | 'paper-night' | null) {
   if (klass) body.classList.add(klass)
 }
 
+// The prefers-color-scheme listener is module-scoped rather than living in
+// Pinia state. Functions in reactive state get proxied, leak into devtools
+// snapshots, and confuse $state cloning. We only ever need one listener at a
+// time; the store action below tears down the previous one before wiring a
+// new one.
+let mediaListener: ((ev: MediaQueryListEvent) => void) | null = null
+
 export const usePaperThemeStore = defineStore('paperTheme', {
   state: () => ({
     mode: readStoredMode() as PaperMode,
-    // Tracks the prefers-color-scheme listener so we can clean up
-    _mediaListener: null as ((ev: MediaQueryListEvent) => void) | null,
   }),
   getters: {
     isOn(state): boolean {
@@ -99,10 +104,10 @@ export const usePaperThemeStore = defineStore('paperTheme', {
     _wireAutoListener() {
       if (typeof window === 'undefined' || !window.matchMedia) return
       const mq = window.matchMedia('(prefers-color-scheme: dark)')
-      // Tear down previous listener if any
-      if (this._mediaListener) {
-        mq.removeEventListener?.('change', this._mediaListener)
-        this._mediaListener = null
+      // Tear down the previously-registered listener if any
+      if (mediaListener) {
+        mq.removeEventListener?.('change', mediaListener)
+        mediaListener = null
       }
       if (this.mode !== 'auto') return
       // Note: re-resolve from `this.mode` directly rather than the
@@ -112,7 +117,7 @@ export const usePaperThemeStore = defineStore('paperTheme', {
       // string itself changing.
       const listener = () => applyBodyClass(resolveBodyClass(this.mode))
       mq.addEventListener?.('change', listener)
-      this._mediaListener = listener
+      mediaListener = listener
     },
   },
 })

--- a/frontend/taskdeck-web/src/tests/store/paperThemeStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/paperThemeStore.spec.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { resolveBodyClass, usePaperThemeStore } from '../../store/paperThemeStore'
+
+const STORAGE_KEY = 'td.paper.mode'
+
+function setMatchMediaDark(isDark: boolean) {
+  const listeners = new Set<(ev: MediaQueryListEvent) => void>()
+  const mql = {
+    matches: isDark,
+    media: '(prefers-color-scheme: dark)',
+    addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'change' && typeof listener === 'function') {
+        listeners.add(listener as (ev: MediaQueryListEvent) => void)
+      }
+    },
+    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'change' && typeof listener === 'function') {
+        listeners.delete(listener as (ev: MediaQueryListEvent) => void)
+      }
+    },
+  }
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue(mql),
+  })
+  return {
+    fire(matches: boolean) {
+      // Real browsers update .matches before firing 'change'.
+      mql.matches = matches
+      listeners.forEach((l) => l({ matches } as MediaQueryListEvent))
+    },
+    listenerCount: () => listeners.size,
+  }
+}
+
+describe('paperThemeStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    window.localStorage.clear()
+    document.body.classList.remove('paper', 'paper-night')
+    setMatchMediaDark(false)
+  })
+
+  afterEach(() => {
+    document.body.classList.remove('paper', 'paper-night')
+  })
+
+  it('defaults to off when nothing stored', () => {
+    const store = usePaperThemeStore()
+    expect(store.mode).toBe('off')
+    expect(store.isOn).toBe(false)
+    expect(store.activeClass).toBeNull()
+  })
+
+  it('restores mode from localStorage', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'paper-night')
+    const store = usePaperThemeStore()
+    expect(store.mode).toBe('paper-night')
+    expect(store.activeClass).toBe('paper-night')
+  })
+
+  it('ignores invalid stored values', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'midnight')
+    const store = usePaperThemeStore()
+    expect(store.mode).toBe('off')
+  })
+
+  it('applies the paper class to <body> on apply()', () => {
+    const store = usePaperThemeStore()
+    store.setMode('paper')
+    expect(document.body.classList.contains('paper')).toBe(true)
+    expect(document.body.classList.contains('paper-night')).toBe(false)
+  })
+
+  it('replaces paper with paper-night cleanly', () => {
+    const store = usePaperThemeStore()
+    store.setMode('paper')
+    store.setMode('paper-night')
+    expect(document.body.classList.contains('paper')).toBe(false)
+    expect(document.body.classList.contains('paper-night')).toBe(true)
+  })
+
+  it('removes any paper class when set to off', () => {
+    const store = usePaperThemeStore()
+    store.setMode('paper-night')
+    store.setMode('off')
+    expect(document.body.classList.contains('paper')).toBe(false)
+    expect(document.body.classList.contains('paper-night')).toBe(false)
+  })
+
+  it('persists the mode to localStorage', () => {
+    const store = usePaperThemeStore()
+    store.setMode('paper-night')
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('paper-night')
+  })
+
+  it('toggleNight flips between paper and paper-night', () => {
+    const store = usePaperThemeStore()
+    store.setMode('paper')
+    store.toggleNight()
+    expect(store.mode).toBe('paper-night')
+    store.toggleNight()
+    expect(store.mode).toBe('paper')
+  })
+
+  it('toggleNight from off enables paper light first', () => {
+    const store = usePaperThemeStore()
+    store.toggleNight()
+    expect(store.mode).toBe('paper')
+  })
+
+  it('auto mode resolves to paper-night when prefers-color-scheme is dark', () => {
+    setMatchMediaDark(true)
+    const store = usePaperThemeStore()
+    store.setMode('auto')
+    expect(store.activeClass).toBe('paper-night')
+    expect(document.body.classList.contains('paper-night')).toBe(true)
+  })
+
+  it('auto mode resolves to paper when prefers-color-scheme is light', () => {
+    setMatchMediaDark(false)
+    const store = usePaperThemeStore()
+    store.setMode('auto')
+    expect(store.activeClass).toBe('paper')
+  })
+
+  it('auto mode reacts to live changes in prefers-color-scheme', () => {
+    const mq = setMatchMediaDark(false)
+    const store = usePaperThemeStore()
+    store.setMode('auto')
+    expect(document.body.classList.contains('paper')).toBe(true)
+    expect(mq.listenerCount()).toBe(1)
+    mq.fire(true)
+    // The body class is the source of truth for what the user sees.
+    // We deliberately bypass the activeClass getter here because Pinia
+    // memoizes it on state.mode and prefersDark() is not a reactive dep —
+    // see the comment in _wireAutoListener.
+    expect(document.body.classList.contains('paper-night')).toBe(true)
+    expect(document.body.classList.contains('paper')).toBe(false)
+    mq.fire(false)
+    expect(document.body.classList.contains('paper')).toBe(true)
+    expect(document.body.classList.contains('paper-night')).toBe(false)
+  })
+
+  it('cleans up the auto listener when leaving auto mode', () => {
+    const mq = setMatchMediaDark(false)
+    const store = usePaperThemeStore()
+    store.setMode('auto')
+    expect(mq.listenerCount()).toBe(1)
+    store.setMode('paper')
+    expect(mq.listenerCount()).toBe(0)
+  })
+
+  it('resolveBodyClass is pure and SSR-safe for off mode', () => {
+    expect(resolveBodyClass('off')).toBeNull()
+    expect(resolveBodyClass('paper')).toBe('paper')
+    expect(resolveBodyClass('paper-night')).toBe('paper-night')
+  })
+
+  it('survives localStorage throwing (private mode)', () => {
+    const original = window.localStorage.setItem
+    window.localStorage.setItem = vi.fn(() => {
+      throw new Error('quota')
+    })
+    try {
+      const store = usePaperThemeStore()
+      expect(() => store.setMode('paper')).not.toThrow()
+      expect(document.body.classList.contains('paper')).toBe(true)
+    } finally {
+      window.localStorage.setItem = original
+    }
+  })
+})

--- a/frontend/taskdeck-web/src/tests/store/paperThemeStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/paperThemeStore.spec.ts
@@ -5,33 +5,56 @@ import { resolveBodyClass, usePaperThemeStore } from '../../store/paperThemeStor
 const STORAGE_KEY = 'td.paper.mode'
 
 function setMatchMediaDark(isDark: boolean) {
-  const listeners = new Set<(ev: MediaQueryListEvent) => void>()
-  const mql = {
-    matches: isDark,
-    media: '(prefers-color-scheme: dark)',
-    addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
-      if (type === 'change' && typeof listener === 'function') {
-        listeners.add(listener as (ev: MediaQueryListEvent) => void)
-      }
-    },
-    removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => {
-      if (type === 'change' && typeof listener === 'function') {
-        listeners.delete(listener as (ev: MediaQueryListEvent) => void)
-      }
-    },
-  }
+  let currentMatches = isDark
+  const instances: Array<{
+    matches: boolean
+    listeners: Set<(ev: MediaQueryListEvent) => void>
+  }> = []
   Object.defineProperty(window, 'matchMedia', {
     configurable: true,
     writable: true,
-    value: vi.fn().mockReturnValue(mql),
+    value: vi.fn().mockImplementation(() => {
+      const instance = {
+        matches: currentMatches,
+        listeners: new Set<(ev: MediaQueryListEvent) => void>(),
+      }
+      instances.push(instance)
+      return {
+        get matches() {
+          return instance.matches
+        },
+        media: '(prefers-color-scheme: dark)',
+        addEventListener: (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+        ) => {
+          if (type === 'change' && typeof listener === 'function') {
+            instance.listeners.add(listener as (ev: MediaQueryListEvent) => void)
+          }
+        },
+        removeEventListener: (
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+        ) => {
+          if (type === 'change' && typeof listener === 'function') {
+            instance.listeners.delete(listener as (ev: MediaQueryListEvent) => void)
+          }
+        },
+      }
+    }),
   })
   return {
     fire(matches: boolean) {
       // Real browsers update .matches before firing 'change'.
-      mql.matches = matches
-      listeners.forEach((l) => l({ matches } as MediaQueryListEvent))
+      currentMatches = matches
+      instances.forEach((instance) => {
+        instance.matches = matches
+        instance.listeners.forEach((l) => l({ matches } as MediaQueryListEvent))
+      })
     },
-    listenerCount: () => listeners.size,
+    listenerCount: () =>
+      instances.reduce((count, instance) => count + instance.listeners.size, 0),
+    instanceCount: () => instances.length,
   }
 }
 
@@ -149,6 +172,7 @@ describe('paperThemeStore', () => {
     const store = usePaperThemeStore()
     store.setMode('auto')
     expect(mq.listenerCount()).toBe(1)
+    expect(mq.instanceCount()).toBeGreaterThanOrEqual(1)
     store.setMode('paper')
     expect(mq.listenerCount()).toBe(0)
   })

--- a/frontend/taskdeck-web/src/tests/store/paperThemeStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/paperThemeStore.spec.ts
@@ -167,6 +167,19 @@ describe('paperThemeStore', () => {
     expect(document.body.classList.contains('paper-night')).toBe(false)
   })
 
+  it('re-resolves auto mode whenever apply() runs after an OS theme change', () => {
+    const mq = setMatchMediaDark(false)
+    const store = usePaperThemeStore()
+    store.setMode('auto')
+    expect(document.body.classList.contains('paper')).toBe(true)
+
+    mq.fire(true)
+    store.apply()
+
+    expect(document.body.classList.contains('paper-night')).toBe(true)
+    expect(document.body.classList.contains('paper')).toBe(false)
+  })
+
   it('cleans up the auto listener when leaving auto mode', () => {
     const mq = setMatchMediaDark(false)
     const store = usePaperThemeStore()

--- a/frontend/taskdeck-web/src/views/PaperStyleGuideView.vue
+++ b/frontend/taskdeck-web/src/views/PaperStyleGuideView.vue
@@ -1,0 +1,283 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { usePaperThemeStore, type PaperMode } from '../store/paperThemeStore'
+
+const themeStore = usePaperThemeStore()
+
+const previewMode = ref<'paper' | 'paper-night'>(
+  themeStore.activeClass === 'paper-night' ? 'paper-night' : 'paper'
+)
+
+const previewClass = computed(() => previewMode.value)
+
+function flip(mode: 'paper' | 'paper-night') {
+  previewMode.value = mode
+}
+
+function setGlobal(mode: PaperMode) {
+  themeStore.setMode(mode)
+  if (mode === 'paper' || mode === 'paper-night') {
+    previewMode.value = mode
+  }
+}
+</script>
+
+<template>
+  <div class="sg-root">
+    <header class="sg-toolbar">
+      <h1>Paper &amp; Graphite styleguide</h1>
+      <div class="sg-toolbar-actions">
+        <span>Preview frame</span>
+        <button
+          type="button"
+          :aria-pressed="previewMode === 'paper'"
+          @click="flip('paper')"
+        >Light</button>
+        <button
+          type="button"
+          :aria-pressed="previewMode === 'paper-night'"
+          @click="flip('paper-night')"
+        >Night</button>
+        <span class="sg-divider" />
+        <span>Apply to app</span>
+        <button type="button" @click="setGlobal('off')">Off (Obsidian)</button>
+        <button type="button" @click="setGlobal('paper')">Paper</button>
+        <button type="button" @click="setGlobal('paper-night')">Night</button>
+        <button type="button" @click="setGlobal('auto')">Auto</button>
+      </div>
+    </header>
+
+    <section :class="['sg-frame', previewClass]">
+      <div class="sg-pad">
+        <h2 class="tk-display">Paper &amp; <em>Graphite</em>.</h2>
+        <p class="tk-lede">
+          A logbook kept in a quiet office. Cream paper, hairline rules, italic
+          serif headlines, a single seal-red ember accent that earns its place
+          on proposals, applied stamps, and decision moments.
+        </p>
+
+        <hr class="hr-double sg-rule" />
+
+        <h3 class="tk-eyebrow">Type scale</h3>
+        <div class="sg-stack">
+          <div><span class="tk-eyebrow">.tk-display</span><span class="tk-display">Today, you moved <em>nine cards.</em></span></div>
+          <div><span class="tk-eyebrow">.tk-h1</span><span class="tk-h1">Split <em>"Implement dark mode"</em> into <em>three smaller cards.</em></span></div>
+          <div><span class="tk-eyebrow">.tk-h2</span><span class="tk-h2">Provenance &amp; <em>side effects</em></span></div>
+          <div><span class="tk-eyebrow">.tk-h3</span><span class="tk-h3">Recently applied · undoable</span></div>
+          <div><span class="tk-eyebrow">.tk-lede</span><span class="tk-lede">Haiku read the card body, the linked design doc, and 7 prior activity entries on this board.</span></div>
+          <div><span class="tk-eyebrow">.tk-body</span><span class="tk-body">Original 4 comments stay on the archived parent.</span></div>
+          <div><span class="tk-eyebrow">.tk-meta</span><span class="tk-meta">2026-04-25 · 11:42 PT</span></div>
+          <div><span class="tk-eyebrow">.tk-serial</span><span class="tk-serial">REVIEW · #014 · LOCAL-FIRST</span></div>
+          <div><span class="tk-eyebrow">.tk-eyebrow</span><span class="tk-eyebrow">QUEUE · 3 AWAITING</span></div>
+          <div><span class="tk-eyebrow">.tk-ink-italic</span><span class="tk-ink-italic">a line for tomorrow</span></div>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Rules</h3>
+        <div class="sg-stack">
+          <hr class="hr-line" />
+          <hr class="hr-soft" />
+          <hr class="hr-double" />
+          <div class="rule-ledger sg-ledger-demo">
+            <span class="tk-body">First entry on the ledger book.</span>
+            <span class="tk-body">Second entry. Stripes every 28px.</span>
+            <span class="tk-body">Third entry. Mind the gap.</span>
+          </div>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Surfaces &amp; cards</h3>
+        <div class="sg-grid-3">
+          <div class="card sg-pad-tight"><span class="tk-eyebrow">.card</span><p class="tk-body">Lifted paper card with hairline border.</p></div>
+          <div class="card-lift sg-pad-tight"><span class="tk-eyebrow">.card-lift</span><p class="tk-body">Stronger lift — used for decision rails.</p></div>
+          <div class="well sg-pad-tight"><span class="tk-eyebrow">.well</span><p class="tk-body">Recessed surface for column wells.</p></div>
+          <div class="card halo-ember sg-pad-tight"><span class="tk-eyebrow" style="color: var(--ember)">.halo-ember</span><p class="tk-body">Active proposal halo.</p></div>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Tagstamps &amp; stamps</h3>
+        <div class="sg-row">
+          <span class="tagstamp" style="color: var(--ember)">PROPOSED · DIFF</span>
+          <span class="tagstamp" style="color: var(--applied)">APPLIED</span>
+          <span class="tagstamp" style="color: var(--overdue)">OVERDUE</span>
+          <span class="tagstamp" style="color: var(--mute)">DRAFT</span>
+        </div>
+        <div class="sg-row sg-stamps">
+          <span class="stamp ember">Proposed<b>Apr 25</b><span class="stamp-num">11:42 · #014</span></span>
+          <span class="stamp applied">Applied<b>Apr 25</b><span class="stamp-num">11:48 · #014</span></span>
+          <span class="stamp">Captured<b>Apr 25</b><span class="stamp-num">10:01 · #021</span></span>
+          <span class="stamp overdue">Overdue<b>3d</b><span class="stamp-num">past · #007</span></span>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Buttons &amp; kbd</h3>
+        <div class="sg-row">
+          <button class="pbtn" type="button">Default <span class="pkbd">⌫</span></button>
+          <button class="pbtn pbtn-primary" type="button">Primary <span class="pkbd">P</span></button>
+          <button class="pbtn pbtn-ember" type="button">Apply <span class="pkbd">⏎</span></button>
+          <button class="pbtn pbtn-ghost" type="button">Ghost</button>
+          <span class="pkbd">⌘</span>
+          <span class="pkbd">K</span>
+          <span class="pkbd-light pkbd">space</span>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Status pills</h3>
+        <div class="sg-row">
+          <span class="pstatus proposed">PROPOSED</span>
+          <span class="pstatus applied">APPLIED</span>
+          <span class="pstatus overdue">OVERDUE</span>
+          <span class="pstatus draft">DRAFT</span>
+          <span class="pstatus live">LIVE</span>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Diff strips</h3>
+        <div class="sg-stack">
+          <div class="diff-rem">- Implement dark mode</div>
+          <div class="diff-add">+ Tokens · darken &amp; QA</div>
+          <div class="diff-add">+ Components · mode switch</div>
+        </div>
+
+        <hr class="hr-line sg-rule" />
+
+        <h3 class="tk-eyebrow">Erasing reversibility line</h3>
+        <p class="tk-body">
+          <span class="erase-line">undo within 6 hours · single keystroke</span>
+        </p>
+
+        <footer class="tk-serial sg-footer">
+          STYLEGUIDE · PAPER &amp; GRAPHITE · {{ previewMode.toUpperCase() }}
+        </footer>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.sg-root {
+  min-height: 100vh;
+  background: var(--td-color-surface, #131313);
+  color: var(--td-text-primary, #fff);
+  padding: 16px;
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.sg-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  background: var(--td-surface-container, #201f1f);
+  border: 1px solid var(--td-border-default, #2a2a2a);
+  border-radius: 6px;
+}
+.sg-toolbar h1 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+}
+.sg-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--td-text-secondary, #c0bdb5);
+}
+.sg-toolbar button {
+  padding: 4px 10px;
+  font-size: 11px;
+  border-radius: 4px;
+  border: 1px solid var(--td-border-default, #2a2a2a);
+  background: var(--td-surface-container-low, #1c1b1b);
+  color: inherit;
+  cursor: pointer;
+}
+.sg-toolbar button[aria-pressed='true'] {
+  border-color: #a8421f;
+  color: #fff;
+  background: #a8421f33;
+}
+.sg-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--td-border-default, #2a2a2a);
+  margin: 0 4px;
+}
+
+/* Paper preview frame: scope variables/typography by adding the class below.
+   The frame is its own .paper / .paper-night so it works regardless of the
+   currently-applied global mode. */
+.sg-frame {
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--td-border-default, #2a2a2a);
+}
+.sg-pad {
+  padding: 36px 48px;
+  min-height: 600px;
+}
+
+.sg-rule {
+  margin: 28px 0;
+}
+.sg-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.sg-stack > div {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  align-items: baseline;
+  gap: 16px;
+}
+.sg-grid-3 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+.sg-pad-tight {
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.sg-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+}
+.sg-stamps {
+  margin-top: 18px;
+  gap: 28px;
+}
+.sg-ledger-demo {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 4px 12px;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+}
+.sg-ledger-demo > * {
+  height: 28px;
+  display: flex;
+  align-items: center;
+}
+.sg-footer {
+  display: block;
+  margin-top: 36px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+</style>

--- a/frontend/taskdeck-web/src/views/PaperStyleGuideView.vue
+++ b/frontend/taskdeck-web/src/views/PaperStyleGuideView.vue
@@ -93,17 +93,17 @@ function setGlobal(mode: PaperMode) {
           <div class="card sg-pad-tight"><span class="tk-eyebrow">.card</span><p class="tk-body">Lifted paper card with hairline border.</p></div>
           <div class="card-lift sg-pad-tight"><span class="tk-eyebrow">.card-lift</span><p class="tk-body">Stronger lift — used for decision rails.</p></div>
           <div class="well sg-pad-tight"><span class="tk-eyebrow">.well</span><p class="tk-body">Recessed surface for column wells.</p></div>
-          <div class="card halo-ember sg-pad-tight"><span class="tk-eyebrow" style="color: var(--ember)">.halo-ember</span><p class="tk-body">Active proposal halo.</p></div>
+          <div class="card halo-ember sg-pad-tight"><span class="tk-eyebrow sg-token-ember">.halo-ember</span><p class="tk-body">Active proposal halo.</p></div>
         </div>
 
         <hr class="hr-line sg-rule" />
 
         <h3 class="tk-eyebrow">Tagstamps &amp; stamps</h3>
         <div class="sg-row">
-          <span class="tagstamp" style="color: var(--ember)">PROPOSED · DIFF</span>
-          <span class="tagstamp" style="color: var(--applied)">APPLIED</span>
-          <span class="tagstamp" style="color: var(--overdue)">OVERDUE</span>
-          <span class="tagstamp" style="color: var(--mute)">DRAFT</span>
+          <span class="tagstamp sg-token-ember">PROPOSED · DIFF</span>
+          <span class="tagstamp sg-token-applied">APPLIED</span>
+          <span class="tagstamp sg-token-overdue">OVERDUE</span>
+          <span class="tagstamp sg-token-mute">DRAFT</span>
         </div>
         <div class="sg-row sg-stamps">
           <span class="stamp ember">Proposed<b>Apr 25</b><span class="stamp-num">11:42 · #014</span></span>
@@ -279,5 +279,17 @@ function setGlobal(mode: PaperMode) {
   margin-top: 36px;
   padding-top: 14px;
   border-top: 1px solid var(--line);
+}
+.sg-token-ember {
+  color: var(--ember);
+}
+.sg-token-applied {
+  color: var(--applied);
+}
+.sg-token-overdue {
+  color: var(--overdue);
+}
+.sg-token-mute {
+  color: var(--mute);
 }
 </style>


### PR DESCRIPTION
## Summary

First slice of the Paper & Graphite, Ember Edition overhaul (master tracker #996; this issue #997). Lands tokens, theme scope, store, and the styleguide; everything else in the overhaul depends on it.

- \`paper-tokens.css\` mirrors \`design_handoff_taskdeck_paper/paper/tokens.css\`. Variables and utility classes (\`.tk-*\`, \`.card\`, \`.stamp\`, \`.tagstamp\`, \`.diff-*\`, \`.erase-line\`, \`.pbtn\`, \`.pkbd\`, \`.pstatus\`, \`.halo-ember\`) are scoped under \`.paper\` / \`.paper-night\` so the current Obsidian (\`--td-*\`) tokens remain canonical until Paper is promoted.
- \`paperThemeStore\` (Pinia) exposes \`off\` / \`paper\` / \`paper-night\` / \`auto\` modes. Persists to \`localStorage\` (\`td.paper.mode\`), applies the body class, and wires a live \`prefers-color-scheme\` listener for auto mode. The listener resolves via \`resolveBodyClass(this.mode)\` directly because the cached Pinia getter is not invalidated by OS scheme changes (\`prefersDark()\` isn't a reactive dep).
- \`PaperStyleGuideView\` at \`/styleguide/paper\` renders every type utility, rule, surface, stamp, button, status pill, and diff strip in both themes side-by-side with toolbar buttons to flip preview vs apply globally. Public route — QA can hit it directly.
- 15 vitest cases cover default state, persistence, body-class apply/clear, auto-mode live response, listener teardown when leaving auto, and private-mode \`localStorage\` failure tolerance.

## Verification

- \`npm run typecheck\` clean
- \`npm run lint\` clean (only 6 pre-existing warnings, none in new code)
- 15 / 15 paperThemeStore unit tests passing
- Manual: \`/styleguide/paper\` renders both themes, toolbar applies global mode and persists across reload

## Test plan

- [x] vitest unit suite for paperThemeStore
- [ ] Manual smoke: load \`/styleguide/paper\` and flip preview + apply global mode
- [ ] Manual smoke: confirm existing routes still render in Obsidian when mode is \`off\`
- [ ] Adversarial review per the checklist on #997 — token scoping, no \`--td-*\` rename, FOUC, focus rings

Closes #997.