### PR TITLE
Add cadence aggregation backend for Today view (#1015)

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/TodayController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/TodayController.cs
@@ -31,6 +31,7 @@ public class TodayController : AuthenticatedControllerBase
     /// Returns 24 hourly buckets with event counts plus first/peak/last action timestamps.
     /// </summary>
     /// <param name="date">Date to aggregate (ISO 8601). Defaults to today (UTC).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Cadence snapshot for the day.</returns>
     /// <response code="200">Cadence snapshot returned successfully.</response>
     /// <response code="400">Invalid date parameter.</response>

--- a/backend/src/Taskdeck.Api/Controllers/TodayController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/TodayController.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Api.Contracts;
+using Taskdeck.Api.Extensions;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+
+namespace Taskdeck.Api.Controllers;
+
+/// <summary>
+/// Today-view endpoints: cadence aggregation and daily dossier data.
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[Produces("application/json")]
+public class TodayController : AuthenticatedControllerBase
+{
+    private readonly ICadenceService _cadenceService;
+
+    public TodayController(
+        ICadenceService cadenceService,
+        IUserContext userContext)
+        : base(userContext)
+    {
+        _cadenceService = cadenceService;
+    }
+
+    /// <summary>
+    /// Get the per-hour cadence snapshot for the authenticated user on the specified date.
+    /// Returns 24 hourly buckets with event counts plus first/peak/last action timestamps.
+    /// </summary>
+    /// <param name="date">Date to aggregate (ISO 8601). Defaults to today (UTC).</param>
+    /// <returns>Cadence snapshot for the day.</returns>
+    /// <response code="200">Cadence snapshot returned successfully.</response>
+    /// <response code="400">Invalid date parameter.</response>
+    /// <response code="401">Authentication required.</response>
+    [HttpGet("cadence")]
+    [ProducesResponseType(typeof(CadenceResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetCadence(
+        [FromQuery] DateTimeOffset? date,
+        CancellationToken cancellationToken)
+    {
+        if (!TryGetCurrentUserId(out var userId, out var errorResult))
+            return errorResult!;
+
+        var targetDate = date ?? DateTimeOffset.UtcNow;
+
+        var result = await _cadenceService.GetDailyCadenceAsync(userId, targetDate, cancellationToken);
+
+        if (!result.IsSuccess)
+            return result.ToErrorActionResult();
+
+        var snapshot = result.Value;
+        var response = new CadenceResponse(
+            Buckets: snapshot.Buckets.Select(b => new CadenceBucketDto(b.Hour, b.EventCount)).ToList(),
+            FirstActionAt: snapshot.FirstActionAt,
+            PeakHour: snapshot.PeakHour,
+            LastActionAt: snapshot.LastActionAt);
+
+        return Ok(response);
+    }
+}

--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -56,6 +56,8 @@ public static class ApplicationServiceRegistration
         services.AddScoped<IBoardContextBuilder, BoardContextBuilder>();
         services.AddScoped<IChatService, ChatService>();
         services.AddScoped<ILogQueryService, LogQueryService>();
+        services.AddScoped<ICadenceService>(sp =>
+            new CadenceService(sp.GetRequiredService<IUnitOfWork>().AuditLogs));
         services.AddScoped<INotificationService, NotificationService>();
         services.AddScoped<IKnowledgeService, KnowledgeService>();
         services.AddScoped<IWorkspaceService, WorkspaceService>();

--- a/backend/src/Taskdeck.Application/DTOs/CadenceDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/CadenceDtos.cs
@@ -1,0 +1,16 @@
+namespace Taskdeck.Application.DTOs;
+
+/// <summary>
+/// A single hour bucket in the cadence response.
+/// </summary>
+public sealed record CadenceBucketDto(int Hour, int EventCount);
+
+/// <summary>
+/// API response DTO for daily cadence aggregation.
+/// Contains 24 per-hour buckets and first/peak/last action metadata.
+/// </summary>
+public sealed record CadenceResponse(
+    IReadOnlyList<CadenceBucketDto> Buckets,
+    DateTimeOffset? FirstActionAt,
+    int? PeakHour,
+    DateTimeOffset? LastActionAt);

--- a/backend/src/Taskdeck.Application/Interfaces/ICadenceService.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ICadenceService.cs
@@ -1,0 +1,23 @@
+using Taskdeck.Domain.Common;
+
+namespace Taskdeck.Application.Interfaces;
+
+/// <summary>
+/// Provides daily cadence aggregation: per-hour activity buckets
+/// derived from audit log entries for a given user and day.
+/// </summary>
+public interface ICadenceService
+{
+    /// <summary>
+    /// Compute the per-hour cadence snapshot for the given user on the specified date.
+    /// Returns 24 buckets (hours 0-23) with event counts, plus first/peak/last timestamps.
+    /// </summary>
+    /// <param name="userId">The user whose activity to aggregate.</param>
+    /// <param name="date">The date to aggregate (only the date portion is used).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A cadence snapshot for the day, or an empty snapshot if no activity.</returns>
+    Task<Result<CadenceSnapshot>> GetDailyCadenceAsync(
+        Guid userId,
+        DateTimeOffset date,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Services/CadenceService.cs
+++ b/backend/src/Taskdeck.Application/Services/CadenceService.cs
@@ -1,0 +1,95 @@
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Computes daily cadence snapshots by querying audit log entries for a user
+/// on a given day, bucketing them into 24 hourly slots, and deriving
+/// first/peak/last action metadata.
+/// </summary>
+public class CadenceService : ICadenceService
+{
+    private readonly IAuditLogRepository _auditLogRepository;
+
+    /// <summary>
+    /// Upper bound on audit entries fetched per day to prevent unbounded queries.
+    /// A single user generating more than 10,000 auditable actions in one day is
+    /// well beyond any reasonable usage pattern.
+    /// </summary>
+    private const int MaxDailyEntries = 10_000;
+
+    public CadenceService(IAuditLogRepository auditLogRepository)
+    {
+        _auditLogRepository = auditLogRepository ?? throw new ArgumentNullException(nameof(auditLogRepository));
+    }
+
+    public async Task<Result<CadenceSnapshot>> GetDailyCadenceAsync(
+        Guid userId,
+        DateTimeOffset date,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+        {
+            return Result.Failure<CadenceSnapshot>(
+                ErrorCodes.ValidationError,
+                "User ID is required.");
+        }
+
+        // Normalize to the start and end of the given UTC day.
+        var dayStart = new DateTimeOffset(date.UtcDateTime.Date, TimeSpan.Zero);
+        var dayEnd = dayStart.AddDays(1).AddTicks(-1);
+
+        var entries = await _auditLogRepository.QueryAsync(
+            from: dayStart,
+            to: dayEnd,
+            userId: userId,
+            limit: MaxDailyEntries,
+            cancellationToken: cancellationToken);
+
+        var entryList = entries.ToList();
+
+        if (entryList.Count == 0)
+        {
+            return Result.Success(CadenceSnapshot.Empty());
+        }
+
+        // Build per-hour counts.
+        var hourCounts = new int[24];
+        DateTimeOffset? firstAction = null;
+        DateTimeOffset? lastAction = null;
+
+        foreach (var entry in entryList)
+        {
+            var hour = entry.Timestamp.UtcDateTime.Hour;
+            hourCounts[hour]++;
+
+            if (firstAction is null || entry.Timestamp < firstAction)
+                firstAction = entry.Timestamp;
+
+            if (lastAction is null || entry.Timestamp > lastAction)
+                lastAction = entry.Timestamp;
+        }
+
+        // Find peak hour (highest event count; ties go to earliest hour).
+        int? peakHour = null;
+        var peakCount = 0;
+        for (var h = 0; h < 24; h++)
+        {
+            if (hourCounts[h] > peakCount)
+            {
+                peakCount = hourCounts[h];
+                peakHour = h;
+            }
+        }
+
+        var buckets = Enumerable.Range(0, 24)
+            .Select(h => new CadenceBucket(h, hourCounts[h]))
+            .ToList()
+            .AsReadOnly();
+
+        var snapshot = new CadenceSnapshot(buckets, firstAction, peakHour, lastAction);
+        return Result.Success(snapshot);
+    }
+}

--- a/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
+++ b/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
@@ -1,0 +1,44 @@
+namespace Taskdeck.Domain.Common;
+
+/// <summary>
+/// A single hour bucket in a daily cadence: how many events occurred in that hour.
+/// </summary>
+public sealed record CadenceBucket(int Hour, int EventCount)
+{
+    /// <summary>
+    /// Validates that Hour is in 0-23 and EventCount is non-negative.
+    /// </summary>
+    public CadenceBucket
+    {
+        if (Hour < 0 || Hour > 23)
+            throw new ArgumentOutOfRangeException(nameof(Hour), Hour, "Hour must be between 0 and 23.");
+
+        if (EventCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(EventCount), EventCount, "EventCount must be non-negative.");
+    }
+}
+
+/// <summary>
+/// Aggregated per-hour activity snapshot for a single day, used to drive the
+/// Today Cadence strip (24 SVG bars + first/peak/last action).
+/// </summary>
+public sealed record CadenceSnapshot(
+    IReadOnlyList<CadenceBucket> Buckets,
+    DateTimeOffset? FirstActionAt,
+    int? PeakHour,
+    DateTimeOffset? LastActionAt)
+{
+    /// <summary>
+    /// Returns an empty snapshot representing a day with no activity.
+    /// All 24 buckets are present with zero counts.
+    /// </summary>
+    public static CadenceSnapshot Empty()
+    {
+        var buckets = Enumerable.Range(0, 24)
+            .Select(h => new CadenceBucket(h, 0))
+            .ToList()
+            .AsReadOnly();
+
+        return new CadenceSnapshot(buckets, null, null, null);
+    }
+}

--- a/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
+++ b/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
@@ -54,6 +54,9 @@ public sealed record CadenceSnapshot
                 $"Buckets must contain exactly {RequiredBucketCount} entries, got {buckets.Count}.",
                 nameof(buckets));
 
+        if (peakHour.HasValue && (peakHour.Value < 0 || peakHour.Value > 23))
+            throw new ArgumentOutOfRangeException(nameof(peakHour), peakHour, "PeakHour must be between 0 and 23.");
+
         Buckets = buckets;
         FirstActionAt = firstActionAt;
         PeakHour = peakHour;

--- a/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
+++ b/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
@@ -3,18 +3,21 @@ namespace Taskdeck.Domain.Common;
 /// <summary>
 /// A single hour bucket in a daily cadence: how many events occurred in that hour.
 /// </summary>
-public sealed record CadenceBucket(int Hour, int EventCount)
+public sealed record CadenceBucket
 {
-    /// <summary>
-    /// Validates that Hour is in 0-23 and EventCount is non-negative.
-    /// </summary>
-    public CadenceBucket
-    {
-        if (Hour < 0 || Hour > 23)
-            throw new ArgumentOutOfRangeException(nameof(Hour), Hour, "Hour must be between 0 and 23.");
+    public int Hour { get; }
+    public int EventCount { get; }
 
-        if (EventCount < 0)
-            throw new ArgumentOutOfRangeException(nameof(EventCount), EventCount, "EventCount must be non-negative.");
+    public CadenceBucket(int hour, int eventCount)
+    {
+        if (hour < 0 || hour > 23)
+            throw new ArgumentOutOfRangeException(nameof(hour), hour, "Hour must be between 0 and 23.");
+
+        if (eventCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(eventCount), eventCount, "EventCount must be non-negative.");
+
+        Hour = hour;
+        EventCount = eventCount;
     }
 }
 

--- a/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
+++ b/backend/src/Taskdeck.Domain/Common/CadenceSnapshot.cs
@@ -25,23 +25,44 @@ public sealed record CadenceBucket
 /// Aggregated per-hour activity snapshot for a single day, used to drive the
 /// Today Cadence strip (24 SVG bars + first/peak/last action).
 /// </summary>
-public sealed record CadenceSnapshot(
-    IReadOnlyList<CadenceBucket> Buckets,
-    DateTimeOffset? FirstActionAt,
-    int? PeakHour,
-    DateTimeOffset? LastActionAt)
+public sealed record CadenceSnapshot
 {
-    /// <summary>
-    /// Returns an empty snapshot representing a day with no activity.
-    /// All 24 buckets are present with zero counts.
-    /// </summary>
-    public static CadenceSnapshot Empty()
-    {
-        var buckets = Enumerable.Range(0, 24)
+    private const int RequiredBucketCount = 24;
+
+    private static readonly CadenceSnapshot EmptyInstance = new(
+        Enumerable.Range(0, RequiredBucketCount)
             .Select(h => new CadenceBucket(h, 0))
             .ToList()
-            .AsReadOnly();
+            .AsReadOnly(),
+        null, null, null);
 
-        return new CadenceSnapshot(buckets, null, null, null);
+    public IReadOnlyList<CadenceBucket> Buckets { get; }
+    public DateTimeOffset? FirstActionAt { get; }
+    public int? PeakHour { get; }
+    public DateTimeOffset? LastActionAt { get; }
+
+    public CadenceSnapshot(
+        IReadOnlyList<CadenceBucket> buckets,
+        DateTimeOffset? firstActionAt,
+        int? peakHour,
+        DateTimeOffset? lastActionAt)
+    {
+        ArgumentNullException.ThrowIfNull(buckets);
+
+        if (buckets.Count != RequiredBucketCount)
+            throw new ArgumentException(
+                $"Buckets must contain exactly {RequiredBucketCount} entries, got {buckets.Count}.",
+                nameof(buckets));
+
+        Buckets = buckets;
+        FirstActionAt = firstActionAt;
+        PeakHour = peakHour;
+        LastActionAt = lastActionAt;
     }
+
+    /// <summary>
+    /// Returns a cached empty snapshot representing a day with no activity.
+    /// All 24 buckets are present with zero counts.
+    /// </summary>
+    public static CadenceSnapshot Empty() => EmptyInstance;
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/CadenceServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CadenceServiceTests.cs
@@ -1,0 +1,268 @@
+using System.Reflection;
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class CadenceServiceTests
+{
+    private readonly Mock<IAuditLogRepository> _auditLogRepoMock;
+    private readonly CadenceService _service;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public CadenceServiceTests()
+    {
+        _auditLogRepoMock = new Mock<IAuditLogRepository>();
+        _service = new CadenceService(_auditLogRepoMock.Object);
+    }
+
+    #region Validation
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_EmptyUserId_ReturnsValidationError()
+    {
+        var result = await _service.GetDailyCadenceAsync(Guid.Empty, DateTimeOffset.UtcNow);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("ValidationError");
+    }
+
+    #endregion
+
+    #region Empty Day
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_NoEntries_ReturnsEmptySnapshot()
+    {
+        SetupQueryReturns(new List<AuditLog>());
+
+        var result = await _service.GetDailyCadenceAsync(_userId, DateTimeOffset.UtcNow);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Buckets.Should().HaveCount(24);
+        result.Value.Buckets.Should().OnlyContain(b => b.EventCount == 0);
+        result.Value.FirstActionAt.Should().BeNull();
+        result.Value.PeakHour.Should().BeNull();
+        result.Value.LastActionAt.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Single Event
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_SingleEvent_BucketsCorrectly()
+    {
+        var timestamp = new DateTimeOffset(2026, 4, 25, 14, 30, 0, TimeSpan.Zero);
+        var entries = new List<AuditLog> { CreateAuditLog(_userId, timestamp) };
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, timestamp);
+
+        result.IsSuccess.Should().BeTrue();
+        var snapshot = result.Value;
+
+        snapshot.Buckets[14].EventCount.Should().Be(1);
+        snapshot.Buckets.Where(b => b.Hour != 14).Should().OnlyContain(b => b.EventCount == 0);
+        snapshot.FirstActionAt.Should().Be(timestamp);
+        snapshot.LastActionAt.Should().Be(timestamp);
+        snapshot.PeakHour.Should().Be(14);
+    }
+
+    #endregion
+
+    #region Multiple Events
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_MultipleEventsInSameHour_Aggregates()
+    {
+        var baseTime = new DateTimeOffset(2026, 4, 25, 10, 0, 0, TimeSpan.Zero);
+        var entries = new List<AuditLog>
+        {
+            CreateAuditLog(_userId, baseTime),
+            CreateAuditLog(_userId, baseTime.AddMinutes(15)),
+            CreateAuditLog(_userId, baseTime.AddMinutes(45)),
+        };
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, baseTime);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Buckets[10].EventCount.Should().Be(3);
+        result.Value.PeakHour.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_EventsAcrossHours_FindsPeakCorrectly()
+    {
+        var date = new DateTimeOffset(2026, 4, 25, 0, 0, 0, TimeSpan.Zero);
+        var entries = new List<AuditLog>
+        {
+            // Hour 8: 1 event
+            CreateAuditLog(_userId, date.AddHours(8)),
+            // Hour 14: 3 events (peak)
+            CreateAuditLog(_userId, date.AddHours(14)),
+            CreateAuditLog(_userId, date.AddHours(14).AddMinutes(10)),
+            CreateAuditLog(_userId, date.AddHours(14).AddMinutes(20)),
+            // Hour 20: 2 events
+            CreateAuditLog(_userId, date.AddHours(20)),
+            CreateAuditLog(_userId, date.AddHours(20).AddMinutes(30)),
+        };
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, date);
+
+        result.IsSuccess.Should().BeTrue();
+        var snapshot = result.Value;
+
+        snapshot.Buckets[8].EventCount.Should().Be(1);
+        snapshot.Buckets[14].EventCount.Should().Be(3);
+        snapshot.Buckets[20].EventCount.Should().Be(2);
+        snapshot.PeakHour.Should().Be(14);
+        snapshot.FirstActionAt.Should().Be(date.AddHours(8));
+        snapshot.LastActionAt.Should().Be(date.AddHours(20).AddMinutes(30));
+    }
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_PeakTie_ReturnsEarliestHour()
+    {
+        var date = new DateTimeOffset(2026, 4, 25, 0, 0, 0, TimeSpan.Zero);
+        var entries = new List<AuditLog>
+        {
+            // Hour 5: 2 events
+            CreateAuditLog(_userId, date.AddHours(5)),
+            CreateAuditLog(_userId, date.AddHours(5).AddMinutes(30)),
+            // Hour 18: 2 events (same count, but later)
+            CreateAuditLog(_userId, date.AddHours(18)),
+            CreateAuditLog(_userId, date.AddHours(18).AddMinutes(15)),
+        };
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, date);
+
+        result.IsSuccess.Should().BeTrue();
+        // Ties go to earliest hour
+        result.Value.PeakHour.Should().Be(5);
+    }
+
+    #endregion
+
+    #region Midnight Boundary
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_MidnightEvent_BucketsToHourZero()
+    {
+        var midnight = new DateTimeOffset(2026, 4, 25, 0, 0, 0, TimeSpan.Zero);
+        var entries = new List<AuditLog>
+        {
+            CreateAuditLog(_userId, midnight),
+            CreateAuditLog(_userId, midnight.AddMinutes(1)),
+        };
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, midnight);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Buckets[0].EventCount.Should().Be(2);
+        result.Value.PeakHour.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_EndOfDay_BucketsToHour23()
+    {
+        var lateNight = new DateTimeOffset(2026, 4, 25, 23, 59, 59, TimeSpan.Zero);
+        var entries = new List<AuditLog>
+        {
+            CreateAuditLog(_userId, lateNight),
+        };
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, lateNight);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Buckets[23].EventCount.Should().Be(1);
+    }
+
+    #endregion
+
+    #region Date Normalization
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_NonUtcDate_NormalizesToUtcDay()
+    {
+        // Pass a date with a non-UTC offset; service should normalize to UTC day
+        var dateWithOffset = new DateTimeOffset(2026, 4, 25, 10, 0, 0, TimeSpan.FromHours(5));
+
+        await _service.GetDailyCadenceAsync(_userId, dateWithOffset);
+
+        // The query should use the UTC date boundaries (April 25 05:00 UTC = April 25 in UTC day)
+        _auditLogRepoMock.Verify(r => r.QueryAsync(
+            It.Is<DateTimeOffset>(d => d.UtcDateTime.Date == dateWithOffset.UtcDateTime.Date),
+            It.IsAny<DateTimeOffset>(),
+            _userId,
+            null, null, null,
+            It.IsAny<int>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region All 24 Hours Filled
+
+    [Fact]
+    public async Task GetDailyCadenceAsync_AllHoursFilled_Returns24Buckets()
+    {
+        var date = new DateTimeOffset(2026, 4, 25, 0, 0, 0, TimeSpan.Zero);
+        var entries = Enumerable.Range(0, 24)
+            .Select(h => CreateAuditLog(_userId, date.AddHours(h).AddMinutes(15)))
+            .ToList();
+        SetupQueryReturns(entries);
+
+        var result = await _service.GetDailyCadenceAsync(_userId, date);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Buckets.Should().HaveCount(24);
+        result.Value.Buckets.Should().OnlyContain(b => b.EventCount == 1);
+        result.Value.FirstActionAt.Should().Be(date.AddMinutes(15));
+        result.Value.LastActionAt.Should().Be(date.AddHours(23).AddMinutes(15));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void SetupQueryReturns(List<AuditLog> entries)
+    {
+        _auditLogRepoMock
+            .Setup(r => r.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(entries);
+    }
+
+    private static AuditLog CreateAuditLog(Guid userId, DateTimeOffset timestamp)
+    {
+        var entry = new AuditLog("Card", Guid.NewGuid(), AuditAction.Created, userId);
+
+        // Use reflection to set the private Timestamp property for testing
+        var timestampProperty = typeof(AuditLog).GetProperty(
+            nameof(AuditLog.Timestamp),
+            BindingFlags.Instance | BindingFlags.Public);
+        timestampProperty!.SetValue(entry, timestamp);
+
+        return entry;
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/CadenceSnapshotTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/CadenceSnapshotTests.cs
@@ -74,6 +74,37 @@ public class CadenceSnapshotTests
     }
 
     [Fact]
+    public void Empty_ReturnsSameInstance()
+    {
+        var a = CadenceSnapshot.Empty();
+        var b = CadenceSnapshot.Empty();
+
+        ReferenceEquals(a, b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_NullBuckets_Throws()
+    {
+        var act = () => new CadenceSnapshot(null!, null, null, null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_WrongBucketCount_Throws()
+    {
+        var buckets = Enumerable.Range(0, 12)
+            .Select(h => new CadenceBucket(h, 0))
+            .ToList()
+            .AsReadOnly();
+
+        var act = () => new CadenceSnapshot(buckets, null, null, null);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*exactly 24*");
+    }
+
+    [Fact]
     public void Constructor_SingleEvent_SetsAllFields()
     {
         var now = DateTimeOffset.UtcNow;

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/CadenceSnapshotTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/CadenceSnapshotTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using Taskdeck.Domain.Common;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class CadenceBucketTests
+{
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(12, 5)]
+    [InlineData(23, 100)]
+    public void Constructor_ValidInputs_CreatesBucket(int hour, int eventCount)
+    {
+        var bucket = new CadenceBucket(hour, eventCount);
+
+        bucket.Hour.Should().Be(hour);
+        bucket.EventCount.Should().Be(eventCount);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(24)]
+    [InlineData(100)]
+    public void Constructor_InvalidHour_Throws(int hour)
+    {
+        var act = () => new CadenceBucket(hour, 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("hour");
+    }
+
+    [Fact]
+    public void Constructor_NegativeEventCount_Throws()
+    {
+        var act = () => new CadenceBucket(0, -1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("eventCount");
+    }
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var a = new CadenceBucket(10, 5);
+        var b = new CadenceBucket(10, 5);
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Equality_DifferentValues_AreNotEqual()
+    {
+        var a = new CadenceBucket(10, 5);
+        var b = new CadenceBucket(10, 6);
+
+        a.Should().NotBe(b);
+    }
+}
+
+public class CadenceSnapshotTests
+{
+    [Fact]
+    public void Empty_Returns24Buckets_AllZero()
+    {
+        var snapshot = CadenceSnapshot.Empty();
+
+        snapshot.Buckets.Should().HaveCount(24);
+        snapshot.Buckets.Select(b => b.Hour).Should().BeEquivalentTo(Enumerable.Range(0, 24));
+        snapshot.Buckets.Should().OnlyContain(b => b.EventCount == 0);
+        snapshot.FirstActionAt.Should().BeNull();
+        snapshot.PeakHour.Should().BeNull();
+        snapshot.LastActionAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_SingleEvent_SetsAllFields()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var buckets = Enumerable.Range(0, 24)
+            .Select(h => new CadenceBucket(h, h == 14 ? 1 : 0))
+            .ToList()
+            .AsReadOnly();
+
+        var snapshot = new CadenceSnapshot(buckets, now, 14, now);
+
+        snapshot.Buckets.Should().HaveCount(24);
+        snapshot.Buckets[14].EventCount.Should().Be(1);
+        snapshot.FirstActionAt.Should().Be(now);
+        snapshot.PeakHour.Should().Be(14);
+        snapshot.LastActionAt.Should().Be(now);
+    }
+
+    [Fact]
+    public void Constructor_AllHoursFilled_PreservesData()
+    {
+        var first = new DateTimeOffset(2026, 4, 25, 0, 5, 0, TimeSpan.Zero);
+        var last = new DateTimeOffset(2026, 4, 25, 23, 55, 0, TimeSpan.Zero);
+
+        var buckets = Enumerable.Range(0, 24)
+            .Select(h => new CadenceBucket(h, h + 1))
+            .ToList()
+            .AsReadOnly();
+
+        var snapshot = new CadenceSnapshot(buckets, first, 23, last);
+
+        snapshot.Buckets.Should().HaveCount(24);
+        snapshot.Buckets[0].EventCount.Should().Be(1);
+        snapshot.Buckets[23].EventCount.Should().Be(24);
+        snapshot.PeakHour.Should().Be(23);
+        snapshot.FirstActionAt.Should().Be(first);
+        snapshot.LastActionAt.Should().Be(last);
+    }
+
+    [Fact]
+    public void Constructor_MidnightBoundary_HandlesHourZero()
+    {
+        var midnight = new DateTimeOffset(2026, 4, 25, 0, 0, 0, TimeSpan.Zero);
+        var buckets = Enumerable.Range(0, 24)
+            .Select(h => new CadenceBucket(h, h == 0 ? 3 : 0))
+            .ToList()
+            .AsReadOnly();
+
+        var snapshot = new CadenceSnapshot(buckets, midnight, 0, midnight);
+
+        snapshot.Buckets[0].EventCount.Should().Be(3);
+        snapshot.PeakHour.Should().Be(0);
+        snapshot.FirstActionAt.Should().Be(midnight);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/CadenceSnapshotTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/CadenceSnapshotTests.cs
@@ -143,6 +143,23 @@ public class CadenceSnapshotTests
         snapshot.LastActionAt.Should().Be(last);
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(24)]
+    [InlineData(100)]
+    public void Constructor_InvalidPeakHour_Throws(int peakHour)
+    {
+        var buckets = Enumerable.Range(0, 24)
+            .Select(h => new CadenceBucket(h, 0))
+            .ToList()
+            .AsReadOnly();
+
+        var act = () => new CadenceSnapshot(buckets, null, peakHour, null);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("peakHour");
+    }
+
     [Fact]
     public void Constructor_MidnightBoundary_HandlesHourZero()
     {


### PR DESCRIPTION
## Summary

Implements the backend cadence aggregation endpoint required by PAPER-08 (#1004) for the Today Cadence strip.

- **Domain**: `CadenceBucket` and `CadenceSnapshot` value objects in `Taskdeck.Domain.Common` with hour validation (0-23) and an `Empty()` factory for zero-activity days
- **Application**: `ICadenceService` interface + `CadenceService` implementation that queries `IAuditLogRepository` for a user's audit entries on a given UTC day, buckets them by hour, and computes first/peak/last action timestamps. `CadenceResponse` DTO for API serialization
- **API**: `TodayController` with `GET /api/today/cadence?date=2026-04-25` endpoint, following `AuthenticatedControllerBase` + `Result<T>` patterns
- **DI**: Wired in `ApplicationServiceRegistration.cs` as scoped, injecting `IAuditLogRepository` from `IUnitOfWork`
- **Tests**: 13 domain tests (validation, equality, empty, boundary) + 10 application tests (validation, empty day, single event, multi-hour aggregation, peak ties, midnight boundary, date normalization, all-24-hours)

No new database migration needed -- reuses existing `IAuditLogRepository.QueryAsync` which already supports user+date-range filtering.

Closes #1015

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Cadence"` -- 23 tests pass (13 domain + 10 application)
- [x] Architecture tests pass (layer boundary validation)
- [ ] CI green on PR