### PR TITLE
Add proposal side-effect analysis with 7-category breakdown and reversibility window

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
@@ -278,7 +278,7 @@ public class AutomationProposalsController : AuthenticatedControllerBase
         if (auth.ErrorResult is not null)
             return auth.ErrorResult;
 
-        var result = await _sideEffectAnalyzer.AnalyzeAsync(id, callerUserId, cancellationToken);
+        var result = await _sideEffectAnalyzer.AnalyzeAsync(id, cancellationToken);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 

--- a/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
@@ -27,16 +27,19 @@ public class AutomationProposalsController : AuthenticatedControllerBase
     private readonly IAutomationProposalService _proposalService;
     private readonly IAutomationExecutorService _executorService;
     private readonly BoardAuthorizationService _authorizationService;
+    private readonly ISideEffectAnalyzer _sideEffectAnalyzer;
 
     public AutomationProposalsController(
         IAutomationProposalService proposalService,
         IAutomationExecutorService executorService,
         BoardAuthorizationService authorizationService,
+        ISideEffectAnalyzer sideEffectAnalyzer,
         IUserContext userContext) : base(userContext)
     {
         _proposalService = proposalService;
         _executorService = executorService;
         _authorizationService = authorizationService;
+        _sideEffectAnalyzer = sideEffectAnalyzer;
     }
 
     /// <summary>
@@ -259,6 +262,24 @@ public class AutomationProposalsController : AuthenticatedControllerBase
         return result.IsSuccess
             ? Ok(new { dismissed = result.Value })
             : result.ToErrorActionResult();
+    }
+
+    /// <summary>
+    /// Gets the side-effect analysis for a proposal, including the 7-category breakdown
+    /// and reversibility posture.
+    /// </summary>
+    [HttpGet("{id}/side-effects")]
+    public async Task<IActionResult> GetProposalSideEffects(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var auth = await AuthorizeProposalAsync(id, callerUserId, requireWriteAccess: false, cancellationToken);
+        if (auth.ErrorResult is not null)
+            return auth.ErrorResult;
+
+        var result = await _sideEffectAnalyzer.AnalyzeAsync(id, callerUserId, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 
     /// <summary>

--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -47,6 +47,7 @@ public static class ApplicationServiceRegistration
         services.AddScoped<HistoryService>();
         services.AddScoped<IHistoryService>(sp => sp.GetRequiredService<HistoryService>());
         services.AddScoped<IAutomationProposalService, AutomationProposalService>();
+        services.AddScoped<ISideEffectAnalyzer, SideEffectAnalyzer>();
         services.AddScoped<IProposalRevisionService, ProposalRevisionService>();
         services.AddScoped<IAutomationPolicyEngine, AutomationPolicyEngine>();
         services.AddScoped<IAutomationPlannerService, AutomationPlannerService>();

--- a/backend/src/Taskdeck.Application/DTOs/SideEffectDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/SideEffectDtos.cs
@@ -1,5 +1,3 @@
-using Taskdeck.Domain.Entities;
-
 namespace Taskdeck.Application.DTOs;
 
 public record SideEffectRowDto(

--- a/backend/src/Taskdeck.Application/DTOs/SideEffectDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/SideEffectDtos.cs
@@ -1,0 +1,20 @@
+using Taskdeck.Domain.Entities;
+
+namespace Taskdeck.Application.DTOs;
+
+public record SideEffectRowDto(
+    string Key,
+    string Value,
+    string Tone // "active" | "passive"
+);
+
+public record ReversibilityDto(
+    string Summary,
+    string Description,
+    long WindowMs
+);
+
+public record ProposalSideEffectsDto(
+    IReadOnlyList<SideEffectRowDto> Rows,
+    ReversibilityDto Reversibility
+);

--- a/backend/src/Taskdeck.Application/Services/ISideEffectAnalyzer.cs
+++ b/backend/src/Taskdeck.Application/Services/ISideEffectAnalyzer.cs
@@ -1,0 +1,16 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Common;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Analyzes a proposal's operations to produce a 7-category side-effect breakdown
+/// and a reversibility posture.
+/// </summary>
+public interface ISideEffectAnalyzer
+{
+    /// <summary>
+    /// Analyzes the side effects of the specified proposal for the given user.
+    /// </summary>
+    Task<Result<ProposalSideEffectsDto>> AnalyzeAsync(Guid proposalId, Guid userId, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Services/ISideEffectAnalyzer.cs
+++ b/backend/src/Taskdeck.Application/Services/ISideEffectAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Taskdeck.Application.Services;
 public interface ISideEffectAnalyzer
 {
     /// <summary>
-    /// Analyzes the side effects of the specified proposal for the given user.
+    /// Analyzes the side effects of the specified proposal.
     /// </summary>
-    Task<Result<ProposalSideEffectsDto>> AnalyzeAsync(Guid proposalId, Guid userId, CancellationToken cancellationToken = default);
+    Task<Result<ProposalSideEffectsDto>> AnalyzeAsync(Guid proposalId, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
+++ b/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
@@ -1,0 +1,171 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Analyzes a proposal's operations to produce a 7-category side-effect breakdown
+/// (Cards, Subtasks, Comments, Activity log, Notifications, Webhooks, Calendar)
+/// and a reversibility posture.
+/// </summary>
+public sealed class SideEffectAnalyzer : ISideEffectAnalyzer
+{
+    // Action types that actively mutate cards
+    private static readonly HashSet<string> CardMutatingActions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "create", "move", "archive", "update", "delete", "bulk_move"
+    };
+
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SideEffectAnalyzer(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Result<ProposalSideEffectsDto>> AnalyzeAsync(
+        Guid proposalId,
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(proposalId, cancellationToken);
+        if (proposal is null)
+            return Result.Failure<ProposalSideEffectsDto>(ErrorCodes.NotFound, "Proposal not found.");
+
+        var operations = proposal.Operations;
+
+        // Determine webhook status for the board
+        bool hasActiveWebhooks = false;
+        if (proposal.BoardId.HasValue)
+        {
+            var webhookSubs = await _unitOfWork.OutboundWebhookSubscriptions
+                .GetActiveByBoardAsync(proposal.BoardId.Value, cancellationToken);
+            hasActiveWebhooks = webhookSubs.Count > 0;
+        }
+
+        var rows = BuildSideEffectRows(operations, hasActiveWebhooks);
+        var reversibility = ComputeReversibility(operations, proposal.RiskLevel);
+
+        var dto = new ProposalSideEffectsDto(
+            Rows: rows.Select(r => new SideEffectRowDto(r.Key, r.Value, r.Tone.ToString().ToLowerInvariant())).ToList(),
+            Reversibility: new ReversibilityDto(reversibility.Summary, reversibility.Description, reversibility.WindowMs));
+
+        return Result.Success(dto);
+    }
+
+    internal static IReadOnlyList<SideEffectRow> BuildSideEffectRows(
+        IReadOnlyList<AutomationProposalOperation> operations,
+        bool hasActiveWebhooks)
+    {
+        bool hasCardMutation = operations.Any(op => CardMutatingActions.Contains(op.ActionType));
+        bool hasColumnMutation = operations.Any(op =>
+            string.Equals(op.TargetType, "column", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(op.ActionType, "create_column", StringComparison.OrdinalIgnoreCase));
+        bool hasAnyOperation = operations.Count > 0;
+
+        return new List<SideEffectRow>
+        {
+            new(
+                "Cards",
+                hasCardMutation
+                    ? "Creates, moves, or archives cards on the board"
+                    : "No card mutations",
+                hasCardMutation ? SideEffectTone.Active : SideEffectTone.Passive),
+
+            new(
+                "Subtasks",
+                "Subtask management not yet supported",
+                SideEffectTone.Passive),
+
+            new(
+                "Comments",
+                "Proposals do not create comments",
+                SideEffectTone.Passive),
+
+            new(
+                "Activity log",
+                hasAnyOperation
+                    ? "Audit entries will be recorded for all applied operations"
+                    : "No operations to log",
+                hasAnyOperation ? SideEffectTone.Active : SideEffectTone.Passive),
+
+            new(
+                "Notifications",
+                hasAnyOperation
+                    ? "Approval or rejection generates notifications"
+                    : "No notifications generated",
+                hasAnyOperation ? SideEffectTone.Active : SideEffectTone.Passive),
+
+            new(
+                "Webhooks",
+                hasActiveWebhooks
+                    ? "Outbound webhooks configured for this board will fire"
+                    : "No outbound webhooks configured",
+                hasActiveWebhooks ? SideEffectTone.Active : SideEffectTone.Passive),
+
+            new(
+                "Calendar",
+                "Calendar integration not yet available",
+                SideEffectTone.Passive)
+        };
+    }
+
+    internal static Reversibility ComputeReversibility(
+        IReadOnlyList<AutomationProposalOperation> operations,
+        RiskLevel riskLevel)
+    {
+        // Base window is 6 hours
+        long windowMs = Reversibility.DefaultWindowMs;
+
+        // Adjust window based on risk level
+        string summary;
+        string description;
+
+        switch (riskLevel)
+        {
+            case RiskLevel.Critical:
+                windowMs = Reversibility.DefaultWindowMs / 2; // 3 hours -- tighter for critical
+                summary = "3 hours · manual intervention required";
+                description = "Critical-risk operations may require manual intervention to reverse. " +
+                              "Archive and delete operations can be recovered within the window, " +
+                              "but downstream effects (webhooks, notifications) cannot be recalled.";
+                break;
+
+            case RiskLevel.High:
+                windowMs = Reversibility.DefaultWindowMs; // 6 hours
+                summary = "6 hours · single keystroke";
+                description = "High-risk operations can be reversed within the window. " +
+                              "Card moves and updates are fully reversible; " +
+                              "archived cards can be restored from the archive.";
+                break;
+
+            case RiskLevel.Medium:
+                windowMs = Reversibility.DefaultWindowMs; // 6 hours
+                summary = "6 hours · single keystroke";
+                description = "Medium-risk operations are fully reversible within the window. " +
+                              "All board mutations can be undone from the activity log.";
+                break;
+
+            case RiskLevel.Low:
+            default:
+                windowMs = Reversibility.DefaultWindowMs; // 6 hours
+                summary = "6 hours · single keystroke";
+                description = "Low-risk operations are fully reversible within the window. " +
+                              "All board mutations can be undone from the activity log.";
+                break;
+        }
+
+        // If there are no operations, the proposal is a no-op
+        if (operations.Count == 0)
+        {
+            summary = "6 hours · no operations";
+            description = "This proposal contains no operations and will have no effect.";
+            windowMs = Reversibility.DefaultWindowMs;
+        }
+
+        return new Reversibility(summary, description, windowMs);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
+++ b/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
@@ -28,7 +28,6 @@ public sealed class SideEffectAnalyzer : ISideEffectAnalyzer
 
     public async Task<Result<ProposalSideEffectsDto>> AnalyzeAsync(
         Guid proposalId,
-        Guid userId,
         CancellationToken cancellationToken = default)
     {
         var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(proposalId, cancellationToken);

--- a/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
+++ b/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
@@ -61,9 +61,6 @@ public sealed class SideEffectAnalyzer : ISideEffectAnalyzer
         bool hasActiveWebhooks)
     {
         bool hasCardMutation = operations.Any(op => CardMutatingActions.Contains(op.ActionType));
-        bool hasColumnMutation = operations.Any(op =>
-            string.Equals(op.TargetType, "column", StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(op.ActionType, "create_column", StringComparison.OrdinalIgnoreCase));
         bool hasAnyOperation = operations.Count > 0;
 
         return new List<SideEffectRow>

--- a/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
+++ b/backend/src/Taskdeck.Application/Services/SideEffectAnalyzer.cs
@@ -60,17 +60,26 @@ public sealed class SideEffectAnalyzer : ISideEffectAnalyzer
         IReadOnlyList<AutomationProposalOperation> operations,
         bool hasActiveWebhooks)
     {
-        bool hasCardMutation = operations.Any(op => CardMutatingActions.Contains(op.ActionType));
+        bool hasCardMutation = operations.Any(op =>
+            CardMutatingActions.Contains(op.ActionType) &&
+            string.Equals(op.TargetType, "card", StringComparison.OrdinalIgnoreCase));
+        bool hasColumnMutation = operations.Any(op =>
+            string.Equals(op.TargetType, "column", StringComparison.OrdinalIgnoreCase));
+        bool hasBoardMutation = hasCardMutation || hasColumnMutation;
         bool hasAnyOperation = operations.Count > 0;
 
         return new List<SideEffectRow>
         {
             new(
                 "Cards",
-                hasCardMutation
-                    ? "Creates, moves, or archives cards on the board"
-                    : "No card mutations",
-                hasCardMutation ? SideEffectTone.Active : SideEffectTone.Passive),
+                hasBoardMutation
+                    ? hasCardMutation && hasColumnMutation
+                        ? "Creates, moves, or archives cards and adds columns on the board"
+                        : hasCardMutation
+                            ? "Creates, moves, or archives cards on the board"
+                            : "Adds columns to the board (no direct card mutations)"
+                    : "No board mutations",
+                hasBoardMutation ? SideEffectTone.Active : SideEffectTone.Passive),
 
             new(
                 "Subtasks",
@@ -98,10 +107,12 @@ public sealed class SideEffectAnalyzer : ISideEffectAnalyzer
 
             new(
                 "Webhooks",
-                hasActiveWebhooks
+                hasActiveWebhooks && hasAnyOperation
                     ? "Outbound webhooks configured for this board will fire"
-                    : "No outbound webhooks configured",
-                hasActiveWebhooks ? SideEffectTone.Active : SideEffectTone.Passive),
+                    : hasActiveWebhooks
+                        ? "Outbound webhooks configured but no operations to trigger them"
+                        : "No outbound webhooks configured",
+                hasActiveWebhooks && hasAnyOperation ? SideEffectTone.Active : SideEffectTone.Passive),
 
             new(
                 "Calendar",

--- a/backend/src/Taskdeck.Domain/Entities/ProposalSideEffects.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ProposalSideEffects.cs
@@ -1,0 +1,46 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Value object aggregating the full side-effect analysis for a proposal:
+/// the 7-row breakdown and the reversibility posture.
+/// </summary>
+public sealed class ProposalSideEffects : IEquatable<ProposalSideEffects>
+{
+    /// <summary>The 7-category side-effect breakdown.</summary>
+    public IReadOnlyList<SideEffectRow> Rows { get; }
+
+    /// <summary>The reversibility posture for this proposal.</summary>
+    public Reversibility Reversibility { get; }
+
+    public ProposalSideEffects(IReadOnlyList<SideEffectRow> rows, Reversibility reversibility)
+    {
+        if (rows is null || rows.Count == 0)
+            throw new ArgumentException("Side-effect rows cannot be null or empty.", nameof(rows));
+        Reversibility = reversibility ?? throw new ArgumentNullException(nameof(reversibility));
+
+        Rows = rows;
+    }
+
+    public bool Equals(ProposalSideEffects? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        if (Rows.Count != other.Rows.Count) return false;
+        for (int i = 0; i < Rows.Count; i++)
+        {
+            if (!Rows[i].Equals(other.Rows[i])) return false;
+        }
+        return Reversibility.Equals(other.Reversibility);
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as ProposalSideEffects);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var row in Rows)
+            hash.Add(row);
+        hash.Add(Reversibility);
+        return hash.ToHashCode();
+    }
+}

--- a/backend/src/Taskdeck.Domain/Entities/Reversibility.cs
+++ b/backend/src/Taskdeck.Domain/Entities/Reversibility.cs
@@ -1,0 +1,47 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Value object representing the reversibility window for a proposal.
+/// Describes how long a user has to undo the effects and the effort required.
+/// </summary>
+public sealed class Reversibility : IEquatable<Reversibility>
+{
+    /// <summary>Default reversibility window: 6 hours in milliseconds.</summary>
+    public const long DefaultWindowMs = 6L * 60 * 60 * 1000; // 21_600_000
+
+    /// <summary>Short summary (e.g. "6 hours - single keystroke").</summary>
+    public string Summary { get; }
+
+    /// <summary>Detailed description of the reversibility posture.</summary>
+    public string Description { get; }
+
+    /// <summary>Reversibility window in milliseconds.</summary>
+    public long WindowMs { get; }
+
+    public Reversibility(string summary, string description, long windowMs)
+    {
+        if (string.IsNullOrWhiteSpace(summary))
+            throw new ArgumentException("Reversibility summary cannot be empty.", nameof(summary));
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Reversibility description cannot be empty.", nameof(description));
+        if (windowMs <= 0)
+            throw new ArgumentOutOfRangeException(nameof(windowMs), "Reversibility window must be positive.");
+
+        Summary = summary;
+        Description = description;
+        WindowMs = windowMs;
+    }
+
+    public bool Equals(Reversibility? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Summary == other.Summary && Description == other.Description && WindowMs == other.WindowMs;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as Reversibility);
+
+    public override int GetHashCode() => HashCode.Combine(Summary, Description, WindowMs);
+
+    public override string ToString() => $"{Summary} ({WindowMs}ms)";
+}

--- a/backend/src/Taskdeck.Domain/Entities/SideEffectRow.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SideEffectRow.cs
@@ -1,0 +1,42 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Value object representing a single side-effect category and its active/passive classification
+/// for a proposal review.
+/// </summary>
+public sealed class SideEffectRow : IEquatable<SideEffectRow>
+{
+    /// <summary>Category key (e.g. "Cards", "Subtasks", "Comments").</summary>
+    public string Key { get; }
+
+    /// <summary>Human-readable description of what happens in this category.</summary>
+    public string Value { get; }
+
+    /// <summary>Whether the proposal actively or passively affects this category.</summary>
+    public SideEffectTone Tone { get; }
+
+    public SideEffectRow(string key, string value, SideEffectTone tone)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Side-effect key cannot be empty.", nameof(key));
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Side-effect value cannot be empty.", nameof(value));
+
+        Key = key;
+        Value = value;
+        Tone = tone;
+    }
+
+    public bool Equals(SideEffectRow? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Key == other.Key && Value == other.Value && Tone == other.Tone;
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as SideEffectRow);
+
+    public override int GetHashCode() => HashCode.Combine(Key, Value, Tone);
+
+    public override string ToString() => $"[{Tone}] {Key}: {Value}";
+}

--- a/backend/src/Taskdeck.Domain/Entities/SideEffectRow.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SideEffectRow.cs
@@ -21,6 +21,8 @@ public sealed class SideEffectRow : IEquatable<SideEffectRow>
             throw new ArgumentException("Side-effect key cannot be empty.", nameof(key));
         if (string.IsNullOrWhiteSpace(value))
             throw new ArgumentException("Side-effect value cannot be empty.", nameof(value));
+        if (!Enum.IsDefined(tone))
+            throw new ArgumentOutOfRangeException(nameof(tone), tone, "Unrecognized SideEffectTone value.");
 
         Key = key;
         Value = value;

--- a/backend/src/Taskdeck.Domain/Entities/SideEffectTone.cs
+++ b/backend/src/Taskdeck.Domain/Entities/SideEffectTone.cs
@@ -1,0 +1,14 @@
+namespace Taskdeck.Domain.Entities;
+
+/// <summary>
+/// Classifies whether a side-effect category is actively mutated by a proposal
+/// or passively unaffected.
+/// </summary>
+public enum SideEffectTone
+{
+    /// <summary>The proposal actively creates or modifies artifacts in this category.</summary>
+    Active,
+
+    /// <summary>The proposal does not create or modify artifacts in this category.</summary>
+    Passive
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/SideEffectAnalyzerTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SideEffectAnalyzerTests.cs
@@ -148,16 +148,18 @@ public class SideEffectAnalyzerTests
     }
 
     [Fact]
-    public async Task AnalyzeAsync_CardsMutation_ShouldBePassive_WhenCreateColumnOnly()
+    public async Task AnalyzeAsync_CardsMutation_ShouldBeActive_WhenCreateColumnOnly()
     {
-        var proposal = CreateProposal(RiskLevel.Low, null, ("create_column", "column"));
+        // Real column creation uses actionType "create" with targetType "column"
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "column"));
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
         var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
-        cardsRow.Tone.Should().Be("passive");
+        cardsRow.Tone.Should().Be("active");
+        cardsRow.Value.Should().Contain("columns");
     }
 
     [Fact]
@@ -299,6 +301,56 @@ public class SideEffectAnalyzerTests
         calendarRow.Tone.Should().Be("passive");
     }
 
+    [Fact]
+    public async Task AnalyzeAsync_CardsMutation_ShouldNotTreatColumnCreateAsCardMutation()
+    {
+        // A "create" operation targeting "column" should NOT be classified as a card mutation
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "column"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        // Should be active (column mutation) but description should mention columns, not card mutations
+        cardsRow.Value.Should().NotContain("Creates, moves, or archives cards on the board");
+        cardsRow.Value.Should().Contain("column");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Cards_ShouldShowBothCardAndColumnMutations()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"), ("create", "column"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be("active");
+        cardsRow.Value.Should().Contain("cards");
+        cardsRow.Value.Should().Contain("columns");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Webhooks_ShouldBePassive_WhenActiveWebhooksButNoOperations()
+    {
+        var boardId = Guid.NewGuid();
+        var proposal = CreateProposal(RiskLevel.Low, boardId);
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var subscription = new OutboundWebhookSubscription(boardId, Guid.NewGuid(), "https://example.com/webhook", "secret-key-123");
+        _webhookRepoMock.Setup(r => r.GetActiveByBoardAsync(boardId, default))
+            .ReturnsAsync(new List<OutboundWebhookSubscription> { subscription });
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
+        webhookRow.Tone.Should().Be("passive");
+        webhookRow.Value.Should().Contain("no operations");
+    }
+
     #endregion
 
     #region Reversibility Tests
@@ -420,6 +472,41 @@ public class SideEffectAnalyzerTests
 
         var webhookRow = rows.First(r => r.Key == "Webhooks");
         webhookRow.Tone.Should().Be(SideEffectTone.Active);
+    }
+
+    [Fact]
+    public void BuildSideEffectRows_CreateColumnOperation_ShouldSetCardsActive()
+    {
+        var op = new AutomationProposalOperation(
+            Guid.NewGuid(), 0, "create", "column", "{}", Guid.NewGuid().ToString());
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(new List<AutomationProposalOperation> { op }, false);
+
+        var cardsRow = rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be(SideEffectTone.Active);
+        cardsRow.Value.Should().Contain("column");
+    }
+
+    [Fact]
+    public void BuildSideEffectRows_CreateTargetingNonCard_ShouldNotSetCardMutation()
+    {
+        // "create" targeting "column" should not say "Creates, moves, or archives cards"
+        var op = new AutomationProposalOperation(
+            Guid.NewGuid(), 0, "create", "column", "{}", Guid.NewGuid().ToString());
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(new List<AutomationProposalOperation> { op }, false);
+
+        var cardsRow = rows.First(r => r.Key == "Cards");
+        cardsRow.Value.Should().NotBe("Creates, moves, or archives cards on the board");
+    }
+
+    [Fact]
+    public void BuildSideEffectRows_WithWebhooksButNoOps_ShouldSetWebhooksPassive()
+    {
+        var operations = new List<AutomationProposalOperation>();
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(operations, hasActiveWebhooks: true);
+
+        var webhookRow = rows.First(r => r.Key == "Webhooks");
+        webhookRow.Tone.Should().Be(SideEffectTone.Passive);
+        webhookRow.Value.Should().Contain("no operations");
     }
 
     #endregion

--- a/backend/tests/Taskdeck.Application.Tests/Services/SideEffectAnalyzerTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SideEffectAnalyzerTests.cs
@@ -61,7 +61,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((AutomationProposal?)null);
 
-        var result = await _analyzer.AnalyzeAsync(Guid.NewGuid(), Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(Guid.NewGuid());
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be("NotFound");
@@ -74,7 +74,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Rows.Should().HaveCount(7);
@@ -87,7 +87,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.IsSuccess.Should().BeTrue();
         var keys = result.Value.Rows.Select(r => r.Key).ToList();
@@ -101,7 +101,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.IsSuccess.Should().BeTrue();
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
@@ -115,7 +115,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
         cardsRow.Tone.Should().Be("active");
@@ -128,7 +128,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
         cardsRow.Tone.Should().Be("active");
@@ -141,7 +141,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
         cardsRow.Tone.Should().Be("active");
@@ -155,7 +155,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
         cardsRow.Tone.Should().Be("active");
@@ -169,7 +169,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var subtasksRow = result.Value.Rows.First(r => r.Key == "Subtasks");
         subtasksRow.Tone.Should().Be("passive");
@@ -182,7 +182,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var commentsRow = result.Value.Rows.First(r => r.Key == "Comments");
         commentsRow.Tone.Should().Be("passive");
@@ -195,7 +195,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var activityRow = result.Value.Rows.First(r => r.Key == "Activity log");
         activityRow.Tone.Should().Be("active");
@@ -208,7 +208,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var activityRow = result.Value.Rows.First(r => r.Key == "Activity log");
         activityRow.Tone.Should().Be("passive");
@@ -221,7 +221,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var notifRow = result.Value.Rows.First(r => r.Key == "Notifications");
         notifRow.Tone.Should().Be("active");
@@ -234,7 +234,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var notifRow = result.Value.Rows.First(r => r.Key == "Notifications");
         notifRow.Tone.Should().Be("passive");
@@ -252,7 +252,7 @@ public class SideEffectAnalyzerTests
         _webhookRepoMock.Setup(r => r.GetActiveByBoardAsync(boardId, default))
             .ReturnsAsync(new List<OutboundWebhookSubscription> { subscription });
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
         webhookRow.Tone.Should().Be("active");
@@ -269,7 +269,7 @@ public class SideEffectAnalyzerTests
         _webhookRepoMock.Setup(r => r.GetActiveByBoardAsync(boardId, default))
             .ReturnsAsync(new List<OutboundWebhookSubscription>());
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
         webhookRow.Tone.Should().Be("passive");
@@ -282,7 +282,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
         webhookRow.Tone.Should().Be("passive");
@@ -295,7 +295,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var calendarRow = result.Value.Rows.First(r => r.Key == "Calendar");
         calendarRow.Tone.Should().Be("passive");
@@ -309,7 +309,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
         // Should be active (column mutation) but description should mention columns, not card mutations
@@ -324,7 +324,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
         cardsRow.Tone.Should().Be("active");
@@ -344,7 +344,7 @@ public class SideEffectAnalyzerTests
         _webhookRepoMock.Setup(r => r.GetActiveByBoardAsync(boardId, default))
             .ReturnsAsync(new List<OutboundWebhookSubscription> { subscription });
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
         webhookRow.Tone.Should().Be("passive");
@@ -362,7 +362,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
     }
@@ -374,7 +374,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
     }
@@ -386,7 +386,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
     }
@@ -398,7 +398,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs / 2);
     }
@@ -410,7 +410,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.Value.Reversibility.Summary.Should().Contain("no operations");
         result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
@@ -423,7 +423,7 @@ public class SideEffectAnalyzerTests
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
             .ReturnsAsync(proposal);
 
-        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+        var result = await _analyzer.AnalyzeAsync(proposal.Id);
 
         result.Value.Reversibility.Summary.Should().Contain("manual intervention");
         result.Value.Reversibility.Description.Should().Contain("Critical-risk");

--- a/backend/tests/Taskdeck.Application.Tests/Services/SideEffectAnalyzerTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SideEffectAnalyzerTests.cs
@@ -1,0 +1,475 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class SideEffectAnalyzerTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IAutomationProposalRepository> _proposalRepoMock;
+    private readonly Mock<IOutboundWebhookSubscriptionRepository> _webhookRepoMock;
+    private readonly SideEffectAnalyzer _analyzer;
+
+    public SideEffectAnalyzerTests()
+    {
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _proposalRepoMock = new Mock<IAutomationProposalRepository>();
+        _webhookRepoMock = new Mock<IOutboundWebhookSubscriptionRepository>();
+
+        _unitOfWorkMock.Setup(u => u.AutomationProposals).Returns(_proposalRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.OutboundWebhookSubscriptions).Returns(_webhookRepoMock.Object);
+
+        _analyzer = new SideEffectAnalyzer(_unitOfWorkMock.Object);
+    }
+
+    private static AutomationProposal CreateProposal(
+        RiskLevel riskLevel = RiskLevel.Low,
+        Guid? boardId = null,
+        params (string actionType, string targetType)[] operations)
+    {
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Test proposal",
+            riskLevel,
+            Guid.NewGuid().ToString(),
+            boardId: boardId);
+
+        for (int i = 0; i < operations.Length; i++)
+        {
+            proposal.AddOperation(new AutomationProposalOperation(
+                proposal.Id,
+                i,
+                operations[i].actionType,
+                operations[i].targetType,
+                "{}",
+                Guid.NewGuid().ToString()));
+        }
+
+        return proposal;
+    }
+
+    #region AnalyzeAsync Tests
+
+    [Fact]
+    public async Task AnalyzeAsync_ShouldReturnNotFound_WhenProposalDoesNotExist()
+    {
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), default))
+            .ReturnsAsync((AutomationProposal?)null);
+
+        var result = await _analyzer.AnalyzeAsync(Guid.NewGuid(), Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ShouldReturnSevenRows()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Rows.Should().HaveCount(7);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ShouldReturnCorrectRowKeys()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.IsSuccess.Should().BeTrue();
+        var keys = result.Value.Rows.Select(r => r.Key).ToList();
+        keys.Should().ContainInOrder("Cards", "Subtasks", "Comments", "Activity log", "Notifications", "Webhooks", "Calendar");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_CardsMutation_ShouldBeActive_WhenCreateOperation()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.IsSuccess.Should().BeTrue();
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_CardsMutation_ShouldBeActive_WhenMoveOperation()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("move", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_CardsMutation_ShouldBeActive_WhenArchiveOperation()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("archive", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_CardsMutation_ShouldBeActive_WhenBulkMoveOperation()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("bulk_move", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_CardsMutation_ShouldBePassive_WhenCreateColumnOnly()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create_column", "column"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var cardsRow = result.Value.Rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Subtasks_ShouldAlwaysBePassive()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"), ("move", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var subtasksRow = result.Value.Rows.First(r => r.Key == "Subtasks");
+        subtasksRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Comments_ShouldAlwaysBePassive()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var commentsRow = result.Value.Rows.First(r => r.Key == "Comments");
+        commentsRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ActivityLog_ShouldBeActive_WhenOperationsExist()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var activityRow = result.Value.Rows.First(r => r.Key == "Activity log");
+        activityRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_ActivityLog_ShouldBePassive_WhenNoOperations()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null);
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var activityRow = result.Value.Rows.First(r => r.Key == "Activity log");
+        activityRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Notifications_ShouldBeActive_WhenOperationsExist()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("move", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var notifRow = result.Value.Rows.First(r => r.Key == "Notifications");
+        notifRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Notifications_ShouldBePassive_WhenNoOperations()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null);
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var notifRow = result.Value.Rows.First(r => r.Key == "Notifications");
+        notifRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Webhooks_ShouldBeActive_WhenBoardHasActiveSubscriptions()
+    {
+        var boardId = Guid.NewGuid();
+        var proposal = CreateProposal(RiskLevel.Low, boardId, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var subscription = new OutboundWebhookSubscription(boardId, Guid.NewGuid(), "https://example.com/webhook", "secret-key-123");
+        _webhookRepoMock.Setup(r => r.GetActiveByBoardAsync(boardId, default))
+            .ReturnsAsync(new List<OutboundWebhookSubscription> { subscription });
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
+        webhookRow.Tone.Should().Be("active");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Webhooks_ShouldBePassive_WhenBoardHasNoSubscriptions()
+    {
+        var boardId = Guid.NewGuid();
+        var proposal = CreateProposal(RiskLevel.Low, boardId, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        _webhookRepoMock.Setup(r => r.GetActiveByBoardAsync(boardId, default))
+            .ReturnsAsync(new List<OutboundWebhookSubscription>());
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
+        webhookRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Webhooks_ShouldBePassive_WhenNoBoardId()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var webhookRow = result.Value.Rows.First(r => r.Key == "Webhooks");
+        webhookRow.Tone.Should().Be("passive");
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Calendar_ShouldAlwaysBePassive()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        var calendarRow = result.Value.Rows.First(r => r.Key == "Calendar");
+        calendarRow.Tone.Should().Be("passive");
+    }
+
+    #endregion
+
+    #region Reversibility Tests
+
+    [Fact]
+    public async Task AnalyzeAsync_Reversibility_ShouldUseDefaultWindow_ForLowRisk()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null, ("create", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Reversibility_ShouldUseDefaultWindow_ForMediumRisk()
+    {
+        var proposal = CreateProposal(RiskLevel.Medium, null, ("move", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Reversibility_ShouldUseDefaultWindow_ForHighRisk()
+    {
+        var proposal = CreateProposal(RiskLevel.High, null, ("archive", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Reversibility_ShouldUseHalfWindow_ForCriticalRisk()
+    {
+        var proposal = CreateProposal(RiskLevel.Critical, null, ("delete", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs / 2);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Reversibility_ShouldDescribeNoOps_WhenNoOperations()
+    {
+        var proposal = CreateProposal(RiskLevel.Low, null);
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.Value.Reversibility.Summary.Should().Contain("no operations");
+        result.Value.Reversibility.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_Reversibility_CriticalRisk_ShouldMentionManualIntervention()
+    {
+        var proposal = CreateProposal(RiskLevel.Critical, null, ("delete", "card"));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposal.Id, default))
+            .ReturnsAsync(proposal);
+
+        var result = await _analyzer.AnalyzeAsync(proposal.Id, Guid.NewGuid());
+
+        result.Value.Reversibility.Summary.Should().Contain("manual intervention");
+        result.Value.Reversibility.Description.Should().Contain("Critical-risk");
+    }
+
+    #endregion
+
+    #region BuildSideEffectRows Static Tests
+
+    [Fact]
+    public void BuildSideEffectRows_ShouldAlwaysReturn7Rows()
+    {
+        var operations = new List<AutomationProposalOperation>();
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(operations, false);
+
+        rows.Should().HaveCount(7);
+    }
+
+    [Fact]
+    public void BuildSideEffectRows_EmptyOperations_ShouldHaveAllPassiveExceptNone()
+    {
+        var operations = new List<AutomationProposalOperation>();
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(operations, false);
+
+        // Cards, Subtasks, Comments, Activity log, Notifications, Webhooks, Calendar all passive
+        rows.Should().OnlyContain(r => r.Tone == SideEffectTone.Passive);
+    }
+
+    [Fact]
+    public void BuildSideEffectRows_WithCardCreate_ShouldSetCardsActive()
+    {
+        var op = new AutomationProposalOperation(
+            Guid.NewGuid(), 0, "create", "card", "{}", Guid.NewGuid().ToString());
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(new List<AutomationProposalOperation> { op }, false);
+
+        var cardsRow = rows.First(r => r.Key == "Cards");
+        cardsRow.Tone.Should().Be(SideEffectTone.Active);
+    }
+
+    [Fact]
+    public void BuildSideEffectRows_WithWebhooks_ShouldSetWebhooksActive()
+    {
+        var op = new AutomationProposalOperation(
+            Guid.NewGuid(), 0, "create", "card", "{}", Guid.NewGuid().ToString());
+        var rows = SideEffectAnalyzer.BuildSideEffectRows(new List<AutomationProposalOperation> { op }, true);
+
+        var webhookRow = rows.First(r => r.Key == "Webhooks");
+        webhookRow.Tone.Should().Be(SideEffectTone.Active);
+    }
+
+    #endregion
+
+    #region ComputeReversibility Static Tests
+
+    [Theory]
+    [InlineData(RiskLevel.Low)]
+    [InlineData(RiskLevel.Medium)]
+    [InlineData(RiskLevel.High)]
+    public void ComputeReversibility_NonCritical_ShouldUseDefaultWindow(RiskLevel level)
+    {
+        var op = new AutomationProposalOperation(
+            Guid.NewGuid(), 0, "create", "card", "{}", Guid.NewGuid().ToString());
+        var rev = SideEffectAnalyzer.ComputeReversibility(new List<AutomationProposalOperation> { op }, level);
+
+        rev.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
+    }
+
+    [Fact]
+    public void ComputeReversibility_Critical_ShouldUseHalfWindow()
+    {
+        var op = new AutomationProposalOperation(
+            Guid.NewGuid(), 0, "delete", "card", "{}", Guid.NewGuid().ToString());
+        var rev = SideEffectAnalyzer.ComputeReversibility(new List<AutomationProposalOperation> { op }, RiskLevel.Critical);
+
+        rev.WindowMs.Should().Be(Reversibility.DefaultWindowMs / 2);
+    }
+
+    [Fact]
+    public void ComputeReversibility_NoOperations_ShouldDescribeNoOps()
+    {
+        var rev = SideEffectAnalyzer.ComputeReversibility(new List<AutomationProposalOperation>(), RiskLevel.Low);
+
+        rev.Summary.Should().Contain("no operations");
+        rev.Description.Should().Contain("no operations");
+        rev.WindowMs.Should().Be(Reversibility.DefaultWindowMs);
+    }
+
+    #endregion
+
+    #region Constructor Tests
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenUnitOfWorkIsNull()
+    {
+        var act = () => new SideEffectAnalyzer(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalSideEffectsTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ProposalSideEffectsTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class ProposalSideEffectsTests
+{
+    private static Reversibility DefaultReversibility()
+        => new("6 hours · single keystroke", "Fully reversible.", Reversibility.DefaultWindowMs);
+
+    private static List<SideEffectRow> DefaultRows()
+        => new()
+        {
+            new SideEffectRow("Cards", "Creates cards", SideEffectTone.Active),
+            new SideEffectRow("Subtasks", "Not supported", SideEffectTone.Passive),
+            new SideEffectRow("Comments", "No comments", SideEffectTone.Passive),
+            new SideEffectRow("Activity log", "Audit entries recorded", SideEffectTone.Active),
+            new SideEffectRow("Notifications", "Generates notifications", SideEffectTone.Active),
+            new SideEffectRow("Webhooks", "No webhooks configured", SideEffectTone.Passive),
+            new SideEffectRow("Calendar", "Not yet integrated", SideEffectTone.Passive),
+        };
+
+    [Fact]
+    public void Constructor_ShouldCreateSideEffects_WithValidData()
+    {
+        var rows = DefaultRows();
+        var rev = DefaultReversibility();
+
+        var sideEffects = new ProposalSideEffects(rows, rev);
+
+        sideEffects.Rows.Should().HaveCount(7);
+        sideEffects.Reversibility.Should().Be(rev);
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenRowsIsNull()
+    {
+        var rev = DefaultReversibility();
+
+        var act = () => new ProposalSideEffects(null!, rev);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Side-effect rows cannot be null or empty.*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenRowsIsEmpty()
+    {
+        var rev = DefaultReversibility();
+
+        var act = () => new ProposalSideEffects(new List<SideEffectRow>(), rev);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Side-effect rows cannot be null or empty.*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldThrow_WhenReversibilityIsNull()
+    {
+        var rows = DefaultRows();
+
+        var act = () => new ProposalSideEffects(rows, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var sideEffects1 = new ProposalSideEffects(DefaultRows(), DefaultReversibility());
+        var sideEffects2 = new ProposalSideEffects(DefaultRows(), DefaultReversibility());
+
+        sideEffects1.Should().Be(sideEffects2);
+        sideEffects1.Equals(sideEffects2).Should().BeTrue();
+        (sideEffects1.GetHashCode() == sideEffects2.GetHashCode()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentRows_ShouldNotBeEqual()
+    {
+        var rows1 = DefaultRows();
+        var rows2 = new List<SideEffectRow>
+        {
+            new SideEffectRow("Cards", "Different value", SideEffectTone.Passive),
+            new SideEffectRow("Subtasks", "Not supported", SideEffectTone.Passive),
+            new SideEffectRow("Comments", "No comments", SideEffectTone.Passive),
+            new SideEffectRow("Activity log", "Audit entries recorded", SideEffectTone.Active),
+            new SideEffectRow("Notifications", "Generates notifications", SideEffectTone.Active),
+            new SideEffectRow("Webhooks", "No webhooks configured", SideEffectTone.Passive),
+            new SideEffectRow("Calendar", "Not yet integrated", SideEffectTone.Passive),
+        };
+
+        var sideEffects1 = new ProposalSideEffects(rows1, DefaultReversibility());
+        var sideEffects2 = new ProposalSideEffects(rows2, DefaultReversibility());
+
+        sideEffects1.Should().NotBe(sideEffects2);
+    }
+
+    [Fact]
+    public void Equals_DifferentReversibility_ShouldNotBeEqual()
+    {
+        var rev1 = DefaultReversibility();
+        var rev2 = new Reversibility("3 hours", "Different", 10_800_000L);
+
+        var sideEffects1 = new ProposalSideEffects(DefaultRows(), rev1);
+        var sideEffects2 = new ProposalSideEffects(DefaultRows(), rev2);
+
+        sideEffects1.Should().NotBe(sideEffects2);
+    }
+
+    [Fact]
+    public void Equals_Null_ShouldNotBeEqual()
+    {
+        var sideEffects = new ProposalSideEffects(DefaultRows(), DefaultReversibility());
+
+        sideEffects.Equals(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentRowCount_ShouldNotBeEqual()
+    {
+        var rows1 = DefaultRows();
+        var rows2 = new List<SideEffectRow>
+        {
+            new SideEffectRow("Cards", "Creates cards", SideEffectTone.Active)
+        };
+
+        var sideEffects1 = new ProposalSideEffects(rows1, DefaultReversibility());
+        var sideEffects2 = new ProposalSideEffects(rows2, DefaultReversibility());
+
+        sideEffects1.Should().NotBe(sideEffects2);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ReversibilityTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ReversibilityTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class ReversibilityTests
+{
+    [Fact]
+    public void DefaultWindowMs_ShouldBe6Hours()
+    {
+        Reversibility.DefaultWindowMs.Should().Be(21_600_000L);
+    }
+
+    [Fact]
+    public void Constructor_ShouldCreateReversibility_WithValidData()
+    {
+        var rev = new Reversibility("6 hours · single keystroke", "Fully reversible.", Reversibility.DefaultWindowMs);
+
+        rev.Summary.Should().Be("6 hours · single keystroke");
+        rev.Description.Should().Be("Fully reversible.");
+        rev.WindowMs.Should().Be(21_600_000L);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenSummaryIsBlank(string summary)
+    {
+        var act = () => new Reversibility(summary, "Description", Reversibility.DefaultWindowMs);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Reversibility summary cannot be empty.*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenDescriptionIsBlank(string description)
+    {
+        var act = () => new Reversibility("Summary", description, Reversibility.DefaultWindowMs);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Reversibility description cannot be empty.*");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public void Constructor_ShouldThrow_WhenWindowMsIsNotPositive(long windowMs)
+    {
+        var act = () => new Reversibility("Summary", "Description", windowMs);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Reversibility window must be positive.*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptCustomWindowMs()
+    {
+        var rev = new Reversibility("3 hours", "Tight window.", 10_800_000L);
+
+        rev.WindowMs.Should().Be(10_800_000L);
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var rev1 = new Reversibility("S", "D", 1000);
+        var rev2 = new Reversibility("S", "D", 1000);
+
+        rev1.Should().Be(rev2);
+        rev1.Equals(rev2).Should().BeTrue();
+        (rev1.GetHashCode() == rev2.GetHashCode()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentSummary_ShouldNotBeEqual()
+    {
+        var rev1 = new Reversibility("Summary A", "Same desc", 1000);
+        var rev2 = new Reversibility("Summary B", "Same desc", 1000);
+
+        rev1.Should().NotBe(rev2);
+    }
+
+    [Fact]
+    public void Equals_DifferentDescription_ShouldNotBeEqual()
+    {
+        var rev1 = new Reversibility("Same", "Desc A", 1000);
+        var rev2 = new Reversibility("Same", "Desc B", 1000);
+
+        rev1.Should().NotBe(rev2);
+    }
+
+    [Fact]
+    public void Equals_DifferentWindowMs_ShouldNotBeEqual()
+    {
+        var rev1 = new Reversibility("Same", "Same", 1000);
+        var rev2 = new Reversibility("Same", "Same", 2000);
+
+        rev1.Should().NotBe(rev2);
+    }
+
+    [Fact]
+    public void Equals_Null_ShouldNotBeEqual()
+    {
+        var rev = new Reversibility("S", "D", 1000);
+
+        rev.Equals(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToString_ShouldFormatCorrectly()
+    {
+        var rev = new Reversibility("6 hours", "Description", 21_600_000L);
+
+        rev.ToString().Should().Be("6 hours (21600000ms)");
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/SideEffectRowTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/SideEffectRowTests.cs
@@ -1,0 +1,114 @@
+using FluentAssertions;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Entities;
+
+public class SideEffectRowTests
+{
+    [Fact]
+    public void Constructor_ShouldCreateRow_WithValidData()
+    {
+        var row = new SideEffectRow("Cards", "Creates cards", SideEffectTone.Active);
+
+        row.Key.Should().Be("Cards");
+        row.Value.Should().Be("Creates cards");
+        row.Tone.Should().Be(SideEffectTone.Active);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenKeyIsBlank(string key)
+    {
+        var act = () => new SideEffectRow(key, "some value", SideEffectTone.Active);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Side-effect key cannot be empty.*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void Constructor_ShouldThrow_WhenValueIsBlank(string value)
+    {
+        var act = () => new SideEffectRow("Cards", value, SideEffectTone.Active);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("Side-effect value cannot be empty.*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptPassiveTone()
+    {
+        var row = new SideEffectRow("Calendar", "Not yet integrated", SideEffectTone.Passive);
+
+        row.Tone.Should().Be(SideEffectTone.Passive);
+    }
+
+    [Fact]
+    public void Equals_SameValues_ShouldBeEqual()
+    {
+        var row1 = new SideEffectRow("Cards", "Creates cards", SideEffectTone.Active);
+        var row2 = new SideEffectRow("Cards", "Creates cards", SideEffectTone.Active);
+
+        row1.Should().Be(row2);
+        row1.Equals(row2).Should().BeTrue();
+        (row1.GetHashCode() == row2.GetHashCode()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentKey_ShouldNotBeEqual()
+    {
+        var row1 = new SideEffectRow("Cards", "Same value", SideEffectTone.Active);
+        var row2 = new SideEffectRow("Subtasks", "Same value", SideEffectTone.Active);
+
+        row1.Should().NotBe(row2);
+    }
+
+    [Fact]
+    public void Equals_DifferentValue_ShouldNotBeEqual()
+    {
+        var row1 = new SideEffectRow("Cards", "Value A", SideEffectTone.Active);
+        var row2 = new SideEffectRow("Cards", "Value B", SideEffectTone.Active);
+
+        row1.Should().NotBe(row2);
+    }
+
+    [Fact]
+    public void Equals_DifferentTone_ShouldNotBeEqual()
+    {
+        var row1 = new SideEffectRow("Cards", "Same value", SideEffectTone.Active);
+        var row2 = new SideEffectRow("Cards", "Same value", SideEffectTone.Passive);
+
+        row1.Should().NotBe(row2);
+    }
+
+    [Fact]
+    public void Equals_Null_ShouldNotBeEqual()
+    {
+        var row = new SideEffectRow("Cards", "Value", SideEffectTone.Active);
+
+        row.Equals(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ToString_ShouldFormatCorrectly()
+    {
+        var row = new SideEffectRow("Cards", "Creates cards", SideEffectTone.Active);
+
+        row.ToString().Should().Be("[Active] Cards: Creates cards");
+    }
+
+    [Theory]
+    [InlineData(SideEffectTone.Active)]
+    [InlineData(SideEffectTone.Passive)]
+    public void Constructor_ShouldAcceptAllToneValues(SideEffectTone tone)
+    {
+        var row = new SideEffectRow("Key", "Value", tone);
+
+        row.Tone.Should().Be(tone);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds domain value objects (`SideEffectTone`, `SideEffectRow`, `Reversibility`, `ProposalSideEffects`) for the paper deep-review Section III side-effects breakdown
- Implements `ISideEffectAnalyzer` / `SideEffectAnalyzer` service that analyzes a proposal's operations to produce a 7-category side-effect table (Cards, Subtasks, Comments, Activity log, Notifications, Webhooks, Calendar) with active/passive tone classification
- Computes per-proposal reversibility window (default 6h, halved for Critical risk) with human-readable summary and description
- Adds `GET /api/automation/proposals/{id}/side-effects` endpoint with board-level authorization
- 59 new tests (25 domain + 34 application) covering value object construction, validation, equality, tone classification for all 7 categories, webhook detection, reversibility computation, and edge cases

## Test plan
- [x] `dotnet build backend/Taskdeck.sln -c Release` passes (0 errors)
- [x] `dotnet test --filter "FullyQualifiedName~SideEffect"` -- 60 tests pass
- [x] `dotnet test --filter "FullyQualifiedName~Reversibility"` -- 31 tests pass
- [x] Domain: value object creation, tone enum, reversibility defaults, equality/hash contracts
- [x] Service: different operation types produce correct active/passive tone for each of 7 categories
- [x] Service: webhook detection via board subscription lookup
- [x] Service: reversibility window computation varies by risk level (Critical = 3h, others = 6h)
- [x] Service: no-operations edge case produces passive-only rows and descriptive reversibility
- [x] Service: proposal not found returns NotFound result
- [x] Authorization reuses existing `AuthorizeProposalAsync` pattern from controller

Closes #1020