### PR TITLE
PAPER-11 · Narrow companions — foundation + composable

### DIFF
--- a/frontend/taskdeck-web/src/composables/useViewportMode.ts
+++ b/frontend/taskdeck-web/src/composables/useViewportMode.ts
@@ -1,23 +1,24 @@
-import { onBeforeUnmount, readonly, ref, type Ref } from 'vue'
+import { onScopeDispose, readonly, ref, type Ref } from 'vue'
 
 export type ViewportMode = 'desktop' | 'tablet' | 'phone'
 
 const PHONE_QUERY = '(max-width: 480px)'
 const TABLET_QUERY = '(max-width: 1024px)'
 
-function detect(): ViewportMode {
-  if (typeof window === 'undefined' || !window.matchMedia) return 'desktop'
-  if (window.matchMedia(PHONE_QUERY).matches) return 'phone'
-  if (window.matchMedia(TABLET_QUERY).matches) return 'tablet'
+function classify(phoneMatches: boolean, tabletMatches: boolean): ViewportMode {
+  if (phoneMatches) return 'phone'
+  if (tabletMatches) return 'tablet'
   return 'desktop'
 }
 
 /**
  * Reactive viewport mode for Paper narrow companions.
- * Listens to matchMedia changes and tears down on unmount.
+ * Listens to matchMedia changes and tears down via onScopeDispose so the
+ * composable can be used inside components, Pinia stores, or any other
+ * reactive effect scope.
  */
 export function useViewportMode(): { mode: Readonly<Ref<ViewportMode>> } {
-  const mode = ref<ViewportMode>(detect())
+  const mode = ref<ViewportMode>('desktop')
 
   if (typeof window === 'undefined' || !window.matchMedia) {
     return { mode: readonly(mode) }
@@ -27,13 +28,16 @@ export function useViewportMode(): { mode: Readonly<Ref<ViewportMode>> } {
   const tabletMq = window.matchMedia(TABLET_QUERY)
 
   const update = () => {
-    mode.value = detect()
+    mode.value = classify(phoneMq.matches, tabletMq.matches)
   }
+
+  // Initialise from the cached MQL state — no extra matchMedia() calls.
+  update()
 
   phoneMq.addEventListener?.('change', update)
   tabletMq.addEventListener?.('change', update)
 
-  onBeforeUnmount(() => {
+  onScopeDispose(() => {
     phoneMq.removeEventListener?.('change', update)
     tabletMq.removeEventListener?.('change', update)
   })

--- a/frontend/taskdeck-web/src/composables/useViewportMode.ts
+++ b/frontend/taskdeck-web/src/composables/useViewportMode.ts
@@ -1,0 +1,42 @@
+import { onBeforeUnmount, readonly, ref, type Ref } from 'vue'
+
+export type ViewportMode = 'desktop' | 'tablet' | 'phone'
+
+const PHONE_QUERY = '(max-width: 480px)'
+const TABLET_QUERY = '(max-width: 1024px)'
+
+function detect(): ViewportMode {
+  if (typeof window === 'undefined' || !window.matchMedia) return 'desktop'
+  if (window.matchMedia(PHONE_QUERY).matches) return 'phone'
+  if (window.matchMedia(TABLET_QUERY).matches) return 'tablet'
+  return 'desktop'
+}
+
+/**
+ * Reactive viewport mode for Paper narrow companions.
+ * Listens to matchMedia changes and tears down on unmount.
+ */
+export function useViewportMode(): { mode: Readonly<Ref<ViewportMode>> } {
+  const mode = ref<ViewportMode>(detect())
+
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return { mode: readonly(mode) }
+  }
+
+  const phoneMq = window.matchMedia(PHONE_QUERY)
+  const tabletMq = window.matchMedia(TABLET_QUERY)
+
+  const update = () => {
+    mode.value = detect()
+  }
+
+  phoneMq.addEventListener?.('change', update)
+  tabletMq.addEventListener?.('change', update)
+
+  onBeforeUnmount(() => {
+    phoneMq.removeEventListener?.('change', update)
+    tabletMq.removeEventListener?.('change', update)
+  })
+
+  return { mode: readonly(mode) }
+}

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -432,9 +432,18 @@
 /* =========================================================
    Narrow companions — PAPER-11
    Phone (≤480px) and tablet (≤1024px) responsive rules.
-   The `--paper-scale` token (default 1) is consumed by .tk-* utilities
-   via calc(...); shrinking it once at the .paper root cascades cleanly
-   without compounding (the leaf utilities multiply, the root only sets).
+
+   Tokens introduced here:
+   - `--paper-scale` (default 1) is consumed by `.tk-*` utilities via
+     calc(...); shrinking it once at the .paper root cascades cleanly
+     without compounding (leaves multiply, the root only sets).
+   - `--paper-safe-bottom` exposes `env(safe-area-inset-bottom, 0px)` for
+     future phone bottom-bar variants of `PaperSidebar` (deferred to the
+     per-surface follow-ups against #1007). Currently unconsumed; do not
+     remove without checking those follow-ups.
+   - `--paper-density` flips to `compact` ≤1024px and is intended for
+     leaf surfaces (e.g. card / row paddings) to opt into a tighter
+     spacing variant in follow-up patches. Currently unconsumed.
    ========================================================= */
 .paper, .paper-night {
   --paper-safe-bottom: env(safe-area-inset-bottom, 0px);

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -428,3 +428,37 @@
   outline-offset: 1px;
   border-radius: var(--r-1);
 }
+
+/* =========================================================
+   Narrow companions — PAPER-11
+   Phone (≤480px) and tablet (≤1024px) responsive rules.
+   The `--paper-scale` token (default 1) is consumed by .tk-* utilities
+   via calc(...); shrinking it once at the .paper root cascades cleanly
+   without compounding (the leaf utilities multiply, the root only sets).
+   ========================================================= */
+.paper, .paper-night {
+  --paper-safe-bottom: env(safe-area-inset-bottom, 0px);
+  --paper-density: comfortable;
+}
+
+@media (max-width: 1024px) {
+  .paper, .paper-night {
+    --paper-density: compact;
+  }
+}
+
+@media (max-width: 480px) {
+  .paper, .paper-night {
+    --paper-scale: 0.9;
+  }
+  .paper .stamp, .paper-night .stamp {
+    width: 48px;
+    height: 48px;
+  }
+  .paper .stamp b, .paper-night .stamp b {
+    font-size: 10px;
+  }
+  .paper .stamp .stamp-num, .paper-night .stamp .stamp-num {
+    font-size: 7px;
+  }
+}

--- a/frontend/taskdeck-web/src/tests/composables/useViewportMode.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useViewportMode.spec.ts
@@ -23,8 +23,12 @@ function installMatchMedia() {
     writable: true,
     value: vi.fn((query: string) => {
       const entry = get(query)
+      // Real MediaQueryList.matches is a live getter; mirror that so
+      // composables that read .matches from a captured MQL stay reactive.
       return {
-        matches: entry.matches,
+        get matches() {
+          return entry.matches
+        },
         media: query,
         addEventListener: (type: string, listener: Listener) => {
           if (type === 'change') entry.listeners.add(listener)
@@ -106,5 +110,34 @@ describe('useViewportMode', () => {
     wrapper.unmount()
     expect(mq.listenerCount('(max-width: 480px)')).toBe(0)
     expect(mq.listenerCount('(max-width: 1024px)')).toBe(0)
+  })
+
+  it('does not leak listeners across multiple mount/unmount cycles', () => {
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      const wrapper = mount(Host)
+      expect(mq.listenerCount('(max-width: 480px)')).toBe(1)
+      expect(mq.listenerCount('(max-width: 1024px)')).toBe(1)
+      wrapper.unmount()
+      expect(mq.listenerCount('(max-width: 480px)')).toBe(0)
+      expect(mq.listenerCount('(max-width: 1024px)')).toBe(0)
+    }
+  })
+
+  it('treats absent matchMedia as desktop without throwing', () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'matchMedia')
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+    try {
+      const wrapper = mount(Host)
+      expect(readMode(wrapper)).toBe('desktop')
+      wrapper.unmount()
+    } finally {
+      if (original) {
+        Object.defineProperty(window, 'matchMedia', original)
+      }
+    }
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useViewportMode.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useViewportMode.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useViewportMode } from '../../composables/useViewportMode'
+
+type Listener = (ev: MediaQueryListEvent) => void
+
+function installMatchMedia() {
+  const queries = new Map<
+    string,
+    { matches: boolean; listeners: Set<Listener> }
+  >()
+  function get(query: string) {
+    let entry = queries.get(query)
+    if (!entry) {
+      entry = { matches: false, listeners: new Set<Listener>() }
+      queries.set(query, entry)
+    }
+    return entry
+  }
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string) => {
+      const entry = get(query)
+      return {
+        matches: entry.matches,
+        media: query,
+        addEventListener: (type: string, listener: Listener) => {
+          if (type === 'change') entry.listeners.add(listener)
+        },
+        removeEventListener: (type: string, listener: Listener) => {
+          if (type === 'change') entry.listeners.delete(listener)
+        },
+      }
+    }),
+  })
+  return {
+    set(query: string, matches: boolean) {
+      const entry = get(query)
+      entry.matches = matches
+      entry.listeners.forEach((l) => l({ matches } as MediaQueryListEvent))
+    },
+    listenerCount(query: string) {
+      return get(query).listeners.size
+    },
+  }
+}
+
+const Host = defineComponent({
+  name: 'ViewportHost',
+  setup() {
+    const { mode } = useViewportMode()
+    return () => h('div', { 'data-mode': mode.value }, mode.value)
+  },
+})
+
+function readMode(wrapper: ReturnType<typeof mount>): string {
+  return wrapper.find('div').attributes('data-mode') ?? ''
+}
+
+describe('useViewportMode', () => {
+  let mq: ReturnType<typeof installMatchMedia>
+
+  beforeEach(() => {
+    mq = installMatchMedia()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reports desktop when no media query matches', () => {
+    const wrapper = mount(Host)
+    expect(readMode(wrapper)).toBe('desktop')
+  })
+
+  it('reports phone when the phone query matches', () => {
+    mq.set('(max-width: 480px)', true)
+    mq.set('(max-width: 1024px)', true)
+    const wrapper = mount(Host)
+    expect(readMode(wrapper)).toBe('phone')
+  })
+
+  it('reports tablet when only the tablet query matches', () => {
+    mq.set('(max-width: 1024px)', true)
+    const wrapper = mount(Host)
+    expect(readMode(wrapper)).toBe('tablet')
+  })
+
+  it('reacts to live media changes', async () => {
+    const wrapper = mount(Host)
+    expect(readMode(wrapper)).toBe('desktop')
+    mq.set('(max-width: 1024px)', true)
+    await nextTick()
+    expect(readMode(wrapper)).toBe('tablet')
+    mq.set('(max-width: 480px)', true)
+    await nextTick()
+    expect(readMode(wrapper)).toBe('phone')
+  })
+
+  it('cleans up listeners on unmount', () => {
+    const wrapper = mount(Host)
+    expect(mq.listenerCount('(max-width: 480px)')).toBe(1)
+    expect(mq.listenerCount('(max-width: 1024px)')).toBe(1)
+    wrapper.unmount()
+    expect(mq.listenerCount('(max-width: 480px)')).toBe(0)
+    expect(mq.listenerCount('(max-width: 1024px)')).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Foundation slice of issue #1007 (master tracker #996). Lands the responsive media-query rules + reactive viewport composable; per-surface narrow tweaks land in follow-ups once the surface branches merge.

- \`paper-tokens.css\` adds phone (≤480px) and tablet (≤1024px) breakpoints scoped under \`.paper\` / \`.paper-night\`. Phone sets \`--paper-scale: 0.9\` (consumed by \`.tk-*\` utilities via the existing \`calc(... * var(--paper-scale, 1))\` math, no compounding) and shrinks stamps to 48px. Tablet flips \`--paper-density\` to \`compact\`. Introduces \`--paper-safe-bottom: env(safe-area-inset-bottom, 0px)\` for the phone bottom-bar variant.
- \`useViewportMode\` composable returns a reactive \`'desktop' | 'tablet' | 'phone'\` ref driven by \`matchMedia\` listeners; teardown on unmount via \`onBeforeUnmount\`.
- 5 vitest cases cover detection, live media changes, and listener cleanup.

## Out of scope (filed as follow-ups against #1007)

The README spec also calls for: sidebar bottom-bar variant on phone (4 letterform glyphs H · T · R · I), icon-only 60px rail on tablet, and board horizontal-snap scroll. These need to land as patches on the respective surface PRs (#1012, #1014, etc.). Filing per-surface follow-up issues to track.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` no new warnings
- [x] vitest 5 / 5 passing
- [ ] Manual smoke at 375 / 768 / desktop after surface PRs merge

Closes #1007 (foundation scope only — see follow-ups list).