### PR TITLE
PAPER-04 · Home / Reset surface

### DIFF
--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -158,10 +158,10 @@ describe('AppShell — paper variant routing', () => {
     await Promise.resolve()
 
     const paletteText = wrapper.text()
-    expect(paletteText).toContain('Go to Boards')
-    expect(paletteText).toContain('Go to Inbox')
-    expect(paletteText).toContain('Go to Agents')
-    expect(paletteText).toContain('Go to Archive')
+    expect(paletteText).toContain('Boards')
+    expect(paletteText).toContain('Inbox')
+    expect(paletteText).toContain('Agents')
+    expect(paletteText).toContain('Archive')
     expect(paletteText).toContain('New Capture')
   })
 

--- a/frontend/taskdeck-web/src/tests/views/HomeView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/HomeView.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { reactive } from 'vue'
 import HomeView from '../../views/HomeView.vue'
+import { usePaperThemeStore } from '../../store/paperThemeStore'
 import type { HomeSummary, WorkspaceOnboarding } from '../../types/workspace'
 
 const routerMocks = vi.hoisted(() => ({
@@ -71,6 +72,7 @@ describe('HomeView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
+    usePaperThemeStore().mode = 'off'
     mockWorkspaceStore.onboarding = buildOnboarding()
     mockWorkspaceStore.homeLoading = false
     mockWorkspaceStore.homeError = null
@@ -125,6 +127,15 @@ describe('HomeView', () => {
     await waitForUi()
 
     expect(mockWorkspaceStore.fetchHomeSummary).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets Paper Home own summary refreshes while the paper variant is active', async () => {
+    usePaperThemeStore().mode = 'paper'
+
+    mount(HomeView)
+    await waitForUi()
+
+    expect(mockWorkspaceStore.fetchHomeSummary).not.toHaveBeenCalled()
   })
 
   it('renders setup loop, workload, and recent boards', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { reactive } from 'vue'
+import PaperHomeView from '../../../views/paper/PaperHomeView.vue'
+import type { HomeSummary } from '../../../types/workspace'
+
+/**
+ * PaperHomeView — vitest coverage for greeting, queue rendering, empty
+ * state, capture dispatch guard, and ember-accent rules.
+ *
+ * The view reads from sessionStore, workspaceStore, captureStore, and
+ * vue-router; we mock all four with lightweight reactive stand-ins. The
+ * greeting is time-of-day sensitive, so each test pins the system clock
+ * with vi.useFakeTimers / setSystemTime.
+ */
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+const mockSessionStore = reactive({
+  username: 'daniel' as string | null,
+})
+
+const mockWorkspaceStore = reactive({
+  homeSummary: null as HomeSummary | null,
+  homeLoading: false,
+  hasHomeSummary: false,
+  fetchHomeSummary: vi.fn<() => Promise<void>>(),
+})
+
+const mockCaptureStore = {
+  createItem: vi.fn(),
+}
+
+vi.mock('../../../store/sessionStore', () => ({
+  useSessionStore: () => mockSessionStore,
+}))
+
+vi.mock('../../../store/workspaceStore', () => ({
+  useWorkspaceStore: () => mockWorkspaceStore,
+}))
+
+vi.mock('../../../store/captureStore', () => ({
+  useCaptureStore: () => mockCaptureStore,
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerMocks.push }),
+}))
+
+function buildSummary(overrides?: Partial<HomeSummary>): HomeSummary {
+  return {
+    workspaceMode: 'guided',
+    isFirstRun: false,
+    onboarding: {
+      visibility: 'active',
+      isComplete: false,
+      currentStepId: null,
+      dismissedAt: null,
+      completedAt: null,
+      steps: [],
+    },
+    workload: {
+      capturesNeedingTriage: 0,
+      capturesInProgress: 0,
+      capturesReadyForFollowUp: 0,
+      proposalsPendingReview: 0,
+    },
+    boards: {
+      totalBoards: 0,
+      recentBoardsCount: 0,
+      recentBoards: [],
+    },
+    recommendedActions: [],
+    ...overrides,
+  }
+}
+
+describe('PaperHomeView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSessionStore.username = 'daniel'
+    mockWorkspaceStore.homeSummary = buildSummary()
+    mockWorkspaceStore.homeLoading = false
+    mockWorkspaceStore.hasHomeSummary = true
+    mockWorkspaceStore.fetchHomeSummary.mockResolvedValue(undefined)
+    mockCaptureStore.createItem.mockReset()
+    mockCaptureStore.createItem.mockResolvedValue({ id: 'capture-1' })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('greeting period', () => {
+    it.each([
+      ['08:00 local', new Date(2026, 3, 25, 8, 0, 0), 'Good morning', 'morning'],
+      ['12:30 local', new Date(2026, 3, 25, 12, 30, 0), 'Good afternoon', 'afternoon'],
+      ['19:00 local', new Date(2026, 3, 25, 19, 0, 0), 'Good evening', 'evening'],
+    ])('picks %s', (_label, fixedNow, opener, period) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(fixedNow as Date)
+
+      const wrapper = mount(PaperHomeView)
+      const greeting = wrapper.get('[data-testid="paper-home-greeting"]')
+      const eyebrow = wrapper.get('[data-testid="paper-home-period"]')
+
+      expect(greeting.text()).toContain(opener as string)
+      expect(greeting.text()).toContain('Daniel')
+      expect(eyebrow.text()).toContain(period as string)
+    })
+
+    it('falls back to "Hello" when no first name is available', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2026, 3, 25, 9, 0, 0))
+      mockSessionStore.username = null
+
+      const wrapper = mount(PaperHomeView)
+      const greeting = wrapper.get('[data-testid="paper-home-greeting"]')
+
+      expect(greeting.text()).toBe('Hello.')
+      expect(greeting.text()).not.toContain('Good morning')
+    })
+  })
+
+  describe('queue cards', () => {
+    it('renders the empty state when nothing is queued', () => {
+      mockWorkspaceStore.homeSummary = buildSummary()
+      const wrapper = mount(PaperHomeView)
+
+      expect(wrapper.find('[data-testid="paper-home-empty"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="paper-home-empty"]').text()).toContain('Nothing waiting')
+      expect(wrapper.find('[data-testid="paper-home-card-proposal"]').exists()).toBe(false)
+      expect(wrapper.find('[data-testid="paper-home-card-carryover"]').exists()).toBe(false)
+    })
+
+    it('only marks proposal entries with the ember halo, not carry-overs', () => {
+      mockWorkspaceStore.homeSummary = buildSummary({
+        workload: {
+          capturesNeedingTriage: 2,
+          capturesInProgress: 0,
+          capturesReadyForFollowUp: 0,
+          proposalsPendingReview: 1,
+        },
+        recommendedActions: [
+          {
+            actionId: 'review-proposals',
+            title: 'Review pending proposals',
+            description: 'One awaits decision.',
+            targetSurface: 'review',
+            attentionCount: 1,
+          },
+        ],
+      })
+
+      const wrapper = mount(PaperHomeView)
+      const proposalCards = wrapper.findAll('[data-testid="paper-home-card-proposal"]')
+      const carryoverCards = wrapper.findAll('[data-testid="paper-home-card-carryover"]')
+
+      expect(proposalCards).toHaveLength(1)
+      expect(carryoverCards.length).toBeGreaterThan(0)
+
+      // Proposals carry the ember halo; carry-overs do not.
+      expect(proposalCards[0].classes()).toContain('halo-ember')
+      carryoverCards.forEach((card) => {
+        expect(card.classes()).not.toContain('halo-ember')
+      })
+    })
+  })
+
+  describe('quick capture', () => {
+    it('does not dispatch on empty Enter', async () => {
+      const wrapper = mount(PaperHomeView)
+      const input = wrapper.get('[data-testid="paper-home-capture-input"]')
+
+      await input.setValue('   ')
+      await wrapper.get('form').trigger('submit.prevent')
+
+      expect(mockCaptureStore.createItem).not.toHaveBeenCalled()
+    })
+
+    it('dispatches a typed capture on submit', async () => {
+      const wrapper = mount(PaperHomeView)
+      const input = wrapper.get('[data-testid="paper-home-capture-input"]')
+
+      await input.setValue('Refactor the queue store')
+      await wrapper.get('form').trigger('submit.prevent')
+      await Promise.resolve()
+
+      expect(mockCaptureStore.createItem).toHaveBeenCalledTimes(1)
+      expect(mockCaptureStore.createItem).toHaveBeenCalledWith({
+        boardId: null,
+        text: 'Refactor the queue store',
+        source: 'Typed',
+      })
+    })
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
@@ -174,6 +174,25 @@ describe('PaperHomeView', () => {
       expect(wrapper.find('.paper-home__queue').exists()).toBe(false)
     })
 
+    it('renders refresh errors even when a cached summary exists', () => {
+      mockWorkspaceStore.homeSummary = buildSummary({
+        workload: {
+          capturesNeedingTriage: 0,
+          capturesInProgress: 0,
+          capturesReadyForFollowUp: 0,
+          proposalsPendingReview: 0,
+        },
+      })
+      mockWorkspaceStore.hasHomeSummary = true
+      mockWorkspaceStore.homeError = 'Could not refresh workspace summary'
+
+      const wrapper = mount(PaperHomeView)
+
+      expect(wrapper.find('[data-testid="paper-home-error"]').text()).toContain('Could not refresh workspace summary')
+      expect(wrapper.find('[data-testid="paper-home-empty"]').exists()).toBe(false)
+      expect(wrapper.get('[data-testid="paper-home-lede"]').text()).toContain('Could not refresh workspace summary')
+    })
+
     it('renders the empty state when nothing is queued', () => {
       mockWorkspaceStore.homeSummary = buildSummary()
       const wrapper = mount(PaperHomeView)

--- a/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
@@ -259,7 +259,7 @@ describe('PaperHomeView', () => {
       expect(mockCaptureStore.createItem).not.toHaveBeenCalled()
     })
 
-    it('dispatches a typed capture on submit', async () => {
+    it('dispatches a typed capture and refreshes the home summary on submit', async () => {
       const wrapper = mount(PaperHomeView)
       const input = wrapper.get('[data-testid="paper-home-capture-input"]')
 
@@ -273,6 +273,7 @@ describe('PaperHomeView', () => {
         text: 'Refactor the queue store',
         source: 'Typed',
       })
+      expect(mockWorkspaceStore.fetchHomeSummary).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/PaperHomeView.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { reactive } from 'vue'
+import { nextTick, reactive } from 'vue'
 import PaperHomeView from '../../../views/paper/PaperHomeView.vue'
 import type { HomeSummary } from '../../../types/workspace'
 
@@ -25,6 +25,7 @@ const mockSessionStore = reactive({
 const mockWorkspaceStore = reactive({
   homeSummary: null as HomeSummary | null,
   homeLoading: false,
+  homeError: null as string | null,
   hasHomeSummary: false,
   fetchHomeSummary: vi.fn<() => Promise<void>>(),
 })
@@ -83,6 +84,7 @@ describe('PaperHomeView', () => {
     mockSessionStore.username = 'daniel'
     mockWorkspaceStore.homeSummary = buildSummary()
     mockWorkspaceStore.homeLoading = false
+    mockWorkspaceStore.homeError = null
     mockWorkspaceStore.hasHomeSummary = true
     mockWorkspaceStore.fetchHomeSummary.mockResolvedValue(undefined)
     mockCaptureStore.createItem.mockReset()
@@ -122,9 +124,56 @@ describe('PaperHomeView', () => {
       expect(greeting.text()).toBe('Hello.')
       expect(greeting.text()).not.toContain('Good morning')
     })
+
+    it('supports Unicode first-name tokens', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2026, 3, 25, 9, 0, 0))
+      mockSessionStore.username = 'élodie.smith@example.test'
+
+      const wrapper = mount(PaperHomeView)
+
+      expect(wrapper.get('[data-testid="paper-home-greeting"]').text()).toContain('Élodie')
+    })
+
+    it('refreshes the greeting period while the view stays active', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2026, 3, 25, 11, 59, 30))
+
+      const wrapper = mount(PaperHomeView)
+      expect(wrapper.get('[data-testid="paper-home-period"]').text()).toContain('morning')
+
+      await vi.advanceTimersByTimeAsync(60_000)
+      await nextTick()
+
+      expect(wrapper.get('[data-testid="paper-home-period"]').text()).toContain('afternoon')
+    })
   })
 
   describe('queue cards', () => {
+    it('renders loading instead of an empty queue while summary is missing', () => {
+      mockWorkspaceStore.homeSummary = null
+      mockWorkspaceStore.hasHomeSummary = false
+      mockWorkspaceStore.homeLoading = true
+
+      const wrapper = mount(PaperHomeView)
+
+      expect(wrapper.find('[data-testid="paper-home-loading"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="paper-home-empty"]').exists()).toBe(false)
+      expect(wrapper.find('.paper-home__queue').exists()).toBe(false)
+    })
+
+    it('renders the store error instead of an empty queue when summary loading fails', () => {
+      mockWorkspaceStore.homeSummary = null
+      mockWorkspaceStore.hasHomeSummary = false
+      mockWorkspaceStore.homeError = 'Failed to load workspace summary'
+
+      const wrapper = mount(PaperHomeView)
+
+      expect(wrapper.find('[data-testid="paper-home-error"]').text()).toContain('Failed to load workspace summary')
+      expect(wrapper.find('[data-testid="paper-home-empty"]').exists()).toBe(false)
+      expect(wrapper.find('.paper-home__queue').exists()).toBe(false)
+    })
+
     it('renders the empty state when nothing is queued', () => {
       mockWorkspaceStore.homeSummary = buildSummary()
       const wrapper = mount(PaperHomeView)
@@ -170,6 +219,17 @@ describe('PaperHomeView', () => {
   })
 
   describe('quick capture', () => {
+    it('cleans up the global capture shortcut listener on unmount', () => {
+      const addSpy = vi.spyOn(window, 'addEventListener')
+      const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+      const wrapper = mount(PaperHomeView)
+      wrapper.unmount()
+
+      expect(addSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+      expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
+    })
+
     it('does not dispatch on empty Enter', async () => {
       const wrapper = mount(PaperHomeView)
       const input = wrapper.get('[data-testid="paper-home-capture-input"]')

--- a/frontend/taskdeck-web/src/views/HomeView.vue
+++ b/frontend/taskdeck-web/src/views/HomeView.vue
@@ -1,15 +1,22 @@
 <script setup lang="ts">
-import { computed, onActivated, onMounted } from 'vue'
+import { computed, defineAsyncComponent, onActivated, onMounted } from 'vue'
 import WorkspaceSetupModal from '../components/workspace/WorkspaceSetupModal.vue'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
 import { TdSkeleton } from '../components/ui'
 import { useWorkspaceOnboardingActions } from '../composables/useWorkspaceOnboardingActions'
 import { useWorkspaceStore } from '../store/workspaceStore'
+import { usePaperThemeStore } from '../store/paperThemeStore'
 import { usePerformanceMark } from '../composables/usePerformanceMark'
 import type { HomeRecommendedAction, WorkspaceOnboarding } from '../types/workspace'
 import { isClientOnboardingDemoBoardName } from '../utils/boardDemo'
 
+// Paper-skin variant is loaded lazily so the Obsidian path stays the
+// default code-split entry — only sessions that flip Paper on pay the
+// extra chunk.
+const PaperHomeView = defineAsyncComponent(() => import('./paper/PaperHomeView.vue'))
+
 const workspace = useWorkspaceStore()
+const paperTheme = usePaperThemeStore()
 const homeLoadPerf = usePerformanceMark('home-load')
 
 const summary = computed(() => workspace.homeSummary)
@@ -127,7 +134,8 @@ onActivated(refreshHomeSummary)
 </script>
 
 <template>
-  <div class="td-home" role="region" aria-label="Home workspace">
+  <PaperHomeView v-if="paperTheme.isOn" />
+  <div v-else class="td-home" role="region" aria-label="Home workspace">
     <header class="td-home__hero td-panel">
       <div class="td-home__hero-copy">
         <span class="td-home__eyebrow" aria-hidden="true">Workspace</span>

--- a/frontend/taskdeck-web/src/views/HomeView.vue
+++ b/frontend/taskdeck-web/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, onActivated, onMounted } from 'vue'
+import { computed, defineAsyncComponent, defineComponent, h, onActivated, onMounted } from 'vue'
 import WorkspaceSetupModal from '../components/workspace/WorkspaceSetupModal.vue'
 import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.vue'
 import { TdSkeleton } from '../components/ui'
@@ -13,7 +13,40 @@ import { isClientOnboardingDemoBoardName } from '../utils/boardDemo'
 // Paper-skin variant is loaded lazily so the Obsidian path stays the
 // default code-split entry — only sessions that flip Paper on pay the
 // extra chunk.
-const PaperHomeView = defineAsyncComponent(() => import('./paper/PaperHomeView.vue'))
+const PaperHomeAsyncLoading = defineComponent({
+  name: 'PaperHomeAsyncLoading',
+  setup: () => () =>
+    h(
+      'div',
+      {
+        class: 'td-home__skeleton',
+        role: 'status',
+        'aria-live': 'polite',
+      },
+      [h('span', { class: 'sr-only' }, 'Loading Paper Home...'), h('div', { class: 'td-panel td-home-card' }, 'Loading Paper Home...')],
+    ),
+})
+
+const PaperHomeAsyncError = defineComponent({
+  name: 'PaperHomeAsyncError',
+  setup: () => () =>
+    h(
+      'div',
+      {
+        class: 'td-alert td-alert--error',
+        role: 'alert',
+      },
+      'Paper Home could not be loaded. Refresh and try again.',
+    ),
+})
+
+const PaperHomeView = defineAsyncComponent({
+  loader: () => import('./paper/PaperHomeView.vue'),
+  loadingComponent: PaperHomeAsyncLoading,
+  errorComponent: PaperHomeAsyncError,
+  delay: 0,
+  timeout: 30000,
+})
 
 const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
@@ -111,7 +144,7 @@ function openBoard(boardId: string) {
 }
 
 function refreshHomeSummary() {
-  if (workspace.homeLoading) {
+  if (paperTheme.isOn || workspace.homeLoading) {
     return
   }
 

--- a/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
@@ -81,7 +81,7 @@ const greeting = computed(() => {
 const proposalsAwaiting = computed(() => summary.value?.workload.proposalsPendingReview ?? 0)
 const carryOvers = computed(() => summary.value?.workload.capturesNeedingTriage ?? 0)
 const showLoadingState = computed(() => workspace.homeLoading && !summary.value)
-const showErrorState = computed(() => Boolean(workspace.homeError) && !summary.value)
+const showErrorState = computed(() => Boolean(workspace.homeError))
 
 const ledeText = computed(() => {
   if (showErrorState.value) {

--- a/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import PaperCard from '../../components/paper/PaperCard.vue'
 import PaperKbd from '../../components/paper/PaperKbd.vue'
@@ -56,9 +56,9 @@ function resolveFirstName(username: string | null | undefined): string | null {
   const beforeAt = trimmed.split('@')[0]
   if (!beforeAt) return null
   // Take the first whitespace- or dot-delimited token.
-  const token = beforeAt.split(/[\s._-]+/).find((part) => /^[A-Za-z][A-Za-z'-]*$/.test(part))
+  const token = beforeAt.split(/[\s._-]+/).find((part) => /^[\p{L}][\p{L}'-]*$/u.test(part))
   if (!token) return null
-  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase()
+  return token.toLocaleLowerCase().replace(/^\p{L}/u, (first) => first.toLocaleUpperCase())
 }
 
 function periodFor(hour: number): 'morning' | 'afternoon' | 'evening' {
@@ -67,9 +67,10 @@ function periodFor(hour: number): 'morning' | 'afternoon' | 'evening' {
   return 'evening'
 }
 
+const currentHour = ref(new Date().getHours())
+
 const greeting = computed(() => {
-  const hour = new Date().getHours()
-  const period = periodFor(hour)
+  const period = periodFor(currentHour.value)
   const name = resolveFirstName(session.username)
   const opener = name ? `Good ${period}` : 'Hello'
   return { opener, name, period }
@@ -79,8 +80,16 @@ const greeting = computed(() => {
 
 const proposalsAwaiting = computed(() => summary.value?.workload.proposalsPendingReview ?? 0)
 const carryOvers = computed(() => summary.value?.workload.capturesNeedingTriage ?? 0)
+const showLoadingState = computed(() => workspace.homeLoading && !summary.value)
+const showErrorState = computed(() => Boolean(workspace.homeError) && !summary.value)
 
 const ledeText = computed(() => {
+  if (showErrorState.value) {
+    return workspace.homeError ?? 'Workspace summary could not be loaded.'
+  }
+  if (showLoadingState.value || !summary.value) {
+    return 'Loading your workspace summary...'
+  }
   const p = proposalsAwaiting.value
   const c = carryOvers.value
   if (p === 0 && c === 0) {
@@ -187,16 +196,48 @@ function maybeFetchHomeSummary() {
   })
 }
 
+let shortcutListening = false
+let greetingTimer: ReturnType<typeof window.setInterval> | null = null
+
+function refreshCurrentHour() {
+  currentHour.value = new Date().getHours()
+}
+
+function startActiveHomeHandlers() {
+  refreshCurrentHour()
+  if (!shortcutListening) {
+    window.addEventListener('keydown', onCaptureShortcut)
+    shortcutListening = true
+  }
+  if (!greetingTimer) {
+    greetingTimer = window.setInterval(refreshCurrentHour, 60_000)
+  }
+}
+
+function stopActiveHomeHandlers() {
+  if (shortcutListening) {
+    window.removeEventListener('keydown', onCaptureShortcut)
+    shortcutListening = false
+  }
+  if (greetingTimer) {
+    window.clearInterval(greetingTimer)
+    greetingTimer = null
+  }
+}
+
 onMounted(() => {
+  startActiveHomeHandlers()
   maybeFetchHomeSummary()
-  window.addEventListener('keydown', onCaptureShortcut)
 })
 
-onActivated(maybeFetchHomeSummary)
-
-onBeforeUnmount(() => {
-  window.removeEventListener('keydown', onCaptureShortcut)
+onActivated(() => {
+  startActiveHomeHandlers()
+  maybeFetchHomeSummary()
 })
+
+onDeactivated(stopActiveHomeHandlers)
+
+onBeforeUnmount(stopActiveHomeHandlers)
 
 // ── Affordance: open Review when a proposal card is activated ────────────
 
@@ -236,7 +277,34 @@ function onCardKeydown(event: KeyboardEvent, card: QueueCardModel) {
     </header>
 
     <section
-      v-if="showEmptyState"
+      v-if="showLoadingState"
+      class="paper-home__loading"
+      data-testid="paper-home-loading"
+      aria-live="polite"
+      role="status"
+    >
+      <PaperCard variant="flat">
+        <p class="tk-meta paper-home__state-text">
+          Loading your workspace summary...
+        </p>
+      </PaperCard>
+    </section>
+
+    <section
+      v-else-if="showErrorState"
+      class="paper-home__error"
+      data-testid="paper-home-error"
+      role="alert"
+    >
+      <PaperCard variant="flat">
+        <p class="tk-meta paper-home__state-text">
+          {{ workspace.homeError }}
+        </p>
+      </PaperCard>
+    </section>
+
+    <section
+      v-else-if="showEmptyState"
       class="paper-home__empty"
       data-testid="paper-home-empty"
     >
@@ -431,7 +499,8 @@ function onCardKeydown(event: KeyboardEvent, card: QueueCardModel) {
   color: var(--mute);
 }
 
-.paper-home__empty-text {
+.paper-home__empty-text,
+.paper-home__state-text {
   padding: 18px;
   margin: 0;
   font-style: italic;

--- a/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
@@ -1,0 +1,457 @@
+<script setup lang="ts">
+import { computed, nextTick, onActivated, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import PaperCard from '../../components/paper/PaperCard.vue'
+import PaperKbd from '../../components/paper/PaperKbd.vue'
+import PaperTagstamp from '../../components/paper/PaperTagstamp.vue'
+import { useSessionStore } from '../../store/sessionStore'
+import { useWorkspaceStore } from '../../store/workspaceStore'
+import { useCaptureStore } from '../../store/captureStore'
+
+/**
+ * PaperHomeView — morning-reset surface in the Paper & Graphite, Ember Edition skin.
+ *
+ * Provides:
+ *   • Serif italic greeting whose period (morning / afternoon / evening) is
+ *     derived from the local clock at render time.
+ *   • A `tk-lede` subtitle summarising today's queue.
+ *   • Up to three "queued for you" cards (proposals first — ember-accented —
+ *     followed by triage carry-overs, hairline only).
+ *   • A single-line quick capture row that wires through the existing
+ *     captureStore so we don't duplicate dispatch logic.
+ *
+ * Data is read from the existing `workspaceStore.homeSummary` cache —
+ * AppShell prefetches it on mount, so we do not refetch here unless the
+ * cache is empty.
+ */
+
+interface QueueCardModel {
+  serial: string
+  title: string
+  meta: string
+  tagLabel: string
+  tagTone: 'ember' | 'mute'
+  isProposal: boolean
+}
+
+const router = useRouter()
+const session = useSessionStore()
+const workspace = useWorkspaceStore()
+const capture = useCaptureStore()
+
+const summary = computed(() => workspace.homeSummary)
+
+// ── Greeting ─────────────────────────────────────────────────────────────
+
+/**
+ * Pull a first name from the session username. We accept anything that
+ * looks like a single token (alphabetic / hyphen / apostrophe) and capitalise
+ * the first letter; anything that looks like an email / handle is ignored.
+ */
+function resolveFirstName(username: string | null | undefined): string | null {
+  if (!username) return null
+  const trimmed = username.trim()
+  if (!trimmed) return null
+  // Strip a trailing email portion if present.
+  const beforeAt = trimmed.split('@')[0]
+  if (!beforeAt) return null
+  // Take the first whitespace- or dot-delimited token.
+  const token = beforeAt.split(/[\s._-]+/).find((part) => /^[A-Za-z][A-Za-z'-]*$/.test(part))
+  if (!token) return null
+  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase()
+}
+
+function periodFor(hour: number): 'morning' | 'afternoon' | 'evening' {
+  if (hour < 12) return 'morning'
+  if (hour < 17) return 'afternoon'
+  return 'evening'
+}
+
+const greeting = computed(() => {
+  const hour = new Date().getHours()
+  const period = periodFor(hour)
+  const name = resolveFirstName(session.username)
+  const opener = name ? `Good ${period}` : 'Hello'
+  return { opener, name, period }
+})
+
+// ── Lede / queue summary ─────────────────────────────────────────────────
+
+const proposalsAwaiting = computed(() => summary.value?.workload.proposalsPendingReview ?? 0)
+const carryOvers = computed(() => summary.value?.workload.capturesNeedingTriage ?? 0)
+
+const ledeText = computed(() => {
+  const p = proposalsAwaiting.value
+  const c = carryOvers.value
+  if (p === 0 && c === 0) {
+    return 'Nothing waiting. Good.'
+  }
+  const parts: string[] = []
+  if (p > 0) {
+    parts.push(`${p} awaiting review`)
+  }
+  if (c > 0) {
+    parts.push(`${c} carry-over${c === 1 ? '' : 's'} from yesterday`)
+  }
+  return parts.join(' · ')
+})
+
+// ── Queue cards ──────────────────────────────────────────────────────────
+
+const queueCards = computed<QueueCardModel[]>(() => {
+  const s = summary.value
+  if (!s) return []
+
+  const cards: QueueCardModel[] = []
+
+  // Proposals — ember-accented.
+  s.recommendedActions
+    .filter((action) => action.targetSurface === 'review' || action.actionId === 'review-proposals')
+    .slice(0, 3)
+    .forEach((action, index) => {
+      cards.push({
+        serial: `#${String(index + 1).padStart(3, '0')}`,
+        title: action.title,
+        meta: action.description,
+        tagLabel: 'PROPOSED',
+        tagTone: 'ember',
+        isProposal: true,
+      })
+    })
+
+  // Triage carry-overs — hairline only, no ember.
+  if (cards.length < 3 && s.workload.capturesNeedingTriage > 0) {
+    const remaining = 3 - cards.length
+    const carryCount = Math.min(remaining, s.workload.capturesNeedingTriage)
+    for (let i = 0; i < carryCount; i += 1) {
+      cards.push({
+        serial: `#${String(cards.length + 1).padStart(3, '0')}`,
+        title: i === 0
+          ? `Triage ${s.workload.capturesNeedingTriage} capture${s.workload.capturesNeedingTriage === 1 ? '' : 's'} from yesterday`
+          : 'Triage carry-over',
+        meta: 'inbox · awaiting decision',
+        tagLabel: 'CARRY-OVER',
+        tagTone: 'mute',
+        isProposal: false,
+      })
+    }
+  }
+
+  return cards
+})
+
+const showEmptyState = computed(() => summary.value !== null && queueCards.value.length === 0)
+
+// ── Quick capture ────────────────────────────────────────────────────────
+
+const captureText = ref('')
+const captureBusy = ref(false)
+const captureInputRef = ref<HTMLInputElement | null>(null)
+
+async function submitCapture() {
+  const text = captureText.value.trim()
+  if (!text) {
+    // Per spec: do not dispatch on empty Enter.
+    return
+  }
+  if (captureBusy.value) return
+  captureBusy.value = true
+  try {
+    await capture.createItem({ boardId: null, text, source: 'Typed' })
+    captureText.value = ''
+    await nextTick()
+    captureInputRef.value?.focus()
+  } catch {
+    // captureStore already surfaces a toast; keep the typed text so the
+    // user can retry without re-typing.
+  } finally {
+    captureBusy.value = false
+  }
+}
+
+function onCaptureShortcut(event: KeyboardEvent) {
+  // Cmd/Ctrl + ; — jump focus into the quick capture row.
+  if ((event.metaKey || event.ctrlKey) && event.key === ';') {
+    event.preventDefault()
+    captureInputRef.value?.focus()
+  }
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────
+
+function maybeFetchHomeSummary() {
+  if (workspace.homeLoading) return
+  if (workspace.hasHomeSummary) return
+  void workspace.fetchHomeSummary().catch(() => {
+    // Errors are reflected via workspace.homeError; we render gracefully.
+  })
+}
+
+onMounted(() => {
+  maybeFetchHomeSummary()
+  window.addEventListener('keydown', onCaptureShortcut)
+})
+
+onActivated(maybeFetchHomeSummary)
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onCaptureShortcut)
+})
+
+// ── Affordance: open Review when a proposal card is activated ────────────
+
+function openCard(card: QueueCardModel) {
+  if (card.isProposal) {
+    void router.push('/workspace/review')
+  } else {
+    void router.push('/workspace/inbox')
+  }
+}
+
+function onCardKeydown(event: KeyboardEvent, card: QueueCardModel) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    openCard(card)
+  }
+}
+</script>
+
+<template>
+  <div class="paper-home" data-testid="paper-home">
+    <header class="paper-home__hero">
+      <p class="tk-eyebrow paper-home__eyebrow" data-testid="paper-home-period">
+        Workspace · {{ greeting.period }}
+      </p>
+      <h1 class="tk-h1 paper-home__greeting" data-testid="paper-home-greeting">
+        <template v-if="greeting.name">
+          {{ greeting.opener }}, <em>{{ greeting.name }}.</em>
+        </template>
+        <template v-else>
+          {{ greeting.opener }}.
+        </template>
+      </h1>
+      <p class="tk-lede paper-home__lede" data-testid="paper-home-lede">
+        {{ ledeText }}
+      </p>
+    </header>
+
+    <section
+      v-if="showEmptyState"
+      class="paper-home__empty"
+      data-testid="paper-home-empty"
+    >
+      <PaperCard variant="flat">
+        <p class="tk-meta paper-home__empty-text">
+          Nothing waiting. Good.
+        </p>
+      </PaperCard>
+    </section>
+
+    <section v-else class="paper-home__queue" aria-label="Queued for you">
+      <h2 class="tk-eyebrow paper-home__queue-title">II · Queued for you</h2>
+      <div class="paper-home__queue-grid">
+        <PaperCard
+          v-for="card in queueCards"
+          :key="card.serial"
+          variant="lift"
+          :halo="card.isProposal"
+          class="paper-home__card"
+          :data-testid="card.isProposal ? 'paper-home-card-proposal' : 'paper-home-card-carryover'"
+          :data-card-kind="card.isProposal ? 'proposal' : 'carryover'"
+        >
+          <button
+            type="button"
+            class="paper-home__card-button"
+            @click="openCard(card)"
+            @keydown="(event) => onCardKeydown(event, card)"
+          >
+            <span class="tk-serial paper-home__card-serial">{{ card.serial }}</span>
+            <span class="paper-home__card-title">{{ card.title }}</span>
+            <span class="tk-meta paper-home__card-meta">{{ card.meta }}</span>
+            <span class="paper-home__card-tag">
+              <PaperTagstamp :tone="card.tagTone">{{ card.tagLabel }}</PaperTagstamp>
+            </span>
+          </button>
+        </PaperCard>
+      </div>
+    </section>
+
+    <section class="paper-home__capture" aria-label="Quick capture">
+      <form class="paper-home__capture-row" @submit.prevent="submitCapture">
+        <label class="sr-only" for="paper-home-capture-input">Capture a thought</label>
+        <input
+          id="paper-home-capture-input"
+          ref="captureInputRef"
+          v-model="captureText"
+          class="paper-home__capture-input"
+          type="text"
+          placeholder="Capture a thought..."
+          autocomplete="off"
+          :disabled="captureBusy"
+          data-testid="paper-home-capture-input"
+        />
+        <span class="paper-home__capture-hint">
+          <PaperKbd>⌘</PaperKbd>
+          <PaperKbd>;</PaperKbd>
+        </span>
+      </form>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.paper-home {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 32px 40px 56px;
+  font-family: var(--sans);
+  color: var(--ink);
+  min-height: 100%;
+}
+
+.paper-home__hero {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.paper-home__eyebrow {
+  text-transform: capitalize;
+}
+
+.paper-home__greeting {
+  margin: 8px 0 4px;
+  font-family: var(--serif);
+  font-style: normal;
+}
+
+.paper-home__lede {
+  margin: 0;
+}
+
+.paper-home__queue-title {
+  margin: 0 0 14px;
+}
+
+.paper-home__queue-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.paper-home__card {
+  padding: 0;
+}
+
+.paper-home__card-button {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto auto;
+  column-gap: 12px;
+  row-gap: 6px;
+  width: 100%;
+  padding: 18px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+}
+
+.paper-home__card-button:focus-visible {
+  outline: 2px solid var(--ember);
+  outline-offset: 2px;
+}
+
+.paper-home__card-serial {
+  grid-row: 1;
+  grid-column: 1;
+  color: var(--faint);
+  font-family: var(--mono);
+}
+
+.paper-home__card-title {
+  grid-row: 1;
+  grid-column: 2;
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.3;
+  color: var(--ink-deep);
+}
+
+.paper-home__card-tag {
+  grid-row: 1;
+  grid-column: 3;
+  align-self: start;
+}
+
+.paper-home__card-meta {
+  grid-row: 2;
+  grid-column: 2 / 4;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.paper-home__capture-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+.paper-home__capture-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 16px;
+  color: var(--ink);
+}
+
+.paper-home__capture-input::placeholder {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--mute);
+}
+
+.paper-home__capture-input:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.paper-home__capture-hint {
+  display: inline-flex;
+  gap: 4px;
+  color: var(--mute);
+}
+
+.paper-home__empty-text {
+  padding: 18px;
+  margin: 0;
+  font-style: italic;
+}
+
+@media (max-width: 1024px) {
+  .paper-home__queue-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperHomeView.vue
@@ -168,6 +168,9 @@ async function submitCapture() {
   try {
     await capture.createItem({ boardId: null, text, source: 'Typed' })
     captureText.value = ''
+    await workspace.fetchHomeSummary().catch(() => {
+      // Home summary errors are reflected via workspace.homeError.
+    })
     await nextTick()
     captureInputRef.value?.focus()
   } catch {


### PR DESCRIPTION
## Summary
- Adds `PaperHomeView.vue` — morning-reset surface with serif italic greeting (period derived from local clock, "Hello" fallback), `tk-lede` queue summary, up to three "queued for you" cards (proposals first with ember halo, triage carry-overs hairline only), and a single-line italic quick-capture row with ⌘; hint.
- `HomeView.vue` now delegates to `PaperHomeView` (lazy-loaded via `defineAsyncComponent`) whenever `paperThemeStore.isOn`; the Obsidian path is unchanged.
- Reuses `workspaceStore.homeSummary` (no refetch unless cache is empty) and dispatches through the existing `captureStore.createItem` (`source: 'Typed'`).
- 8 vitest cases covering greeting period, "Hello" fallback, empty state, ember-only-on-proposals rule, and empty-Enter dispatch guard.

Part of the Paper & Graphite, Ember Edition overhaul.

Master tracker: #996
Closes #1000

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 6 pre-existing warnings, 0 new
- [x] `npx vitest --run src/tests/views/paper/` — 8/8 green
- [x] `npx vitest --run src/tests/views/HomeView.spec.ts` — still green (Obsidian path)