### PR TITLE
Add 90-day streak query for Today view

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/TodayController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/TodayController.cs
@@ -31,6 +31,7 @@ public class TodayController : AuthenticatedControllerBase
     /// Get streak data (daily activity intensity and sealed status) for the authenticated user.
     /// </summary>
     /// <param name="days">Number of days to include (1-365, default 90).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Streak data with daily intensity buckets and streak lengths.</returns>
     /// <response code="200">Streak data returned successfully.</response>
     /// <response code="400">Invalid days parameter.</response>

--- a/backend/src/Taskdeck.Api/Controllers/TodayController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/TodayController.cs
@@ -39,12 +39,14 @@ public class TodayController : AuthenticatedControllerBase
     [ProducesResponseType(typeof(StreakResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
-    public async Task<IActionResult> GetStreak([FromQuery] int days = 90)
+    public async Task<IActionResult> GetStreak(
+        [FromQuery] int days = 90,
+        CancellationToken cancellationToken = default)
     {
         if (!TryGetCurrentUserId(out var userId, out var errorResult))
             return errorResult!;
 
-        var result = await _streakService.GetStreakAsync(userId, days);
+        var result = await _streakService.GetStreakAsync(userId, days, cancellationToken);
 
         if (!result.IsSuccess)
             return result.ToErrorActionResult();

--- a/backend/src/Taskdeck.Api/Controllers/TodayController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/TodayController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Api.Contracts;
+using Taskdeck.Api.Extensions;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+/// <summary>
+/// Today view endpoints: streak data, dossier, and daily summaries.
+/// </summary>
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+[Produces("application/json")]
+public class TodayController : AuthenticatedControllerBase
+{
+    private readonly IStreakService _streakService;
+
+    public TodayController(
+        IStreakService streakService,
+        IUserContext userContext)
+        : base(userContext)
+    {
+        _streakService = streakService;
+    }
+
+    /// <summary>
+    /// Get streak data (daily activity intensity and sealed status) for the authenticated user.
+    /// </summary>
+    /// <param name="days">Number of days to include (1-365, default 90).</param>
+    /// <returns>Streak data with daily intensity buckets and streak lengths.</returns>
+    /// <response code="200">Streak data returned successfully.</response>
+    /// <response code="400">Invalid days parameter.</response>
+    /// <response code="401">Authentication required.</response>
+    [HttpGet("streak")]
+    [ProducesResponseType(typeof(StreakResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetStreak([FromQuery] int days = 90)
+    {
+        if (!TryGetCurrentUserId(out var userId, out var errorResult))
+            return errorResult!;
+
+        var result = await _streakService.GetStreakAsync(userId, days);
+
+        if (!result.IsSuccess)
+            return result.ToErrorActionResult();
+
+        var streakResult = result.Value;
+        var response = new StreakResponse(
+            streakResult.Days.Select(d => new StreakDayResponse(d.Date, d.IsSealed, d.IntensityBucket)).ToList(),
+            streakResult.CurrentStreakLength,
+            streakResult.LongestStreakLength,
+            streakResult.Days.Count);
+
+        return Ok(response);
+    }
+}

--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -73,6 +73,7 @@ public static class ApplicationServiceRegistration
             new BoardMetricsService(
                 sp.GetRequiredService<IUnitOfWork>(),
                 sp.GetRequiredService<IAuthorizationService>()));
+        services.AddScoped<IStreakService, StreakService>();
         services.AddScoped<ApiKeyService>();
         services.AddScoped<IForecastingService>(sp =>
             new ForecastingService(

--- a/backend/src/Taskdeck.Application/DTOs/StreakDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/StreakDtos.cs
@@ -1,0 +1,18 @@
+namespace Taskdeck.Application.DTOs;
+
+/// <summary>
+/// Response DTO for a single day in the streak grid.
+/// </summary>
+public sealed record StreakDayResponse(
+    DateOnly Date,
+    bool IsSealed,
+    int IntensityBucket);
+
+/// <summary>
+/// Response DTO for the full streak query result.
+/// </summary>
+public sealed record StreakResponse(
+    IReadOnlyList<StreakDayResponse> Days,
+    int CurrentStreakLength,
+    int LongestStreakLength,
+    int DayCount);

--- a/backend/src/Taskdeck.Application/Interfaces/IAuditLogRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IAuditLogRepository.cs
@@ -3,6 +3,12 @@ using Taskdeck.Domain.Enums;
 
 namespace Taskdeck.Application.Interfaces;
 
+/// <summary>
+/// Lightweight projection record for per-day audit entry counts.
+/// Used by <see cref="IAuditLogRepository.CountByDateAsync"/> to avoid loading full entities.
+/// </summary>
+public sealed record DailyAuditCount(DateOnly Date, int Count);
+
 public interface IAuditLogRepository : IRepository<AuditLog>
 {
     Task<IEnumerable<AuditLog>> GetByEntityAsync(string entityType, Guid entityId, int limit = 100, CancellationToken cancellationToken = default);
@@ -16,6 +22,21 @@ public interface IAuditLogRepository : IRepository<AuditLog>
         string? source = null,
         string? level = null,
         int limit = 100,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns per-day entry counts for a user within a time range.
+    /// Uses a server-side GROUP BY projection to avoid loading full entities into memory.
+    /// </summary>
+    /// <param name="from">Start of the time range (inclusive).</param>
+    /// <param name="to">End of the time range (inclusive).</param>
+    /// <param name="userId">The user whose entries to count.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A list of (Date, Count) pairs for days with at least one entry.</returns>
+    Task<IReadOnlyList<DailyAuditCount>> CountByDateAsync(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        Guid userId,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/backend/src/Taskdeck.Application/Services/IStreakService.cs
+++ b/backend/src/Taskdeck.Application/Services/IStreakService.cs
@@ -1,0 +1,22 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Provides streak data (daily activity + sealed status) for a user
+/// over a configurable window, driving the Today Streak grid.
+/// </summary>
+public interface IStreakService
+{
+    /// <summary>
+    /// Returns streak data for the specified user over the last <paramref name="dayCount"/> days.
+    /// </summary>
+    /// <param name="userId">The authenticated user's ID.</param>
+    /// <param name="dayCount">Number of days to include (default 90).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<Result<StreakResult>> GetStreakAsync(
+        Guid userId,
+        int dayCount = 90,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Services/StreakService.cs
+++ b/backend/src/Taskdeck.Application/Services/StreakService.cs
@@ -36,16 +36,12 @@ public class StreakService : IStreakService
         var from = new DateTimeOffset(startDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
         var to = new DateTimeOffset(today.ToDateTime(TimeOnly.MaxValue), TimeSpan.Zero);
 
-        var auditLogs = await _unitOfWork.AuditLogs.QueryAsync(
-            from, to,
-            userId: userId,
-            limit: 100_000,
-            cancellationToken: cancellationToken);
+        // Use a lightweight projection that groups and counts on the server
+        // instead of loading full AuditLog entities into memory.
+        var dailyAuditCounts = await _unitOfWork.AuditLogs.CountByDateAsync(
+            from, to, userId, cancellationToken);
 
-        // Group audit entries by date and count daily activity
-        var dailyCounts = auditLogs
-            .GroupBy(a => DateOnly.FromDateTime(a.Timestamp.UtcDateTime.Date))
-            .ToDictionary(g => g.Key, g => g.Count());
+        var dailyCounts = dailyAuditCounts.ToDictionary(d => d.Date, d => d.Count);
 
         // Compute intensity buckets via quartile-based bucketing
         var days = ComputeDays(startDate, today, dailyCounts);

--- a/backend/src/Taskdeck.Application/Services/StreakService.cs
+++ b/backend/src/Taskdeck.Application/Services/StreakService.cs
@@ -1,0 +1,148 @@
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Computes streak data by querying audit log entries for a user,
+/// grouping by date, computing intensity quartiles, and calculating
+/// current/longest streak lengths.
+/// </summary>
+public class StreakService : IStreakService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public StreakService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<Result<StreakResult>> GetStreakAsync(
+        Guid userId,
+        int dayCount = 90,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+            return Result.Failure<StreakResult>(ErrorCodes.ValidationError, "User ID cannot be empty.");
+
+        if (dayCount < 1 || dayCount > 365)
+            return Result.Failure<StreakResult>(ErrorCodes.ValidationError, "Day count must be between 1 and 365.");
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var startDate = today.AddDays(-(dayCount - 1));
+
+        var from = new DateTimeOffset(startDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+        var to = new DateTimeOffset(today.ToDateTime(TimeOnly.MaxValue), TimeSpan.Zero);
+
+        var auditLogs = await _unitOfWork.AuditLogs.QueryAsync(
+            from, to,
+            userId: userId,
+            limit: 100_000,
+            cancellationToken: cancellationToken);
+
+        // Group audit entries by date and count daily activity
+        var dailyCounts = auditLogs
+            .GroupBy(a => DateOnly.FromDateTime(a.Timestamp.UtcDateTime.Date))
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        // Compute intensity buckets via quartile-based bucketing
+        var days = ComputeDays(startDate, today, dailyCounts);
+        var currentStreak = ComputeCurrentStreak(days);
+        var longestStreak = ComputeLongestStreak(days);
+
+        return Result.Success(new StreakResult(days, currentStreak, longestStreak));
+    }
+
+    /// <summary>
+    /// Build a StreakDay for each date in the range.
+    /// Intensity bucket: 0 = no activity; 1-4 = quartile-based on max daily count.
+    /// </summary>
+    internal static IReadOnlyList<StreakDay> ComputeDays(
+        DateOnly startDate,
+        DateOnly endDate,
+        Dictionary<DateOnly, int> dailyCounts)
+    {
+        var maxCount = dailyCounts.Count > 0 ? dailyCounts.Values.Max() : 0;
+        var days = new List<StreakDay>();
+
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            var count = dailyCounts.GetValueOrDefault(date, 0);
+            var bucket = ComputeIntensityBucket(count, maxCount);
+            // IsSealed defaults to false -- will be driven by #1017 seal entity
+            days.Add(new StreakDay(date, isSealed: false, intensityBucket: bucket));
+        }
+
+        return days;
+    }
+
+    /// <summary>
+    /// Maps a count to a 0-4 intensity bucket.
+    /// 0 = no activity; 1-4 = quartile position within the max.
+    /// When maxCount is 0, all days are bucket 0.
+    /// </summary>
+    internal static int ComputeIntensityBucket(int count, int maxCount)
+    {
+        if (count == 0 || maxCount == 0)
+            return 0;
+
+        // Compute position as a fraction of max, then map to 1-4
+        var ratio = (double)count / maxCount;
+
+        return ratio switch
+        {
+            <= 0.25 => 1,
+            <= 0.50 => 2,
+            <= 0.75 => 3,
+            _ => 4
+        };
+    }
+
+    /// <summary>
+    /// Computes current streak: consecutive days with activity (bucket > 0)
+    /// counting backwards from the last day (today).
+    /// </summary>
+    internal static int ComputeCurrentStreak(IReadOnlyList<StreakDay> days)
+    {
+        if (days.Count == 0)
+            return 0;
+
+        var streak = 0;
+        for (var i = days.Count - 1; i >= 0; i--)
+        {
+            if (days[i].IntensityBucket > 0)
+                streak++;
+            else
+                break;
+        }
+
+        return streak;
+    }
+
+    /// <summary>
+    /// Computes the longest streak of consecutive days with activity (bucket > 0).
+    /// </summary>
+    internal static int ComputeLongestStreak(IReadOnlyList<StreakDay> days)
+    {
+        var longest = 0;
+        var current = 0;
+
+        foreach (var day in days)
+        {
+            if (day.IntensityBucket > 0)
+            {
+                current++;
+                if (current > longest)
+                    longest = current;
+            }
+            else
+            {
+                current = 0;
+            }
+        }
+
+        return longest;
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/StreakDay.cs
+++ b/backend/src/Taskdeck.Domain/Entities/StreakDay.cs
@@ -1,0 +1,25 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Value object representing a single day in a streak grid.
+/// IntensityBucket ranges from 0 (no activity) to 4 (highest quartile).
+/// </summary>
+public sealed record StreakDay
+{
+    public DateOnly Date { get; }
+    public bool IsSealed { get; }
+    public int IntensityBucket { get; }
+
+    public StreakDay(DateOnly date, bool isSealed, int intensityBucket)
+    {
+        if (intensityBucket < 0 || intensityBucket > 4)
+            throw new ArgumentOutOfRangeException(
+                nameof(intensityBucket),
+                intensityBucket,
+                "IntensityBucket must be between 0 and 4.");
+
+        Date = date;
+        IsSealed = isSealed;
+        IntensityBucket = intensityBucket;
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/StreakResult.cs
+++ b/backend/src/Taskdeck.Domain/Entities/StreakResult.cs
@@ -1,0 +1,41 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Value object representing a streak query result with daily activity data
+/// and computed streak metrics.
+/// </summary>
+public sealed record StreakResult
+{
+    public IReadOnlyList<StreakDay> Days { get; }
+    public int CurrentStreakLength { get; }
+    public int LongestStreakLength { get; }
+
+    public StreakResult(
+        IReadOnlyList<StreakDay> days,
+        int currentStreakLength,
+        int longestStreakLength)
+    {
+        ArgumentNullException.ThrowIfNull(days);
+
+        if (currentStreakLength < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(currentStreakLength),
+                currentStreakLength,
+                "CurrentStreakLength cannot be negative.");
+
+        if (longestStreakLength < 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(longestStreakLength),
+                longestStreakLength,
+                "LongestStreakLength cannot be negative.");
+
+        if (currentStreakLength > longestStreakLength)
+            throw new ArgumentException(
+                "CurrentStreakLength cannot exceed LongestStreakLength.",
+                nameof(currentStreakLength));
+
+        Days = days;
+        CurrentStreakLength = currentStreakLength;
+        LongestStreakLength = longestStreakLength;
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
@@ -251,6 +251,57 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
         return ids;
     }
 
+    public async Task<IReadOnlyList<DailyAuditCount>> CountByDateAsync(
+        DateTimeOffset from,
+        DateTimeOffset to,
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (_context.Database.IsSqlite())
+        {
+            // SQLite stores DateTimeOffset as a string; use SUBSTR to extract the date portion
+            // and push the GROUP BY into SQL. The IX_AuditLogs_UserId_Timestamp index covers
+            // the WHERE clause so this avoids a full table scan.
+            var fromStr = from.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff") + "+00:00";
+            var toStr = to.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff") + "+00:00";
+
+            var rows = await _context.Database
+                .SqlQueryRaw<DateCountRow>(
+                    "SELECT SUBSTR(Timestamp, 1, 10) AS DateStr, COUNT(*) AS Count " +
+                    "FROM AuditLogs " +
+                    "WHERE UserId = {0} AND Timestamp >= {1} AND Timestamp <= {2} " +
+                    "GROUP BY SUBSTR(Timestamp, 1, 10)",
+                    userId, fromStr, toStr)
+                .ToListAsync(cancellationToken);
+
+            return rows
+                .Select(r => new DailyAuditCount(DateOnly.Parse(r.DateStr), r.Count))
+                .ToList();
+        }
+
+        // Non-SQLite: use EF LINQ projection with server-side GROUP BY.
+        var results = await _context.AuditLogs
+            .AsNoTracking()
+            .Where(al => al.UserId == userId && al.Timestamp >= from && al.Timestamp <= to)
+            .GroupBy(al => al.Timestamp.Date)
+            .Select(g => new { Date = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        return results
+            .Select(r => new DailyAuditCount(DateOnly.FromDateTime(r.Date), r.Count))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Internal row type for SQLite raw SQL date-count projection.
+    /// EF Core's SqlQueryRaw requires a concrete type for materialisation.
+    /// </summary>
+    internal class DateCountRow
+    {
+        public string DateStr { get; set; } = string.Empty;
+        public int Count { get; set; }
+    }
+
     public async Task<int> DeleteOldEntriesAsync(DateTimeOffset olderThan, int batchSize, CancellationToken cancellationToken = default)
     {
         var totalDeleted = 0;

--- a/backend/tests/Taskdeck.Api.Tests/AuditRetentionWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuditRetentionWorkerTests.cs
@@ -159,6 +159,11 @@ public class AuditRetentionWorkerTests
             int limit = 100, CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<AuditLog>>(Array.Empty<AuditLog>());
 
+        public Task<IReadOnlyList<DailyAuditCount>> CountByDateAsync(
+            DateTimeOffset from, DateTimeOffset to,
+            Guid userId, CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlyList<DailyAuditCount>>(Array.Empty<DailyAuditCount>());
+
         public Task<AuditLog?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult<AuditLog?>(null);
 

--- a/backend/tests/Taskdeck.Application.Tests/Services/StreakServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/StreakServiceTests.cs
@@ -3,7 +3,6 @@ using Moq;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 using Taskdeck.Domain.Entities;
-using Taskdeck.Domain.Enums;
 using Taskdeck.Domain.Exceptions;
 using Xunit;
 
@@ -23,16 +22,12 @@ public class StreakServiceTests
         _unitOfWorkMock.Setup(u => u.AuditLogs).Returns(_auditLogRepoMock.Object);
 
         _auditLogRepoMock
-            .Setup(a => a.QueryAsync(
+            .Setup(a => a.CountByDateAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
-                It.IsAny<Guid?>(),
-                It.IsAny<Guid?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<int>(),
+                It.IsAny<Guid>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<AuditLog>());
+            .ReturnsAsync(new List<DailyAuditCount>());
 
         _service = new StreakService(_unitOfWorkMock.Object);
     }
@@ -86,20 +81,19 @@ public class StreakServiceTests
     [Fact]
     public async Task GetStreakAsync_SingleDayActivity_ShouldHaveCurrentStreakOfOne()
     {
-        var today = DateTimeOffset.UtcNow;
-        var auditLog = CreateAuditLog(_userId, today);
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counts = new List<DailyAuditCount>
+        {
+            new(todayDate, 1)
+        };
 
         _auditLogRepoMock
-            .Setup(a => a.QueryAsync(
+            .Setup(a => a.CountByDateAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
-                It.Is<Guid?>(id => id == _userId),
-                It.IsAny<Guid?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<int>(),
+                It.Is<Guid>(id => id == _userId),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<AuditLog> { auditLog });
+            .ReturnsAsync(counts);
 
         var result = await _service.GetStreakAsync(_userId, 7);
 
@@ -107,7 +101,6 @@ public class StreakServiceTests
         result.Value.CurrentStreakLength.Should().Be(1);
         result.Value.LongestStreakLength.Should().Be(1);
 
-        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
         var todayDay = result.Value.Days.SingleOrDefault(d => d.Date == todayDate);
         todayDay.Should().NotBeNull();
         todayDay!.IntensityBucket.Should().BeGreaterThan(0);
@@ -120,26 +113,22 @@ public class StreakServiceTests
     [Fact]
     public async Task GetStreakAsync_ContinuousStreak_ShouldComputeCorrectly()
     {
-        var today = DateTimeOffset.UtcNow;
-        var audits = new List<AuditLog>();
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counts = new List<DailyAuditCount>();
 
         // 5 consecutive days of activity (today and 4 days before)
         for (int i = 0; i < 5; i++)
         {
-            audits.Add(CreateAuditLog(_userId, today.AddDays(-i)));
+            counts.Add(new DailyAuditCount(todayDate.AddDays(-i), 1));
         }
 
         _auditLogRepoMock
-            .Setup(a => a.QueryAsync(
+            .Setup(a => a.CountByDateAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
-                It.Is<Guid?>(id => id == _userId),
-                It.IsAny<Guid?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<int>(),
+                It.Is<Guid>(id => id == _userId),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(audits);
+            .ReturnsAsync(counts);
 
         var result = await _service.GetStreakAsync(_userId, 10);
 
@@ -155,30 +144,26 @@ public class StreakServiceTests
     [Fact]
     public async Task GetStreakAsync_GapInStreak_ShouldBreakCurrentStreak()
     {
-        var today = DateTimeOffset.UtcNow;
-        var audits = new List<AuditLog>
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counts = new List<DailyAuditCount>
         {
             // Today and yesterday: current streak = 2
-            CreateAuditLog(_userId, today),
-            CreateAuditLog(_userId, today.AddDays(-1)),
+            new(todayDate, 1),
+            new(todayDate.AddDays(-1), 1),
             // Gap on day -2
             // 3 days of activity before the gap: day -3, -4, -5
-            CreateAuditLog(_userId, today.AddDays(-3)),
-            CreateAuditLog(_userId, today.AddDays(-4)),
-            CreateAuditLog(_userId, today.AddDays(-5)),
+            new(todayDate.AddDays(-3), 1),
+            new(todayDate.AddDays(-4), 1),
+            new(todayDate.AddDays(-5), 1),
         };
 
         _auditLogRepoMock
-            .Setup(a => a.QueryAsync(
+            .Setup(a => a.CountByDateAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
-                It.Is<Guid?>(id => id == _userId),
-                It.IsAny<Guid?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<int>(),
+                It.Is<Guid>(id => id == _userId),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(audits);
+            .ReturnsAsync(counts);
 
         var result = await _service.GetStreakAsync(_userId, 10);
 
@@ -190,25 +175,21 @@ public class StreakServiceTests
     [Fact]
     public async Task GetStreakAsync_GapAtEnd_ShouldHaveZeroCurrentStreak()
     {
-        var today = DateTimeOffset.UtcNow;
-        var audits = new List<AuditLog>
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counts = new List<DailyAuditCount>
         {
             // Activity only 3 days ago (no activity today, yesterday, or day before)
-            CreateAuditLog(_userId, today.AddDays(-3)),
-            CreateAuditLog(_userId, today.AddDays(-4)),
+            new(todayDate.AddDays(-3), 1),
+            new(todayDate.AddDays(-4), 1),
         };
 
         _auditLogRepoMock
-            .Setup(a => a.QueryAsync(
+            .Setup(a => a.CountByDateAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
-                It.Is<Guid?>(id => id == _userId),
-                It.IsAny<Guid?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<int>(),
+                It.Is<Guid>(id => id == _userId),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(audits);
+            .ReturnsAsync(counts);
 
         var result = await _service.GetStreakAsync(_userId, 10);
 
@@ -254,37 +235,29 @@ public class StreakServiceTests
     [Fact]
     public async Task GetStreakAsync_VaryingActivity_ShouldProduceCorrectBuckets()
     {
-        var today = DateTimeOffset.UtcNow;
-        var audits = new List<AuditLog>();
-
-        // Day 0 (today): 4 entries
-        for (int i = 0; i < 4; i++)
-            audits.Add(CreateAuditLog(_userId, today));
-
-        // Day -1: 1 entry
-        audits.Add(CreateAuditLog(_userId, today.AddDays(-1)));
-
-        // Day -2: 2 entries
-        for (int i = 0; i < 2; i++)
-            audits.Add(CreateAuditLog(_userId, today.AddDays(-2)));
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var counts = new List<DailyAuditCount>
+        {
+            // Day 0 (today): 4 entries
+            new(todayDate, 4),
+            // Day -1: 1 entry
+            new(todayDate.AddDays(-1), 1),
+            // Day -2: 2 entries
+            new(todayDate.AddDays(-2), 2),
+        };
 
         _auditLogRepoMock
-            .Setup(a => a.QueryAsync(
+            .Setup(a => a.CountByDateAsync(
                 It.IsAny<DateTimeOffset>(),
                 It.IsAny<DateTimeOffset>(),
-                It.Is<Guid?>(id => id == _userId),
-                It.IsAny<Guid?>(),
-                It.IsAny<string?>(),
-                It.IsAny<string?>(),
-                It.IsAny<int>(),
+                It.Is<Guid>(id => id == _userId),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(audits);
+            .ReturnsAsync(counts);
 
         var result = await _service.GetStreakAsync(_userId, 5);
 
         result.IsSuccess.Should().BeTrue();
 
-        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
         var todayDay = result.Value.Days.Single(d => d.Date == todayDate);
         todayDay.IntensityBucket.Should().Be(4); // max = 4, count = 4 => ratio 1.0 => bucket 4
 
@@ -474,26 +447,6 @@ public class StreakServiceTests
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Days.Should().HaveCount(90);
-    }
-
-    #endregion
-
-    #region Helpers
-
-    private static AuditLog CreateAuditLog(Guid userId, DateTimeOffset timestamp)
-    {
-        var auditLog = new AuditLog(
-            entityType: "card",
-            entityId: Guid.NewGuid(),
-            action: AuditAction.Created,
-            userId: userId,
-            changes: "test audit entry");
-
-        // Use reflection to set the Timestamp since it's set in constructor to UtcNow
-        var timestampProperty = typeof(AuditLog).GetProperty("Timestamp")!;
-        timestampProperty.SetValue(auditLog, timestamp);
-
-        return auditLog;
     }
 
     #endregion

--- a/backend/tests/Taskdeck.Application.Tests/Services/StreakServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/StreakServiceTests.cs
@@ -1,0 +1,500 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class StreakServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IAuditLogRepository> _auditLogRepoMock;
+    private readonly StreakService _service;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public StreakServiceTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _auditLogRepoMock = new Mock<IAuditLogRepository>();
+        _unitOfWorkMock.Setup(u => u.AuditLogs).Returns(_auditLogRepoMock.Object);
+
+        _auditLogRepoMock
+            .Setup(a => a.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AuditLog>());
+
+        _service = new StreakService(_unitOfWorkMock.Object);
+    }
+
+    #region Validation
+
+    [Fact]
+    public async Task GetStreakAsync_ShouldFail_WhenUserIdIsEmpty()
+    {
+        var result = await _service.GetStreakAsync(Guid.Empty);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("User ID");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(366)]
+    [InlineData(1000)]
+    public async Task GetStreakAsync_ShouldFail_WhenDayCountOutOfRange(int dayCount)
+    {
+        var result = await _service.GetStreakAsync(_userId, dayCount);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("Day count");
+    }
+
+    #endregion
+
+    #region Empty History
+
+    [Fact]
+    public async Task GetStreakAsync_EmptyHistory_ShouldReturnAllZeroBuckets()
+    {
+        var result = await _service.GetStreakAsync(_userId, 7);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Days.Should().HaveCount(7);
+        result.Value.Days.Should().OnlyContain(d => d.IntensityBucket == 0);
+        result.Value.CurrentStreakLength.Should().Be(0);
+        result.Value.LongestStreakLength.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Single Day
+
+    [Fact]
+    public async Task GetStreakAsync_SingleDayActivity_ShouldHaveCurrentStreakOfOne()
+    {
+        var today = DateTimeOffset.UtcNow;
+        var auditLog = CreateAuditLog(_userId, today);
+
+        _auditLogRepoMock
+            .Setup(a => a.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.Is<Guid?>(id => id == _userId),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AuditLog> { auditLog });
+
+        var result = await _service.GetStreakAsync(_userId, 7);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStreakLength.Should().Be(1);
+        result.Value.LongestStreakLength.Should().Be(1);
+
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var todayDay = result.Value.Days.SingleOrDefault(d => d.Date == todayDate);
+        todayDay.Should().NotBeNull();
+        todayDay!.IntensityBucket.Should().BeGreaterThan(0);
+    }
+
+    #endregion
+
+    #region Continuous Streak
+
+    [Fact]
+    public async Task GetStreakAsync_ContinuousStreak_ShouldComputeCorrectly()
+    {
+        var today = DateTimeOffset.UtcNow;
+        var audits = new List<AuditLog>();
+
+        // 5 consecutive days of activity (today and 4 days before)
+        for (int i = 0; i < 5; i++)
+        {
+            audits.Add(CreateAuditLog(_userId, today.AddDays(-i)));
+        }
+
+        _auditLogRepoMock
+            .Setup(a => a.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.Is<Guid?>(id => id == _userId),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(audits);
+
+        var result = await _service.GetStreakAsync(_userId, 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStreakLength.Should().Be(5);
+        result.Value.LongestStreakLength.Should().Be(5);
+    }
+
+    #endregion
+
+    #region Gap in Streak
+
+    [Fact]
+    public async Task GetStreakAsync_GapInStreak_ShouldBreakCurrentStreak()
+    {
+        var today = DateTimeOffset.UtcNow;
+        var audits = new List<AuditLog>
+        {
+            // Today and yesterday: current streak = 2
+            CreateAuditLog(_userId, today),
+            CreateAuditLog(_userId, today.AddDays(-1)),
+            // Gap on day -2
+            // 3 days of activity before the gap: day -3, -4, -5
+            CreateAuditLog(_userId, today.AddDays(-3)),
+            CreateAuditLog(_userId, today.AddDays(-4)),
+            CreateAuditLog(_userId, today.AddDays(-5)),
+        };
+
+        _auditLogRepoMock
+            .Setup(a => a.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.Is<Guid?>(id => id == _userId),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(audits);
+
+        var result = await _service.GetStreakAsync(_userId, 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStreakLength.Should().Be(2);
+        result.Value.LongestStreakLength.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task GetStreakAsync_GapAtEnd_ShouldHaveZeroCurrentStreak()
+    {
+        var today = DateTimeOffset.UtcNow;
+        var audits = new List<AuditLog>
+        {
+            // Activity only 3 days ago (no activity today, yesterday, or day before)
+            CreateAuditLog(_userId, today.AddDays(-3)),
+            CreateAuditLog(_userId, today.AddDays(-4)),
+        };
+
+        _auditLogRepoMock
+            .Setup(a => a.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.Is<Guid?>(id => id == _userId),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(audits);
+
+        var result = await _service.GetStreakAsync(_userId, 10);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.CurrentStreakLength.Should().Be(0);
+        result.Value.LongestStreakLength.Should().Be(2);
+    }
+
+    #endregion
+
+    #region Intensity Bucketing
+
+    [Theory]
+    [InlineData(0, 10, 0)]
+    [InlineData(1, 4, 1)]
+    [InlineData(2, 4, 2)]
+    [InlineData(3, 4, 3)]
+    [InlineData(4, 4, 4)]
+    [InlineData(1, 1, 4)] // Only one entry => max => bucket 4
+    [InlineData(0, 0, 0)] // maxCount 0 => bucket 0
+    public void ComputeIntensityBucket_ShouldReturnCorrectBucket(
+        int count, int maxCount, int expectedBucket)
+    {
+        var bucket = StreakService.ComputeIntensityBucket(count, maxCount);
+        bucket.Should().Be(expectedBucket);
+    }
+
+    [Fact]
+    public void ComputeIntensityBucket_BoundaryValues_ShouldBeConsistent()
+    {
+        // At exactly 25%, 50%, 75% boundaries
+        StreakService.ComputeIntensityBucket(25, 100).Should().Be(1);
+        StreakService.ComputeIntensityBucket(50, 100).Should().Be(2);
+        StreakService.ComputeIntensityBucket(75, 100).Should().Be(3);
+        StreakService.ComputeIntensityBucket(100, 100).Should().Be(4);
+
+        // Just above boundaries
+        StreakService.ComputeIntensityBucket(26, 100).Should().Be(2);
+        StreakService.ComputeIntensityBucket(51, 100).Should().Be(3);
+        StreakService.ComputeIntensityBucket(76, 100).Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetStreakAsync_VaryingActivity_ShouldProduceCorrectBuckets()
+    {
+        var today = DateTimeOffset.UtcNow;
+        var audits = new List<AuditLog>();
+
+        // Day 0 (today): 4 entries
+        for (int i = 0; i < 4; i++)
+            audits.Add(CreateAuditLog(_userId, today));
+
+        // Day -1: 1 entry
+        audits.Add(CreateAuditLog(_userId, today.AddDays(-1)));
+
+        // Day -2: 2 entries
+        for (int i = 0; i < 2; i++)
+            audits.Add(CreateAuditLog(_userId, today.AddDays(-2)));
+
+        _auditLogRepoMock
+            .Setup(a => a.QueryAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>(),
+                It.Is<Guid?>(id => id == _userId),
+                It.IsAny<Guid?>(),
+                It.IsAny<string?>(),
+                It.IsAny<string?>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(audits);
+
+        var result = await _service.GetStreakAsync(_userId, 5);
+
+        result.IsSuccess.Should().BeTrue();
+
+        var todayDate = DateOnly.FromDateTime(DateTime.UtcNow);
+        var todayDay = result.Value.Days.Single(d => d.Date == todayDate);
+        todayDay.IntensityBucket.Should().Be(4); // max = 4, count = 4 => ratio 1.0 => bucket 4
+
+        var yesterdayDay = result.Value.Days.Single(d => d.Date == todayDate.AddDays(-1));
+        yesterdayDay.IntensityBucket.Should().Be(1); // count = 1, max = 4 => ratio 0.25 => bucket 1
+
+        var twoDaysAgoDay = result.Value.Days.Single(d => d.Date == todayDate.AddDays(-2));
+        twoDaysAgoDay.IntensityBucket.Should().Be(2); // count = 2, max = 4 => ratio 0.5 => bucket 2
+    }
+
+    #endregion
+
+    #region ComputeDays Unit Tests
+
+    [Fact]
+    public void ComputeDays_ShouldIncludeEveryDateInRange()
+    {
+        var start = new DateOnly(2026, 4, 1);
+        var end = new DateOnly(2026, 4, 5);
+        var counts = new Dictionary<DateOnly, int>();
+
+        var days = StreakService.ComputeDays(start, end, counts);
+
+        days.Should().HaveCount(5);
+        days[0].Date.Should().Be(new DateOnly(2026, 4, 1));
+        days[4].Date.Should().Be(new DateOnly(2026, 4, 5));
+    }
+
+    [Fact]
+    public void ComputeDays_SingleDay_ShouldReturnOne()
+    {
+        var date = new DateOnly(2026, 4, 20);
+        var counts = new Dictionary<DateOnly, int> { { date, 5 } };
+
+        var days = StreakService.ComputeDays(date, date, counts);
+
+        days.Should().HaveCount(1);
+        days[0].Date.Should().Be(date);
+        days[0].IntensityBucket.Should().Be(4); // count = max = 5 => ratio 1.0 => bucket 4
+    }
+
+    [Fact]
+    public void ComputeDays_ShouldDefaultSealedToFalse()
+    {
+        var start = new DateOnly(2026, 4, 1);
+        var end = new DateOnly(2026, 4, 3);
+
+        var days = StreakService.ComputeDays(start, end, new Dictionary<DateOnly, int>());
+
+        days.Should().OnlyContain(d => d.IsSealed == false);
+    }
+
+    #endregion
+
+    #region ComputeCurrentStreak Unit Tests
+
+    [Fact]
+    public void ComputeCurrentStreak_Empty_ShouldReturnZero()
+    {
+        StreakService.ComputeCurrentStreak(Array.Empty<StreakDay>()).Should().Be(0);
+    }
+
+    [Fact]
+    public void ComputeCurrentStreak_AllActive_ShouldReturnTotal()
+    {
+        var days = Enumerable.Range(0, 5)
+            .Select(i => new StreakDay(new DateOnly(2026, 4, 1).AddDays(i), false, 2))
+            .ToList();
+
+        StreakService.ComputeCurrentStreak(days).Should().Be(5);
+    }
+
+    [Fact]
+    public void ComputeCurrentStreak_LastDayInactive_ShouldReturnZero()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 1), false, 3),
+            new(new DateOnly(2026, 4, 2), false, 2),
+            new(new DateOnly(2026, 4, 3), false, 0), // last day inactive
+        };
+
+        StreakService.ComputeCurrentStreak(days).Should().Be(0);
+    }
+
+    [Fact]
+    public void ComputeCurrentStreak_GapThenActive_ShouldCountOnlyTrailingActive()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 1), false, 3),
+            new(new DateOnly(2026, 4, 2), false, 0), // gap
+            new(new DateOnly(2026, 4, 3), false, 1),
+            new(new DateOnly(2026, 4, 4), false, 2),
+        };
+
+        StreakService.ComputeCurrentStreak(days).Should().Be(2);
+    }
+
+    #endregion
+
+    #region ComputeLongestStreak Unit Tests
+
+    [Fact]
+    public void ComputeLongestStreak_Empty_ShouldReturnZero()
+    {
+        StreakService.ComputeLongestStreak(Array.Empty<StreakDay>()).Should().Be(0);
+    }
+
+    [Fact]
+    public void ComputeLongestStreak_AllActive_ShouldReturnTotal()
+    {
+        var days = Enumerable.Range(0, 7)
+            .Select(i => new StreakDay(new DateOnly(2026, 4, 1).AddDays(i), false, 1))
+            .ToList();
+
+        StreakService.ComputeLongestStreak(days).Should().Be(7);
+    }
+
+    [Fact]
+    public void ComputeLongestStreak_AllInactive_ShouldReturnZero()
+    {
+        var days = Enumerable.Range(0, 5)
+            .Select(i => new StreakDay(new DateOnly(2026, 4, 1).AddDays(i), false, 0))
+            .ToList();
+
+        StreakService.ComputeLongestStreak(days).Should().Be(0);
+    }
+
+    [Fact]
+    public void ComputeLongestStreak_MultipleRuns_ShouldReturnLongest()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 1), false, 1),
+            new(new DateOnly(2026, 4, 2), false, 2),
+            new(new DateOnly(2026, 4, 3), false, 0), // gap
+            new(new DateOnly(2026, 4, 4), false, 3),
+            new(new DateOnly(2026, 4, 5), false, 4),
+            new(new DateOnly(2026, 4, 6), false, 1),
+            new(new DateOnly(2026, 4, 7), false, 0), // gap
+            new(new DateOnly(2026, 4, 8), false, 2),
+        };
+
+        StreakService.ComputeLongestStreak(days).Should().Be(3); // days 4-5-6
+    }
+
+    [Fact]
+    public void ComputeLongestStreak_SingleActiveDay_ShouldReturnOne()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 1), false, 0),
+            new(new DateOnly(2026, 4, 2), false, 1),
+            new(new DateOnly(2026, 4, 3), false, 0),
+        };
+
+        StreakService.ComputeLongestStreak(days).Should().Be(1);
+    }
+
+    #endregion
+
+    #region Day Count Boundary Tests
+
+    [Fact]
+    public async Task GetStreakAsync_MinDayCount_ShouldSucceed()
+    {
+        var result = await _service.GetStreakAsync(_userId, 1);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Days.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetStreakAsync_MaxDayCount_ShouldSucceed()
+    {
+        var result = await _service.GetStreakAsync(_userId, 365);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Days.Should().HaveCount(365);
+    }
+
+    [Fact]
+    public async Task GetStreakAsync_DefaultDayCount_ShouldBe90()
+    {
+        var result = await _service.GetStreakAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Days.Should().HaveCount(90);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static AuditLog CreateAuditLog(Guid userId, DateTimeOffset timestamp)
+    {
+        var auditLog = new AuditLog(
+            entityType: "card",
+            entityId: Guid.NewGuid(),
+            action: AuditAction.Created,
+            userId: userId,
+            changes: "test audit entry");
+
+        // Use reflection to set the Timestamp since it's set in constructor to UtcNow
+        var timestampProperty = typeof(AuditLog).GetProperty("Timestamp")!;
+        timestampProperty.SetValue(auditLog, timestamp);
+
+        return auditLog;
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/StreakDayTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/StreakDayTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class StreakDayTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void Constructor_ShouldSucceed_WithValidIntensityBucket(int bucket)
+    {
+        var date = new DateOnly(2026, 4, 20);
+        var day = new StreakDay(date, isSealed: false, intensityBucket: bucket);
+
+        day.Date.Should().Be(date);
+        day.IsSealed.Should().BeFalse();
+        day.IntensityBucket.Should().Be(bucket);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(5)]
+    [InlineData(100)]
+    [InlineData(-42)]
+    public void Constructor_ShouldThrow_WhenIntensityBucketOutOfRange(int bucket)
+    {
+        var act = () => new StreakDay(new DateOnly(2026, 4, 20), false, bucket);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("intensityBucket");
+    }
+
+    [Fact]
+    public void Constructor_ShouldStoreIsSealed_WhenTrue()
+    {
+        var day = new StreakDay(new DateOnly(2026, 4, 20), isSealed: true, intensityBucket: 3);
+
+        day.IsSealed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var date = new DateOnly(2026, 4, 20);
+        var day1 = new StreakDay(date, true, 2);
+        var day2 = new StreakDay(date, true, 2);
+
+        day1.Should().Be(day2);
+        day1.Equals(day2).Should().BeTrue();
+        (day1.GetHashCode() == day2.GetHashCode()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentValues_ShouldNotBeEqual()
+    {
+        var date = new DateOnly(2026, 4, 20);
+        var day1 = new StreakDay(date, false, 1);
+        var day2 = new StreakDay(date, false, 2);
+
+        day1.Should().NotBe(day2);
+    }
+
+    [Fact]
+    public void Equals_DifferentSealed_ShouldNotBeEqual()
+    {
+        var date = new DateOnly(2026, 4, 20);
+        var day1 = new StreakDay(date, true, 1);
+        var day2 = new StreakDay(date, false, 1);
+
+        day1.Should().NotBe(day2);
+    }
+
+    [Fact]
+    public void Equals_DifferentDates_ShouldNotBeEqual()
+    {
+        var day1 = new StreakDay(new DateOnly(2026, 4, 20), false, 1);
+        var day2 = new StreakDay(new DateOnly(2026, 4, 21), false, 1);
+
+        day1.Should().NotBe(day2);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/StreakResultTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/StreakResultTests.cs
@@ -1,0 +1,111 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class StreakResultTests
+{
+    [Fact]
+    public void Constructor_ShouldSucceed_WithValidData()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 20), false, 1),
+            new(new DateOnly(2026, 4, 21), false, 3),
+        };
+
+        var result = new StreakResult(days, currentStreakLength: 2, longestStreakLength: 5);
+
+        result.Days.Should().HaveCount(2);
+        result.CurrentStreakLength.Should().Be(2);
+        result.LongestStreakLength.Should().Be(5);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSucceed_WithEmptyDays()
+    {
+        var result = new StreakResult(Array.Empty<StreakDay>(), 0, 0);
+
+        result.Days.Should().BeEmpty();
+        result.CurrentStreakLength.Should().Be(0);
+        result.LongestStreakLength.Should().Be(0);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSucceed_WhenCurrentEqualsLongest()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 20), false, 2),
+        };
+
+        var result = new StreakResult(days, currentStreakLength: 3, longestStreakLength: 3);
+
+        result.CurrentStreakLength.Should().Be(3);
+        result.LongestStreakLength.Should().Be(3);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenDaysIsNull()
+    {
+        var act = () => new StreakResult(null!, 0, 0);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenCurrentStreakIsNegative()
+    {
+        var act = () => new StreakResult(Array.Empty<StreakDay>(), -1, 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("currentStreakLength");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenLongestStreakIsNegative()
+    {
+        var act = () => new StreakResult(Array.Empty<StreakDay>(), 0, -1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("longestStreakLength");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenCurrentExceedsLongest()
+    {
+        var act = () => new StreakResult(Array.Empty<StreakDay>(), 5, 3);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("currentStreakLength");
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 20), false, 1),
+        };
+
+        var result1 = new StreakResult(days, 1, 1);
+        var result2 = new StreakResult(days, 1, 1);
+
+        result1.Should().Be(result2);
+    }
+
+    [Fact]
+    public void Equals_DifferentStreakLengths_ShouldNotBeEqual()
+    {
+        var days = new List<StreakDay>
+        {
+            new(new DateOnly(2026, 4, 20), false, 1),
+        };
+
+        var result1 = new StreakResult(days, 1, 1);
+        var result2 = new StreakResult(days, 0, 1);
+
+        result1.Should().NotBe(result2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `StreakDay` and `StreakResult` domain value objects for daily activity tracking with intensity buckets (0-4) and sealed flag
- Implements `StreakService` that queries `IAuditLogRepository` for user audit entries, groups by date, computes quartile-based intensity buckets, and calculates current/longest streak lengths
- Adds `GET /api/today/streak?days=90` endpoint on new `TodayController` (authenticated, claims-first)
- Wires `IStreakService` into DI registration
- 57 tests: 23 domain (StreakDay/StreakResult validation, equality, edge cases) + 34 application (StreakService: empty history, single day, continuous streak, gap handling, intensity bucketing boundaries, day count validation)

## Notes
- `IsSealed` defaults to `false` for all days -- will be driven by #1017 seal entity when available
- Intensity bucketing uses quartile-based approach: count/max ratio mapped to buckets 1-4, with 0 for no activity
- Day count parameter validated to 1-365 range

Closes #1016
Required by PAPER-08 (#1004)

## Test plan
- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~Streak"` -- 57 tests pass (23 domain + 34 application)
- [ ] Adversarial self-review of all changed files