### PR TITLE
PAPER-08 · Today / End-of-day dossier in Paper

### DIFF
--- a/frontend/taskdeck-web/src/composables/useTodayDossier.ts
+++ b/frontend/taskdeck-web/src/composables/useTodayDossier.ts
@@ -272,7 +272,7 @@ export function useTodayDossier(options: UseTodayDossierOptions = {}) {
     liveNow.value = new Date()
     const nextDay = new Date(liveNow.value)
     nextDay.setHours(24, 0, 0, 0)
-    const delay = Math.max(1_000, nextDay.getTime() - liveNow.value.getTime() + 1_000)
+    const delay = Math.max(0, nextDay.getTime() - liveNow.value.getTime())
     dayTimer = setTimeout(scheduleNextDayTick, delay)
   }
 

--- a/frontend/taskdeck-web/src/composables/useTodayDossier.ts
+++ b/frontend/taskdeck-web/src/composables/useTodayDossier.ts
@@ -1,0 +1,290 @@
+import { computed, ref, watch, type Ref } from 'vue'
+import { useWorkspaceStore } from '../store/workspaceStore'
+import type { TodaySummary } from '../types/workspace'
+
+/**
+ * useTodayDossier — composable that returns the data shape expected by
+ * `PaperTodayView` and its 9 sub-sections.  Wherever the live workspace
+ * `todaySummary` already provides a value (overdue cards, captures, etc.)
+ * we surface it; everything else is mocked behind clearly-marked stubs so
+ * the surface ships now and follow-up backend issues (#1015–#1018) can wire
+ * real data later.
+ *
+ * Stubs are deterministic given the same `now` so tests can exercise the
+ * shape without flake.  Components must continue to work with both stub
+ * and real data — never branch on whether a section is mocked.
+ */
+
+export type DossierLedgerWho = 'you' | 'haiku' | 'system'
+export type DossierLedgerTone = 'ember' | 'applied' | 'active' | 'passive' | 'mute'
+
+export interface DossierLedgerEntry {
+  serial: string
+  time: string
+  who: DossierLedgerWho
+  what: string
+  tone: DossierLedgerTone
+}
+
+export type DossierDecisionVerdict = 'applied' | 'rejected' | 'deferred'
+
+export interface DossierDecision {
+  serial: string
+  title: string
+  verdict: DossierDecisionVerdict
+  confidence: number
+  when: string
+  stale?: boolean
+}
+
+export interface DossierBoardLine {
+  name: string
+  moves: number
+  proposals: number
+}
+
+export interface DossierCarryOverCard {
+  serial: string
+  title: string
+  age: string
+  reason: string
+}
+
+export interface DossierStatCard {
+  id: 'cards-moved' | 'proposals-applied' | 'captures-triaged' | 'longest-focus' | 'overdue'
+  /** Numeric (or formatted) value used for the big italic-serif number. */
+  value: number | string
+  /** Whether `value` is a raw number that should run through Intl.NumberFormat. */
+  numeric: boolean
+  label: string
+  sub: string
+  tone: 'ink' | 'ember' | 'applied' | 'overdue'
+}
+
+export interface DossierCadence {
+  weights: number[]
+  peakHourIndex: number
+  firstAction: string
+  peakAction: string
+  lastAction: string
+}
+
+export interface DossierStreak {
+  cells: number[]
+  todayIndex: number
+  totalDays: number
+  longestThisYear: number
+}
+
+export interface DossierData {
+  serial: string
+  date: Date
+  headlineCardsMoved: number
+  lede: string
+  autoSealsIn: string
+  stats: DossierStatCard[]
+  cadence: DossierCadence
+  ledger: DossierLedgerEntry[]
+  decisions: DossierDecision[]
+  boards: DossierBoardLine[]
+  carryOver: DossierCarryOverCard[]
+  streak: DossierStreak
+  /** Initial value for the "line for tomorrow" text-area. */
+  lineForTomorrow: string
+}
+
+const DOSSIER_NUMBER_RE = /D-\d{4}-\d{2}-\d{2}-\d{3}/
+
+/**
+ * Format the dossier serial as `D-YYYY-MM-DD-NNN`.  `seq` defaults to 001;
+ * a real backend should hand in the per-day sequence number.
+ */
+export function formatDossierSerial(date: Date, seq = 1): string {
+  const yyyy = date.getFullYear().toString().padStart(4, '0')
+  const mm = (date.getMonth() + 1).toString().padStart(2, '0')
+  const dd = date.getDate().toString().padStart(2, '0')
+  const nnn = seq.toString().padStart(3, '0')
+  const serial = `D-${yyyy}-${mm}-${dd}-${nnn}`
+  // Light invariant — useful in dev, harmless in prod.
+  if (!DOSSIER_NUMBER_RE.test(serial)) {
+    throw new Error(`Invalid dossier serial: ${serial}`)
+  }
+  return serial
+}
+
+/** Stub data the surface falls back to when the backend is silent. */
+function buildStubDossier(now: Date, summary: TodaySummary | null): DossierData {
+  const overdueCount = summary?.summary.overdueCards ?? 2
+  const capturesTriaged = 11
+  const cardsMoved = 9
+  const proposalsApplied = 3
+
+  const stats: DossierStatCard[] = [
+    {
+      id: 'cards-moved',
+      value: cardsMoved,
+      numeric: true,
+      label: 'cards moved',
+      sub: '+2 vs your wk avg',
+      tone: 'ink',
+    },
+    {
+      id: 'proposals-applied',
+      value: proposalsApplied,
+      numeric: true,
+      label: 'proposals applied',
+      sub: 'of 4 reviewed · 75%',
+      tone: 'ember',
+    },
+    {
+      id: 'captures-triaged',
+      value: capturesTriaged,
+      numeric: true,
+      label: 'captures triaged',
+      sub: '0 left in inbox',
+      tone: 'ink',
+    },
+    {
+      id: 'longest-focus',
+      value: '2h 14m',
+      numeric: false,
+      label: 'focus time · longest',
+      sub: '13:02 — 15:16 · uninterrupted',
+      tone: 'applied',
+    },
+    {
+      id: 'overdue',
+      value: overdueCount,
+      numeric: true,
+      label: 'overdue',
+      sub: 'C-072, C-061',
+      tone: 'overdue',
+    },
+  ]
+
+  const cadenceWeights = [
+    0, 0, 0, 0, 0, 0, 0, 0,
+    1, 3, 2, 1, 3, 4, 2, 3, 4, 2,
+    0, 0, 0, 0, 0, 0,
+  ]
+
+  const cadence: DossierCadence = {
+    weights: cadenceWeights,
+    peakHourIndex: 13,
+    firstAction: '08:42 · capture',
+    peakAction: '13:00 — 14:00 · 7 events',
+    lastAction: '17:18 · seal',
+  }
+
+  const ledger: DossierLedgerEntry[] = [
+    { serial: 'L-018', time: '17:18', who: 'you', what: "Sealed proposal #011 · Set up CI → Done", tone: 'applied' },
+    { serial: 'L-017', time: '16:04', who: 'haiku', what: 'Proposed split · #014 · ready for review', tone: 'ember' },
+    { serial: 'L-016', time: '15:42', who: 'you', what: 'Triaged 7 captures into Product Backlog', tone: 'active' },
+    { serial: 'L-015', time: '15:16', who: 'you', what: 'End of focus block (2h 14m)', tone: 'passive' },
+    { serial: 'L-014', time: '13:55', who: 'haiku', what: 'Proposed merge of duplicates · #008 · rejected', tone: 'mute' },
+    { serial: 'L-013', time: '13:02', who: 'you', what: 'Started focus block · DnD off · 2h 14m', tone: 'active' },
+    { serial: 'L-012', time: '12:48', who: 'you', what: "Renamed board · 'Sprint 12 · QA'", tone: 'active' },
+    { serial: 'L-011', time: '11:42', who: 'you', what: 'Applied #014 · 3 cards land · undo 6h', tone: 'applied' },
+    { serial: 'L-010', time: '11:38', who: 'haiku', what: 'Proposed split · #014 · 0.84 confidence', tone: 'ember' },
+    { serial: 'L-009', time: '10:14', who: 'you', what: "Deferred #012 · 'Add Blocked column'", tone: 'passive' },
+    { serial: 'L-008', time: '09:18', who: 'you', what: "Applied #011 · 'Set up CI' → Done", tone: 'applied' },
+    { serial: 'L-007', time: '09:00', who: 'system', what: 'Day opened · 5 cards on Today board', tone: 'passive' },
+  ]
+
+  const decisions: DossierDecision[] = [
+    { serial: '#014', title: 'Split: Implement dark mode', verdict: 'applied', confidence: 0.84, when: '11:42' },
+    { serial: '#012', title: "Add 'Blocked' column", verdict: 'deferred', confidence: 0.71, when: '10:14' },
+    { serial: '#011', title: "Move 'Set up CI' → Done", verdict: 'applied', confidence: 0.91, when: '09:18' },
+    { serial: '#008', title: 'Merge duplicates', verdict: 'rejected', confidence: 0.62, when: 'yest', stale: true },
+  ]
+
+  const boards: DossierBoardLine[] = [
+    { name: 'Product Backlog', moves: 6, proposals: 2 },
+    { name: 'Sprint 12', moves: 3, proposals: 1 },
+    { name: 'Personal', moves: 1, proposals: 0 },
+    { name: 'Side projects', moves: 0, proposals: 0 },
+    { name: 'Notes & references', moves: 0, proposals: 0 },
+  ]
+
+  const carryOver: DossierCarryOverCard[] = [
+    { serial: 'C-072', title: 'Audit AA contrast on toasts', age: '3d overdue', reason: 'rolled over twice' },
+    { serial: 'C-061', title: 'Reply: design system intro', age: '1d overdue', reason: 'snoozed yesterday' },
+  ]
+
+  // 90 deterministic streak cells — last cell is "today".
+  const cells = Array.from({ length: 90 }, (_, i) => {
+    if (i === 89) return 4
+    if (i === 73) return 0
+    // Deterministic pseudo-random based on index
+    return ((i * 31) % 5)
+  })
+
+  const streak: DossierStreak = {
+    cells,
+    todayIndex: 89,
+    totalDays: 17,
+    longestThisYear: 23,
+  }
+
+  return {
+    serial: formatDossierSerial(now),
+    date: now,
+    headlineCardsMoved: cardsMoved,
+    lede:
+      "A quiet Saturday. You triaged the morning inbox, applied two of haiku's proposals, and closed the dark-mode hand-off. Two cards drifted past their due — bring them up tomorrow.",
+    autoSealsIn: '2h 18m',
+    stats,
+    cadence,
+    ledger,
+    decisions,
+    boards,
+    carryOver,
+    streak,
+    lineForTomorrow:
+      "Pick up the AA contrast audit first — it's been carried twice. Aim to seal Sprint 12 by Wednesday.",
+  }
+}
+
+export interface UseTodayDossierOptions {
+  /** Override "now" for tests so dossier serial is deterministic. */
+  now?: Ref<Date> | Date
+}
+
+export function useTodayDossier(options: UseTodayDossierOptions = {}) {
+  const workspace = useWorkspaceStore()
+  const fixedNow = options.now instanceof Date ? options.now : null
+  const now = computed<Date>(() => {
+    if (fixedNow) return fixedNow
+    if (options.now && 'value' in options.now) return options.now.value
+    return new Date()
+  })
+
+  const sealed = ref(false)
+
+  const dossier = computed<DossierData>(() => buildStubDossier(now.value, workspace.todaySummary))
+
+  // Keep `dossier.serial` in lock-step with the current date even when
+  // tests advance the clock by re-assigning the now ref.
+  watch(now, () => {
+    /* recompute via getter */
+  })
+
+  function sealDay(): { sealed: boolean; alreadySealed: boolean } {
+    if (sealed.value) {
+      return { sealed: true, alreadySealed: true }
+    }
+    sealed.value = true
+    return { sealed: true, alreadySealed: false }
+  }
+
+  function resetSealForTesting() {
+    sealed.value = false
+  }
+
+  return {
+    dossier,
+    sealed,
+    sealDay,
+    resetSealForTesting,
+  }
+}

--- a/frontend/taskdeck-web/src/composables/useTodayDossier.ts
+++ b/frontend/taskdeck-web/src/composables/useTodayDossier.ts
@@ -100,9 +100,7 @@ const DOSSIER_NUMBER_RE = /D-\d{4}-\d{2}-\d{2}-\d{3}/
  * a real backend should hand in the per-day sequence number.
  */
 export function formatDossierSerial(date: Date, seq = 1): string {
-  const yyyy = date.getFullYear().toString().padStart(4, '0')
-  const mm = (date.getMonth() + 1).toString().padStart(2, '0')
-  const dd = date.getDate().toString().padStart(2, '0')
+  const { yyyy, mm, dd } = formatLocalDossierDateParts(date)
   const nnn = seq.toString().padStart(3, '0')
   const serial = `D-${yyyy}-${mm}-${dd}-${nnn}`
   // Light invariant — useful in dev, harmless in prod.
@@ -110,6 +108,19 @@ export function formatDossierSerial(date: Date, seq = 1): string {
     throw new Error(`Invalid dossier serial: ${serial}`)
   }
   return serial
+}
+
+export function formatLocalDossierDate(date: Date): string {
+  const { yyyy, mm, dd } = formatLocalDossierDateParts(date)
+  return `${yyyy}-${mm}-${dd}`
+}
+
+function formatLocalDossierDateParts(date: Date): { yyyy: string; mm: string; dd: string } {
+  return {
+    yyyy: date.getFullYear().toString().padStart(4, '0'),
+    mm: (date.getMonth() + 1).toString().padStart(2, '0'),
+    dd: date.getDate().toString().padStart(2, '0'),
+  }
 }
 
 /** Stub data the surface falls back to when the backend is silent. */

--- a/frontend/taskdeck-web/src/composables/useTodayDossier.ts
+++ b/frontend/taskdeck-web/src/composables/useTodayDossier.ts
@@ -38,6 +38,7 @@ export interface DossierDecision {
 }
 
 export interface DossierBoardLine {
+  id: string
   name: string
   moves: number
   proposals: number
@@ -210,11 +211,11 @@ function buildStubDossier(now: Date, summary: TodaySummary | null): DossierData 
   ]
 
   const boards: DossierBoardLine[] = [
-    { name: 'Product Backlog', moves: 6, proposals: 2 },
-    { name: 'Sprint 12', moves: 3, proposals: 1 },
-    { name: 'Personal', moves: 1, proposals: 0 },
-    { name: 'Side projects', moves: 0, proposals: 0 },
-    { name: 'Notes & references', moves: 0, proposals: 0 },
+    { id: 'product-backlog', name: 'Product Backlog', moves: 6, proposals: 2 },
+    { id: 'sprint-12', name: 'Sprint 12', moves: 3, proposals: 1 },
+    { id: 'personal', name: 'Personal', moves: 1, proposals: 0 },
+    { id: 'side-projects', name: 'Side projects', moves: 0, proposals: 0 },
+    { id: 'notes-references', name: 'Notes & references', moves: 0, proposals: 0 },
   ]
 
   const carryOver: DossierCarryOverCard[] = [

--- a/frontend/taskdeck-web/src/composables/useTodayDossier.ts
+++ b/frontend/taskdeck-web/src/composables/useTodayDossier.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, type Ref } from 'vue'
+import { computed, ref, type Ref } from 'vue'
 import { useWorkspaceStore } from '../store/workspaceStore'
 import type { TodaySummary } from '../types/workspace'
 
@@ -262,12 +262,6 @@ export function useTodayDossier(options: UseTodayDossierOptions = {}) {
   const sealed = ref(false)
 
   const dossier = computed<DossierData>(() => buildStubDossier(now.value, workspace.todaySummary))
-
-  // Keep `dossier.serial` in lock-step with the current date even when
-  // tests advance the clock by re-assigning the now ref.
-  watch(now, () => {
-    /* recompute via getter */
-  })
 
   function sealDay(): { sealed: boolean; alreadySealed: boolean } {
     if (sealed.value) {

--- a/frontend/taskdeck-web/src/composables/useTodayDossier.ts
+++ b/frontend/taskdeck-web/src/composables/useTodayDossier.ts
@@ -1,4 +1,4 @@
-import { computed, ref, type Ref } from 'vue'
+import { computed, onScopeDispose, ref, type Ref } from 'vue'
 import { useWorkspaceStore } from '../store/workspaceStore'
 import type { TodaySummary } from '../types/workspace'
 
@@ -265,10 +265,32 @@ export interface UseTodayDossierOptions {
 export function useTodayDossier(options: UseTodayDossierOptions = {}) {
   const workspace = useWorkspaceStore()
   const fixedNow = options.now instanceof Date ? options.now : null
+  const liveNow = ref(new Date())
+  let dayTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleNextDayTick() {
+    liveNow.value = new Date()
+    const nextDay = new Date(liveNow.value)
+    nextDay.setHours(24, 0, 0, 0)
+    const delay = Math.max(1_000, nextDay.getTime() - liveNow.value.getTime() + 1_000)
+    dayTimer = setTimeout(scheduleNextDayTick, delay)
+  }
+
+  if (!fixedNow && !options.now) {
+    scheduleNextDayTick()
+  }
+
+  onScopeDispose(() => {
+    if (dayTimer) {
+      clearTimeout(dayTimer)
+      dayTimer = null
+    }
+  })
+
   const now = computed<Date>(() => {
     if (fixedNow) return fixedNow
     if (options.now && 'value' in options.now) return options.now.value
-    return new Date()
+    return liveNow.value
   })
 
   const sealed = ref(false)

--- a/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
@@ -93,7 +93,7 @@ describe('PaperTodayView', () => {
 
     expect(wrapper.find('[data-testid="dossier-serial"]').text()).toContain('2026-04-25')
 
-    vi.advanceTimersByTime(2_000)
+    await vi.advanceTimersByTimeAsync(1_000)
     await wrapper.vm.$nextTick()
 
     expect(wrapper.find('[data-testid="dossier-serial"]').text()).toContain('2026-04-26')

--- a/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import PaperTodayView from '../../../../views/paper/PaperTodayView.vue'
+
+const mockWorkspaceStore = {
+  todaySummary: null,
+}
+
+vi.mock('../../../../store/workspaceStore', () => ({
+  useWorkspaceStore: () => mockWorkspaceStore,
+}))
+
+describe('PaperTodayView', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  it('smoke renders the dossier with all 9 sections present', () => {
+    const wrapper = mount(PaperTodayView)
+
+    expect(wrapper.find('[data-paper-today]').exists()).toBe(true)
+
+    // Sections we expect to land on the page (exposed via data-section)
+    const expected = [
+      'cover',
+      'stats',
+      'cadence',
+      'ledger',
+      'decisions',
+      'boards',
+      'carry-over',
+      'streak',
+      'line-for-tomorrow',
+    ]
+    for (const section of expected) {
+      expect(wrapper.find(`[data-section="${section}"]`).exists()).toBe(true)
+    }
+  })
+
+  it('renders the dossier serial in the cover and footer', () => {
+    const wrapper = mount(PaperTodayView)
+    const serial = wrapper.find('[data-testid="dossier-serial"]').text()
+    expect(serial).toMatch(/^D-\d{4}-\d{2}-\d{2}-\d{3}$/)
+    // Footer also surfaces the same serial token
+    expect(wrapper.text()).toContain(serial)
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
@@ -6,15 +6,23 @@ import PaperTodayView from '../../../../views/paper/PaperTodayView.vue'
 const mockWorkspaceStore = {
   todaySummary: null,
 }
+const mockSessionStore = {
+  userId: 'user-1' as string | null,
+}
 
 vi.mock('../../../../store/workspaceStore', () => ({
   useWorkspaceStore: () => mockWorkspaceStore,
+}))
+
+vi.mock('../../../../store/sessionStore', () => ({
+  useSessionStore: () => mockSessionStore,
 }))
 
 describe('PaperTodayView', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     localStorage.clear()
+    mockSessionStore.userId = 'user-1'
   })
 
   it('smoke renders the dossier with all 9 sections present', () => {
@@ -45,5 +53,25 @@ describe('PaperTodayView', () => {
     expect(serial).toMatch(/^D-\d{4}-\d{2}-\d{2}-\d{3}$/)
     // Footer also surfaces the same serial token
     expect(wrapper.text()).toContain(serial)
+  })
+
+  it('scopes line-for-tomorrow storage by user and dossier date', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    localStorage.setItem(`td.paper.line-for-tomorrow:user-1:${today}`, 'user-one note')
+    localStorage.setItem(`td.paper.line-for-tomorrow:user-2:${today}`, 'user-two note')
+
+    const wrapper = mount(PaperTodayView)
+    const input = wrapper.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]')
+
+    expect(input.element.value).toBe('user-one note')
+    expect(input.element.value).not.toBe('user-two note')
+  })
+
+  it('does not advertise unimplemented global shortcuts in the footer', () => {
+    const wrapper = mount(PaperTodayView)
+
+    expect(wrapper.text()).not.toContain('PRESS S TO SEAL')
+    expect(wrapper.text()).not.toContain('⌘L FOR LEDGER')
+    expect(wrapper.text()).toContain('SEAL ABOVE')
   })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
+import { formatLocalDossierDate } from '../../../../composables/useTodayDossier'
 import PaperTodayView from '../../../../views/paper/PaperTodayView.vue'
 
 const mockWorkspaceStore = {
@@ -56,7 +57,7 @@ describe('PaperTodayView', () => {
   })
 
   it('scopes line-for-tomorrow storage by user and dossier date', () => {
-    const today = new Date().toISOString().slice(0, 10)
+    const today = formatLocalDossierDate(new Date())
     localStorage.setItem(`td.paper.line-for-tomorrow:user-1:${today}`, 'user-one note')
     localStorage.setItem(`td.paper.line-for-tomorrow:user-2:${today}`, 'user-two note')
 
@@ -73,5 +74,11 @@ describe('PaperTodayView', () => {
     expect(wrapper.text()).not.toContain('PRESS S TO SEAL')
     expect(wrapper.text()).not.toContain('⌘L FOR LEDGER')
     expect(wrapper.text()).toContain('SEAL ABOVE')
+  })
+
+  it('formats dossier storage dates from local calendar parts', () => {
+    const localEvening = new Date(2026, 3, 25, 23, 30)
+
+    expect(formatLocalDossierDate(localEvening)).toBe('2026-04-25')
   })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/PaperTodayView.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { formatLocalDossierDate } from '../../../../composables/useTodayDossier'
@@ -24,6 +24,10 @@ describe('PaperTodayView', () => {
     setActivePinia(createPinia())
     localStorage.clear()
     mockSessionStore.userId = 'user-1'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('smoke renders the dossier with all 9 sections present', () => {
@@ -80,5 +84,18 @@ describe('PaperTodayView', () => {
     const localEvening = new Date(2026, 3, 25, 23, 30)
 
     expect(formatLocalDossierDate(localEvening)).toBe('2026-04-25')
+  })
+
+  it('rolls the dossier serial to the next local day in long-lived sessions', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 25, 23, 59, 59))
+    const wrapper = mount(PaperTodayView)
+
+    expect(wrapper.find('[data-testid="dossier-serial"]').text()).toContain('2026-04-25')
+
+    vi.advanceTimersByTime(2_000)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="dossier-serial"]').text()).toContain('2026-04-26')
   })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayBoards.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayBoards.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayBoards from '../../../../views/paper/today/TodayBoards.vue'
+import type { DossierBoardLine } from '../../../../composables/useTodayDossier'
+
+describe('TodayBoards', () => {
+  it('uses stable board ids so duplicate names do not trigger duplicate key warnings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const boards: DossierBoardLine[] = [
+      { id: 'board-a', name: 'Operations', moves: 2, proposals: 1 },
+      { id: 'board-b', name: 'Operations', moves: 1, proposals: 0 },
+    ]
+
+    const wrapper = mount(TodayBoards, { props: { boards } })
+
+    expect(wrapper.findAll('.today-board')).toHaveLength(2)
+    expect(warn.mock.calls.flat().join(' ')).not.toContain('Duplicate keys')
+    warn.mockRestore()
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayCadence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayCadence.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayCadence from '../../../../views/paper/today/TodayCadence.vue'
+import type { DossierCadence } from '../../../../composables/useTodayDossier'
+
+const CADENCE: DossierCadence = {
+  weights: Array.from({ length: 24 }, (_, i) => (i === 13 ? 4 : i % 5)),
+  peakHourIndex: 13,
+  firstAction: '08:00 · capture',
+  peakAction: '13:00 · 7 events',
+  lastAction: '17:00 · seal',
+}
+
+const ORIGINAL_MATCH_MEDIA = window.matchMedia
+
+function setReducedMotion(prefers: boolean) {
+  // Stub matchMedia for the prefers-reduced-motion query.
+  // Other queries fall back to the default implementation.
+  window.matchMedia = vi.fn().mockImplementation((query: string) => {
+    if (query === '(prefers-reduced-motion: reduce)') {
+      return {
+        matches: prefers,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      } as unknown as MediaQueryList
+    }
+    return {
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    } as unknown as MediaQueryList
+  })
+}
+
+describe('TodayCadence', () => {
+  beforeEach(() => {
+    setReducedMotion(false)
+  })
+
+  afterEach(() => {
+    window.matchMedia = ORIGINAL_MATCH_MEDIA
+  })
+
+  it('renders 24 SVG bars (one per hour)', () => {
+    const wrapper = mount(TodayCadence, { props: { cadence: CADENCE } })
+    const bars = wrapper.findAll('rect.today-cadence__bar')
+    expect(bars).toHaveLength(24)
+  })
+
+  it('marks the peak hour bar with data-peak', () => {
+    const wrapper = mount(TodayCadence, { props: { cadence: CADENCE } })
+    const peak = wrapper.findAll('rect.today-cadence__bar').find(b => b.attributes('data-peak') === 'true')
+    expect(peak?.attributes('data-hour')).toBe('13')
+  })
+
+  it('disables the ember pulse when prefers-reduced-motion is on', async () => {
+    setReducedMotion(true)
+    const wrapper = mount(TodayCadence, { props: { cadence: CADENCE } })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.today-cadence').attributes('data-pulse')).toBe('off')
+  })
+
+  it('keeps the ember pulse on when reduced motion is not requested', async () => {
+    setReducedMotion(false)
+    const wrapper = mount(TodayCadence, { props: { cadence: CADENCE } })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.today-cadence').attributes('data-pulse')).toBe('on')
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayCadence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayCadence.spec.ts
@@ -57,6 +57,17 @@ describe('TodayCadence', () => {
     expect(bars).toHaveLength(24)
   })
 
+  it('renders 24 aligned hour labels for the 24-hour strip', () => {
+    const wrapper = mount(TodayCadence, { props: { cadence: CADENCE } })
+    const labels = wrapper.findAll('.today-cadence__label')
+    expect(labels).toHaveLength(24)
+    expect(labels[0]?.text()).toBe('00')
+    expect(labels[6]?.text()).toBe('06')
+    expect(labels[12]?.text()).toBe('12')
+    expect(labels[18]?.text()).toBe('18')
+    expect(labels[23]?.text()).toBe('23')
+  })
+
   it('marks the peak hour bar with data-peak', () => {
     const wrapper = mount(TodayCadence, { props: { cadence: CADENCE } })
     const peak = wrapper.findAll('rect.today-cadence__bar').find(b => b.attributes('data-peak') === 'true')

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayCover.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayCover.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayCover from '../../../../views/paper/today/TodayCover.vue'
+import { formatDossierSerial } from '../../../../composables/useTodayDossier'
+
+describe('TodayCover', () => {
+  it('renders the dossier serial in D-YYYY-MM-DD-NNN format', () => {
+    const date = new Date('2026-04-25T10:00:00Z')
+    const serial = formatDossierSerial(date)
+    expect(serial).toMatch(/^D-\d{4}-\d{2}-\d{2}-\d{3}$/)
+    expect(serial).toBe('D-2026-04-25-001')
+
+    const wrapper = mount(TodayCover, {
+      props: {
+        serial,
+        cardsMoved: 9,
+        lede: 'A quiet Saturday.',
+        autoSealsIn: '2h 18m',
+        sealed: false,
+      },
+    })
+    expect(wrapper.find('[data-testid="dossier-serial"]').text()).toBe(serial)
+  })
+
+  it('rejects invalid serials at format-time', () => {
+    // Defensive — formatDossierSerial validates its own output
+    expect(() => formatDossierSerial(new Date('2026-04-25T10:00:00Z'), 1)).not.toThrow()
+  })
+
+  it('shows "Auto-seals in …" when not sealed and "Sealed for the day" when sealed', async () => {
+    const wrapper = mount(TodayCover, {
+      props: {
+        serial: 'D-2026-04-25-001',
+        cardsMoved: 9,
+        lede: 'lede',
+        autoSealsIn: '2h 18m',
+        sealed: false,
+      },
+    })
+    expect(wrapper.find('[data-testid="auto-seals-in"]').text()).toContain('Auto-seals in 2h 18m')
+
+    await wrapper.setProps({ sealed: true })
+    expect(wrapper.find('[data-testid="auto-seals-in"]').text()).toContain('Sealed for the day')
+  })
+
+  it('seal button emits seal event each click; parent decides idempotency', async () => {
+    // The cover is a dumb component: it always emits `seal`.  The parent
+    // (PaperTodayView) keeps idempotency by calling sealDay() which is a
+    // no-op the second time.
+    const wrapper = mount(TodayCover, {
+      props: {
+        serial: 'D-2026-04-25-001',
+        cardsMoved: 9,
+        lede: 'lede',
+        autoSealsIn: '2h 18m',
+        sealed: false,
+      },
+    })
+    const sealBtn = wrapper.find('[data-action="seal"]')
+    await sealBtn.trigger('click')
+    expect(wrapper.emitted('seal')).toHaveLength(1)
+  })
+
+  it('seal click while already sealed is a parent-level no-op (idempotent contract)', () => {
+    // Verifies the contract by exercising the composable's sealDay() —
+    // which is what PaperTodayView calls.  Second invocation reports
+    // alreadySealed: true so the toast can become "already sealed".
+    vi.resetModules()
+    return import('../../../../composables/useTodayDossier').then(async ({ useTodayDossier }) => {
+      const { setActivePinia, createPinia } = await import('pinia')
+      setActivePinia(createPinia())
+      const { sealDay } = useTodayDossier()
+      const first = sealDay()
+      const second = sealDay()
+      expect(first.alreadySealed).toBe(false)
+      expect(second.alreadySealed).toBe(true)
+    })
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayLineForTomorrow.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayLineForTomorrow.spec.ts
@@ -52,4 +52,20 @@ describe('TodayLineForTomorrow', () => {
     const text = (b.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]').element).value
     expect(text).toBe('persisted')
   })
+
+  it('reloads from storage when the scoped storage key changes', async () => {
+    localStorage.setItem(`${KEY}:user-a`, 'user a line')
+    localStorage.setItem(`${KEY}:user-b`, 'user b line')
+
+    const wrapper = mount(TodayLineForTomorrow, {
+      props: { storageKey: `${KEY}:user-a`, debounceMs: 50, initial: '' },
+    })
+    const input = wrapper.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]')
+    expect(input.element.value).toBe('user a line')
+
+    await wrapper.setProps({ storageKey: `${KEY}:user-b` })
+    await wrapper.vm.$nextTick()
+
+    expect(input.element.value).toBe('user b line')
+  })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayLineForTomorrow.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayLineForTomorrow.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayLineForTomorrow from '../../../../views/paper/today/TodayLineForTomorrow.vue'
+
+const KEY = 'td.test.line-for-tomorrow'
+
+describe('TodayLineForTomorrow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('autosaves on debounce after typing', async () => {
+    const wrapper = mount(TodayLineForTomorrow, {
+      props: { storageKey: KEY, debounceMs: 100, initial: '' },
+    })
+    const input = wrapper.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]')
+    await input.setValue('AA contrast first')
+
+    // Status flips to "Saving…" before timer fires
+    expect(wrapper.find('[data-testid="line-for-tomorrow-status"]').text()).toContain('Saving')
+    expect(localStorage.getItem(KEY)).toBe(null)
+
+    // Advance debounce
+    vi.advanceTimersByTime(150)
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem(KEY)).toBe('AA contrast first')
+    expect(wrapper.find('[data-testid="line-for-tomorrow-status"]').text()).toContain('Saved')
+    expect(wrapper.emitted('save')?.[0]).toEqual(['AA contrast first'])
+  })
+
+  it('persists across remount via the same storage key', async () => {
+    // First mount writes
+    const a = mount(TodayLineForTomorrow, {
+      props: { storageKey: KEY, debounceMs: 50, initial: '' },
+    })
+    await a.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]').setValue('persisted')
+    vi.advanceTimersByTime(75)
+    await a.vm.$nextTick()
+    expect(localStorage.getItem(KEY)).toBe('persisted')
+    a.unmount()
+
+    // Second mount reads back
+    const b = mount(TodayLineForTomorrow, {
+      props: { storageKey: KEY, debounceMs: 50, initial: '' },
+    })
+    const text = (b.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]').element).value
+    expect(text).toBe('persisted')
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayLineForTomorrow.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayLineForTomorrow.spec.ts
@@ -34,6 +34,31 @@ describe('TodayLineForTomorrow', () => {
     expect(wrapper.emitted('save')?.[0]).toEqual(['AA contrast first'])
   })
 
+  it('reports save failures without emitting a successful save', async () => {
+    const originalLocalStorage = window.localStorage
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(() => {
+          throw new Error('quota')
+        }),
+      },
+    })
+    const wrapper = mount(TodayLineForTomorrow, {
+      props: { storageKey: KEY, debounceMs: 100, initial: '' },
+    })
+    const input = wrapper.find<HTMLTextAreaElement>('[data-testid="line-for-tomorrow-input"]')
+
+    await input.setValue('AA contrast first')
+    vi.advanceTimersByTime(150)
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-testid="line-for-tomorrow-status"]').text()).toContain('Save unavailable')
+    expect(wrapper.emitted('save')).toBeUndefined()
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: originalLocalStorage })
+  })
+
   it('persists across remount via the same storage key', async () => {
     // First mount writes
     const a = mount(TodayLineForTomorrow, {

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayStats.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayStats.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayStats from '../../../../views/paper/today/TodayStats.vue'
+import type { DossierStatCard } from '../../../../composables/useTodayDossier'
+
+const STATS: DossierStatCard[] = [
+  { id: 'cards-moved', value: 12345, numeric: true, label: 'cards moved', sub: '', tone: 'ink' },
+  { id: 'proposals-applied', value: 3, numeric: true, label: 'proposals applied', sub: '', tone: 'ember' },
+  { id: 'captures-triaged', value: 11, numeric: true, label: 'captures triaged', sub: '', tone: 'ink' },
+  { id: 'longest-focus', value: '2h 14m', numeric: false, label: 'focus', sub: '', tone: 'applied' },
+  { id: 'overdue', value: 2, numeric: true, label: 'overdue', sub: '', tone: 'overdue' },
+]
+
+describe('TodayStats', () => {
+  it('formats numeric values via Intl.NumberFormat', () => {
+    const wrapper = mount(TodayStats, { props: { stats: STATS, locale: 'en-US' } })
+    const values = wrapper.findAll('[data-testid="stat-value"]').map(n => n.text())
+    expect(values[0]).toBe('12,345')
+    expect(values[1]).toBe('3')
+    expect(values[2]).toBe('11')
+    // String pass-through
+    expect(values[3]).toBe('2h 14m')
+    expect(values[4]).toBe('2')
+  })
+
+  it('respects the provided locale separator', () => {
+    const wrapper = mount(TodayStats, {
+      props: {
+        stats: [{ id: 'cards-moved', value: 12345, numeric: true, label: 'x', sub: '', tone: 'ink' }],
+        locale: 'de-DE',
+      },
+    })
+    // de-DE uses '.' as thousands separator.
+    expect(wrapper.find('[data-testid="stat-value"]').text()).toBe('12.345')
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/today/TodayStreak.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/today/TodayStreak.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TodayStreak from '../../../../views/paper/today/TodayStreak.vue'
+import type { DossierStreak } from '../../../../composables/useTodayDossier'
+
+function makeStreak(overrides: Partial<DossierStreak> = {}): DossierStreak {
+  // Deterministic intensity: each cell is index modulo 5 -> buckets 0..4
+  const cells = Array.from({ length: 90 }, (_, i) => i % 5)
+  return {
+    cells,
+    todayIndex: 89,
+    totalDays: 17,
+    longestThisYear: 23,
+    ...overrides,
+  }
+}
+
+describe('TodayStreak', () => {
+  it('renders 90 cells in the grid', () => {
+    const wrapper = mount(TodayStreak, { props: { streak: makeStreak() } })
+    const cells = wrapper.findAll('.today-streak__cell')
+    expect(cells).toHaveLength(90)
+  })
+
+  it('highlights only the today cell', () => {
+    const wrapper = mount(TodayStreak, { props: { streak: makeStreak() } })
+    const cells = wrapper.findAll('.today-streak__cell')
+    const todayCells = cells.filter(c => c.attributes('data-today') === 'true')
+    expect(todayCells).toHaveLength(1)
+    expect(cells[89].classes()).toContain('today-streak__cell--today')
+  })
+
+  it('buckets intensity deterministically based on cell value', () => {
+    // Same input → same output, no randomness in the component itself.
+    const wrapper1 = mount(TodayStreak, { props: { streak: makeStreak() } })
+    const wrapper2 = mount(TodayStreak, { props: { streak: makeStreak() } })
+    const buckets1 = wrapper1.findAll('.today-streak__cell').map(c => c.attributes('data-bucket'))
+    const buckets2 = wrapper2.findAll('.today-streak__cell').map(c => c.attributes('data-bucket'))
+    expect(buckets1).toEqual(buckets2)
+    // Spot-check the modulo pattern
+    expect(buckets1[0]).toBe('0')
+    expect(buckets1[1]).toBe('1')
+    expect(buckets1[4]).toBe('4')
+    expect(buckets1[5]).toBe('0')
+  })
+})

--- a/frontend/taskdeck-web/src/views/TodayView.vue
+++ b/frontend/taskdeck-web/src/views/TodayView.vue
@@ -5,6 +5,8 @@ import WorkspaceHelpCallout from '../components/workspace/WorkspaceHelpCallout.v
 import { TdSkeleton } from '../components/ui'
 import { useWorkspaceOnboardingActions } from '../composables/useWorkspaceOnboardingActions'
 import { useWorkspaceStore } from '../store/workspaceStore'
+import { usePaperThemeStore } from '../store/paperThemeStore'
+import PaperTodayView from './paper/PaperTodayView.vue'
 import type {
   HomeRecommendedAction,
   TodayAgendaCard,
@@ -12,6 +14,7 @@ import type {
 } from '../types/workspace'
 
 const workspace = useWorkspaceStore()
+const paperTheme = usePaperThemeStore()
 
 const summary = computed(() => workspace.todaySummary)
 const onboarding = computed<WorkspaceOnboarding | null>(() => summary.value?.onboarding ?? workspace.onboarding)
@@ -208,7 +211,8 @@ onActivated(refreshTodaySummary)
 </script>
 
 <template>
-  <div class="td-today" role="region" aria-label="Today agenda">
+  <PaperTodayView v-if="paperTheme.isOn" />
+  <div v-else class="td-today" role="region" aria-label="Today agenda">
     <header class="td-today__hero td-panel">
       <div class="td-today__hero-copy">
         <span class="td-today__eyebrow" aria-hidden="true">Daily Agenda</span>

--- a/frontend/taskdeck-web/src/views/paper/PaperTodayView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperTodayView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useTodayDossier } from '../../composables/useTodayDossier'
+import { formatLocalDossierDate, useTodayDossier } from '../../composables/useTodayDossier'
 import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
 
@@ -31,7 +31,7 @@ const toast = useToastStore()
 const ledgerEntryCount = computed(() => dossier.value.ledger.length)
 const lineForTomorrowStorageKey = computed(() => {
   const userPart = encodeURIComponent(session.userId?.trim() || 'anonymous')
-  const dayPart = dossier.value.date.toISOString().slice(0, 10)
+  const dayPart = formatLocalDossierDate(dossier.value.date)
   return `td.paper.line-for-tomorrow:${userPart}:${dayPart}`
 })
 

--- a/frontend/taskdeck-web/src/views/paper/PaperTodayView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperTodayView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useTodayDossier } from '../../composables/useTodayDossier'
+import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
 
 import TodayCover from './today/TodayCover.vue'
@@ -24,9 +25,15 @@ import TodayLineForTomorrow from './today/TodayLineForTomorrow.vue'
  * .isOn`.
  */
 const { dossier, sealed, sealDay } = useTodayDossier()
+const session = useSessionStore()
 const toast = useToastStore()
 
 const ledgerEntryCount = computed(() => dossier.value.ledger.length)
+const lineForTomorrowStorageKey = computed(() => {
+  const userPart = encodeURIComponent(session.userId?.trim() || 'anonymous')
+  const dayPart = dossier.value.date.toISOString().slice(0, 10)
+  return `td.paper.line-for-tomorrow:${userPart}:${dayPart}`
+})
 
 function onSeal() {
   const result = sealDay()
@@ -126,14 +133,17 @@ function onPinCarryOver(serials: string[]) {
             <h3 class="tk-h3 paper-today__section-title">A line for tomorrow</h3>
             <span class="tk-meta paper-today__section-sub">A note your tomorrow-self will see at first open</span>
           </header>
-          <TodayLineForTomorrow :initial="dossier.lineForTomorrow" />
+          <TodayLineForTomorrow
+            :initial="dossier.lineForTomorrow"
+            :storage-key="lineForTomorrowStorageKey"
+          />
         </div>
       </div>
     </section>
 
     <footer class="paper-today__footer">
       <span class="tk-serial">DOSSIER · {{ dossier.serial }} · YEAR LEDGER</span>
-      <span class="tk-serial">PRESS S TO SEAL · ⌘L FOR LEDGER</span>
+      <span class="tk-serial">SEAL ABOVE · LEDGER IN § II</span>
     </footer>
   </div>
 </template>

--- a/frontend/taskdeck-web/src/views/paper/PaperTodayView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperTodayView.vue
@@ -1,0 +1,220 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useTodayDossier } from '../../composables/useTodayDossier'
+import { useToastStore } from '../../store/toastStore'
+
+import TodayCover from './today/TodayCover.vue'
+import TodayStats from './today/TodayStats.vue'
+import TodayCadence from './today/TodayCadence.vue'
+import TodayLedger from './today/TodayLedger.vue'
+import TodayDecisions from './today/TodayDecisions.vue'
+import TodayBoards from './today/TodayBoards.vue'
+import TodayCarryOver from './today/TodayCarryOver.vue'
+import TodayStreak from './today/TodayStreak.vue'
+import TodayLineForTomorrow from './today/TodayLineForTomorrow.vue'
+
+/**
+ * PaperTodayView — orchestrator for the Paper "Today / End-of-day dossier".
+ * Reads stub data from `useTodayDossier` (real backend wiring tracked under
+ * #1015–#1018) and arranges the 9 dossier sections into a 1.5fr / 1fr
+ * two-column body.
+ *
+ * The Obsidian `TodayView` continues to render when paper mode is off; the
+ * `TodayView.vue` shell delegates to this component when `paperThemeStore
+ * .isOn`.
+ */
+const { dossier, sealed, sealDay } = useTodayDossier()
+const toast = useToastStore()
+
+const ledgerEntryCount = computed(() => dossier.value.ledger.length)
+
+function onSeal() {
+  const result = sealDay()
+  if (result.alreadySealed) {
+    toast.info('Day is already sealed.')
+    return
+  }
+  toast.success('Day sealed. The dossier is archived.')
+}
+
+function onWriteNote() {
+  // Note-writing surface lives outside this slice; we surface a hint so
+  // the affordance is discoverable.
+  toast.info('Notes will land in tomorrow’s morning briefing.')
+}
+
+function onPinCarryOver(serials: string[]) {
+  toast.success(`Pinned ${serials.length} card${serials.length === 1 ? '' : 's'} to tomorrow.`)
+}
+</script>
+
+<template>
+  <div class="paper-today" data-paper-today>
+    <TodayCover
+      :serial="dossier.serial"
+      :cards-moved="dossier.headlineCardsMoved"
+      :lede="dossier.lede"
+      :auto-seals-in="dossier.autoSealsIn"
+      :sealed="sealed"
+      @seal="onSeal"
+      @note="onWriteNote"
+    />
+
+    <TodayStats :stats="dossier.stats" />
+
+    <section class="paper-today__body">
+      <div class="paper-today__col paper-today__col--left">
+        <div class="card paper-today__card">
+          <header class="paper-today__section-head">
+            <span class="tk-serial paper-today__section-num">§ I</span>
+            <h3 class="tk-h3 paper-today__section-title">Cadence</h3>
+            <span class="tk-meta paper-today__section-sub">When you worked · 24h strip</span>
+          </header>
+          <TodayCadence :cadence="dossier.cadence" />
+        </div>
+
+        <div class="card paper-today__card paper-today__card--ledger">
+          <header class="paper-today__section-head paper-today__section-head--inline">
+            <span class="tk-serial paper-today__section-num">§ II</span>
+            <h3 class="tk-h3 paper-today__section-title">Ledger</h3>
+            <span class="tk-meta paper-today__section-sub">Every meaningful event today · {{ ledgerEntryCount }} entries</span>
+          </header>
+          <TodayLedger :entries="dossier.ledger" />
+        </div>
+
+        <div class="card paper-today__card">
+          <header class="paper-today__section-head">
+            <span class="tk-serial paper-today__section-num">§ III</span>
+            <h3 class="tk-h3 paper-today__section-title">Decisions</h3>
+            <span class="tk-meta paper-today__section-sub">Proposals you weighed today</span>
+          </header>
+          <TodayDecisions :decisions="dossier.decisions" />
+        </div>
+      </div>
+
+      <div class="paper-today__col paper-today__col--right">
+        <div class="card paper-today__card">
+          <header class="paper-today__section-head">
+            <span class="tk-serial paper-today__section-num">§ IV</span>
+            <h3 class="tk-h3 paper-today__section-title">Boards touched</h3>
+            <span class="tk-meta paper-today__section-sub">Touch summary</span>
+          </header>
+          <TodayBoards :boards="dossier.boards" />
+        </div>
+
+        <div class="card paper-today__card paper-today__card--carry">
+          <header class="paper-today__section-head">
+            <span class="tk-serial paper-today__section-num">§ V</span>
+            <h3 class="tk-h3 paper-today__section-title">Carry-over</h3>
+            <span class="tk-meta paper-today__section-sub">Bring to tomorrow · {{ dossier.carryOver.length }} cards</span>
+          </header>
+          <TodayCarryOver :cards="dossier.carryOver" @pin="onPinCarryOver" />
+        </div>
+
+        <div class="card paper-today__card paper-today__card--streak">
+          <header class="paper-today__section-head">
+            <span class="tk-serial paper-today__section-num">§ VI</span>
+            <h3 class="tk-h3 paper-today__section-title">Streak</h3>
+            <span class="tk-meta paper-today__section-sub">Days in a row · this quarter</span>
+          </header>
+          <TodayStreak :streak="dossier.streak" />
+        </div>
+
+        <div class="card paper-today__card">
+          <header class="paper-today__section-head">
+            <span class="tk-serial paper-today__section-num">§ VII</span>
+            <h3 class="tk-h3 paper-today__section-title">A line for tomorrow</h3>
+            <span class="tk-meta paper-today__section-sub">A note your tomorrow-self will see at first open</span>
+          </header>
+          <TodayLineForTomorrow :initial="dossier.lineForTomorrow" />
+        </div>
+      </div>
+    </section>
+
+    <footer class="paper-today__footer">
+      <span class="tk-serial">DOSSIER · {{ dossier.serial }} · YEAR LEDGER</span>
+      <span class="tk-serial">PRESS S TO SEAL · ⌘L FOR LEDGER</span>
+    </footer>
+  </div>
+</template>
+
+<style scoped>
+.paper-today {
+  display: flex;
+  flex-direction: column;
+  background: var(--paper);
+  color: var(--ink);
+  min-height: 100%;
+}
+
+.paper-today__body {
+  padding: 20px 56px 0;
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 28px;
+}
+.paper-today__col {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.paper-today__card {
+  padding: 22px;
+}
+.paper-today__card--ledger {
+  padding: 0;
+  overflow: hidden;
+}
+.paper-today__card--carry {
+  border-color: var(--overdue);
+  border-left: 2px solid var(--overdue);
+}
+.paper-today__card--streak {
+  background: var(--paper-2);
+}
+
+.paper-today__section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.paper-today__card--ledger .paper-today__section-head--inline {
+  margin-bottom: 0;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.paper-today__section-num {
+  color: var(--faint);
+}
+.paper-today__section-title {
+  margin: 0;
+  font-size: 17px;
+}
+.paper-today__section-sub {
+  margin-left: auto;
+}
+
+.paper-today__footer {
+  padding: 30px 56px 20px;
+  margin-top: 36px;
+  border-top: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+@media (max-width: 1100px) {
+  .paper-today__body {
+    grid-template-columns: 1fr;
+    padding: 20px 24px 0;
+  }
+  .paper-today__footer {
+    padding: 24px 24px 16px;
+  }
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayBoards.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayBoards.vue
@@ -25,7 +25,7 @@ const summary = computed(() => {
     </div>
     <div
       v-for="board in boards"
-      :key="board.name"
+      :key="board.id"
       class="today-board"
       :class="{ 'today-board--dim': board.moves === 0 && board.proposals === 0 }"
     >

--- a/frontend/taskdeck-web/src/views/paper/today/TodayBoards.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayBoards.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import PaperTagstamp from '../../../components/paper/PaperTagstamp.vue'
+import type { DossierBoardLine } from '../../../composables/useTodayDossier'
+
+/**
+ * TodayBoards — list of boards touched today, with move counts and a
+ * "N PROP" pill when proposals exist.  Boards with zero moves and zero
+ * proposals are dimmed.
+ */
+const props = defineProps<{
+  boards: DossierBoardLine[]
+}>()
+
+const summary = computed(() => {
+  const touched = props.boards.filter(b => b.moves > 0 || b.proposals > 0).length
+  return { touched, total: props.boards.length }
+})
+</script>
+
+<template>
+  <div class="today-boards" data-section="boards">
+    <div class="tk-eyebrow today-boards__summary">
+      {{ summary.touched }} of {{ summary.total }} touched today
+    </div>
+    <div
+      v-for="board in boards"
+      :key="board.name"
+      class="today-board"
+      :class="{ 'today-board--dim': board.moves === 0 && board.proposals === 0 }"
+    >
+      <span class="today-board__name">{{ board.name }}</span>
+      <span class="tk-meta today-board__moves">
+        <template v-if="board.moves > 0">
+          <b>{{ board.moves }}</b> moves
+        </template>
+        <template v-else>—</template>
+      </span>
+      <span class="today-board__prop">
+        <PaperTagstamp v-if="board.proposals > 0" tone="ember">{{ board.proposals }} PROP</PaperTagstamp>
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-boards__summary {
+  margin-bottom: 8px;
+}
+.today-board {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 10px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: center;
+}
+.today-board--dim {
+  opacity: 0.55;
+}
+.today-board__name {
+  font-family: var(--serif);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink-deep);
+}
+.today-board--dim .today-board__name {
+  color: var(--mute);
+}
+.today-board__moves {
+  font-size: 11px;
+}
+.today-board__moves b {
+  color: var(--ink);
+}
+.today-board__prop {
+  min-width: 72px;
+  text-align: right;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayCadence.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayCadence.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import type { DossierCadence } from '../../../composables/useTodayDossier'
+
+/**
+ * TodayCadence — 24-hour activity strip rendered as 24 SVG bars (one per
+ * hour).  The peak hour glows ember and pulses gently — but only when
+ * the user hasn't asked for reduced motion.  The pulse lives in CSS,
+ * keyed off a `data-pulse="off"` attribute we set when `prefers-reduced-
+ * motion: reduce` matches.
+ */
+const props = defineProps<{
+  cadence: DossierCadence
+}>()
+
+const HOUR_LABELS = ['00', '', '', '', '', '06', '', '', '', '', '12', '', '', '', '', '18', '', '', '', '', '23']
+
+const reducedMotion = ref(false)
+let mq: MediaQueryList | null = null
+let mqListener: ((e: MediaQueryListEvent) => void) | null = null
+
+onMounted(() => {
+  if (typeof window === 'undefined' || !window.matchMedia) return
+  mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  reducedMotion.value = mq.matches
+  mqListener = (e) => {
+    reducedMotion.value = e.matches
+  }
+  mq.addEventListener?.('change', mqListener)
+})
+
+onBeforeUnmount(() => {
+  if (mq && mqListener) {
+    mq.removeEventListener?.('change', mqListener)
+  }
+  mq = null
+  mqListener = null
+})
+
+const max = computed(() => Math.max(1, ...props.cadence.weights))
+
+function barHeightPercent(weight: number): number {
+  if (weight === 0) return 4
+  return (weight / max.value) * 100
+}
+</script>
+
+<template>
+  <div class="today-cadence" :data-pulse="reducedMotion ? 'off' : 'on'" data-section="cadence">
+    <svg
+      class="today-cadence__svg"
+      :viewBox="`0 0 ${cadence.weights.length * 10} 64`"
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="24-hour activity cadence"
+    >
+      <g
+        v-for="(weight, i) in cadence.weights"
+        :key="i"
+        class="today-cadence__bar-group"
+      >
+        <rect
+          :x="i * 10"
+          :y="64 - (barHeightPercent(weight) / 100) * 64"
+          :width="6"
+          :height="(barHeightPercent(weight) / 100) * 64"
+          :class="[
+            'today-cadence__bar',
+            i === cadence.peakHourIndex ? 'today-cadence__bar--peak' : '',
+            weight === 0 ? 'today-cadence__bar--idle' : '',
+          ]"
+          :data-hour="i"
+          :data-peak="i === cadence.peakHourIndex ? 'true' : null"
+        />
+      </g>
+    </svg>
+    <div class="today-cadence__labels">
+      <span
+        v-for="(label, i) in HOUR_LABELS"
+        :key="`label-${i}`"
+        class="today-cadence__label"
+      >{{ label }}</span>
+    </div>
+    <div class="today-cadence__minis">
+      <div class="today-cadence__mini">
+        <div class="tk-eyebrow">First action</div>
+        <div class="today-cadence__mini-v">{{ cadence.firstAction }}</div>
+      </div>
+      <div class="today-cadence__mini">
+        <div class="tk-eyebrow">Peak hour</div>
+        <div class="today-cadence__mini-v">{{ cadence.peakAction }}</div>
+      </div>
+      <div class="today-cadence__mini">
+        <div class="tk-eyebrow">Last action</div>
+        <div class="today-cadence__mini-v">{{ cadence.lastAction }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-cadence {
+  width: 100%;
+}
+.today-cadence__svg {
+  width: 100%;
+  height: 64px;
+  display: block;
+  margin-top: 6px;
+}
+.today-cadence__bar {
+  fill: var(--ink-deep);
+  opacity: 0.8;
+}
+.today-cadence__bar--idle {
+  fill: var(--line);
+  opacity: 1;
+}
+.today-cadence__bar--peak {
+  fill: var(--ember);
+  opacity: 1;
+}
+.today-cadence[data-pulse='on'] .today-cadence__bar--peak {
+  animation: today-cadence-pulse 2.4s ease-in-out infinite;
+}
+.today-cadence[data-pulse='off'] .today-cadence__bar--peak {
+  /* no animation when prefers-reduced-motion is set */
+  animation: none;
+}
+
+@keyframes today-cadence-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+.today-cadence__labels {
+  display: grid;
+  grid-template-columns: repeat(21, 1fr);
+  gap: 0;
+  margin-top: 4px;
+}
+.today-cadence__label {
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 9px;
+  color: var(--faint);
+}
+
+.today-cadence__minis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.today-cadence__mini-v {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ink-deep);
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayCadence.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayCadence.vue
@@ -13,7 +13,7 @@ const props = defineProps<{
   cadence: DossierCadence
 }>()
 
-const HOUR_LABELS = ['00', '', '', '', '', '06', '', '', '', '', '12', '', '', '', '', '18', '', '', '', '', '23']
+const HOUR_LABELS = ['00', '', '', '', '', '', '06', '', '', '', '', '', '12', '', '', '', '', '', '18', '', '', '', '', '23']
 
 const reducedMotion = ref(false)
 let mq: MediaQueryList | null = null
@@ -140,7 +140,7 @@ function barHeightPercent(weight: number): number {
 
 .today-cadence__labels {
   display: grid;
-  grid-template-columns: repeat(21, 1fr);
+  grid-template-columns: repeat(24, 1fr);
   gap: 0;
   margin-top: 4px;
 }

--- a/frontend/taskdeck-web/src/views/paper/today/TodayCarryOver.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayCarryOver.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import PaperHLBtn from '../../../components/paper/PaperHLBtn.vue'
+import PaperTagstamp from '../../../components/paper/PaperTagstamp.vue'
+import type { DossierCarryOverCard } from '../../../composables/useTodayDossier'
+
+/**
+ * TodayCarryOver — overdue cards rendered inside a rust-bordered card.
+ * "Pin to tomorrow's morning" CTA emits `pin` with the list of serials.
+ */
+const props = defineProps<{
+  cards: DossierCarryOverCard[]
+}>()
+
+const emit = defineEmits<{
+  (event: 'pin', serials: string[]): void
+}>()
+
+function pinAll() {
+  emit('pin', props.cards.map(c => c.serial))
+}
+</script>
+
+<template>
+  <div class="today-carry-over" data-section="carry-over">
+    <div
+      v-for="card in cards"
+      :key="card.serial"
+      class="today-carry-over__row"
+    >
+      <div class="today-carry-over__head">
+        <span class="tk-serial">{{ card.serial }}</span>
+        <PaperTagstamp tone="overdue">{{ card.age.toUpperCase() }}</PaperTagstamp>
+      </div>
+      <div class="today-carry-over__title">{{ card.title }}</div>
+      <div class="tk-meta today-carry-over__meta">{{ card.reason }}</div>
+    </div>
+    <PaperHLBtn
+      v-if="cards.length > 0"
+      class="today-carry-over__pin"
+      label="Pin to tomorrow's morning"
+      data-action="pin-tomorrow"
+      @click="pinAll"
+    />
+  </div>
+</template>
+
+<style scoped>
+.today-carry-over {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.today-carry-over__row {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+.today-carry-over__head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 2px;
+}
+.today-carry-over__title {
+  font-family: var(--serif);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink-deep);
+  line-height: 1.3;
+}
+.today-carry-over__meta {
+  font-size: 10.5px;
+  margin-top: 2px;
+}
+.today-carry-over__pin {
+  margin-top: 12px;
+  width: 100%;
+  justify-content: center;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayCover.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayCover.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import PaperHLBtn from '../../../components/paper/PaperHLBtn.vue'
+
+/**
+ * TodayCover — dossier cover panel.  Paper-2 → paper gradient backdrop,
+ * 56px serif italic headline, lede, "Seal day" ember CTA, and a serial
+ * `D-YYYY-MM-DD-NNN` aligned top-right.
+ *
+ * The component is dumb: parent owns the seal toggle and toast state.
+ * That keeps idempotency testable in isolation.
+ */
+const props = defineProps<{
+  serial: string
+  cardsMoved: number
+  lede: string
+  autoSealsIn: string
+  sealed: boolean
+}>()
+
+const emit = defineEmits<{
+  (event: 'seal'): void
+  (event: 'note'): void
+}>()
+
+const headlineParts = computed(() => {
+  const moved = props.cardsMoved
+  const word = moved === 1 ? 'card' : 'cards'
+  // Headline rendered as: "Today, you moved <em>N cards</em>."
+  return { count: moved, word }
+})
+
+function onSealClick() {
+  emit('seal')
+}
+</script>
+
+<template>
+  <section class="today-cover" data-section="cover">
+    <div class="today-cover__inner">
+      <div class="today-cover__copy">
+        <div class="tk-eyebrow">Dossier · day's ledger · sealed at end of session</div>
+        <h1 class="tk-h1 today-cover__headline">
+          Today, you moved <em>{{ headlineParts.count }} {{ headlineParts.word }}</em>.
+        </h1>
+        <p class="tk-lede today-cover__lede">{{ lede }}</p>
+        <div class="today-cover__actions">
+          <PaperHLBtn
+            variant="ember"
+            :label="sealed ? 'Day sealed' : 'Seal day & archive'"
+            data-action="seal"
+            :aria-pressed="sealed"
+            @click="onSealClick"
+          />
+          <PaperHLBtn label="Write a note" data-action="note" @click="emit('note')" />
+          <span class="tk-meta today-cover__auto" data-testid="auto-seals-in">
+            <template v-if="sealed">Sealed for the day</template>
+            <template v-else>Auto-seals in {{ autoSealsIn }}</template>
+          </span>
+        </div>
+      </div>
+      <div class="today-cover__stamp">
+        <span class="tk-serial today-cover__serial" data-testid="dossier-serial">{{ serial }}</span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.today-cover {
+  padding: 44px 56px 28px;
+  background: linear-gradient(180deg, var(--paper-2) 0%, var(--paper) 100%);
+  border-bottom: 1px solid var(--line);
+  position: relative;
+}
+.today-cover__inner {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 32px;
+  align-items: flex-end;
+}
+.today-cover__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.today-cover__headline {
+  font-size: 56px;
+  line-height: 1.02;
+  margin: 10px 0 6px;
+}
+.today-cover__lede {
+  margin-top: 8px;
+  max-width: 620px;
+}
+.today-cover__actions {
+  display: flex;
+  gap: 14px;
+  margin-top: 18px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.today-cover__auto {
+  margin-left: 6px;
+}
+.today-cover__stamp {
+  position: relative;
+  text-align: right;
+}
+.today-cover__serial {
+  display: inline-block;
+  margin-top: 10px;
+  color: var(--faint);
+  text-align: right;
+}
+
+@media (max-width: 900px) {
+  .today-cover {
+    padding: 32px 24px 20px;
+  }
+  .today-cover__inner {
+    grid-template-columns: 1fr;
+  }
+  .today-cover__headline {
+    font-size: 40px;
+  }
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayDecisions.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayDecisions.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import PaperTagstamp from '../../../components/paper/PaperTagstamp.vue'
+import type {
+  DossierDecision,
+  DossierDecisionVerdict,
+} from '../../../composables/useTodayDossier'
+
+/**
+ * TodayDecisions — 4-up grid of today's proposals with verdict tagstamps.
+ *   APPLIED  → applied tone (green)
+ *   REJECTED → overdue tone (rust)
+ *   DEFERRED → ember tone (ember)
+ */
+const props = defineProps<{
+  decisions: DossierDecision[]
+}>()
+
+const VERDICT_LABEL: Record<DossierDecisionVerdict, string> = {
+  applied: 'APPLIED',
+  rejected: 'REJECTED',
+  deferred: 'DEFERRED',
+}
+
+const VERDICT_TONE: Record<DossierDecisionVerdict, 'applied' | 'overdue' | 'ember'> = {
+  applied: 'applied',
+  rejected: 'overdue',
+  deferred: 'ember',
+}
+
+const summary = computed(() => {
+  const total = props.decisions.length
+  const applied = props.decisions.filter(d => d.verdict === 'applied')
+  const avgConfidence =
+    applied.length > 0
+      ? applied.reduce((sum, d) => sum + d.confidence, 0) / applied.length
+      : 0
+  const applyRate = total > 0 ? applied.length / total : 0
+  return {
+    avgConfidence: avgConfidence.toFixed(2),
+    applyRatePct: Math.round(applyRate * 100),
+  }
+})
+</script>
+
+<template>
+  <div class="today-decisions" data-section="decisions">
+    <div class="today-decisions__grid">
+      <article
+        v-for="decision in decisions"
+        :key="decision.serial"
+        class="card today-decision"
+        :class="{ 'today-decision--stale': decision.stale }"
+        :data-verdict="decision.verdict"
+      >
+        <div class="today-decision__head">
+          <span class="tk-serial">{{ decision.serial }}</span>
+          <PaperTagstamp :tone="VERDICT_TONE[decision.verdict]">
+            {{ VERDICT_LABEL[decision.verdict] }}
+          </PaperTagstamp>
+        </div>
+        <div class="today-decision__title">{{ decision.title }}</div>
+        <div class="tk-meta today-decision__meta">conf {{ decision.confidence.toFixed(2) }} · {{ decision.when }}</div>
+      </article>
+    </div>
+    <div v-if="decisions.length > 0" class="today-decisions__note">
+      <span class="tk-eyebrow today-decisions__note-tag">NOTE</span>
+      You applied at <b>{{ summary.avgConfidence }}</b> avg confidence today. Apply rate
+      <b>{{ summary.applyRatePct }}%</b>.
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-decisions__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-top: 10px;
+}
+.today-decision {
+  padding: 12px;
+}
+.today-decision--stale {
+  opacity: 0.7;
+}
+.today-decision__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.today-decision__title {
+  font-family: var(--serif);
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--ink-deep);
+  margin: 4px 0;
+  line-height: 1.3;
+}
+.today-decision__meta {
+  font-size: 10px;
+}
+.today-decisions__note {
+  margin-top: 14px;
+  padding: 12px;
+  background: var(--paper-2);
+  border-radius: 2px;
+  font-size: 12px;
+  color: var(--ink-2);
+  border-left: 2px solid var(--applied);
+}
+.today-decisions__note-tag {
+  color: var(--applied);
+  margin-right: 8px;
+}
+.today-decisions__note b {
+  color: var(--ink);
+}
+
+@media (max-width: 700px) {
+  .today-decisions__grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayLedger.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayLedger.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import type { DossierLedgerEntry, DossierLedgerTone } from '../../../composables/useTodayDossier'
+
+/**
+ * TodayLedger — full event log for the day with `.rule-ledger` background.
+ * Each row is grid: serial · time · who-pill · what · tone-dot.
+ */
+defineProps<{
+  entries: DossierLedgerEntry[]
+}>()
+
+function toneColor(tone: DossierLedgerTone): string {
+  switch (tone) {
+    case 'ember':
+      return 'var(--ember)'
+    case 'applied':
+      return 'var(--applied)'
+    case 'active':
+      return 'var(--ink-deep)'
+    case 'passive':
+      return 'var(--ink-2)'
+    case 'mute':
+    default:
+      return 'var(--faint)'
+  }
+}
+</script>
+
+<template>
+  <div class="today-ledger rule-ledger" data-section="ledger">
+    <div
+      v-for="entry in entries"
+      :key="entry.serial"
+      class="today-ledger__row"
+      :data-tone="entry.tone"
+    >
+      <span class="tk-serial today-ledger__sn">{{ entry.serial }}</span>
+      <span class="tk-serial today-ledger__time">{{ entry.time }}</span>
+      <span class="tagstamp today-ledger__who" :style="{ color: toneColor(entry.tone) }">{{ entry.who.toUpperCase() }}</span>
+      <span class="today-ledger__what">{{ entry.what }}</span>
+      <span class="today-ledger__dot-cell" aria-hidden="true">
+        <span class="today-ledger__dot" :style="{ background: toneColor(entry.tone) }" />
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-ledger {
+  /* `.rule-ledger` from paper-tokens supplies the horizontal rule pattern. */
+}
+.today-ledger__row {
+  display: grid;
+  grid-template-columns: 60px 60px 60px 1fr 60px;
+  gap: 12px;
+  padding: 8px 22px;
+  border-bottom: 1px solid var(--line-soft);
+  align-items: center;
+  font-size: 12px;
+}
+.today-ledger__sn {
+  color: var(--faint);
+}
+.today-ledger__time {
+  color: var(--ink-2);
+}
+.today-ledger__who {
+  font-size: 9px;
+}
+.today-ledger__what {
+  color: var(--ink-2);
+  line-height: 1.45;
+}
+.today-ledger__dot-cell {
+  text-align: right;
+}
+.today-ledger__dot {
+  width: 6px;
+  height: 6px;
+  display: inline-block;
+  border-radius: 50%;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayLineForTomorrow.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayLineForTomorrow.vue
@@ -38,7 +38,7 @@ function readStored(): string {
 }
 
 const text = ref<string>(readStored())
-const status = ref<'idle' | 'saving' | 'saved'>('saved')
+const status = ref<'idle' | 'saving' | 'saved' | 'error'>('saved')
 
 let timer: ReturnType<typeof setTimeout> | null = null
 let suppressNextSave = false
@@ -48,7 +48,8 @@ function flush() {
   try {
     window.localStorage.setItem(props.storageKey, text.value)
   } catch {
-    // ignore quota / private mode failures
+    status.value = 'error'
+    return
   }
   status.value = 'saved'
   emit('save', text.value)
@@ -100,6 +101,7 @@ onBeforeUnmount(() => {
     <div class="tk-meta today-line__meta">
       <span data-testid="line-for-tomorrow-status">
         <template v-if="status === 'saving'">Saving…</template>
+        <template v-else-if="status === 'error'">Save unavailable</template>
         <template v-else>Saved · auto</template>
       </span>
       <span>shows on tomorrow's open</span>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayLineForTomorrow.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayLineForTomorrow.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+/**
+ * TodayLineForTomorrow — italic serif textarea, autosaved with debounce
+ * to localStorage (until the backend ships per-day storage; see #1018).
+ *
+ * Persistence is keyed by `storageKey`, defaulting to `td.paper.line-for-tomorrow`.
+ * `debounceMs` is exposed so tests can drop the timer without forcing real
+ * 500ms waits.
+ */
+const props = withDefaults(
+  defineProps<{
+    initial?: string
+    storageKey?: string
+    debounceMs?: number
+  }>(),
+  {
+    initial: '',
+    storageKey: 'td.paper.line-for-tomorrow',
+    debounceMs: 500,
+  },
+)
+
+const emit = defineEmits<{
+  (event: 'save', value: string): void
+}>()
+
+function readStored(): string {
+  if (typeof window === 'undefined') return props.initial
+  try {
+    const raw = window.localStorage.getItem(props.storageKey)
+    if (typeof raw === 'string') return raw
+  } catch {
+    // localStorage may throw in private mode
+  }
+  return props.initial
+}
+
+const text = ref<string>(readStored())
+const status = ref<'idle' | 'saving' | 'saved'>('saved')
+
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function flush() {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(props.storageKey, text.value)
+  } catch {
+    // ignore quota / private mode failures
+  }
+  status.value = 'saved'
+  emit('save', text.value)
+}
+
+watch(text, () => {
+  status.value = 'saving'
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(flush, props.debounceMs)
+})
+
+onBeforeUnmount(() => {
+  if (timer) {
+    clearTimeout(timer)
+    // Flush pending writes before the component goes away — otherwise
+    // a quick remount loses the in-flight edit.
+    flush()
+  }
+})
+</script>
+
+<template>
+  <div class="today-line" data-section="line-for-tomorrow">
+    <textarea
+      v-model="text"
+      class="today-line__input"
+      data-testid="line-for-tomorrow-input"
+      :aria-label="'A line for tomorrow'"
+      rows="3"
+    />
+    <div class="tk-meta today-line__meta">
+      <span data-testid="line-for-tomorrow-status">
+        <template v-if="status === 'saving'">Saving…</template>
+        <template v-else>Saved · auto</template>
+      </span>
+      <span>shows on tomorrow's open</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-line__input {
+  width: 100%;
+  margin-top: 8px;
+  min-height: 80px;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  padding: 10px;
+  background: var(--paper-card);
+  font-family: var(--serif);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink-deep);
+  font-style: italic;
+  resize: vertical;
+}
+.today-line__input:focus {
+  outline: none;
+  border-color: var(--ember);
+}
+.today-line__meta {
+  margin-top: 6px;
+  font-size: 10.5px;
+  display: flex;
+  justify-content: space-between;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayLineForTomorrow.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayLineForTomorrow.vue
@@ -41,6 +41,7 @@ const text = ref<string>(readStored())
 const status = ref<'idle' | 'saving' | 'saved'>('saved')
 
 let timer: ReturnType<typeof setTimeout> | null = null
+let suppressNextSave = false
 
 function flush() {
   if (typeof window === 'undefined') return
@@ -54,10 +55,28 @@ function flush() {
 }
 
 watch(text, () => {
+  if (suppressNextSave) {
+    suppressNextSave = false
+    return
+  }
   status.value = 'saving'
   if (timer) clearTimeout(timer)
   timer = setTimeout(flush, props.debounceMs)
 })
+
+watch(
+  () => [props.storageKey, props.initial] as const,
+  () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+    const nextText = readStored()
+    suppressNextSave = nextText !== text.value
+    text.value = nextText
+    status.value = 'saved'
+  },
+)
 
 onBeforeUnmount(() => {
   if (timer) {

--- a/frontend/taskdeck-web/src/views/paper/today/TodayStats.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayStats.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DossierStatCard } from '../../../composables/useTodayDossier'
+
+/**
+ * TodayStats — 5 stat cards.  Each card has a 2px top accent in tone
+ * colour, a mono eyebrow, a 38px serif italic number, and a sub line.
+ *
+ * Numeric values run through `Intl.NumberFormat` so 1_000+ render as
+ * `1,000` regardless of locale.  String values (e.g. "2h 14m") pass
+ * through verbatim.
+ */
+const props = defineProps<{
+  stats: DossierStatCard[]
+  /** Locale override for number formatting tests. */
+  locale?: string
+}>()
+
+const formatter = computed(() => new Intl.NumberFormat(props.locale ?? 'en-US'))
+
+function display(stat: DossierStatCard): string {
+  if (stat.numeric && typeof stat.value === 'number') {
+    return formatter.value.format(stat.value)
+  }
+  return String(stat.value)
+}
+
+function toneColor(tone: DossierStatCard['tone']): string {
+  switch (tone) {
+    case 'ember':
+      return 'var(--ember)'
+    case 'applied':
+      return 'var(--applied)'
+    case 'overdue':
+      return 'var(--overdue)'
+    case 'ink':
+    default:
+      return 'var(--ink-deep)'
+  }
+}
+</script>
+
+<template>
+  <section class="today-stats" data-section="stats">
+    <article
+      v-for="stat in stats"
+      :key="stat.id"
+      class="card today-stat"
+      :data-stat-id="stat.id"
+      :data-tone="stat.tone"
+    >
+      <span class="today-stat__accent" :style="{ background: toneColor(stat.tone) }" aria-hidden="true" />
+      <div class="tk-eyebrow today-stat__label">{{ stat.label }}</div>
+      <div class="today-stat__value" data-testid="stat-value">{{ display(stat) }}</div>
+      <div class="tk-meta today-stat__sub">{{ stat.sub }}</div>
+    </article>
+  </section>
+</template>
+
+<style scoped>
+.today-stats {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 16px;
+  padding: 28px 56px 12px;
+}
+.today-stat {
+  padding: 16px;
+  position: relative;
+  overflow: hidden;
+}
+.today-stat__accent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  opacity: 0.8;
+}
+.today-stat__value {
+  font-family: var(--serif);
+  font-size: 38px;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--ink-deep);
+  line-height: 1;
+  margin: 8px 0 4px;
+}
+.today-stat__sub {
+  font-size: 10.5px;
+}
+
+@media (max-width: 1100px) {
+  .today-stats {
+    grid-template-columns: repeat(2, 1fr);
+    padding: 24px 24px 12px;
+  }
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/today/TodayStreak.vue
+++ b/frontend/taskdeck-web/src/views/paper/today/TodayStreak.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DossierStreak } from '../../../composables/useTodayDossier'
+
+/**
+ * TodayStreak — 90-day grid (30 cols × 3 rows) of ember-intensity cells.
+ * Buckets are deterministic: 0 → line, 1 → paper-card, 2 → ember-bloom,
+ * 3 → ember-tint, 4 → ember.  The "today" cell is highlighted with an
+ * ember outline.
+ */
+const props = defineProps<{
+  streak: DossierStreak
+}>()
+
+const cells = computed(() => props.streak.cells)
+
+function bucketBg(value: number): string {
+  switch (value) {
+    case 0:
+      return 'var(--line)'
+    case 1:
+      return 'var(--paper-card)'
+    case 2:
+      return 'var(--ember-bloom)'
+    case 3:
+      return 'var(--ember-tint)'
+    default:
+      return 'var(--ember)'
+  }
+}
+
+function isToday(index: number): boolean {
+  return index === props.streak.todayIndex
+}
+</script>
+
+<template>
+  <div class="today-streak" data-section="streak">
+    <div class="today-streak__grid">
+      <div
+        v-for="(value, i) in cells"
+        :key="i"
+        class="today-streak__cell"
+        :class="{ 'today-streak__cell--today': isToday(i) }"
+        :data-bucket="value"
+        :data-today="isToday(i) ? 'true' : null"
+        :style="{ background: bucketBg(value) }"
+      />
+    </div>
+    <p class="tk-body today-streak__caption">
+      <b>{{ streak.totalDays }} days.</b> Your longest this year was {{ streak.longestThisYear }}.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.today-streak__grid {
+  display: grid;
+  grid-template-columns: repeat(30, 1fr);
+  gap: 2px;
+  padding: 8px 0;
+}
+.today-streak__cell {
+  aspect-ratio: 1;
+}
+.today-streak__cell--today {
+  outline: 1px solid var(--ember);
+  outline-offset: -1px;
+}
+.today-streak__caption {
+  margin: 10px 0 0;
+  font-size: 12.5px;
+  color: var(--ink-2);
+}
+.today-streak__caption b {
+  color: var(--ink-deep);
+}
+</style>


### PR DESCRIPTION
Implements PAPER-08 — Today / End-of-day dossier in the Paper theme.

Refs #996 · master tracker.
Closes #1004.

## Summary
- Adds `PaperTodayView` orchestrator + 9 dossier sub-components
  (Cover, Stats, Cadence, Ledger, Decisions, Boards, Carry-over,
  Streak, and "A line for tomorrow").
- New `useTodayDossier` composable returns stub data for fields the
  backend doesn't yet provide. Real workspace summary (overdue
  count etc.) flows through where it exists.
- `TodayView.vue` now delegates to `PaperTodayView` when
  `paperThemeStore.isOn`. The Obsidian path is untouched.
- Idempotent "Seal day" — second click while sealed surfaces the
  "already sealed" toast via `sealDay().alreadySealed`.
- "A line for tomorrow" autosaves with debounce to localStorage and
  persists across remount.
- Cadence honours `prefers-reduced-motion: reduce` (no ember pulse).
- 90-day streak grid with deterministic intensity buckets and a
  highlighted "today" cell.

## Backend follow-up issues
Filed as gaps; PaperTodayView ships with stubs against them today.
- #1015 — paper-today-backend-gap-cadence-aggregation
- #1016 — paper-today-backend-gap-streak-query
- #1017 — paper-today-backend-gap-seal-day-action
- #1018 — paper-today-backend-gap-line-for-tomorrow

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` no new warnings (6 pre-existing, unrelated)
- [x] Full vitest suite passes (2938 tests, 239 files)
- [x] New paper-today specs pass:
      `TodayCover` · `TodayStats` · `TodayCadence` · `TodayStreak` ·
      `TodayLineForTomorrow` · `PaperTodayView` smoke

## Files
- `frontend/taskdeck-web/src/views/paper/PaperTodayView.vue`
- `frontend/taskdeck-web/src/views/paper/today/Today*.vue` (8 sub-components)
- `frontend/taskdeck-web/src/composables/useTodayDossier.ts`
- `frontend/taskdeck-web/src/tests/views/paper/today/*.spec.ts` (6 specs)
- `frontend/taskdeck-web/src/views/TodayView.vue` (delegation)