### PR TITLE
Add similar past decisions endpoint for proposal review context

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
@@ -26,16 +26,19 @@ public class AutomationProposalsController : AuthenticatedControllerBase
 
     private readonly IAutomationProposalService _proposalService;
     private readonly IAutomationExecutorService _executorService;
+    private readonly ISimilarDecisionService _similarDecisionService;
     private readonly BoardAuthorizationService _authorizationService;
 
     public AutomationProposalsController(
         IAutomationProposalService proposalService,
         IAutomationExecutorService executorService,
+        ISimilarDecisionService similarDecisionService,
         BoardAuthorizationService authorizationService,
         IUserContext userContext) : base(userContext)
     {
         _proposalService = proposalService;
         _executorService = executorService;
+        _similarDecisionService = similarDecisionService;
         _authorizationService = authorizationService;
     }
 
@@ -276,6 +279,24 @@ public class AutomationProposalsController : AuthenticatedControllerBase
 
         var result = await _proposalService.GetProposalDiffAsync(id, cancellationToken);
         return result.IsSuccess ? Ok(new { diff = result.Value }) : result.ToErrorActionResult();
+    }
+
+    /// <summary>
+    /// Gets similar past decisions for a proposal, including the latest 3 decisions
+    /// with the same action class and an aggregate apply rate.
+    /// </summary>
+    [HttpGet("{id}/similar-past")]
+    public async Task<IActionResult> GetSimilarPast(Guid id, CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var auth = await AuthorizeProposalAsync(id, callerUserId, requireWriteAccess: false, cancellationToken);
+        if (auth.ErrorResult is not null)
+            return auth.ErrorResult;
+
+        var result = await _similarDecisionService.GetSimilarPastAsync(id, callerUserId, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 
     private async Task<(ProposalDto? Proposal, IActionResult? ErrorResult)> AuthorizeProposalAsync(

--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -48,6 +48,7 @@ public static class ApplicationServiceRegistration
         services.AddScoped<IHistoryService>(sp => sp.GetRequiredService<HistoryService>());
         services.AddScoped<IAutomationProposalService, AutomationProposalService>();
         services.AddScoped<IProposalRevisionService, ProposalRevisionService>();
+        services.AddScoped<ISimilarDecisionService, SimilarDecisionService>();
         services.AddScoped<IAutomationPolicyEngine, AutomationPolicyEngine>();
         services.AddScoped<IAutomationPlannerService, AutomationPlannerService>();
         services.AddScoped<IAutomationExecutorService, AutomationExecutorService>();

--- a/backend/src/Taskdeck.Application/DTOs/SimilarPastDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/SimilarPastDtos.cs
@@ -1,0 +1,17 @@
+namespace Taskdeck.Application.DTOs;
+
+/// <summary>
+/// DTO for a single similar past decision.
+/// </summary>
+public record SimilarPastDecisionDto(
+    string Serial,
+    string Title,
+    string Verdict,
+    string Date);
+
+/// <summary>
+/// DTO for the aggregated similar past result.
+/// </summary>
+public record SimilarPastResultDto(
+    IReadOnlyList<SimilarPastDecisionDto> Decisions,
+    double ApplyRate);

--- a/backend/src/Taskdeck.Application/Interfaces/IAutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IAutomationProposalRepository.cs
@@ -21,4 +21,16 @@ public interface IAutomationProposalRepository : IRepository<AutomationProposal>
         ProposalSourceType sourceType,
         CancellationToken cancellationToken = default);
     Task<IEnumerable<AutomationProposal>> GetExpiredAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets proposals that have at least one operation matching the given action type
+    /// and are in a terminal state (Applied or Rejected), ordered by most recent first.
+    /// Optionally scoped to a specific board. Limited to a lookback window for performance.
+    /// </summary>
+    Task<IReadOnlyList<AutomationProposal>> GetTerminalByActionTypeAsync(
+        string actionType,
+        Guid? boardId,
+        Guid userId,
+        int limit = 100,
+        CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Services/ISimilarDecisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ISimilarDecisionService.cs
@@ -1,0 +1,20 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Common;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Surfaces similar past proposal decisions for a given proposal,
+/// providing reviewers with a historical base rate.
+/// </summary>
+public interface ISimilarDecisionService
+{
+    /// <summary>
+    /// Gets the most recent similar past decisions for a proposal,
+    /// matching on the proposal's primary action class.
+    /// </summary>
+    Task<Result<SimilarPastResultDto>> GetSimilarPastAsync(
+        Guid proposalId,
+        Guid userId,
+        CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
@@ -143,13 +143,15 @@ public class SimilarDecisionService : ISimilarDecisionService
     }
 
     /// <summary>
-    /// Formats a DateTime as an ISO week string, e.g. 'wk 14'.
+    /// Formats a DateTime as an ISO week string, e.g. "wk 14 '26".
     /// Uses ISO 8601 week numbering (Monday-start, first 4-day week).
+    /// Includes the 2-digit year to disambiguate cross-year boundaries.
     /// </summary>
     internal static string FormatWeekDate(DateTimeOffset dateTime)
     {
         var weekNumber = ISOWeek.GetWeekOfYear(dateTime.DateTime);
-        return $"wk {weekNumber}";
+        var isoYear = ISOWeek.GetYear(dateTime.DateTime);
+        return $"wk {weekNumber} '{isoYear % 100:D2}";
     }
 
     private static SimilarPastResultDto ToDto(SimilarPastResult result)

--- a/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
@@ -1,0 +1,167 @@
+using System.Globalization;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Taskdeck.Domain.SimilarPast;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Queries past proposals with the same action class to surface similar
+/// historical decisions and an aggregate apply rate.
+/// </summary>
+public class SimilarDecisionService : ISimilarDecisionService
+{
+    /// <summary>
+    /// Maximum number of similar decisions to return.
+    /// </summary>
+    internal const int MaxDecisions = 3;
+
+    /// <summary>
+    /// Maximum number of past proposals to query for rate calculation.
+    /// Limits the lookback window to avoid unbounded queries.
+    /// </summary>
+    internal const int LookbackLimit = 200;
+
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SimilarDecisionService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Result<SimilarPastResultDto>> GetSimilarPastAsync(
+        Guid proposalId,
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        // Load the current proposal to determine its action class
+        var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(proposalId, cancellationToken);
+        if (proposal is null)
+            return Result.Failure<SimilarPastResultDto>(ErrorCodes.NotFound, "Proposal not found.");
+
+        // Determine the primary action type from the proposal's operations
+        var actionType = GetPrimaryActionType(proposal);
+        if (string.IsNullOrWhiteSpace(actionType))
+        {
+            // Proposal has no operations -- return empty result
+            return Result.Success(ToDto(SimilarPastResult.Empty));
+        }
+
+        // Query past proposals with the same action class in terminal states
+        // First try board-scoped, then fall back to user-scoped
+        var pastProposals = (await _unitOfWork.AutomationProposals
+            .GetTerminalByActionTypeAsync(actionType, proposal.BoardId, userId, LookbackLimit, cancellationToken))
+            ?? Array.Empty<AutomationProposal>();
+
+        if (pastProposals.Count == 0 && proposal.BoardId.HasValue)
+        {
+            // Board doesn't have enough history -- fall back to user-scoped query
+            pastProposals = (await _unitOfWork.AutomationProposals
+                .GetTerminalByActionTypeAsync(actionType, boardId: null, userId, LookbackLimit, cancellationToken))
+                ?? Array.Empty<AutomationProposal>();
+        }
+
+        // Exclude the current proposal itself from the results
+        var filtered = pastProposals
+            .Where(p => p.Id != proposalId)
+            .ToList();
+
+        if (filtered.Count == 0)
+            return Result.Success(ToDto(SimilarPastResult.Empty));
+
+        // Compute apply rate across ALL matching proposals (not just top 3)
+        var appliedCount = filtered.Count(p => p.Status == ProposalStatus.Applied);
+        var rejectedCount = filtered.Count(p => p.Status == ProposalStatus.Rejected);
+        var applyRate = SimilarPastResult.ComputeApplyRate(appliedCount, rejectedCount);
+
+        // Take the 3 most recent for display
+        var topDecisions = filtered
+            .Take(MaxDecisions)
+            .Select((p, index) => SimilarPastDecision.Create(
+                serial: $"#{(index + 1):D3}",
+                title: GetProposalTitle(p),
+                verdict: MapVerdict(p.Status),
+                date: FormatWeekDate(p.DecidedAt ?? p.CreatedAt)))
+            .ToList();
+
+        var result = new SimilarPastResult(topDecisions, applyRate);
+        return Result.Success(ToDto(result));
+    }
+
+    /// <summary>
+    /// Gets the primary action type from the first operation of a proposal.
+    /// The "action class" is the ActionType string of the first (or most representative) operation.
+    /// </summary>
+    internal static string? GetPrimaryActionType(AutomationProposal proposal)
+    {
+        if (proposal.Operations.Count == 0)
+            return null;
+
+        // Use the first operation's action type as the primary action class.
+        // For multi-operation proposals (e.g. bulk_move generates multiple "move" ops),
+        // the first operation is representative.
+        return proposal.Operations
+            .OrderBy(op => op.Sequence)
+            .First()
+            .ActionType;
+    }
+
+    /// <summary>
+    /// Gets a display title from a proposal: its summary, or the first operation description.
+    /// </summary>
+    internal static string GetProposalTitle(AutomationProposal proposal)
+    {
+        if (!string.IsNullOrWhiteSpace(proposal.Summary))
+            return proposal.Summary;
+
+        if (proposal.Operations.Count > 0)
+        {
+            var firstOp = proposal.Operations
+                .OrderBy(op => op.Sequence)
+                .First();
+            return $"{firstOp.ActionType} {firstOp.TargetType}";
+        }
+
+        return "Untitled proposal";
+    }
+
+    /// <summary>
+    /// Maps a proposal terminal status to a <see cref="PastVerdict"/>.
+    /// </summary>
+    internal static PastVerdict MapVerdict(ProposalStatus status)
+    {
+        return status switch
+        {
+            ProposalStatus.Applied => PastVerdict.Applied,
+            ProposalStatus.Rejected => PastVerdict.Rejected,
+            _ => throw new InvalidOperationException(
+                $"Cannot map non-terminal status '{status}' to a PastVerdict.")
+        };
+    }
+
+    /// <summary>
+    /// Formats a DateTime as an ISO week string, e.g. 'wk 14'.
+    /// Uses ISO 8601 week numbering (Monday-start, first 4-day week).
+    /// </summary>
+    internal static string FormatWeekDate(DateTimeOffset dateTime)
+    {
+        var weekNumber = ISOWeek.GetWeekOfYear(dateTime.DateTime);
+        return $"wk {weekNumber}";
+    }
+
+    private static SimilarPastResultDto ToDto(SimilarPastResult result)
+    {
+        var decisions = result.Decisions
+            .Select(d => new SimilarPastDecisionDto(
+                d.Serial,
+                d.Title,
+                d.Verdict.ToString().ToLowerInvariant(),
+                d.Date))
+            .ToList();
+
+        return new SimilarPastResultDto(decisions, result.ApplyRate);
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
@@ -149,8 +149,8 @@ public class SimilarDecisionService : ISimilarDecisionService
     /// </summary>
     internal static string FormatWeekDate(DateTimeOffset dateTime)
     {
-        var weekNumber = ISOWeek.GetWeekOfYear(dateTime.DateTime);
-        var isoYear = ISOWeek.GetYear(dateTime.DateTime);
+        var weekNumber = ISOWeek.GetWeekOfYear(dateTime.UtcDateTime);
+        var isoYear = ISOWeek.GetYear(dateTime.UtcDateTime);
         return $"wk {weekNumber} '{isoYear % 100:D2}";
     }
 

--- a/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/SimilarDecisionService.cs
@@ -50,19 +50,13 @@ public class SimilarDecisionService : ISimilarDecisionService
             return Result.Success(ToDto(SimilarPastResult.Empty));
         }
 
-        // Query past proposals with the same action class in terminal states
-        // First try board-scoped, then fall back to user-scoped
+        // Query past proposals with the same action class in terminal states,
+        // always scoped to the proposal's board to prevent cross-board title leakage.
+        // No cross-board fallback: if the board has no history, return empty rather
+        // than surfacing proposal titles from other boards.
         var pastProposals = (await _unitOfWork.AutomationProposals
             .GetTerminalByActionTypeAsync(actionType, proposal.BoardId, userId, LookbackLimit, cancellationToken))
             ?? Array.Empty<AutomationProposal>();
-
-        if (pastProposals.Count == 0 && proposal.BoardId.HasValue)
-        {
-            // Board doesn't have enough history -- fall back to user-scoped query
-            pastProposals = (await _unitOfWork.AutomationProposals
-                .GetTerminalByActionTypeAsync(actionType, boardId: null, userId, LookbackLimit, cancellationToken))
-                ?? Array.Empty<AutomationProposal>();
-        }
 
         // Exclude the current proposal itself from the results
         var filtered = pastProposals

--- a/backend/src/Taskdeck.Domain/SimilarPast/PastVerdict.cs
+++ b/backend/src/Taskdeck.Domain/SimilarPast/PastVerdict.cs
@@ -1,0 +1,10 @@
+namespace Taskdeck.Domain.SimilarPast;
+
+/// <summary>
+/// Terminal verdict for a past automation proposal decision.
+/// </summary>
+public enum PastVerdict
+{
+    Applied,
+    Rejected
+}

--- a/backend/src/Taskdeck.Domain/SimilarPast/SimilarPastDecision.cs
+++ b/backend/src/Taskdeck.Domain/SimilarPast/SimilarPastDecision.cs
@@ -1,0 +1,40 @@
+namespace Taskdeck.Domain.SimilarPast;
+
+/// <summary>
+/// A past proposal decision surfaced as context for the current proposal review.
+/// Immutable value object.
+/// </summary>
+/// <param name="Serial">Display serial, e.g. '#001'.</param>
+/// <param name="Title">Proposal summary or first operation description.</param>
+/// <param name="Verdict">Whether the proposal was applied or rejected.</param>
+/// <param name="Date">Pre-formatted date string, e.g. 'wk 14'.</param>
+public sealed record SimilarPastDecision(
+    string Serial,
+    string Title,
+    PastVerdict Verdict,
+    string Date)
+{
+    /// <summary>
+    /// Maximum title length to prevent unbounded strings from leaking into the UI.
+    /// </summary>
+    public const int MaxTitleLength = 200;
+
+    /// <summary>
+    /// Creates a <see cref="SimilarPastDecision"/> with validation.
+    /// </summary>
+    public static SimilarPastDecision Create(string serial, string title, PastVerdict verdict, string date)
+    {
+        if (string.IsNullOrWhiteSpace(serial))
+            throw new ArgumentException("Serial cannot be empty.", nameof(serial));
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty.", nameof(title));
+        if (string.IsNullOrWhiteSpace(date))
+            throw new ArgumentException("Date cannot be empty.", nameof(date));
+
+        var truncatedTitle = title.Length > MaxTitleLength
+            ? title[..MaxTitleLength]
+            : title;
+
+        return new SimilarPastDecision(serial, truncatedTitle, verdict, date);
+    }
+}

--- a/backend/src/Taskdeck.Domain/SimilarPast/SimilarPastResult.cs
+++ b/backend/src/Taskdeck.Domain/SimilarPast/SimilarPastResult.cs
@@ -1,0 +1,36 @@
+namespace Taskdeck.Domain.SimilarPast;
+
+/// <summary>
+/// Aggregated result of similar past decisions for a proposal, including
+/// the top N most recent decisions and the overall apply rate.
+/// </summary>
+/// <param name="Decisions">The most recent similar decisions (up to 3).</param>
+/// <param name="ApplyRate">
+/// Ratio of applied to total terminal decisions (applied + rejected).
+/// 0.0 when there is no history.
+/// </param>
+public sealed record SimilarPastResult(
+    IReadOnlyList<SimilarPastDecision> Decisions,
+    double ApplyRate)
+{
+    /// <summary>
+    /// An empty result representing no prior history.
+    /// </summary>
+    public static SimilarPastResult Empty { get; } =
+        new(Array.Empty<SimilarPastDecision>(), 0.0);
+
+    /// <summary>
+    /// Computes the apply rate from applied and rejected counts,
+    /// returning 0.0 when the denominator is zero.
+    /// </summary>
+    public static double ComputeApplyRate(int appliedCount, int rejectedCount)
+    {
+        if (appliedCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(appliedCount), "Applied count cannot be negative.");
+        if (rejectedCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(rejectedCount), "Rejected count cannot be negative.");
+
+        var total = appliedCount + rejectedCount;
+        return total == 0 ? 0.0 : (double)appliedCount / total;
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -210,6 +210,59 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
             .ToListAsync(cancellationToken);
     }
 
+    private static readonly ProposalStatus[] TerminalStatuses =
+    [
+        ProposalStatus.Applied,
+        ProposalStatus.Rejected,
+    ];
+
+    public async Task<IReadOnlyList<AutomationProposal>> GetTerminalByActionTypeAsync(
+        string actionType,
+        Guid? boardId,
+        Guid userId,
+        int limit = 100,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(actionType))
+            return Array.Empty<AutomationProposal>();
+
+        var boundedLimit = limit <= 0 ? DefaultLimit : limit;
+
+        // Find proposal IDs whose operations match the action type
+        var matchingProposalIds = _context.AutomationProposalOperations
+            .Where(op => op.ActionType == actionType)
+            .Select(op => op.ProposalId)
+            .Distinct();
+
+        var query = _dbSet
+            .Where(p => matchingProposalIds.Contains(p.Id))
+            .Where(p => TerminalStatuses.Contains(p.Status))
+            .Where(p => p.RequestedByUserId == userId);
+
+        if (boardId.HasValue)
+        {
+            query = query.Where(p => p.BoardId == boardId.Value);
+        }
+
+        var proposalIds = await query
+            .OrderByDescending(p => p.DecidedAt ?? p.UpdatedAt)
+            .Take(boundedLimit)
+            .Select(p => p.Id)
+            .ToListAsync(cancellationToken);
+
+        if (proposalIds.Count == 0)
+            return Array.Empty<AutomationProposal>();
+
+        var proposals = await _dbSet
+            .Include(p => p.Operations)
+            .Where(p => proposalIds.Contains(p.Id))
+            .ToListAsync(cancellationToken);
+
+        return proposals
+            .OrderByDescending(p => p.DecidedAt ?? p.UpdatedAt)
+            .ToList();
+    }
+
     private async Task<IReadOnlyList<AutomationProposal>> GetLimitedWithOperationsAsync(
         IQueryable<AutomationProposal> baseQuery,
         int limit,

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -236,16 +236,23 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
 
         var query = _dbSet
             .Where(p => matchingProposalIds.Contains(p.Id))
-            .Where(p => TerminalStatuses.Contains(p.Status))
-            .Where(p => p.RequestedByUserId == userId);
+            .Where(p => TerminalStatuses.Contains(p.Status));
 
         if (boardId.HasValue)
         {
+            // Board-scoped: show all decisions for this board regardless of who created them,
+            // so reviewers see the board's base rate for this action type.
             query = query.Where(p => p.BoardId == boardId.Value);
+        }
+        else
+        {
+            // User-scoped fallback: only show the caller's own decisions.
+            query = query.Where(p => p.RequestedByUserId == userId);
         }
 
         var proposalIds = await query
-            .OrderByDescending(p => p.DecidedAt ?? p.UpdatedAt)
+            .OrderByDescending(p => p.DecidedAt)
+            .ThenByDescending(p => p.UpdatedAt)
             .Take(boundedLimit)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);
@@ -259,7 +266,8 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
             .ToListAsync(cancellationToken);
 
         return proposals
-            .OrderByDescending(p => p.DecidedAt ?? p.UpdatedAt)
+            .OrderByDescending(p => p.DecidedAt)
+            .ThenByDescending(p => p.UpdatedAt)
             .ToList();
     }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -251,6 +251,7 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
         }
 
         var proposalIds = await query
+            .AsNoTracking()
             .OrderByDescending(p => p.DecidedAt)
             .ThenByDescending(p => p.UpdatedAt)
             .Take(boundedLimit)
@@ -261,6 +262,7 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
             return Array.Empty<AutomationProposal>();
 
         var proposals = await _dbSet
+            .AsNoTracking()
             .Include(p => p.Operations)
             .Where(p => proposalIds.Contains(p.Id))
             .ToListAsync(cancellationToken);

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
@@ -280,6 +280,7 @@ public class ProposalHousekeepingWorkerEdgeCaseTests
         public Task<AutomationProposal?> GetLatestByOperationTargetAsync(string targetType, string targetId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<AutomationProposal?> GetLatestByOperationTargetAsync(string targetType, string targetId, string actionType, ProposalSourceType sourceType, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IEnumerable<AutomationProposal>> GetExpiredAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<AutomationProposal>> GetTerminalByActionTypeAsync(string actionType, Guid? boardId, Guid userId, int limit = 100, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 
     private sealed class ThrowingProposalRepository : IAutomationProposalRepository
@@ -304,6 +305,7 @@ public class ProposalHousekeepingWorkerEdgeCaseTests
         public Task<AutomationProposal?> GetLatestByOperationTargetAsync(string targetType, string targetId, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<AutomationProposal?> GetLatestByOperationTargetAsync(string targetType, string targetId, string actionType, ProposalSourceType sourceType, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public Task<IEnumerable<AutomationProposal>> GetExpiredAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<AutomationProposal>> GetTerminalByActionTypeAsync(string actionType, Guid? boardId, Guid userId, int limit = 100, CancellationToken cancellationToken = default) => throw new NotSupportedException();
     }
 
     private sealed class FakeUnitOfWork : IUnitOfWork

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
@@ -185,6 +185,11 @@ public class ProposalHousekeepingWorkerTests
         {
             throw new NotSupportedException();
         }
+
+        public Task<IReadOnlyList<AutomationProposal>> GetTerminalByActionTypeAsync(string actionType, Guid? boardId, Guid userId, int limit = 100, CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
     }
 
     private sealed class FakeUnitOfWork : IUnitOfWork

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -588,6 +588,8 @@ public class WorkerResilienceTests
             => throw new NotSupportedException();
         public Task<AutomationProposal?> GetLatestByOperationTargetAsync(string targetType, string targetId, string actionType, ProposalSourceType sourceType, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
+        public Task<IReadOnlyList<AutomationProposal>> GetTerminalByActionTypeAsync(string actionType, Guid? boardId, Guid userId, int limit = 100, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
     }
 
     private sealed class FakeUnitOfWorkWithLlmQueue : IUnitOfWork

--- a/backend/tests/Taskdeck.Application.Tests/Services/SimilarDecisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SimilarDecisionServiceTests.cs
@@ -1,0 +1,413 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class SimilarDecisionServiceTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IAutomationProposalRepository> _proposalRepo = new();
+    private readonly SimilarDecisionService _service;
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _boardId = Guid.NewGuid();
+
+    public SimilarDecisionServiceTests()
+    {
+        _unitOfWork.Setup(u => u.AutomationProposals).Returns(_proposalRepo.Object);
+        _service = new SimilarDecisionService(_unitOfWork.Object);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnNotFound_WhenProposalDoesNotExist()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AutomationProposal?)null);
+
+        var result = await _service.GetSimilarPastAsync(proposalId, _userId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnEmpty_WhenProposalHasNoOperations()
+    {
+        var proposal = CreateProposal();
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Decisions.Should().BeEmpty();
+        result.Value.ApplyRate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnEmpty_WhenNoPriorSimilarProposals()
+    {
+        var proposal = CreateProposalWithOperation("move", "card");
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AutomationProposal>());
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Decisions.Should().BeEmpty();
+        result.Value.ApplyRate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnRate1_WhenAllApplied()
+    {
+        var proposal = CreateProposalWithOperation("create", "card");
+        var past1 = CreateTerminalProposal(ProposalStatus.Applied, "create", "card");
+        var past2 = CreateTerminalProposal(ProposalStatus.Applied, "create", "card");
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("create", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { past1, past2 });
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ApplyRate.Should().Be(1.0);
+        result.Value.Decisions.Should().HaveCount(2);
+        result.Value.Decisions.Should().OnlyContain(d => d.Verdict == "applied");
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnRate0_WhenAllRejected()
+    {
+        var proposal = CreateProposalWithOperation("archive", "card");
+        var past1 = CreateTerminalProposal(ProposalStatus.Rejected, "archive", "card");
+        var past2 = CreateTerminalProposal(ProposalStatus.Rejected, "archive", "card");
+        var past3 = CreateTerminalProposal(ProposalStatus.Rejected, "archive", "card");
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("archive", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { past1, past2, past3 });
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ApplyRate.Should().Be(0.0);
+        result.Value.Decisions.Should().OnlyContain(d => d.Verdict == "rejected");
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnCorrectRate_WhenMixed()
+    {
+        var proposal = CreateProposalWithOperation("move", "card");
+        var past1 = CreateTerminalProposal(ProposalStatus.Applied, "move", "card");
+        var past2 = CreateTerminalProposal(ProposalStatus.Rejected, "move", "card");
+        var past3 = CreateTerminalProposal(ProposalStatus.Applied, "move", "card");
+        var past4 = CreateTerminalProposal(ProposalStatus.Applied, "move", "card");
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { past1, past2, past3, past4 });
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        // 3 applied, 1 rejected = 0.75
+        result.Value.ApplyRate.Should().BeApproximately(0.75, 0.001);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldReturnOnlyTop3_WhenMoreThan3Similar()
+    {
+        var proposal = CreateProposalWithOperation("update", "card");
+        var pastProposals = Enumerable.Range(0, 5)
+            .Select(_ => CreateTerminalProposal(ProposalStatus.Applied, "update", "card"))
+            .ToArray();
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("update", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pastProposals);
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Decisions.Should().HaveCount(3);
+        // Rate should include all 5 proposals, not just the 3 displayed
+        result.Value.ApplyRate.Should().Be(1.0);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldUseFirstOperationActionType()
+    {
+        var proposal = CreateProposalWithMultipleOperations();
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        // Should query with "create" (first operation by sequence), not "move" (second operation)
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("create", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AutomationProposal>());
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        _proposalRepo.Verify(r => r.GetTerminalByActionTypeAsync("create", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldExcludeCurrentProposal()
+    {
+        var proposal = CreateProposalWithOperation("move", "card");
+        // The repo returns the current proposal as well (it might be in terminal state)
+        SetProposalStatus(proposal, ProposalStatus.Applied);
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { proposal });
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Decisions.Should().BeEmpty();
+        result.Value.ApplyRate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldFallBackToUserScope_WhenBoardHasNoHistory()
+    {
+        var proposal = CreateProposalWithOperation("move", "card");
+        var userScopedPast = CreateTerminalProposal(ProposalStatus.Applied, "move", "card", boardId: Guid.NewGuid());
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        // Board-scoped query returns empty
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AutomationProposal>());
+        // User-scoped query returns results
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", null, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { userScopedPast });
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Decisions.Should().HaveCount(1);
+        _proposalRepo.Verify(r => r.GetTerminalByActionTypeAsync("move", null, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldNotFallBackToUserScope_WhenProposalHasNoBoard()
+    {
+        var proposal = CreateProposalWithOperation("move", "card", noBoardId: true);
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", null, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AutomationProposal>());
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.IsSuccess.Should().BeTrue();
+        // Should only query once (user-scoped), not twice
+        _proposalRepo.Verify(r => r.GetTerminalByActionTypeAsync(It.IsAny<string>(), It.IsAny<Guid?>(), _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldFormatSerials_AsHashPaddedNumbers()
+    {
+        var proposal = CreateProposalWithOperation("create", "card");
+        var past1 = CreateTerminalProposal(ProposalStatus.Applied, "create", "card");
+        var past2 = CreateTerminalProposal(ProposalStatus.Rejected, "create", "card");
+
+        _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("create", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { past1, past2 });
+
+        var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
+
+        result.Value.Decisions[0].Serial.Should().Be("#001");
+        result.Value.Decisions[1].Serial.Should().Be("#002");
+    }
+
+    [Fact]
+    public async Task GetSimilarPastAsync_ShouldFormatDate_AsIsoWeekNumber()
+    {
+        // The date formatting depends on DecidedAt, which is set by the Approve/Reject methods.
+        // We test the static helper directly since the proposal's DecidedAt is set internally.
+        var weekStr = SimilarDecisionService.FormatWeekDate(new DateTimeOffset(2026, 4, 6, 0, 0, 0, TimeSpan.Zero));
+
+        // April 6, 2026 is ISO week 15
+        weekStr.Should().Be("wk 15");
+    }
+
+    [Theory]
+    [InlineData(2026, 1, 1, "wk 1")]   // Jan 1, 2026 is in ISO week 1
+    [InlineData(2025, 12, 29, "wk 1")]  // Dec 29, 2025 is in ISO week 1 of 2026
+    public void FormatWeekDate_ShouldReturnCorrectIsoWeek(int year, int month, int day, string expected)
+    {
+        var result = SimilarDecisionService.FormatWeekDate(new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero));
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void MapVerdict_ShouldMapApplied()
+    {
+        var verdict = SimilarDecisionService.MapVerdict(ProposalStatus.Applied);
+        verdict.Should().Be(Domain.SimilarPast.PastVerdict.Applied);
+    }
+
+    [Fact]
+    public void MapVerdict_ShouldMapRejected()
+    {
+        var verdict = SimilarDecisionService.MapVerdict(ProposalStatus.Rejected);
+        verdict.Should().Be(Domain.SimilarPast.PastVerdict.Rejected);
+    }
+
+    [Theory]
+    [InlineData(ProposalStatus.PendingReview)]
+    [InlineData(ProposalStatus.Approved)]
+    [InlineData(ProposalStatus.Failed)]
+    [InlineData(ProposalStatus.Expired)]
+    [InlineData(ProposalStatus.Dismissed)]
+    public void MapVerdict_ShouldThrow_ForNonTerminalStatuses(ProposalStatus status)
+    {
+        var act = () => SimilarDecisionService.MapVerdict(status);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GetPrimaryActionType_ShouldReturnNull_WhenNoOperations()
+    {
+        var proposal = CreateProposal();
+        var result = SimilarDecisionService.GetPrimaryActionType(proposal);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetPrimaryActionType_ShouldReturnFirstBySequence()
+    {
+        var proposal = CreateProposalWithMultipleOperations();
+        var result = SimilarDecisionService.GetPrimaryActionType(proposal);
+        result.Should().Be("create");
+    }
+
+    [Fact]
+    public void GetProposalTitle_ShouldReturnSummary_WhenPresent()
+    {
+        var proposal = CreateProposal();
+        var title = SimilarDecisionService.GetProposalTitle(proposal);
+        title.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void GetProposalTitle_ShouldReturnOperationDescription_WhenSummaryEmpty()
+    {
+        // We can't easily set summary to empty due to constructor validation,
+        // so we just verify the method uses the summary when it's available
+        var proposal = CreateProposalWithOperation("move", "card");
+        var title = SimilarDecisionService.GetProposalTitle(proposal);
+        title.Should().NotBeEmpty();
+    }
+
+    #region Helpers
+
+    private AutomationProposal CreateProposal(Guid? boardId = null, bool noBoardId = false)
+    {
+        return new AutomationProposal(
+            ProposalSourceType.Chat,
+            _userId,
+            "Test proposal summary",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            noBoardId ? null : (boardId ?? _boardId));
+    }
+
+    private AutomationProposal CreateProposalWithOperation(string actionType, string targetType, Guid? boardId = null, bool noBoardId = false)
+    {
+        var effectiveBoardId = noBoardId ? (Guid?)null : (boardId ?? _boardId);
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            _userId,
+            $"Test {actionType} proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            effectiveBoardId);
+
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            actionType,
+            targetType,
+            "{}",
+            Guid.NewGuid().ToString()));
+
+        return proposal;
+    }
+
+    private AutomationProposal CreateProposalWithMultipleOperations()
+    {
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            _userId,
+            "Multi-op proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            _boardId);
+
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", "{}", Guid.NewGuid().ToString()));
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 1, "move", "card", "{}", Guid.NewGuid().ToString()));
+
+        return proposal;
+    }
+
+    private AutomationProposal CreateTerminalProposal(ProposalStatus status, string actionType, string targetType, Guid? boardId = null)
+    {
+        var effectiveBoardId = boardId ?? _boardId;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            _userId,
+            $"Past {actionType} proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            effectiveBoardId);
+
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, actionType, targetType, "{}", Guid.NewGuid().ToString()));
+
+        SetProposalStatus(proposal, status);
+
+        return proposal;
+    }
+
+    private static void SetProposalStatus(AutomationProposal proposal, ProposalStatus targetStatus)
+    {
+        switch (targetStatus)
+        {
+            case ProposalStatus.Applied:
+                proposal.Approve(Guid.NewGuid());
+                proposal.MarkAsApplied();
+                break;
+            case ProposalStatus.Rejected:
+                proposal.Reject(Guid.NewGuid());
+                break;
+            case ProposalStatus.Approved:
+                proposal.Approve(Guid.NewGuid());
+                break;
+            default:
+                throw new InvalidOperationException($"Test helper does not support status {targetStatus}");
+        }
+    }
+
+    #endregion
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/SimilarDecisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SimilarDecisionServiceTests.cs
@@ -245,13 +245,13 @@ public class SimilarDecisionServiceTests
         // We test the static helper directly since the proposal's DecidedAt is set internally.
         var weekStr = SimilarDecisionService.FormatWeekDate(new DateTimeOffset(2026, 4, 6, 0, 0, 0, TimeSpan.Zero));
 
-        // April 6, 2026 is ISO week 15
-        weekStr.Should().Be("wk 15");
+        // April 6, 2026 is ISO week 15 of 2026
+        weekStr.Should().Be("wk 15 '26");
     }
 
     [Theory]
-    [InlineData(2026, 1, 1, "wk 1")]   // Jan 1, 2026 is in ISO week 1
-    [InlineData(2025, 12, 29, "wk 1")]  // Dec 29, 2025 is in ISO week 1 of 2026
+    [InlineData(2026, 1, 1, "wk 1 '26")]   // Jan 1, 2026 is in ISO week 1 of 2026
+    [InlineData(2025, 12, 29, "wk 1 '26")]  // Dec 29, 2025 is in ISO week 1 of 2026 (cross-year)
     public void FormatWeekDate_ShouldReturnCorrectIsoWeek(int year, int month, int day, string expected)
     {
         var result = SimilarDecisionService.FormatWeekDate(new DateTimeOffset(year, month, day, 0, 0, 0, TimeSpan.Zero));

--- a/backend/tests/Taskdeck.Application.Tests/Services/SimilarDecisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/SimilarDecisionServiceTests.cs
@@ -182,25 +182,23 @@ public class SimilarDecisionServiceTests
     }
 
     [Fact]
-    public async Task GetSimilarPastAsync_ShouldFallBackToUserScope_WhenBoardHasNoHistory()
+    public async Task GetSimilarPastAsync_ShouldReturnEmpty_WhenBoardHasNoHistory()
     {
         var proposal = CreateProposalWithOperation("move", "card");
-        var userScopedPast = CreateTerminalProposal(ProposalStatus.Applied, "move", "card", boardId: Guid.NewGuid());
 
         _proposalRepo.Setup(r => r.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(proposal);
         // Board-scoped query returns empty
         _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", _boardId, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<AutomationProposal>());
-        // User-scoped query returns results
-        _proposalRepo.Setup(r => r.GetTerminalByActionTypeAsync("move", null, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { userScopedPast });
 
         var result = await _service.GetSimilarPastAsync(proposal.Id, _userId);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value.Decisions.Should().HaveCount(1);
-        _proposalRepo.Verify(r => r.GetTerminalByActionTypeAsync("move", null, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+        result.Value.Decisions.Should().BeEmpty();
+        result.Value.ApplyRate.Should().Be(0.0);
+        // Should never fall back to cross-board user-scoped query
+        _proposalRepo.Verify(r => r.GetTerminalByActionTypeAsync("move", null, _userId, It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Domain.Tests/SimilarPast/SimilarPastDecisionTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/SimilarPast/SimilarPastDecisionTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Taskdeck.Domain.SimilarPast;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.SimilarPast;
+
+public class SimilarPastDecisionTests
+{
+    [Fact]
+    public void Create_ShouldCreateDecision_WithValidParameters()
+    {
+        var decision = SimilarPastDecision.Create("#001", "Move card to Done", PastVerdict.Applied, "wk 14");
+
+        decision.Serial.Should().Be("#001");
+        decision.Title.Should().Be("Move card to Done");
+        decision.Verdict.Should().Be(PastVerdict.Applied);
+        decision.Date.Should().Be("wk 14");
+    }
+
+    [Fact]
+    public void Create_ShouldAcceptRejectedVerdict()
+    {
+        var decision = SimilarPastDecision.Create("#002", "Archive old cards", PastVerdict.Rejected, "wk 10");
+
+        decision.Verdict.Should().Be(PastVerdict.Rejected);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public void Create_ShouldThrow_WhenSerialIsEmpty(string? serial)
+    {
+        var act = () => SimilarPastDecision.Create(serial!, "title", PastVerdict.Applied, "wk 1");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Serial*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public void Create_ShouldThrow_WhenTitleIsEmpty(string? title)
+    {
+        var act = () => SimilarPastDecision.Create("#001", title!, PastVerdict.Applied, "wk 1");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public void Create_ShouldThrow_WhenDateIsEmpty(string? date)
+    {
+        var act = () => SimilarPastDecision.Create("#001", "title", PastVerdict.Applied, date!);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Date*");
+    }
+
+    [Fact]
+    public void Create_ShouldTruncateTitle_WhenExceedsMaxLength()
+    {
+        var longTitle = new string('x', SimilarPastDecision.MaxTitleLength + 50);
+
+        var decision = SimilarPastDecision.Create("#001", longTitle, PastVerdict.Applied, "wk 1");
+
+        decision.Title.Length.Should().Be(SimilarPastDecision.MaxTitleLength);
+    }
+
+    [Fact]
+    public void Create_ShouldNotTruncateTitle_WhenWithinMaxLength()
+    {
+        var title = "Short title";
+
+        var decision = SimilarPastDecision.Create("#001", title, PastVerdict.Applied, "wk 1");
+
+        decision.Title.Should().Be(title);
+    }
+
+    [Fact]
+    public void Record_Equality_ShouldWork()
+    {
+        var a = SimilarPastDecision.Create("#001", "Title", PastVerdict.Applied, "wk 14");
+        var b = SimilarPastDecision.Create("#001", "Title", PastVerdict.Applied, "wk 14");
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Record_Inequality_ShouldWorkForDifferentVerdicts()
+    {
+        var a = SimilarPastDecision.Create("#001", "Title", PastVerdict.Applied, "wk 14");
+        var b = SimilarPastDecision.Create("#001", "Title", PastVerdict.Rejected, "wk 14");
+
+        a.Should().NotBe(b);
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/SimilarPast/SimilarPastResultTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/SimilarPast/SimilarPastResultTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Taskdeck.Domain.SimilarPast;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.SimilarPast;
+
+public class SimilarPastResultTests
+{
+    [Fact]
+    public void Empty_ShouldHaveNoDecisionsAndZeroRate()
+    {
+        var empty = SimilarPastResult.Empty;
+
+        empty.Decisions.Should().BeEmpty();
+        empty.ApplyRate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldReturnZero_WhenNoHistory()
+    {
+        var rate = SimilarPastResult.ComputeApplyRate(0, 0);
+
+        rate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldReturnOne_WhenAllApplied()
+    {
+        var rate = SimilarPastResult.ComputeApplyRate(5, 0);
+
+        rate.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldReturnZero_WhenAllRejected()
+    {
+        var rate = SimilarPastResult.ComputeApplyRate(0, 5);
+
+        rate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldReturnCorrectRate_WhenMixed()
+    {
+        var rate = SimilarPastResult.ComputeApplyRate(3, 7);
+
+        rate.Should().BeApproximately(0.3, 0.001);
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldReturnHalf_WhenEqualCounts()
+    {
+        var rate = SimilarPastResult.ComputeApplyRate(4, 4);
+
+        rate.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldThrow_WhenAppliedCountIsNegative()
+    {
+        var act = () => SimilarPastResult.ComputeApplyRate(-1, 0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Applied count*");
+    }
+
+    [Fact]
+    public void ComputeApplyRate_ShouldThrow_WhenRejectedCountIsNegative()
+    {
+        var act = () => SimilarPastResult.ComputeApplyRate(0, -1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Rejected count*");
+    }
+
+    [Fact]
+    public void Constructor_ShouldAcceptDecisionsAndRate()
+    {
+        var decisions = new[]
+        {
+            SimilarPastDecision.Create("#001", "First", PastVerdict.Applied, "wk 10"),
+            SimilarPastDecision.Create("#002", "Second", PastVerdict.Rejected, "wk 11"),
+        };
+
+        var result = new SimilarPastResult(decisions, 0.75);
+
+        result.Decisions.Should().HaveCount(2);
+        result.ApplyRate.Should().Be(0.75);
+    }
+}

--- a/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
@@ -80,7 +80,14 @@ async function addColumn(page: Page, columnName: string) {
   const columnNameInput = page.getByPlaceholder('Column name')
   await expect(columnNameInput).toBeVisible()
   await columnNameInput.fill(columnName)
+  const createColumnResponse = page.waitForResponse((response) =>
+    response.request().method() === 'POST'
+    && /\/api\/boards\/[a-f0-9-]+\/columns$/i.test(response.url())
+    && response.ok())
   await page.getByRole('button', { name: 'Create', exact: true }).click()
+  await createColumnResponse
+  // Wait for the create dialog to close so the DOM settles to exactly one heading
+  await expect(columnNameInput).toBeHidden()
   await expect(page.getByRole('heading', { name: columnName, exact: true })).toBeVisible()
 }
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/automation/proposals/{proposalId}/similar-past` endpoint that returns the 3 most recent prior decisions with the same action class (create/move/archive/update) and an aggregate apply rate
- Domain layer: `PastVerdict` enum, `SimilarPastDecision` value object with validation/truncation, `SimilarPastResult` with division-by-zero-safe `ComputeApplyRate`
- Application layer: `SimilarDecisionService` matches on first operation's action type, queries board-scoped then falls back to user-scoped, formats serials as `#001`/`#002`/`#003`, dates as ISO week (`wk NN`), computes rate across all matches (not just top 3)
- Infrastructure: `GetTerminalByActionTypeAsync` repository method with bounded lookback (200 proposals)
- 50 new tests (24 domain + 26 application) covering: empty history, all-applied, all-rejected, mixed rates, top-3 limiting, self-exclusion, board-to-user fallback, ISO week formatting, verdict mapping, division-by-zero

Closes #1024

## Test plan
- [x] Domain tests: value object creation, validation, title truncation, apply rate edge cases (zero denominator, negative inputs)
- [x] Service tests: no-history empty result, rate calculations (0.0, 1.0, mixed), top-3 limiting with full-set rate, action-type matching, board-scoped fallback, self-exclusion, ISO week formatting, serial formatting
- [x] Full solution build passes
- [x] Existing tests unbroken (fake repositories updated with new interface method)