### PR TITLE
Agent runtime hardening: quotas, egress control, tool-hash pinning

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -94,6 +94,11 @@ public static class ApplicationServiceRegistration
                 sp.GetRequiredService<IBoardMetricsService>()));
         services.AddScoped<AgentProfileService>();
         services.AddScoped<AgentRunService>();
+        services.AddScoped<AgentPolicy>();
+        services.AddScoped<AgentRuntime>();
+        services.AddScoped<McpToolDefinitionHashService>();
+        services.AddScoped<InboxTriageDigestAgent>();
+        services.AddSingleton<IEgressRegistry, EgressRegistry>();
         services.AddScoped<SignalRBoardRealtimeNotifier>();
         services.AddScoped<WebhookBoardMutationNotifier>();
         services.AddScoped<IBoardRealtimeNotifier, CompositeBoardRealtimeNotifier>();

--- a/backend/src/Taskdeck.Application/Interfaces/IAgentRunRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IAgentRunRepository.cs
@@ -6,4 +6,6 @@ public interface IAgentRunRepository : IRepository<AgentRun>
 {
     Task<IEnumerable<AgentRun>> GetByAgentProfileIdAsync(Guid agentProfileId, int limit = 100, CancellationToken cancellationToken = default);
     Task<AgentRun?> GetByIdWithEventsAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AgentRun>> GetActiveByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task AddEventAsync(AgentRunEvent agentRunEvent, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Interfaces/IMcpToolHashRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IMcpToolHashRepository.cs
@@ -1,0 +1,16 @@
+using Taskdeck.Domain.Agents;
+
+namespace Taskdeck.Application.Interfaces;
+
+/// <summary>
+/// Repository for MCP tool definition hashes.
+/// </summary>
+public interface IMcpToolHashRepository
+{
+    Task<McpToolHash?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<McpToolHash?> GetByUserAndToolAsync(Guid userId, string toolName, CancellationToken cancellationToken = default);
+    Task<IEnumerable<McpToolHash>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task AddAsync(McpToolHash entity, CancellationToken cancellationToken = default);
+    Task UpdateAsync(McpToolHash entity, CancellationToken cancellationToken = default);
+    Task DeleteAsync(McpToolHash entity, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Interfaces/IUnitOfWork.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IUnitOfWork.cs
@@ -36,6 +36,7 @@ public interface IUnitOfWork
     IProposalRevisionRepository ProposalRevisions { get; }
     IDailySnapshotRepository DailySnapshots { get; }
     ITomorrowNoteRepository TomorrowNotes { get; }
+    IMcpToolHashRepository McpToolHashes { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     Task BeginTransactionAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Services/AgentPolicy.cs
+++ b/backend/src/Taskdeck.Application/Services/AgentPolicy.cs
@@ -79,8 +79,8 @@ public sealed class AgentPolicy
                 continue;
             }
 
-            // Check profile-level allowlist if specified
-            if (profileAllowlist is { Count: > 0 } &&
+            // Check profile-level allowlist if specified (fail-closed: empty allowlist denies all)
+            if (profileAllowlist is not null &&
                 !profileAllowlist.Any(a => string.Equals(a, toolKey, StringComparison.OrdinalIgnoreCase)))
             {
                 decisions.Add(new ToolBundleDecision(toolKey, false,

--- a/backend/src/Taskdeck.Application/Services/AgentPolicy.cs
+++ b/backend/src/Taskdeck.Application/Services/AgentPolicy.cs
@@ -1,0 +1,121 @@
+using Microsoft.Extensions.Logging;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Domain.Enums;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Validates agent tool bundles against security policies.
+/// Implements fail-closed defaults: unknown tools are denied.
+/// GP-06: approve_proposal and direct board mutation tools are permanently excluded.
+/// GP-09: all policy decisions are inspectable.
+/// </summary>
+public sealed class AgentPolicy
+{
+    /// <summary>
+    /// Tools that agents are NEVER allowed to use, regardless of policy configuration.
+    /// approve_proposal and any direct board mutation tools are permanently excluded
+    /// to enforce review-first automation safety (GP-06).
+    /// </summary>
+    private static readonly HashSet<string> PermanentlyExcludedTools = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "approve_proposal",
+        "apply_proposal",
+        "board.direct_update",
+        "board.direct_delete",
+        "card.direct_move",
+        "card.direct_delete",
+        "column.direct_delete",
+    };
+
+    private readonly ITaskdeckToolRegistry _toolRegistry;
+    private readonly ILogger<AgentPolicy>? _logger;
+
+    public AgentPolicy(ITaskdeckToolRegistry toolRegistry, ILogger<AgentPolicy>? logger = null)
+    {
+        _toolRegistry = toolRegistry ?? throw new ArgumentNullException(nameof(toolRegistry));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Validates that a set of tool keys is allowed for an agent to use.
+    /// Returns a list of policy decisions, one per tool.
+    /// Fail-closed: any tool not in the registry or in the exclusion list is denied.
+    /// </summary>
+    public IReadOnlyList<ToolBundleDecision> ValidateToolBundle(
+        IEnumerable<string> requestedToolKeys,
+        IReadOnlyList<string>? profileAllowlist = null)
+    {
+        ArgumentNullException.ThrowIfNull(requestedToolKeys);
+
+        var decisions = new List<ToolBundleDecision>();
+
+        foreach (var toolKey in requestedToolKeys)
+        {
+            if (string.IsNullOrWhiteSpace(toolKey))
+            {
+                decisions.Add(new ToolBundleDecision(toolKey ?? string.Empty, false,
+                    "Tool key is empty or null."));
+                continue;
+            }
+
+            // Check permanent exclusion list first
+            if (PermanentlyExcludedTools.Contains(toolKey))
+            {
+                _logger?.LogWarning(
+                    "Tool '{ToolKey}' is permanently excluded from agent use (GP-06)", toolKey);
+                decisions.Add(new ToolBundleDecision(toolKey, false,
+                    $"Tool '{toolKey}' is permanently excluded. Agents cannot approve proposals or directly mutate boards."));
+                continue;
+            }
+
+            // Check tool exists in registry
+            var tool = _toolRegistry.GetTool(toolKey);
+            if (tool is null)
+            {
+                _logger?.LogWarning("Tool '{ToolKey}' not found in registry — denied by default", toolKey);
+                decisions.Add(new ToolBundleDecision(toolKey, false,
+                    $"Tool '{toolKey}' is not registered. Unknown tools are denied."));
+                continue;
+            }
+
+            // Check profile-level allowlist if specified
+            if (profileAllowlist is { Count: > 0 } &&
+                !profileAllowlist.Any(a => string.Equals(a, toolKey, StringComparison.OrdinalIgnoreCase)))
+            {
+                decisions.Add(new ToolBundleDecision(toolKey, false,
+                    $"Tool '{toolKey}' is not in the agent profile's allowed tool list."));
+                continue;
+            }
+
+            decisions.Add(new ToolBundleDecision(toolKey, true,
+                $"Tool '{tool.DisplayName}' is allowed."));
+        }
+
+        return decisions;
+    }
+
+    /// <summary>
+    /// Returns true if the tool key is in the permanently excluded set.
+    /// </summary>
+    public static bool IsPermanentlyExcluded(string toolKey)
+    {
+        return PermanentlyExcludedTools.Contains(toolKey);
+    }
+
+    /// <summary>
+    /// Returns the set of permanently excluded tool keys (for inspection/auditing).
+    /// </summary>
+    public static IReadOnlySet<string> GetPermanentlyExcludedTools()
+    {
+        return PermanentlyExcludedTools;
+    }
+}
+
+/// <summary>
+/// Result of a single tool's policy validation within a bundle.
+/// </summary>
+public sealed record ToolBundleDecision(
+    string ToolKey,
+    bool Allowed,
+    string Reason);

--- a/backend/src/Taskdeck.Application/Services/AgentRuntime.cs
+++ b/backend/src/Taskdeck.Application/Services/AgentRuntime.cs
@@ -301,7 +301,9 @@ public sealed class AgentRuntime
             return new List<string>();
         }
 
-        return null;
+        // Fail-closed: policy JSON is present but has no allowedTools array —
+        // treat as empty allowlist (deny all) rather than null (skip enforcement)
+        return new List<string>();
     }
 
     private static AgentRunDto MapToDto(AgentRun run)

--- a/backend/src/Taskdeck.Application/Services/AgentRuntime.cs
+++ b/backend/src/Taskdeck.Application/Services/AgentRuntime.cs
@@ -1,0 +1,367 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Single entrypoint for agent execution with quotas, tool-bundle allowlists,
+/// and inspectable policy decisions.
+/// GP-06: No agent bundle may include approve_proposal or direct board mutation tools.
+/// GP-09: All runs, policies, and resulting proposals stay inspectable.
+/// </summary>
+public sealed class AgentRuntime
+{
+    /// <summary>Maximum number of steps an agent can execute per run.</summary>
+    public const int DefaultMaxStepsPerRun = 50;
+
+    /// <summary>Maximum tokens an agent can consume per run.</summary>
+    public const int DefaultMaxTokensPerRun = 100_000;
+
+    /// <summary>Maximum concurrent runs per user.</summary>
+    public const int DefaultMaxConcurrentRunsPerUser = 3;
+
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly AgentPolicy _agentPolicy;
+    private readonly IAgentPolicyEvaluator _policyEvaluator;
+    private readonly ILogger<AgentRuntime>? _logger;
+
+    public AgentRuntime(
+        IUnitOfWork unitOfWork,
+        AgentPolicy agentPolicy,
+        IAgentPolicyEvaluator policyEvaluator,
+        ILogger<AgentRuntime>? logger = null)
+    {
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _agentPolicy = agentPolicy ?? throw new ArgumentNullException(nameof(agentPolicy));
+        _policyEvaluator = policyEvaluator ?? throw new ArgumentNullException(nameof(policyEvaluator));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Execute an agent run with full policy enforcement, quota tracking, and event recording.
+    /// This is the single entrypoint for all agent execution.
+    /// </summary>
+    /// <param name="agentProfileId">The agent profile to run.</param>
+    /// <param name="userId">The user who owns the profile.</param>
+    /// <param name="objective">What the agent is trying to accomplish.</param>
+    /// <param name="requestedTools">Tool keys the agent wants to use.</param>
+    /// <param name="executeStep">Callback for executing each step — returns (eventType, payload, tokensUsed).</param>
+    /// <param name="triggerType">How the run was triggered (manual, scheduled, etc.).</param>
+    /// <param name="boardId">Optional board scope.</param>
+    /// <param name="maxSteps">Maximum steps allowed (defaults to <see cref="DefaultMaxStepsPerRun"/>).</param>
+    /// <param name="maxTokens">Maximum tokens allowed (defaults to <see cref="DefaultMaxTokensPerRun"/>).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The completed agent run with all events.</returns>
+    public async Task<Result<AgentRunDto>> RunAsync(
+        Guid agentProfileId,
+        Guid userId,
+        string objective,
+        IReadOnlyList<string> requestedTools,
+        Func<AgentRun, int, CancellationToken, Task<AgentStepResult>> executeStep,
+        string triggerType = "manual",
+        Guid? boardId = null,
+        int? maxSteps = null,
+        int? maxTokens = null,
+        CancellationToken cancellationToken = default)
+    {
+        var effectiveMaxSteps = maxSteps ?? DefaultMaxStepsPerRun;
+        var effectiveMaxTokens = maxTokens ?? DefaultMaxTokensPerRun;
+
+        // 1. Validate agent profile exists and is owned by the user
+        var profile = await _unitOfWork.AgentProfiles.GetByIdAsync(agentProfileId, cancellationToken);
+        if (profile is null)
+            return Result.Failure<AgentRunDto>(ErrorCodes.NotFound, "Agent profile not found.");
+
+        if (profile.UserId != userId)
+            return Result.Failure<AgentRunDto>(ErrorCodes.Forbidden, "Access denied to this agent profile.");
+
+        if (!profile.IsEnabled)
+            return Result.Failure<AgentRunDto>(ErrorCodes.InvalidOperation, "Agent profile is disabled.");
+
+        // 2. Check concurrent run quota
+        var activeRuns = await _unitOfWork.AgentRuns.GetActiveByUserIdAsync(userId, cancellationToken);
+        if (activeRuns.Count() >= DefaultMaxConcurrentRunsPerUser)
+        {
+            _logger?.LogWarning(
+                "User '{UserId}' has reached max concurrent runs ({Max})", userId, DefaultMaxConcurrentRunsPerUser);
+            return Result.Failure<AgentRunDto>(ErrorCodes.TooManyRequests,
+                $"Maximum of {DefaultMaxConcurrentRunsPerUser} concurrent agent runs allowed.");
+        }
+
+        // 3. Validate tool bundle (fail-closed: deny unknown or excluded tools)
+        var profileAllowlist = ParseProfileAllowlist(profile.PolicyJson);
+        var bundleDecisions = _agentPolicy.ValidateToolBundle(requestedTools, profileAllowlist);
+        var denied = bundleDecisions.Where(d => !d.Allowed).ToList();
+        if (denied.Count > 0)
+        {
+            var reasons = string.Join("; ", denied.Select(d => d.Reason));
+            _logger?.LogWarning(
+                "Agent tool bundle denied for profile '{ProfileId}': {Reasons}",
+                agentProfileId, reasons);
+            return Result.Failure<AgentRunDto>(ErrorCodes.Forbidden,
+                $"Tool bundle validation failed: {reasons}");
+        }
+
+        // 4. Create the agent run
+        AgentRun run;
+        try
+        {
+            run = new AgentRun(
+                agentProfileId,
+                userId,
+                objective,
+                triggerType,
+                boardId ?? profile.ScopeBoardId);
+
+            await _unitOfWork.AgentRuns.AddAsync(run, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+        catch (DomainException ex)
+        {
+            return Result.Failure<AgentRunDto>(ex.ErrorCode, ex.Message);
+        }
+
+        // 5. Record policy decisions as the first event
+        var policyEvent = new AgentRunEvent(
+            run.Id,
+            sequenceNumber: 0,
+            eventType: "policy.validated",
+            payload: JsonSerializer.Serialize(new
+            {
+                toolsRequested = requestedTools,
+                decisions = bundleDecisions.Select(d => new { d.ToolKey, d.Allowed, d.Reason })
+            }));
+        await _unitOfWork.AgentRuns.AddEventAsync(policyEvent, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        // 6. Execute steps with quota enforcement
+        run.TransitionTo(AgentRunStatus.GatheringContext);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var sequenceNumber = 1;
+        try
+        {
+            for (var step = 0; step < effectiveMaxSteps; step++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Check token quota
+                if (run.TokensUsed >= effectiveMaxTokens)
+                {
+                    _logger?.LogWarning(
+                        "Agent run '{RunId}' hit token quota ({Tokens}/{Max})",
+                        run.Id, run.TokensUsed, effectiveMaxTokens);
+
+                    var quotaEvent = new AgentRunEvent(run.Id, sequenceNumber++,
+                        "quota.exceeded", $"{{\"tokensUsed\":{run.TokensUsed},\"maxTokens\":{effectiveMaxTokens}}}");
+                    await _unitOfWork.AgentRuns.AddEventAsync(quotaEvent, cancellationToken);
+
+                    run.TransitionTo(AgentRunStatus.Completed,
+                        $"Token quota exceeded ({run.TokensUsed}/{effectiveMaxTokens}).");
+                    await _unitOfWork.SaveChangesAsync(cancellationToken);
+                    break;
+                }
+
+                // Execute the step
+                var stepResult = await executeStep(run, step, cancellationToken);
+
+                // Record the step event
+                var stepEvent = new AgentRunEvent(run.Id, sequenceNumber++,
+                    stepResult.EventType, stepResult.Payload);
+                await _unitOfWork.AgentRuns.AddEventAsync(stepEvent, cancellationToken);
+
+                run.IncrementSteps();
+                if (stepResult.TokensUsed > 0)
+                {
+                    run.AddTokenUsage(stepResult.TokensUsed, stepResult.CostUsd);
+                }
+
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+                // Check if the step signals completion
+                if (stepResult.IsTerminal)
+                {
+                    if (stepResult.ProposalId.HasValue)
+                    {
+                        run.AttachProposal(stepResult.ProposalId.Value, stepResult.Summary);
+                        run.TransitionTo(AgentRunStatus.ProposalCreated, stepResult.Summary);
+                    }
+                    else
+                    {
+                        run.TransitionTo(AgentRunStatus.Completed, stepResult.Summary);
+                    }
+                    await _unitOfWork.SaveChangesAsync(cancellationToken);
+                    break;
+                }
+            }
+
+            // If we exhausted all steps without terminal signal
+            if (run.Status != AgentRunStatus.Completed && run.Status != AgentRunStatus.ProposalCreated
+                && run.Status != AgentRunStatus.Failed)
+            {
+                var exhaustedEvent = new AgentRunEvent(run.Id, sequenceNumber,
+                    "quota.steps_exhausted", $"{{\"stepsExecuted\":{run.StepsExecuted},\"maxSteps\":{effectiveMaxSteps}}}");
+                await _unitOfWork.AgentRuns.AddEventAsync(exhaustedEvent, cancellationToken);
+
+                run.TransitionTo(AgentRunStatus.Completed,
+                    $"Step quota exhausted ({run.StepsExecuted}/{effectiveMaxSteps}).");
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            run.TransitionTo(AgentRunStatus.Cancelled, "Run was cancelled.");
+            try { await _unitOfWork.SaveChangesAsync(CancellationToken.None); }
+            catch (Exception saveEx)
+            {
+                _logger?.LogError(saveEx, "Failed to persist cancellation state for run '{RunId}'", run.Id);
+            }
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger?.LogWarning(ex, "Agent run '{RunId}' timed out (not user-cancelled)", run.Id);
+            run.MarkFailed("Operation timed out.");
+            try { await _unitOfWork.SaveChangesAsync(CancellationToken.None); }
+            catch (Exception saveEx)
+            {
+                _logger?.LogError(saveEx, "Failed to persist timeout state for run '{RunId}'", run.Id);
+            }
+            return Result.Failure<AgentRunDto>(ErrorCodes.InvalidOperation, "Agent run timed out.");
+        }
+        catch (EgressViolationException evx)
+        {
+            _logger?.LogError(evx,
+                "Agent run '{RunId}' failed with egress violation: {Violation}",
+                run.Id, evx.Violation);
+
+            var egressEvent = new AgentRunEvent(run.Id, sequenceNumber,
+                "egress.violation", JsonSerializer.Serialize(new
+                {
+                    host = evx.Violation.AttemptedHost,
+                    uri = evx.Violation.RequestUri,
+                    type = evx.Violation.ViolationType.ToString(),
+                    reason = evx.Violation.Reason
+                }));
+            try
+            {
+                await _unitOfWork.AgentRuns.AddEventAsync(egressEvent, CancellationToken.None);
+                run.MarkFailed($"Egress violation: {evx.Violation.Reason}");
+                await _unitOfWork.SaveChangesAsync(CancellationToken.None);
+            }
+            catch (Exception saveEx)
+            {
+                _logger?.LogError(saveEx, "Failed to persist egress violation state for run '{RunId}'", run.Id);
+            }
+            return Result.Failure<AgentRunDto>(ErrorCodes.Forbidden, $"Egress violation: {evx.Violation.Reason}");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Agent run '{RunId}' failed unexpectedly", run.Id);
+            run.MarkFailed($"Unexpected error: {ex.Message}");
+            try { await _unitOfWork.SaveChangesAsync(CancellationToken.None); }
+            catch (Exception saveEx)
+            {
+                _logger?.LogError(saveEx, "Failed to persist failure state for run '{RunId}'", run.Id);
+            }
+            return Result.Failure<AgentRunDto>(ErrorCodes.UnexpectedError, $"Agent run failed: {ex.Message}");
+        }
+
+        if (run.Status == AgentRunStatus.Failed)
+            return Result.Failure<AgentRunDto>(ErrorCodes.UnexpectedError, run.FailureReason ?? "Agent run failed.");
+
+        return Result.Success(MapToDto(run));
+    }
+
+    private static IReadOnlyList<string>? ParseProfileAllowlist(string? policyJson)
+    {
+        if (string.IsNullOrWhiteSpace(policyJson) || policyJson == "{}")
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(policyJson);
+            if (doc.RootElement.TryGetProperty("allowedTools", out var toolsElement)
+                && toolsElement.ValueKind == JsonValueKind.Array)
+            {
+                return toolsElement.EnumerateArray()
+                    .Select(e => e.GetString())
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToList()!;
+            }
+        }
+        catch (JsonException)
+        {
+            // Fail-closed: malformed policy JSON denies all profile-level tools
+            return new List<string>();
+        }
+
+        return null;
+    }
+
+    private static AgentRunDto MapToDto(AgentRun run)
+    {
+        return new AgentRunDto(
+            run.Id,
+            run.AgentProfileId,
+            run.UserId,
+            run.BoardId,
+            run.TriggerType,
+            run.Objective,
+            run.Status,
+            run.Summary,
+            run.FailureReason,
+            run.ProposalId,
+            run.StepsExecuted,
+            run.TokensUsed,
+            run.ApproxCostUsd,
+            run.StartedAt,
+            run.CompletedAt,
+            run.CreatedAt,
+            run.UpdatedAt);
+    }
+}
+
+/// <summary>
+/// Result of a single agent execution step.
+/// </summary>
+public sealed record AgentStepResult
+{
+    public string EventType { get; }
+    public string? Payload { get; }
+    public int TokensUsed { get; }
+    public decimal? CostUsd { get; }
+    public bool IsTerminal { get; }
+    public Guid? ProposalId { get; }
+    public string? Summary { get; }
+
+    public AgentStepResult(
+        string EventType,
+        string? Payload = null,
+        int TokensUsed = 0,
+        decimal? CostUsd = null,
+        bool IsTerminal = false,
+        Guid? ProposalId = null,
+        string? Summary = null)
+    {
+        if (string.IsNullOrWhiteSpace(EventType))
+            throw new ArgumentException("EventType cannot be empty.", nameof(EventType));
+        if (TokensUsed < 0)
+            throw new ArgumentException("TokensUsed cannot be negative.", nameof(TokensUsed));
+        if (ProposalId.HasValue && !IsTerminal)
+            throw new ArgumentException("ProposalId can only be set on terminal steps.", nameof(ProposalId));
+
+        this.EventType = EventType;
+        this.Payload = Payload;
+        this.TokensUsed = TokensUsed;
+        this.CostUsd = CostUsd;
+        this.IsTerminal = IsTerminal;
+        this.ProposalId = ProposalId;
+        this.Summary = Summary;
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/AgentTelemetry.cs
+++ b/backend/src/Taskdeck.Application/Services/AgentTelemetry.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// OpenTelemetry instrumentation for agent runs and events.
+/// Content-free by default: captures only counts, durations, status codes,
+/// egress host names, and payload categories — never prompt text, capture text,
+/// card titles, transcripts, or other user content.
+/// GP-10: local telemetry must reject user content by default.
+/// </summary>
+public static class AgentTelemetry
+{
+    /// <summary>ActivitySource name for agent operations.</summary>
+    public const string ActivitySourceName = "Taskdeck.Agent";
+
+    /// <summary>Meter name for agent metrics.</summary>
+    public const string MeterName = "Taskdeck.Agent";
+
+    private static readonly ActivitySource Source = new(ActivitySourceName);
+    private static readonly Meter AgentMeter = new(MeterName);
+
+    // Counters (content-free)
+    private static readonly Counter<long> RunsStarted = AgentMeter.CreateCounter<long>(
+        "agent.runs.started", description: "Number of agent runs started");
+
+    private static readonly Counter<long> RunsCompleted = AgentMeter.CreateCounter<long>(
+        "agent.runs.completed", description: "Number of agent runs completed successfully");
+
+    private static readonly Counter<long> RunsFailed = AgentMeter.CreateCounter<long>(
+        "agent.runs.failed", description: "Number of agent runs that failed");
+
+    private static readonly Counter<long> RunsCancelled = AgentMeter.CreateCounter<long>(
+        "agent.runs.cancelled", description: "Number of agent runs that were cancelled");
+
+    private static readonly Counter<long> StepsExecuted = AgentMeter.CreateCounter<long>(
+        "agent.steps.executed", description: "Total agent steps executed");
+
+    private static readonly Counter<long> TokensConsumed = AgentMeter.CreateCounter<long>(
+        "agent.tokens.consumed", description: "Total tokens consumed by agent runs");
+
+    private static readonly Counter<long> ProposalsCreated = AgentMeter.CreateCounter<long>(
+        "agent.proposals.created", description: "Number of proposals created by agents");
+
+    private static readonly Counter<long> PolicyDenials = AgentMeter.CreateCounter<long>(
+        "agent.policy.denials", description: "Number of tool uses denied by policy");
+
+    private static readonly Counter<long> EgressViolations = AgentMeter.CreateCounter<long>(
+        "agent.egress.violations", description: "Number of egress violations detected");
+
+    private static readonly Counter<long> QuotaExceeded = AgentMeter.CreateCounter<long>(
+        "agent.quota.exceeded", description: "Number of runs stopped by quota limits");
+
+    // Histograms (content-free)
+    private static readonly Histogram<double> RunDurationMs = AgentMeter.CreateHistogram<double>(
+        "agent.run.duration_ms", description: "Agent run duration in milliseconds");
+
+    private static readonly Histogram<int> StepsPerRun = AgentMeter.CreateHistogram<int>(
+        "agent.run.steps", description: "Steps executed per agent run");
+
+    /// <summary>Start an Activity span for an agent run. Returns null if no listener.</summary>
+    public static Activity? StartRunActivity(Guid runId, string triggerType, string templateKey)
+    {
+        var activity = Source.StartActivity("agent.run", ActivityKind.Internal);
+        if (activity is not null)
+        {
+            // Content-free tags only
+            activity.SetTag("agent.run.id", runId.ToString());
+            activity.SetTag("agent.run.trigger_type", triggerType);
+            activity.SetTag("agent.template_key", templateKey);
+        }
+        return activity;
+    }
+
+    /// <summary>Record that a run was started.</summary>
+    public static void RecordRunStarted(string triggerType, string templateKey)
+    {
+        RunsStarted.Add(1,
+            new KeyValuePair<string, object?>("trigger_type", triggerType),
+            new KeyValuePair<string, object?>("template_key", templateKey));
+    }
+
+    /// <summary>Record that a run completed successfully.</summary>
+    public static void RecordRunCompleted(string triggerType, string templateKey,
+        double durationMs, int steps, int tokens)
+    {
+        RunsCompleted.Add(1,
+            new KeyValuePair<string, object?>("trigger_type", triggerType),
+            new KeyValuePair<string, object?>("template_key", templateKey));
+        RunDurationMs.Record(durationMs,
+            new KeyValuePair<string, object?>("trigger_type", triggerType));
+        StepsPerRun.Record(steps,
+            new KeyValuePair<string, object?>("trigger_type", triggerType));
+        if (tokens > 0)
+        {
+            TokensConsumed.Add(tokens,
+                new KeyValuePair<string, object?>("trigger_type", triggerType));
+        }
+    }
+
+    /// <summary>Record that a run failed.</summary>
+    public static void RecordRunFailed(string triggerType, string templateKey)
+    {
+        RunsFailed.Add(1,
+            new KeyValuePair<string, object?>("trigger_type", triggerType),
+            new KeyValuePair<string, object?>("template_key", templateKey));
+    }
+
+    /// <summary>Record that a run was cancelled.</summary>
+    public static void RecordRunCancelled(string triggerType, string templateKey)
+    {
+        RunsCancelled.Add(1,
+            new KeyValuePair<string, object?>("trigger_type", triggerType),
+            new KeyValuePair<string, object?>("template_key", templateKey));
+    }
+
+    /// <summary>Record a step execution (content-free).</summary>
+    public static void RecordStep(string eventType)
+    {
+        StepsExecuted.Add(1,
+            new KeyValuePair<string, object?>("event_type", eventType));
+    }
+
+    /// <summary>Record that a proposal was created by an agent.</summary>
+    public static void RecordProposalCreated(string templateKey)
+    {
+        ProposalsCreated.Add(1,
+            new KeyValuePair<string, object?>("template_key", templateKey));
+    }
+
+    /// <summary>Record a policy denial.</summary>
+    public static void RecordPolicyDenial(string toolKey, string templateKey)
+    {
+        PolicyDenials.Add(1,
+            new KeyValuePair<string, object?>("tool_key", toolKey),
+            new KeyValuePair<string, object?>("template_key", templateKey));
+    }
+
+    /// <summary>Record an egress violation (content-free: host and category only).</summary>
+    public static void RecordEgressViolation(string host, string payloadCategory)
+    {
+        EgressViolations.Add(1,
+            new KeyValuePair<string, object?>("host", host),
+            new KeyValuePair<string, object?>("payload_category", payloadCategory));
+    }
+
+    /// <summary>Record that a quota limit was hit.</summary>
+    public static void RecordQuotaExceeded(string quotaType, string templateKey)
+    {
+        QuotaExceeded.Add(1,
+            new KeyValuePair<string, object?>("quota_type", quotaType),
+            new KeyValuePair<string, object?>("template_key", templateKey));
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/EgressEnvelopeHandler.cs
+++ b/backend/src/Taskdeck.Application/Services/EgressEnvelopeHandler.cs
@@ -1,0 +1,118 @@
+using Microsoft.Extensions.Logging;
+using Taskdeck.Domain.Agents;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// DelegatingHandler that enforces the egress envelope for all outbound HTTP requests.
+/// Rejects requests to hosts not in the EgressRegistry and blocks redirects to
+/// out-of-envelope destinations.
+/// GP-10: EgressViolations are loud, structured, and never swallowed.
+/// </summary>
+public sealed class EgressEnvelopeHandler : DelegatingHandler
+{
+    private readonly IEgressRegistry _egressRegistry;
+    private readonly ILogger<EgressEnvelopeHandler>? _logger;
+    private readonly string? _sourceComponent;
+
+    public EgressEnvelopeHandler(
+        IEgressRegistry egressRegistry,
+        ILogger<EgressEnvelopeHandler>? logger = null,
+        string? sourceComponent = null)
+    {
+        _egressRegistry = egressRegistry ?? throw new ArgumentNullException(nameof(egressRegistry));
+        _logger = logger;
+        _sourceComponent = sourceComponent;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Validate the request host against the egress registry
+        var host = request.RequestUri?.Host;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            var violation = new EgressViolation(
+                attemptedHost: "(empty)",
+                requestUri: request.RequestUri?.ToString() ?? "(null)",
+                violationType: EgressViolationType.UnknownHost,
+                reason: "Request has no host specified.",
+                sourceComponent: _sourceComponent);
+
+            _logger?.LogError(
+                "EgressViolation: request with no host. URI={Uri}, Source={Source}",
+                request.RequestUri, _sourceComponent);
+
+            throw new EgressViolationException(violation);
+        }
+
+        if (!_egressRegistry.IsHostAllowed(host))
+        {
+            var violation = new EgressViolation(
+                attemptedHost: host,
+                requestUri: request.RequestUri!.ToString(),
+                violationType: EgressViolationType.UnknownHost,
+                reason: $"Host '{host}' is not in the egress envelope. Request blocked.",
+                sourceComponent: _sourceComponent);
+
+            _logger?.LogError(
+                "EgressViolation: host '{Host}' not in egress envelope. URI={Uri}, Source={Source}",
+                host, request.RequestUri, _sourceComponent);
+
+            throw new EgressViolationException(violation);
+        }
+
+        var response = await base.SendAsync(request, cancellationToken);
+
+        // Check redirect targets — block redirects to out-of-envelope hosts
+        if (IsRedirect(response) && response.Headers.Location is { } redirectUri)
+        {
+            var redirectHost = redirectUri.IsAbsoluteUri
+                ? redirectUri.Host
+                : request.RequestUri?.Host;
+
+            if (!string.IsNullOrWhiteSpace(redirectHost) && !_egressRegistry.IsHostAllowed(redirectHost))
+            {
+                var violation = new EgressViolation(
+                    attemptedHost: redirectHost,
+                    requestUri: redirectUri.ToString(),
+                    violationType: EgressViolationType.RedirectToUnknownHost,
+                    reason: $"Redirect to host '{redirectHost}' is not in the egress envelope. Redirect blocked.",
+                    sourceComponent: _sourceComponent);
+
+                _logger?.LogError(
+                    "EgressViolation: redirect to '{Host}' not in egress envelope. OriginalURI={OriginalUri}, RedirectURI={RedirectUri}, Source={Source}",
+                    redirectHost, request.RequestUri, redirectUri, _sourceComponent);
+
+                throw new EgressViolationException(violation);
+            }
+        }
+
+        return response;
+    }
+
+    private static bool IsRedirect(HttpResponseMessage response)
+    {
+        var statusCode = (int)response.StatusCode;
+        return statusCode is >= 300 and < 400;
+    }
+}
+
+/// <summary>
+/// Exception thrown when an egress policy violation is detected.
+/// Contains the structured <see cref="EgressViolation"/> for audit and logging.
+/// This exception must never be caught and swallowed — it represents a security boundary.
+/// </summary>
+public sealed class EgressViolationException : Exception
+{
+    public EgressViolation Violation { get; }
+
+    public EgressViolationException(EgressViolation violation)
+        : base(violation.Reason)
+    {
+        Violation = violation ?? throw new ArgumentNullException(nameof(violation));
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/EgressEnvelopeHandler.cs
+++ b/backend/src/Taskdeck.Application/Services/EgressEnvelopeHandler.cs
@@ -25,6 +25,9 @@ public sealed class EgressEnvelopeHandler : DelegatingHandler
         _sourceComponent = sourceComponent;
     }
 
+    /// <summary>Maximum number of redirects to follow manually.</summary>
+    private const int MaxRedirects = 10;
+
     protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
@@ -32,19 +35,76 @@ public sealed class EgressEnvelopeHandler : DelegatingHandler
         ArgumentNullException.ThrowIfNull(request);
 
         // Validate the request host against the egress registry
-        var host = request.RequestUri?.Host;
+        ValidateHost(request.RequestUri);
+
+        // IMPORTANT: The HttpClient MUST be configured with AllowAutoRedirect = false
+        // so that this handler sees 3xx responses and can validate redirect targets
+        // against the egress allowlist. If auto-redirect is enabled, the handler only
+        // sees the final response and the redirect check becomes ineffective.
+
+        var response = await base.SendAsync(request, cancellationToken);
+
+        // Manually follow redirects, validating each target against the egress envelope
+        var redirectCount = 0;
+        while (IsRedirect(response) && response.Headers.Location is { } redirectUri && redirectCount < MaxRedirects)
+        {
+            redirectCount++;
+
+            var resolvedRedirectUri = redirectUri.IsAbsoluteUri
+                ? redirectUri
+                : new Uri(request.RequestUri!, redirectUri);
+
+            var redirectHost = resolvedRedirectUri.Host;
+
+            if (string.IsNullOrWhiteSpace(redirectHost) || !_egressRegistry.IsHostAllowed(redirectHost))
+            {
+                var violation = new EgressViolation(
+                    attemptedHost: redirectHost ?? "(empty)",
+                    requestUri: resolvedRedirectUri.ToString(),
+                    violationType: EgressViolationType.RedirectToUnknownHost,
+                    reason: $"Redirect to host '{redirectHost}' is not in the egress envelope. Redirect blocked.",
+                    sourceComponent: _sourceComponent);
+
+                _logger?.LogError(
+                    "EgressViolation: redirect to '{Host}' not in egress envelope. OriginalURI={OriginalUri}, RedirectURI={RedirectUri}, Source={Source}",
+                    redirectHost, request.RequestUri, resolvedRedirectUri, _sourceComponent);
+
+                throw new EgressViolationException(violation);
+            }
+
+            // Follow the redirect: create a new request preserving the method for 307/308
+            var redirectRequest = new HttpRequestMessage
+            {
+                RequestUri = resolvedRedirectUri,
+                Version = request.Version,
+            };
+
+            // 307 and 308 preserve the method; others use GET
+            var statusCode = (int)response.StatusCode;
+            redirectRequest.Method = statusCode is 307 or 308 ? request.Method : HttpMethod.Get;
+
+            response.Dispose();
+            response = await base.SendAsync(redirectRequest, cancellationToken);
+        }
+
+        return response;
+    }
+
+    private void ValidateHost(Uri? requestUri)
+    {
+        var host = requestUri?.Host;
         if (string.IsNullOrWhiteSpace(host))
         {
             var violation = new EgressViolation(
                 attemptedHost: "(empty)",
-                requestUri: request.RequestUri?.ToString() ?? "(null)",
+                requestUri: requestUri?.ToString() ?? "(null)",
                 violationType: EgressViolationType.UnknownHost,
                 reason: "Request has no host specified.",
                 sourceComponent: _sourceComponent);
 
             _logger?.LogError(
                 "EgressViolation: request with no host. URI={Uri}, Source={Source}",
-                request.RequestUri, _sourceComponent);
+                requestUri, _sourceComponent);
 
             throw new EgressViolationException(violation);
         }
@@ -53,45 +113,17 @@ public sealed class EgressEnvelopeHandler : DelegatingHandler
         {
             var violation = new EgressViolation(
                 attemptedHost: host,
-                requestUri: request.RequestUri!.ToString(),
+                requestUri: requestUri!.ToString(),
                 violationType: EgressViolationType.UnknownHost,
                 reason: $"Host '{host}' is not in the egress envelope. Request blocked.",
                 sourceComponent: _sourceComponent);
 
             _logger?.LogError(
                 "EgressViolation: host '{Host}' not in egress envelope. URI={Uri}, Source={Source}",
-                host, request.RequestUri, _sourceComponent);
+                host, requestUri, _sourceComponent);
 
             throw new EgressViolationException(violation);
         }
-
-        var response = await base.SendAsync(request, cancellationToken);
-
-        // Check redirect targets — block redirects to out-of-envelope hosts
-        if (IsRedirect(response) && response.Headers.Location is { } redirectUri)
-        {
-            var redirectHost = redirectUri.IsAbsoluteUri
-                ? redirectUri.Host
-                : request.RequestUri?.Host;
-
-            if (!string.IsNullOrWhiteSpace(redirectHost) && !_egressRegistry.IsHostAllowed(redirectHost))
-            {
-                var violation = new EgressViolation(
-                    attemptedHost: redirectHost,
-                    requestUri: redirectUri.ToString(),
-                    violationType: EgressViolationType.RedirectToUnknownHost,
-                    reason: $"Redirect to host '{redirectHost}' is not in the egress envelope. Redirect blocked.",
-                    sourceComponent: _sourceComponent);
-
-                _logger?.LogError(
-                    "EgressViolation: redirect to '{Host}' not in egress envelope. OriginalURI={OriginalUri}, RedirectURI={RedirectUri}, Source={Source}",
-                    redirectHost, request.RequestUri, redirectUri, _sourceComponent);
-
-                throw new EgressViolationException(violation);
-            }
-        }
-
-        return response;
     }
 
     private static bool IsRedirect(HttpResponseMessage response)

--- a/backend/src/Taskdeck.Application/Services/InboxTriageDigestAgent.cs
+++ b/backend/src/Taskdeck.Application/Services/InboxTriageDigestAgent.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// First scheduled bounded agent. Coalesces pending inbox items into a single
+/// triage digest proposal per board. Behind a feature flag.
+///
+/// Key constraints:
+/// - Creates only proposals, never directly mutates boards (GP-06)
+/// - Records inspectable trace via AgentRunEvent records
+/// - Quota guardrails: max items per digest, max digests per day
+/// - Can be triggered manually or on schedule
+/// </summary>
+public sealed class InboxTriageDigestAgent
+{
+    public const string AgentTemplateKey = "inbox-triage-digest";
+    public const string FeatureFlagKey = "Agent:InboxTriageDigest:Enabled";
+
+    /// <summary>Maximum inbox items to include per digest proposal.</summary>
+    public const int MaxItemsPerDigest = 50;
+
+    /// <summary>Maximum digest proposals per user per 24-hour window.</summary>
+    public const int MaxDigestsPerDay = 10;
+
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly AgentRuntime _runtime;
+    private readonly IAutomationProposalService _proposalService;
+    private readonly ILogger<InboxTriageDigestAgent>? _logger;
+
+    public InboxTriageDigestAgent(
+        IUnitOfWork unitOfWork,
+        AgentRuntime runtime,
+        IAutomationProposalService proposalService,
+        ILogger<InboxTriageDigestAgent>? logger = null)
+    {
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        _proposalService = proposalService ?? throw new ArgumentNullException(nameof(proposalService));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run the inbox triage digest for a user, creating a coalesced proposal
+    /// for all pending inbox items across their boards.
+    /// </summary>
+    public async Task<Result<InboxDigestResultDto>> RunDigestAsync(
+        Guid agentProfileId,
+        Guid userId,
+        Guid boardId,
+        string triggerType = "manual",
+        CancellationToken cancellationToken = default)
+    {
+        if (agentProfileId == Guid.Empty)
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.ValidationError, "Agent profile ID is required.");
+        if (userId == Guid.Empty)
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.ValidationError, "User ID is required.");
+        if (boardId == Guid.Empty)
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.ValidationError, "Board ID is required.");
+
+        // Check daily quota
+        var recentRuns = await _unitOfWork.AgentRuns.GetByAgentProfileIdAsync(agentProfileId, MaxDigestsPerDay + 1, cancellationToken);
+        var todayRuns = recentRuns.Count(r =>
+            r.TriggerType == triggerType &&
+            r.StartedAt >= DateTimeOffset.UtcNow.AddHours(-24));
+
+        if (todayRuns >= MaxDigestsPerDay)
+        {
+            _logger?.LogWarning(
+                "Inbox digest daily quota exceeded for profile '{ProfileId}' ({Count}/{Max})",
+                agentProfileId, todayRuns, MaxDigestsPerDay);
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.TooManyRequests,
+                $"Maximum of {MaxDigestsPerDay} inbox digests per 24 hours.");
+        }
+
+        // Gather pending inbox items
+        var pendingItems = (await _unitOfWork.LlmQueue.GetByUserAsync(userId, cancellationToken))
+            .Where(r => r.Status == RequestStatus.Pending)
+            .OrderBy(r => r.CreatedAt)
+            .Take(MaxItemsPerDigest)
+            .ToList();
+
+        if (pendingItems.Count == 0)
+        {
+            _logger?.LogInformation("Inbox digest found no pending items for user '{UserId}'", userId);
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.NotFound, "No pending inbox items to digest.");
+        }
+
+        // Verify board exists and get columns
+        var board = await _unitOfWork.Boards.GetByIdAsync(boardId, cancellationToken);
+        if (board is null)
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.NotFound, $"Board '{boardId}' not found.");
+
+        var columns = (await _unitOfWork.Columns.GetByBoardIdAsync(boardId, cancellationToken))
+            .OrderBy(c => c.Position)
+            .ToList();
+
+        if (columns.Count == 0)
+            return Result.Failure<InboxDigestResultDto>(ErrorCodes.NotFound, "Board has no columns to triage into.");
+
+        var defaultColumnId = columns[0].Id;
+
+        // Use the AgentRuntime for execution with full policy and quota tracking
+        var requestedTools = new List<string> { InboxTriageAssistant.ToolKey };
+
+        var runtimeResult = await _runtime.RunAsync(
+            agentProfileId,
+            userId,
+            $"Inbox triage digest: {pendingItems.Count} items for board '{board.Name}'",
+            requestedTools,
+            executeStep: async (run, step, ct) =>
+            {
+                if (step == 0)
+                {
+                    // First step: create the coalesced proposal
+                    var operations = pendingItems.Select((item, i) =>
+                    {
+                        var parameters = JsonSerializer.Serialize(new
+                        {
+                            title = TruncateTitle(item.Payload),
+                            description = $"Triaged from inbox item {item.Id} (digest run {run.Id})",
+                            columnId = defaultColumnId,
+                            boardId
+                        });
+
+                        return new CreateProposalOperationDto(
+                            Sequence: i,
+                            ActionType: "create",
+                            TargetType: "card",
+                            Parameters: parameters,
+                            IdempotencyKey: $"digest:{run.Id:N}:{item.Id:N}");
+                    }).ToList();
+
+                    var summary = pendingItems.Count == 1
+                        ? $"Inbox digest: 1 item for board '{board.Name}'"
+                        : $"Inbox digest: {pendingItems.Count} items for board '{board.Name}'";
+
+                    var createResult = await _proposalService.CreateProposalAsync(
+                        new CreateProposalDto(
+                            SourceType: ProposalSourceType.Queue,
+                            RequestedByUserId: userId,
+                            Summary: summary,
+                            RiskLevel: RiskLevel.Low,
+                            CorrelationId: run.Id.ToString(),
+                            BoardId: boardId,
+                            Operations: operations),
+                        ct);
+
+                    if (!createResult.IsSuccess)
+                    {
+                        return new AgentStepResult(
+                            EventType: "digest.proposal_failed",
+                            Payload: JsonSerializer.Serialize(new { error = createResult.ErrorMessage }),
+                            IsTerminal: true,
+                            Summary: $"Proposal creation failed: {createResult.ErrorMessage}");
+                    }
+
+                    return new AgentStepResult(
+                        EventType: "digest.proposal_created",
+                        Payload: JsonSerializer.Serialize(new
+                        {
+                            proposalId = createResult.Value.Id,
+                            itemCount = pendingItems.Count,
+                            boardId,
+                            boardName = board.Name
+                        }),
+                        IsTerminal: true,
+                        ProposalId: createResult.Value.Id,
+                        Summary: summary);
+                }
+
+                return new AgentStepResult("digest.noop", IsTerminal: true);
+            },
+            triggerType: triggerType,
+            boardId: boardId,
+            maxSteps: 1,
+            maxTokens: 0,
+            cancellationToken: cancellationToken);
+
+        if (!runtimeResult.IsSuccess)
+            return Result.Failure<InboxDigestResultDto>(runtimeResult.ErrorCode, runtimeResult.ErrorMessage);
+
+        return Result.Success(new InboxDigestResultDto(
+            RunId: runtimeResult.Value.Id,
+            ProposalId: runtimeResult.Value.ProposalId,
+            ItemsCoalesced: pendingItems.Count,
+            TriggerType: triggerType,
+            Summary: runtimeResult.Value.Summary));
+    }
+
+    private static string TruncateTitle(string input)
+    {
+        const int maxLength = 200;
+        var firstLine = input.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? input;
+        var trimmed = firstLine.Trim();
+        return trimmed.Length > maxLength ? trimmed[..maxLength].TrimEnd() : trimmed;
+    }
+}
+
+/// <summary>
+/// Result DTO for an inbox triage digest run.
+/// </summary>
+public sealed record InboxDigestResultDto(
+    Guid RunId,
+    Guid? ProposalId,
+    int ItemsCoalesced,
+    string TriggerType,
+    string? Summary);

--- a/backend/src/Taskdeck.Application/Services/InboxTriageDigestAgent.cs
+++ b/backend/src/Taskdeck.Application/Services/InboxTriageDigestAgent.cs
@@ -80,9 +80,8 @@ public sealed class InboxTriageDigestAgent
                 $"Maximum of {MaxDigestsPerDay} inbox digests per 24 hours.");
         }
 
-        // Gather pending inbox items
-        var pendingItems = (await _unitOfWork.LlmQueue.GetByUserAsync(userId, cancellationToken))
-            .Where(r => r.Status == RequestStatus.Pending)
+        // Gather pending inbox items (use status-filtered query to avoid loading all items in memory)
+        var pendingItems = (await _unitOfWork.LlmQueue.GetByUserAndStatusAsync(userId, RequestStatus.Pending, cancellationToken))
             .OrderBy(r => r.CreatedAt)
             .Take(MaxItemsPerDigest)
             .ToList();
@@ -181,7 +180,7 @@ public sealed class InboxTriageDigestAgent
             triggerType: triggerType,
             boardId: boardId,
             maxSteps: 1,
-            maxTokens: 0,
+            maxTokens: 4096,
             cancellationToken: cancellationToken);
 
         if (!runtimeResult.IsSuccess)

--- a/backend/src/Taskdeck.Application/Services/McpToolDefinitionHashService.cs
+++ b/backend/src/Taskdeck.Application/Services/McpToolDefinitionHashService.cs
@@ -32,7 +32,7 @@ public sealed class McpToolDefinitionHashService
     /// </summary>
     public static string ComputeDefinitionHash(string name, string description, string inputSchema)
     {
-        var combined = $"{name}\n{description}\n{inputSchema}";
+        var combined = $"N:{name.Length}:{name}|D:{description.Length}:{description}|S:{inputSchema.Length}:{inputSchema}";
         var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(combined));
         return Convert.ToHexString(hashBytes).ToLowerInvariant();
     }

--- a/backend/src/Taskdeck.Application/Services/McpToolDefinitionHashService.cs
+++ b/backend/src/Taskdeck.Application/Services/McpToolDefinitionHashService.cs
@@ -1,0 +1,169 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Service for hash-pinning MCP tool definitions.
+/// Computes SHA-256 hashes of (name, description, inputSchema) and tracks
+/// approval state. When a tool's definition changes, the hash changes and
+/// user re-approval is required before the tool can be used.
+/// </summary>
+public sealed class McpToolDefinitionHashService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<McpToolDefinitionHashService>? _logger;
+
+    public McpToolDefinitionHashService(
+        IUnitOfWork unitOfWork,
+        ILogger<McpToolDefinitionHashService>? logger = null)
+    {
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Computes a SHA-256 hash of the tool definition (name + description + schema).
+    /// </summary>
+    public static string ComputeDefinitionHash(string name, string description, string inputSchema)
+    {
+        var combined = $"{name}\n{description}\n{inputSchema}";
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(combined));
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Checks whether a tool definition is approved for use by the given user.
+    /// Returns false if the tool has never been seen, if the definition has changed
+    /// since approval, or if the user has not yet approved.
+    /// </summary>
+    public async Task<Result<bool>> IsToolApprovedAsync(
+        Guid userId,
+        string toolName,
+        string currentHash,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+            return Result.Failure<bool>(ErrorCodes.ValidationError, "UserId is required.");
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            return Result.Failure<bool>(ErrorCodes.ValidationError, "ToolName is required.");
+
+        if (string.IsNullOrWhiteSpace(currentHash))
+            return Result.Failure<bool>(ErrorCodes.ValidationError, "CurrentHash is required.");
+
+        var existing = await _unitOfWork.McpToolHashes.GetByUserAndToolAsync(userId, toolName, cancellationToken);
+        if (existing is null)
+        {
+            return Result.Success(false);
+        }
+
+        return Result.Success(existing.IsDefinitionApproved(currentHash));
+    }
+
+    /// <summary>
+    /// Records or updates a tool definition hash, and optionally approves it.
+    /// If the definition has changed since last recorded, approval is revoked.
+    /// </summary>
+    public async Task<Result<McpToolHash>> RecordToolDefinitionAsync(
+        Guid userId,
+        string toolName,
+        string definitionHash,
+        bool approve = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+            return Result.Failure<McpToolHash>(ErrorCodes.ValidationError, "UserId is required.");
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            return Result.Failure<McpToolHash>(ErrorCodes.ValidationError, "ToolName is required.");
+
+        if (string.IsNullOrWhiteSpace(definitionHash))
+            return Result.Failure<McpToolHash>(ErrorCodes.ValidationError, "DefinitionHash is required.");
+
+        var existing = await _unitOfWork.McpToolHashes.GetByUserAndToolAsync(userId, toolName, cancellationToken);
+
+        if (existing is not null)
+        {
+            var previousHash = existing.DefinitionHash;
+            existing.UpdateHash(definitionHash);
+
+            if (previousHash != definitionHash)
+            {
+                _logger?.LogInformation(
+                    "MCP tool '{ToolName}' definition changed for user '{UserId}'. Approval revoked, re-approval required.",
+                    toolName, userId);
+            }
+
+            if (approve)
+            {
+                existing.Approve();
+            }
+
+            await _unitOfWork.McpToolHashes.UpdateAsync(existing, cancellationToken);
+        }
+        else
+        {
+            existing = new McpToolHash(userId, toolName, definitionHash);
+
+            if (approve)
+            {
+                existing.Approve();
+            }
+
+            await _unitOfWork.McpToolHashes.AddAsync(existing, cancellationToken);
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(existing);
+    }
+
+    /// <summary>
+    /// Approves a tool definition hash for a user. Returns failure if the tool
+    /// has not been recorded yet.
+    /// </summary>
+    public async Task<Result> ApproveToolAsync(
+        Guid userId,
+        string toolName,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+            return Result.Failure(ErrorCodes.ValidationError, "UserId is required.");
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            return Result.Failure(ErrorCodes.ValidationError, "ToolName is required.");
+
+        var existing = await _unitOfWork.McpToolHashes.GetByUserAndToolAsync(userId, toolName, cancellationToken);
+        if (existing is null)
+            return Result.Failure(ErrorCodes.NotFound, $"Tool '{toolName}' has not been recorded yet.");
+
+        existing.Approve();
+        await _unitOfWork.McpToolHashes.UpdateAsync(existing, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        _logger?.LogInformation(
+            "MCP tool '{ToolName}' approved for user '{UserId}'", toolName, userId);
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Returns all tool hashes for a user, for inspection.
+    /// </summary>
+    public async Task<Result<IReadOnlyList<McpToolHash>>> GetToolHashesAsync(
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (userId == Guid.Empty)
+            return Result.Failure<IReadOnlyList<McpToolHash>>(ErrorCodes.ValidationError, "UserId is required.");
+
+        var hashes = await _unitOfWork.McpToolHashes.GetByUserAsync(userId, cancellationToken);
+        return Result.Success<IReadOnlyList<McpToolHash>>(hashes.ToList());
+    }
+}

--- a/backend/src/Taskdeck.Domain/Agents/EgressViolation.cs
+++ b/backend/src/Taskdeck.Domain/Agents/EgressViolation.cs
@@ -1,0 +1,70 @@
+namespace Taskdeck.Domain.Agents;
+
+/// <summary>
+/// Value object representing a detected egress policy violation.
+/// Created when an agent or tool attempts to contact an unauthorized host
+/// or when a redirect leads to an out-of-envelope destination.
+/// GP-10: violations must be loud, never swallowed.
+/// </summary>
+public sealed class EgressViolation
+{
+    /// <summary>The host that was attempted but is not in the egress envelope.</summary>
+    public string AttemptedHost { get; }
+
+    /// <summary>The original request URI that triggered the violation.</summary>
+    public string RequestUri { get; }
+
+    /// <summary>Category of the violation.</summary>
+    public EgressViolationType ViolationType { get; }
+
+    /// <summary>Human-readable explanation of why this was blocked.</summary>
+    public string Reason { get; }
+
+    /// <summary>When the violation was detected (UTC).</summary>
+    public DateTimeOffset DetectedAt { get; }
+
+    /// <summary>The tool or agent name that initiated the request, if known.</summary>
+    public string? SourceComponent { get; }
+
+    public EgressViolation(
+        string attemptedHost,
+        string requestUri,
+        EgressViolationType violationType,
+        string reason,
+        string? sourceComponent = null)
+    {
+        if (string.IsNullOrWhiteSpace(attemptedHost))
+            throw new ArgumentException("AttemptedHost cannot be empty.", nameof(attemptedHost));
+
+        if (string.IsNullOrWhiteSpace(requestUri))
+            throw new ArgumentException("RequestUri cannot be empty.", nameof(requestUri));
+
+        if (string.IsNullOrWhiteSpace(reason))
+            throw new ArgumentException("Reason cannot be empty.", nameof(reason));
+
+        AttemptedHost = attemptedHost;
+        RequestUri = requestUri;
+        ViolationType = violationType;
+        Reason = reason;
+        SourceComponent = sourceComponent;
+        DetectedAt = DateTimeOffset.UtcNow;
+    }
+
+    public override string ToString()
+        => $"EgressViolation({ViolationType}: {AttemptedHost} — {Reason})";
+}
+
+/// <summary>
+/// Categories of egress violations.
+/// </summary>
+public enum EgressViolationType
+{
+    /// <summary>The host is not in the egress registry allowlist.</summary>
+    UnknownHost = 0,
+
+    /// <summary>An HTTP redirect led to an out-of-envelope host.</summary>
+    RedirectToUnknownHost = 1,
+
+    /// <summary>The host resolved to a private/internal IP range.</summary>
+    PrivateNetworkAttempt = 2
+}

--- a/backend/src/Taskdeck.Domain/Agents/McpToolHash.cs
+++ b/backend/src/Taskdeck.Domain/Agents/McpToolHash.cs
@@ -1,0 +1,95 @@
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Domain.Agents;
+
+/// <summary>
+/// Tracks the hash of an MCP tool definition (name + description + schema).
+/// When a tool's definition changes, the hash changes and user re-approval
+/// is required before the tool can be used again.
+/// </summary>
+public sealed class McpToolHash : Entity
+{
+    private const int MaxToolNameLength = 200;
+    private const int MaxHashLength = 128;
+
+    /// <summary>The user who approved this tool definition.</summary>
+    public Guid UserId { get; private set; }
+
+    /// <summary>The MCP tool name (unique per user).</summary>
+    public string ToolName { get; private set; } = string.Empty;
+
+    /// <summary>SHA-256 hash of (name, description, inputSchema).</summary>
+    public string DefinitionHash { get; private set; } = string.Empty;
+
+    /// <summary>Whether the user has approved this specific definition hash.</summary>
+    public bool IsApproved { get; private set; }
+
+    /// <summary>When the user last approved (or null if never approved).</summary>
+    public DateTimeOffset? ApprovedAt { get; private set; }
+
+    private McpToolHash() : base() { } // EF Core
+
+    public McpToolHash(Guid userId, string toolName, string definitionHash)
+        : base()
+    {
+        if (userId == Guid.Empty)
+            throw new DomainException(ErrorCodes.ValidationError, "UserId cannot be empty");
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            throw new DomainException(ErrorCodes.ValidationError, "ToolName cannot be empty");
+
+        if (toolName.Length > MaxToolNameLength)
+            throw new DomainException(ErrorCodes.ValidationError, $"ToolName cannot exceed {MaxToolNameLength} characters");
+
+        if (string.IsNullOrWhiteSpace(definitionHash))
+            throw new DomainException(ErrorCodes.ValidationError, "DefinitionHash cannot be empty");
+
+        if (definitionHash.Length > MaxHashLength)
+            throw new DomainException(ErrorCodes.ValidationError, $"DefinitionHash cannot exceed {MaxHashLength} characters");
+
+        UserId = userId;
+        ToolName = toolName;
+        DefinitionHash = definitionHash;
+        IsApproved = false;
+    }
+
+    /// <summary>
+    /// Approve the current definition hash. Only valid when the hash is current.
+    /// </summary>
+    public void Approve()
+    {
+        IsApproved = true;
+        ApprovedAt = DateTimeOffset.UtcNow;
+        Touch();
+    }
+
+    /// <summary>
+    /// Update the definition hash when the tool definition changes.
+    /// Automatically revokes approval, requiring user re-approval.
+    /// </summary>
+    public void UpdateHash(string newHash)
+    {
+        if (string.IsNullOrWhiteSpace(newHash))
+            throw new DomainException(ErrorCodes.ValidationError, "DefinitionHash cannot be empty");
+
+        if (newHash.Length > MaxHashLength)
+            throw new DomainException(ErrorCodes.ValidationError, $"DefinitionHash cannot exceed {MaxHashLength} characters");
+
+        if (DefinitionHash == newHash)
+            return; // No change — keep existing approval state
+
+        DefinitionHash = newHash;
+        IsApproved = false;
+        ApprovedAt = null;
+        Touch();
+    }
+
+    /// <summary>
+    /// Returns true if the tool is approved and the given hash matches the stored hash.
+    /// </summary>
+    public bool IsDefinitionApproved(string currentHash)
+    {
+        return IsApproved && DefinitionHash == currentHash;
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
@@ -78,6 +78,7 @@ public static class DependencyInjection
         services.AddScoped<IProposalProvenanceRepository, ProposalProvenanceRepository>();
         services.AddScoped<IDailySnapshotRepository, DailySnapshotRepository>();
         services.AddScoped<ITomorrowNoteRepository, TomorrowNoteRepository>();
+        services.AddScoped<IMcpToolHashRepository, McpToolHashRepository>();
 
         // Vector index is local; hash-based in-memory embeddings are development/test
         // oriented and stay disabled unless explicitly opted in.

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/McpToolHashConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/McpToolHashConfiguration.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Taskdeck.Domain.Agents;
+
+namespace Taskdeck.Infrastructure.Persistence.Configurations;
+
+public class McpToolHashConfiguration : IEntityTypeConfiguration<McpToolHash>
+{
+    public void Configure(EntityTypeBuilder<McpToolHash> builder)
+    {
+        builder.ToTable("McpToolHashes");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.UserId)
+            .IsRequired();
+
+        builder.Property(e => e.ToolName)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(e => e.DefinitionHash)
+            .IsRequired()
+            .HasMaxLength(128);
+
+        builder.Property(e => e.IsApproved)
+            .IsRequired();
+
+        builder.Property(e => e.ApprovedAt);
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.Property(e => e.UpdatedAt)
+            .IsRequired();
+
+        // Unique index: one hash record per user per tool name
+        builder.HasIndex(e => new { e.UserId, e.ToolName })
+            .IsUnique();
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260508200834_AddMcpToolHashes.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260508200834_AddMcpToolHashes.Designer.cs
@@ -2,17 +2,20 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Taskdeck.Infrastructure.Persistence;
 
 #nullable disable
 
-namespace Taskdeck.Infrastructure.Migrations
+namespace Taskdeck.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(TaskdeckDbContext))]
-    partial class TaskdeckDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508200834_AddMcpToolHashes")]
+    partial class AddMcpToolHashes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.26");

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260508200834_AddMcpToolHashes.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Migrations/20260508200834_AddMcpToolHashes.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Taskdeck.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMcpToolHashes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "McpToolHashes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    UserId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ToolName = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    DefinitionHash = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                    IsApproved = table.Column<bool>(type: "INTEGER", nullable: false),
+                    ApprovedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_McpToolHashes", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_McpToolHashes_UserId_ToolName",
+                table: "McpToolHashes",
+                columns: new[] { "UserId", "ToolName" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "McpToolHashes");
+        }
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckDbContext.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Taskdeck.Domain.Agents;
 using Taskdeck.Domain.Entities;
 
 namespace Taskdeck.Infrastructure.Persistence;
@@ -52,6 +53,7 @@ public class TaskdeckDbContext : DbContext
     public DbSet<ProvenanceEvidenceLink> ProvenanceEvidenceLinks => Set<ProvenanceEvidenceLink>();
     public DbSet<DailySnapshot> DailySnapshots => Set<DailySnapshot>();
     public DbSet<TomorrowNote> TomorrowNotes => Set<TomorrowNote>();
+    public DbSet<McpToolHash> McpToolHashes => Set<McpToolHash>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AgentRunRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AgentRunRepository.cs
@@ -39,4 +39,19 @@ public class AgentRunRepository : Repository<AgentRun>, IAgentRunRepository
             .Include(ar => ar.Events)
             .FirstOrDefaultAsync(ar => ar.Id == id, cancellationToken);
     }
+
+    public async Task<IEnumerable<AgentRun>> GetActiveByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .Where(ar => ar.UserId == userId
+                && ar.Status != AgentRunStatus.Completed
+                && ar.Status != AgentRunStatus.Failed
+                && ar.Status != AgentRunStatus.Cancelled)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddEventAsync(AgentRunEvent agentRunEvent, CancellationToken cancellationToken = default)
+    {
+        await _context.Set<AgentRunEvent>().AddAsync(agentRunEvent, cancellationToken);
+    }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/McpToolHashRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/McpToolHashRepository.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Infrastructure.Persistence;
+
+namespace Taskdeck.Infrastructure.Repositories;
+
+public class McpToolHashRepository : IMcpToolHashRepository
+{
+    private readonly TaskdeckDbContext _context;
+    private readonly DbSet<McpToolHash> _dbSet;
+
+    public McpToolHashRepository(TaskdeckDbContext context)
+    {
+        _context = context;
+        _dbSet = context.Set<McpToolHash>();
+    }
+
+    public async Task<McpToolHash?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet.FindAsync(new object[] { id }, cancellationToken);
+    }
+
+    public async Task<McpToolHash?> GetByUserAndToolAsync(Guid userId, string toolName, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .FirstOrDefaultAsync(h => h.UserId == userId && h.ToolName == toolName, cancellationToken);
+    }
+
+    public async Task<IEnumerable<McpToolHash>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .Where(h => h.UserId == userId)
+            .OrderBy(h => h.ToolName)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(McpToolHash entity, CancellationToken cancellationToken = default)
+    {
+        await _dbSet.AddAsync(entity, cancellationToken);
+    }
+
+    public Task UpdateAsync(McpToolHash entity, CancellationToken cancellationToken = default)
+    {
+        _context.Entry(entity).State = EntityState.Modified;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(McpToolHash entity, CancellationToken cancellationToken = default)
+    {
+        _dbSet.Remove(entity);
+        return Task.CompletedTask;
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
@@ -50,7 +50,8 @@ public class UnitOfWork : IUnitOfWork
         IConnectorCredentialRepository connectorCredentials,
         IProposalRevisionRepository proposalRevisions,
         IDailySnapshotRepository dailySnapshots,
-        ITomorrowNoteRepository tomorrowNotes)
+        ITomorrowNoteRepository tomorrowNotes,
+        IMcpToolHashRepository mcpToolHashes)
     {
         _context = context;
         Boards = boards;
@@ -87,6 +88,7 @@ public class UnitOfWork : IUnitOfWork
         ProposalRevisions = proposalRevisions;
         DailySnapshots = dailySnapshots;
         TomorrowNotes = tomorrowNotes;
+        McpToolHashes = mcpToolHashes;
     }
 
     public IBoardRepository Boards { get; }
@@ -123,6 +125,7 @@ public class UnitOfWork : IUnitOfWork
     public IProposalRevisionRepository ProposalRevisions { get; }
     public IDailySnapshotRepository DailySnapshots { get; }
     public ITomorrowNoteRepository TomorrowNotes { get; }
+    public IMcpToolHashRepository McpToolHashes { get; }
 
     public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {

--- a/backend/tests/Taskdeck.Api.Tests/ActiveUserValidationMiddlewareTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ActiveUserValidationMiddlewareTests.cs
@@ -309,6 +309,7 @@ public class ActiveUserValidationMiddlewareTests
         public IProposalRevisionRepository ProposalRevisions => throw new NotImplementedException();
         public IDailySnapshotRepository DailySnapshots => throw new NotImplementedException();
         public ITomorrowNoteRepository TomorrowNotes => throw new NotImplementedException();
+        public IMcpToolHashRepository McpToolHashes => throw new NotImplementedException();
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -852,6 +852,7 @@ public class LlmQueueToProposalWorkerTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerReliabilityTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerReliabilityTests.cs
@@ -651,6 +651,7 @@ public class OutboundWebhookDeliveryWorkerReliabilityTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(0);

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryWorkerTests.cs
@@ -557,6 +557,7 @@ public class OutboundWebhookDeliveryWorkerTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookHmacDeliveryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookHmacDeliveryTests.cs
@@ -544,6 +544,7 @@ public class OutboundWebhookHmacDeliveryTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(0);

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerEdgeCaseTests.cs
@@ -354,6 +354,7 @@ public class ProposalHousekeepingWorkerEdgeCaseTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalHousekeepingWorkerTests.cs
@@ -241,6 +241,7 @@ public class ProposalHousekeepingWorkerTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
 
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -631,6 +631,7 @@ public class WorkerResilienceTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task CommitTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
@@ -674,6 +675,7 @@ public class WorkerResilienceTests
         public IProposalRevisionRepository ProposalRevisions => null!;
         public IDailySnapshotRepository DailySnapshots => null!;
         public ITomorrowNoteRepository TomorrowNotes => null!;
+        public IMcpToolHashRepository McpToolHashes => null!;
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) => Task.FromResult(0);
         public Task BeginTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task CommitTransactionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;

--- a/backend/tests/Taskdeck.Application.Tests/Services/AgentPolicyTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AgentPolicyTests.cs
@@ -135,7 +135,7 @@ public class AgentPolicyTests
     }
 
     [Fact]
-    public void ValidateToolBundle_EmptyProfileAllowlist_AllowsAll()
+    public void ValidateToolBundle_EmptyProfileAllowlist_DeniesAll_FailClosed()
     {
         var policy = CreatePolicy(
             ("inbox.triage", ToolRiskLevel.Medium),
@@ -145,7 +145,7 @@ public class AgentPolicyTests
             new[] { "inbox.triage", "board.read" }, new List<string>());
 
         decisions.Should().HaveCount(2);
-        decisions.Should().AllSatisfy(d => d.Allowed.Should().BeTrue());
+        decisions.Should().AllSatisfy(d => d.Allowed.Should().BeFalse());
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/AgentPolicyTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AgentPolicyTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class AgentPolicyTests
+{
+    private AgentPolicy CreatePolicy(params (string Key, ToolRiskLevel Risk)[] tools)
+    {
+        var registry = new TaskdeckToolRegistry();
+        foreach (var (key, risk) in tools)
+        {
+            registry.RegisterTool(new TaskdeckToolDefinition(key, key, $"Test {key}", ToolScope.Board, risk));
+        }
+        return new AgentPolicy(registry);
+    }
+
+    [Fact]
+    public void ValidateToolBundle_EmptyBundle_ReturnsEmpty()
+    {
+        var policy = CreatePolicy(("inbox.triage", ToolRiskLevel.Medium));
+        var decisions = policy.ValidateToolBundle(Array.Empty<string>());
+        decisions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ValidateToolBundle_RegisteredTool_IsAllowed()
+    {
+        var policy = CreatePolicy(("inbox.triage", ToolRiskLevel.Medium));
+        var decisions = policy.ValidateToolBundle(new[] { "inbox.triage" });
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeTrue();
+        decisions[0].ToolKey.Should().Be("inbox.triage");
+    }
+
+    [Fact]
+    public void ValidateToolBundle_UnregisteredTool_IsDenied()
+    {
+        var policy = CreatePolicy(("inbox.triage", ToolRiskLevel.Medium));
+        var decisions = policy.ValidateToolBundle(new[] { "unknown.tool" });
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+        decisions[0].Reason.Should().Contain("not registered");
+    }
+
+    [Fact]
+    public void ValidateToolBundle_ApproveProposal_IsPermanentlyExcluded()
+    {
+        var policy = CreatePolicy();
+        var decisions = policy.ValidateToolBundle(new[] { "approve_proposal" });
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+        decisions[0].Reason.Should().Contain("permanently excluded");
+    }
+
+    [Fact]
+    public void ValidateToolBundle_ApplyProposal_IsPermanentlyExcluded()
+    {
+        var policy = CreatePolicy();
+        var decisions = policy.ValidateToolBundle(new[] { "apply_proposal" });
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+        decisions[0].Reason.Should().Contain("permanently excluded");
+    }
+
+    [Fact]
+    public void ValidateToolBundle_DirectBoardMutation_IsPermanentlyExcluded()
+    {
+        var policy = CreatePolicy();
+        var mutations = new[]
+        {
+            "board.direct_update", "board.direct_delete",
+            "card.direct_move", "card.direct_delete",
+            "column.direct_delete"
+        };
+        var decisions = policy.ValidateToolBundle(mutations);
+        decisions.Should().HaveCount(5);
+        decisions.Should().AllSatisfy(d => d.Allowed.Should().BeFalse());
+    }
+
+    [Fact]
+    public void ValidateToolBundle_MixedBundle_ReturnsPerToolDecisions()
+    {
+        var policy = CreatePolicy(
+            ("inbox.triage", ToolRiskLevel.Medium),
+            ("board.read", ToolRiskLevel.Low));
+
+        var decisions = policy.ValidateToolBundle(new[]
+        {
+            "inbox.triage", "approve_proposal", "board.read", "unknown"
+        });
+
+        decisions.Should().HaveCount(4);
+        decisions[0].Allowed.Should().BeTrue();
+        decisions[1].Allowed.Should().BeFalse(); // approve_proposal
+        decisions[2].Allowed.Should().BeTrue();
+        decisions[3].Allowed.Should().BeFalse(); // unknown
+    }
+
+    [Fact]
+    public void ValidateToolBundle_NullToolKey_IsDenied()
+    {
+        var policy = CreatePolicy(("inbox.triage", ToolRiskLevel.Medium));
+        var decisions = policy.ValidateToolBundle(new string[] { null! });
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateToolBundle_EmptyToolKey_IsDenied()
+    {
+        var policy = CreatePolicy(("inbox.triage", ToolRiskLevel.Medium));
+        var decisions = policy.ValidateToolBundle(new[] { "" });
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateToolBundle_WithProfileAllowlist_RestrictsToAllowedTools()
+    {
+        var policy = CreatePolicy(
+            ("inbox.triage", ToolRiskLevel.Medium),
+            ("board.read", ToolRiskLevel.Low));
+
+        var profileAllowlist = new List<string> { "inbox.triage" };
+        var decisions = policy.ValidateToolBundle(
+            new[] { "inbox.triage", "board.read" }, profileAllowlist);
+
+        decisions.Should().HaveCount(2);
+        decisions[0].Allowed.Should().BeTrue(); // inbox.triage in allowlist
+        decisions[1].Allowed.Should().BeFalse(); // board.read not in allowlist
+    }
+
+    [Fact]
+    public void ValidateToolBundle_EmptyProfileAllowlist_AllowsAll()
+    {
+        var policy = CreatePolicy(
+            ("inbox.triage", ToolRiskLevel.Medium),
+            ("board.read", ToolRiskLevel.Low));
+
+        var decisions = policy.ValidateToolBundle(
+            new[] { "inbox.triage", "board.read" }, new List<string>());
+
+        decisions.Should().HaveCount(2);
+        decisions.Should().AllSatisfy(d => d.Allowed.Should().BeTrue());
+    }
+
+    [Fact]
+    public void IsPermanentlyExcluded_ApproveProposal_ReturnsTrue()
+    {
+        AgentPolicy.IsPermanentlyExcluded("approve_proposal").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPermanentlyExcluded_RegisteredTool_ReturnsFalse()
+    {
+        AgentPolicy.IsPermanentlyExcluded("inbox.triage").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPermanentlyExcluded_IsCaseInsensitive()
+    {
+        AgentPolicy.IsPermanentlyExcluded("APPROVE_PROPOSAL").Should().BeTrue();
+        AgentPolicy.IsPermanentlyExcluded("Approve_Proposal").Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetPermanentlyExcludedTools_ContainsAllExpected()
+    {
+        var excluded = AgentPolicy.GetPermanentlyExcludedTools();
+        excluded.Should().Contain("approve_proposal");
+        excluded.Should().Contain("apply_proposal");
+        excluded.Should().Contain("board.direct_update");
+        excluded.Should().Contain("board.direct_delete");
+        excluded.Should().Contain("card.direct_move");
+        excluded.Should().Contain("card.direct_delete");
+        excluded.Should().Contain("column.direct_delete");
+    }
+
+    [Fact]
+    public void ValidateToolBundle_NullRequestedTools_Throws()
+    {
+        var policy = CreatePolicy();
+        var act = () => policy.ValidateToolBundle(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ValidateToolBundle_ProfileAllowlistCaseInsensitive()
+    {
+        var policy = CreatePolicy(("inbox.triage", ToolRiskLevel.Medium));
+        var profileAllowlist = new List<string> { "INBOX.TRIAGE" };
+        var decisions = policy.ValidateToolBundle(new[] { "inbox.triage" }, profileAllowlist);
+        decisions.Should().HaveCount(1);
+        decisions[0].Allowed.Should().BeTrue();
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/AgentRuntimeTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AgentRuntimeTests.cs
@@ -1,0 +1,292 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class AgentRuntimeTests
+{
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IAgentProfileRepository> _profileRepo = new();
+    private readonly Mock<IAgentRunRepository> _runRepo = new();
+    private readonly Mock<IAgentPolicyEvaluator> _policyEvaluator = new();
+    private readonly TaskdeckToolRegistry _toolRegistry = new();
+    private readonly AgentPolicy _agentPolicy;
+    private readonly AgentRuntime _runtime;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _profileId = Guid.NewGuid();
+
+    public AgentRuntimeTests()
+    {
+        _toolRegistry.RegisterTool(InboxTriageAssistant.GetToolDefinition());
+
+        _agentPolicy = new AgentPolicy(_toolRegistry);
+
+        _unitOfWork.Setup(u => u.AgentProfiles).Returns(_profileRepo.Object);
+        _unitOfWork.Setup(u => u.AgentRuns).Returns(_runRepo.Object);
+        _unitOfWork.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _runtime = new AgentRuntime(
+            _unitOfWork.Object,
+            _agentPolicy,
+            _policyEvaluator.Object);
+    }
+
+    private AgentProfile CreateProfile(bool enabled = true, string? policyJson = null)
+    {
+        return new AgentProfile(
+            _userId, "Test Agent", "inbox-triage-digest",
+            AgentScopeType.Workspace, description: "Test",
+            policyJson: policyJson);
+    }
+
+    [Fact]
+    public async Task RunAsync_ProfileNotFound_ReturnsFailure()
+    {
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentProfile?)null);
+
+        var result = await _runtime.RunAsync(
+            _profileId, _userId, "test objective",
+            new[] { "inbox.triage" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult("test", IsTerminal: true)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task RunAsync_WrongUser_ReturnsFailure()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+
+        var result = await _runtime.RunAsync(
+            _profileId, Guid.NewGuid(), "test objective",
+            new[] { "inbox.triage" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult("test", IsTerminal: true)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("Forbidden");
+    }
+
+    [Fact]
+    public async Task RunAsync_DisabledProfile_ReturnsFailure()
+    {
+        var profile = CreateProfile(enabled: false);
+        profile.SetEnabled(false);
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "test objective",
+            new[] { "inbox.triage" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult("test", IsTerminal: true)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("InvalidOperation");
+    }
+
+    [Fact]
+    public async Task RunAsync_ExcludedTool_ReturnsFailure()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "test objective",
+            new[] { "approve_proposal" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult("test", IsTerminal: true)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("Forbidden");
+        result.ErrorMessage.Should().Contain("permanently excluded");
+    }
+
+    [Fact]
+    public async Task RunAsync_UnknownTool_ReturnsFailure()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "test objective",
+            new[] { "nonexistent_tool" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult("test", IsTerminal: true)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("Forbidden");
+    }
+
+    [Fact]
+    public async Task RunAsync_ValidRun_CompletesSuccessfully()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        var proposalId = Guid.NewGuid();
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "triage inbox",
+            new[] { "inbox.triage" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult(
+                EventType: "triage.done",
+                Payload: "{}",
+                IsTerminal: true,
+                ProposalId: proposalId,
+                Summary: "Triaged 5 items")));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(AgentRunStatus.ProposalCreated);
+        result.Value.ProposalId.Should().Be(proposalId);
+    }
+
+    [Fact]
+    public async Task RunAsync_MaxStepsExhausted_CompletesWithQuotaMessage()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        var stepCount = 0;
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "run many steps",
+            new[] { "inbox.triage" },
+            (run, step, ct) =>
+            {
+                stepCount++;
+                return Task.FromResult(new AgentStepResult("step.working"));
+            },
+            maxSteps: 3);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(AgentRunStatus.Completed);
+        result.Value.Summary.Should().Contain("Step quota exhausted");
+        stepCount.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task RunAsync_ConcurrentRunQuota_ReturnsFailure()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+
+        // Simulate max concurrent runs already active
+        var activeRuns = Enumerable.Range(0, AgentRuntime.DefaultMaxConcurrentRunsPerUser)
+            .Select(_ => new AgentRun(profile.Id, _userId, "active run"));
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(activeRuns);
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "new run",
+            new[] { "inbox.triage" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult("test", IsTerminal: true)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("TooManyRequests");
+    }
+
+    [Fact]
+    public async Task RunAsync_Cancellation_MarksCancelled()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        using var cts = new CancellationTokenSource();
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "will be cancelled",
+            new[] { "inbox.triage" },
+            (run, step, ct) =>
+            {
+                cts.Cancel();
+                ct.ThrowIfCancellationRequested();
+                return Task.FromResult(new AgentStepResult("test", IsTerminal: true));
+            },
+            cancellationToken: cts.Token);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(AgentRunStatus.Cancelled);
+    }
+
+    [Fact]
+    public async Task RunAsync_EgressViolation_MarksFailedWithViolation()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "will violate egress",
+            new[] { "inbox.triage" },
+            (run, step, ct) =>
+            {
+                var violation = new EgressViolation(
+                    "attacker.example", "https://attacker.example",
+                    EgressViolationType.UnknownHost, "Not in envelope");
+                throw new EgressViolationException(violation);
+            });
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be("Forbidden");
+        result.ErrorMessage.Should().Contain("Egress violation");
+    }
+
+    [Fact]
+    public async Task RunAsync_RecordsEvents()
+    {
+        var profile = CreateProfile();
+        _profileRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(profile);
+        _runRepo.Setup(r => r.GetActiveByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Enumerable.Empty<AgentRun>());
+
+        var eventsRecorded = new List<AgentRunEvent>();
+        _runRepo.Setup(r => r.AddEventAsync(It.IsAny<AgentRunEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<AgentRunEvent, CancellationToken>((e, _) => eventsRecorded.Add(e));
+
+        var result = await _runtime.RunAsync(
+            profile.Id, _userId, "test",
+            new[] { "inbox.triage" },
+            (run, step, ct) => Task.FromResult(new AgentStepResult(
+                "test.step", Payload: "{}", IsTerminal: true,
+                Summary: "Done")));
+
+        result.IsSuccess.Should().BeTrue();
+        eventsRecorded.Should().HaveCountGreaterOrEqualTo(2); // policy + step
+        eventsRecorded[0].EventType.Should().Be("policy.validated");
+    }
+
+    [Fact]
+    public void DefaultConstants_AreReasonable()
+    {
+        AgentRuntime.DefaultMaxStepsPerRun.Should().BeGreaterThan(0);
+        AgentRuntime.DefaultMaxTokensPerRun.Should().BeGreaterThan(0);
+        AgentRuntime.DefaultMaxConcurrentRunsPerUser.Should().BeGreaterThan(0);
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/AgentTelemetryTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AgentTelemetryTests.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Taskdeck.Application.Services;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+/// <summary>
+/// Tests that agent telemetry instrumentation is content-free by design.
+/// These tests verify the API shape and that no method accepts user content parameters.
+/// Acceptance criteria: OTel/SQLite run events do not include prompt, capture,
+/// card title, transcript, or other user content by default.
+/// </summary>
+public class AgentTelemetryTests
+{
+    [Fact]
+    public void ActivitySourceName_IsTaskdeckAgent()
+    {
+        AgentTelemetry.ActivitySourceName.Should().Be("Taskdeck.Agent");
+    }
+
+    [Fact]
+    public void MeterName_IsTaskdeckAgent()
+    {
+        AgentTelemetry.MeterName.Should().Be("Taskdeck.Agent");
+    }
+
+    [Fact]
+    public void RecordRunStarted_DoesNotThrow()
+    {
+        // Content-free: only triggerType and templateKey (both system-defined identifiers)
+        var act = () => AgentTelemetry.RecordRunStarted("manual", "inbox-triage-digest");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordRunCompleted_DoesNotThrow()
+    {
+        // Content-free: only numeric values and system identifiers
+        var act = () => AgentTelemetry.RecordRunCompleted("scheduled", "inbox-triage-digest", 1500.0, 5, 100);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordRunFailed_DoesNotThrow()
+    {
+        var act = () => AgentTelemetry.RecordRunFailed("manual", "inbox-triage-digest");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordRunCancelled_DoesNotThrow()
+    {
+        var act = () => AgentTelemetry.RecordRunCancelled("manual", "inbox-triage-digest");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordStep_DoesNotThrow()
+    {
+        // eventType is a system-defined category, not user content
+        var act = () => AgentTelemetry.RecordStep("triage.proposal_created");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordProposalCreated_DoesNotThrow()
+    {
+        var act = () => AgentTelemetry.RecordProposalCreated("inbox-triage-digest");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordPolicyDenial_DoesNotThrow()
+    {
+        var act = () => AgentTelemetry.RecordPolicyDenial("approve_proposal", "inbox-triage-digest");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordEgressViolation_DoesNotThrow()
+    {
+        // Content-free: host and payloadCategory are system-defined
+        var act = () => AgentTelemetry.RecordEgressViolation("attacker.example", "unknown");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordQuotaExceeded_DoesNotThrow()
+    {
+        var act = () => AgentTelemetry.RecordQuotaExceeded("tokens", "inbox-triage-digest");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void StartRunActivity_ReturnsNullWithoutListener()
+    {
+        // Without an ActivityListener registered, activities are not created
+        var activity = AgentTelemetry.StartRunActivity(Guid.NewGuid(), "manual", "test-template");
+        // Activity may be null if no listener — that's expected and safe
+        activity?.Dispose();
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/EgressEnvelopeHandlerTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/EgressEnvelopeHandlerTests.cs
@@ -74,7 +74,7 @@ public class EgressEnvelopeHandlerTests
     public async Task SendAsync_RedirectToUnknownHost_ThrowsEgressViolation()
     {
         var registry = CreateRegistry("trusted.example.com");
-        var inner = new RedirectHandler("https://evil.example.com/callback");
+        var inner = new SingleRedirectHandler("https://evil.example.com/callback");
         var handler = new EgressEnvelopeHandler(registry, sourceComponent: "test")
         {
             InnerHandler = inner
@@ -91,10 +91,10 @@ public class EgressEnvelopeHandlerTests
     }
 
     [Fact]
-    public async Task SendAsync_RedirectToAllowedHost_Succeeds()
+    public async Task SendAsync_RedirectToAllowedHost_FollowsRedirect()
     {
         var registry = CreateRegistry("trusted.example.com", "also-trusted.example.com");
-        var inner = new RedirectHandler("https://also-trusted.example.com/continue");
+        var inner = new SingleRedirectHandler("https://also-trusted.example.com/continue");
         var handler = new EgressEnvelopeHandler(registry)
         {
             InnerHandler = inner
@@ -104,7 +104,8 @@ public class EgressEnvelopeHandlerTests
         var request = new HttpRequestMessage(HttpMethod.Get, "https://trusted.example.com/start");
         var response = await invoker.SendAsync(request, CancellationToken.None);
 
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+        // Handler follows the redirect and returns the final OK response
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
     }
 
     [Fact]
@@ -205,6 +206,32 @@ public class EgressEnvelopeHandlerTests
             var response = new HttpResponseMessage(System.Net.HttpStatusCode.Redirect);
             response.Headers.Location = new Uri(_redirectUri);
             return Task.FromResult(response);
+        }
+    }
+
+    /// <summary>
+    /// Returns a redirect on the first call, then OK on subsequent calls.
+    /// Used with the manual redirect-following logic in EgressEnvelopeHandler.
+    /// </summary>
+    private sealed class SingleRedirectHandler : HttpMessageHandler
+    {
+        private readonly string _redirectUri;
+        private bool _redirected;
+
+        public SingleRedirectHandler(string redirectUri) => _redirectUri = redirectUri;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!_redirected)
+            {
+                _redirected = true;
+                var response = new HttpResponseMessage(System.Net.HttpStatusCode.Redirect);
+                response.Headers.Location = new Uri(_redirectUri);
+                return Task.FromResult(response);
+            }
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
         }
     }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/EgressEnvelopeHandlerTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/EgressEnvelopeHandlerTests.cs
@@ -1,0 +1,210 @@
+using FluentAssertions;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Agents;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class EgressEnvelopeHandlerTests
+{
+    private static EgressRegistry CreateRegistry(params string[] hosts)
+    {
+        var entries = hosts.Select(h => new EgressEntry(h, "test", "test", EgressDataClassification.None));
+        return new EgressRegistry(entries);
+    }
+
+    private static (EgressEnvelopeHandler Handler, HttpMessageHandler Inner) CreateHandler(
+        params string[] allowedHosts)
+    {
+        var registry = CreateRegistry(allowedHosts);
+        var inner = new StubHandler();
+        var handler = new EgressEnvelopeHandler(registry, sourceComponent: "test")
+        {
+            InnerHandler = inner
+        };
+        return (handler, inner);
+    }
+
+    [Fact]
+    public async Task SendAsync_AllowedHost_Succeeds()
+    {
+        var (handler, _) = CreateHandler("api.openai.com");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://api.openai.com/v1/chat");
+        var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendAsync_UnknownHost_ThrowsEgressViolation()
+    {
+        var (handler, _) = CreateHandler("api.openai.com");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://attacker.example/steal");
+
+        var act = async () => await invoker.SendAsync(request, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<EgressViolationException>();
+        ex.Which.Violation.AttemptedHost.Should().Be("attacker.example");
+        ex.Which.Violation.ViolationType.Should().Be(EgressViolationType.UnknownHost);
+        ex.Which.Violation.SourceComponent.Should().Be("test");
+    }
+
+    [Fact]
+    public async Task SendAsync_AttackerExample_FailsWithEgressViolation()
+    {
+        // Deliberate test from acceptance criteria:
+        // "Test agent attempting https://attacker.example fails with EgressViolation"
+        var (handler, _) = CreateHandler("api.openai.com", "generativelanguage.googleapis.com");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://attacker.example");
+
+        var act = async () => await invoker.SendAsync(request, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<EgressViolationException>();
+        ex.Which.Violation.AttemptedHost.Should().Be("attacker.example");
+        ex.Which.Violation.Reason.Should().Contain("not in the egress envelope");
+    }
+
+    [Fact]
+    public async Task SendAsync_RedirectToUnknownHost_ThrowsEgressViolation()
+    {
+        var registry = CreateRegistry("trusted.example.com");
+        var inner = new RedirectHandler("https://evil.example.com/callback");
+        var handler = new EgressEnvelopeHandler(registry, sourceComponent: "test")
+        {
+            InnerHandler = inner
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://trusted.example.com/start");
+
+        var act = async () => await invoker.SendAsync(request, CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<EgressViolationException>();
+        ex.Which.Violation.ViolationType.Should().Be(EgressViolationType.RedirectToUnknownHost);
+        ex.Which.Violation.AttemptedHost.Should().Be("evil.example.com");
+    }
+
+    [Fact]
+    public async Task SendAsync_RedirectToAllowedHost_Succeeds()
+    {
+        var registry = CreateRegistry("trusted.example.com", "also-trusted.example.com");
+        var inner = new RedirectHandler("https://also-trusted.example.com/continue");
+        var handler = new EgressEnvelopeHandler(registry)
+        {
+            InnerHandler = inner
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "https://trusted.example.com/start");
+        var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.Redirect);
+    }
+
+    [Fact]
+    public async Task SendAsync_NullRequestUri_ThrowsEgressViolation()
+    {
+        var (handler, _) = CreateHandler("api.openai.com");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage { Method = HttpMethod.Get };
+
+        var act = async () => await invoker.SendAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<EgressViolationException>();
+    }
+
+    [Fact]
+    public async Task SendAsync_WildcardHost_MatchesSubdomains()
+    {
+        var registry = CreateRegistry("*.sentry.io");
+        var handler = new EgressEnvelopeHandler(registry)
+        {
+            InnerHandler = new StubHandler()
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://abc123.ingest.sentry.io/api/event");
+        var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task SendAsync_NullRequest_Throws()
+    {
+        var (handler, _) = CreateHandler("api.openai.com");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var act = async () => await invoker.SendAsync(null!, CancellationToken.None);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void EgressViolationException_CarriesViolation()
+    {
+        var violation = new EgressViolation(
+            "bad.host", "https://bad.host/steal",
+            EgressViolationType.UnknownHost, "Not allowed");
+
+        var ex = new EgressViolationException(violation);
+
+        ex.Violation.Should().BeSameAs(violation);
+        ex.Message.Should().Be("Not allowed");
+    }
+
+    [Fact]
+    public void EgressViolation_ValidatesRequiredFields()
+    {
+        var act1 = () => new EgressViolation("", "uri", EgressViolationType.UnknownHost, "reason");
+        var act2 = () => new EgressViolation("host", "", EgressViolationType.UnknownHost, "reason");
+        var act3 = () => new EgressViolation("host", "uri", EgressViolationType.UnknownHost, "");
+
+        act1.Should().Throw<ArgumentException>();
+        act2.Should().Throw<ArgumentException>();
+        act3.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void EgressViolation_ToString_ContainsKey()
+    {
+        var violation = new EgressViolation(
+            "evil.com", "https://evil.com",
+            EgressViolationType.UnknownHost, "blocked");
+
+        violation.ToString().Should().Contain("UnknownHost");
+        violation.ToString().Should().Contain("evil.com");
+    }
+
+    // --- Test Helpers ---
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class RedirectHandler : HttpMessageHandler
+    {
+        private readonly string _redirectUri;
+
+        public RedirectHandler(string redirectUri) => _redirectUri = redirectUri;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.Redirect);
+            response.Headers.Location = new Uri(_redirectUri);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/McpToolDefinitionHashServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/McpToolDefinitionHashServiceTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Taskdeck.Application.Services;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class McpToolDefinitionHashServiceTests
+{
+    [Fact]
+    public void ComputeDefinitionHash_DeterministicForSameInput()
+    {
+        var hash1 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "test_tool", "Description", "{\"type\":\"object\"}");
+        var hash2 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "test_tool", "Description", "{\"type\":\"object\"}");
+
+        hash1.Should().Be(hash2);
+    }
+
+    [Fact]
+    public void ComputeDefinitionHash_DifferentForDifferentName()
+    {
+        var hash1 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool_a", "Description", "{\"type\":\"object\"}");
+        var hash2 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool_b", "Description", "{\"type\":\"object\"}");
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public void ComputeDefinitionHash_DifferentForDifferentDescription()
+    {
+        var hash1 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool", "Description A", "{\"type\":\"object\"}");
+        var hash2 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool", "Description B", "{\"type\":\"object\"}");
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public void ComputeDefinitionHash_DifferentForDifferentSchema()
+    {
+        var hash1 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool", "Description", "{\"type\":\"object\"}");
+        var hash2 = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool", "Description", "{\"type\":\"string\"}");
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public void ComputeDefinitionHash_ReturnsLowercaseHex()
+    {
+        var hash = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool", "desc", "schema");
+
+        hash.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void ComputeDefinitionHash_Has64CharLength()
+    {
+        var hash = McpToolDefinitionHashService.ComputeDefinitionHash(
+            "tool", "desc", "schema");
+
+        hash.Should().HaveLength(64); // SHA-256 = 256 bits = 64 hex chars
+    }
+}

--- a/backend/tests/Taskdeck.Domain.Tests/Agents/McpToolHashTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Agents/McpToolHashTests.cs
@@ -1,0 +1,169 @@
+using FluentAssertions;
+using Taskdeck.Domain.Agents;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Domain.Tests.Agents;
+
+public class McpToolHashTests
+{
+    private static readonly Guid ValidUserId = Guid.NewGuid();
+
+    [Fact]
+    public void Constructor_ValidInputs_CreatesEntity()
+    {
+        var hash = new McpToolHash(ValidUserId, "test_tool", "abc123hash");
+
+        hash.UserId.Should().Be(ValidUserId);
+        hash.ToolName.Should().Be("test_tool");
+        hash.DefinitionHash.Should().Be("abc123hash");
+        hash.IsApproved.Should().BeFalse();
+        hash.ApprovedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_EmptyUserId_Throws()
+    {
+        var act = () => new McpToolHash(Guid.Empty, "tool", "hash");
+        act.Should().Throw<DomainException>().WithMessage("*UserId*");
+    }
+
+    [Fact]
+    public void Constructor_EmptyToolName_Throws()
+    {
+        var act = () => new McpToolHash(ValidUserId, "", "hash");
+        act.Should().Throw<DomainException>().WithMessage("*ToolName*");
+    }
+
+    [Fact]
+    public void Constructor_NullToolName_Throws()
+    {
+        var act = () => new McpToolHash(ValidUserId, null!, "hash");
+        act.Should().Throw<DomainException>().WithMessage("*ToolName*");
+    }
+
+    [Fact]
+    public void Constructor_EmptyHash_Throws()
+    {
+        var act = () => new McpToolHash(ValidUserId, "tool", "");
+        act.Should().Throw<DomainException>().WithMessage("*DefinitionHash*");
+    }
+
+    [Fact]
+    public void Constructor_ToolNameTooLong_Throws()
+    {
+        var longName = new string('a', 201);
+        var act = () => new McpToolHash(ValidUserId, longName, "hash");
+        act.Should().Throw<DomainException>().WithMessage("*ToolName*200*");
+    }
+
+    [Fact]
+    public void Constructor_HashTooLong_Throws()
+    {
+        var longHash = new string('a', 129);
+        var act = () => new McpToolHash(ValidUserId, "tool", longHash);
+        act.Should().Throw<DomainException>().WithMessage("*DefinitionHash*128*");
+    }
+
+    [Fact]
+    public void Approve_SetsApprovalState()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+
+        hash.Approve();
+
+        hash.IsApproved.Should().BeTrue();
+        hash.ApprovedAt.Should().NotBeNull();
+        hash.ApprovedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void UpdateHash_SameHash_KeepsApproval()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        hash.Approve();
+
+        hash.UpdateHash("hash123");
+
+        hash.IsApproved.Should().BeTrue();
+        hash.DefinitionHash.Should().Be("hash123");
+    }
+
+    [Fact]
+    public void UpdateHash_DifferentHash_RevokesApproval()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        hash.Approve();
+
+        hash.UpdateHash("new_hash_456");
+
+        hash.IsApproved.Should().BeFalse();
+        hash.ApprovedAt.Should().BeNull();
+        hash.DefinitionHash.Should().Be("new_hash_456");
+    }
+
+    [Fact]
+    public void UpdateHash_EmptyHash_Throws()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        var act = () => hash.UpdateHash("");
+        act.Should().Throw<DomainException>().WithMessage("*DefinitionHash*");
+    }
+
+    [Fact]
+    public void UpdateHash_HashTooLong_Throws()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        var longHash = new string('x', 129);
+        var act = () => hash.UpdateHash(longHash);
+        act.Should().Throw<DomainException>().WithMessage("*DefinitionHash*128*");
+    }
+
+    [Fact]
+    public void IsDefinitionApproved_ApprovedAndMatching_ReturnsTrue()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        hash.Approve();
+
+        hash.IsDefinitionApproved("hash123").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDefinitionApproved_ApprovedButDifferent_ReturnsFalse()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        hash.Approve();
+
+        hash.IsDefinitionApproved("different_hash").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDefinitionApproved_NotApproved_ReturnsFalse()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+
+        hash.IsDefinitionApproved("hash123").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDefinitionApproved_AfterHashChange_ReturnsFalse()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        hash.Approve();
+        hash.UpdateHash("new_hash");
+
+        hash.IsDefinitionApproved("hash123").Should().BeFalse();
+        hash.IsDefinitionApproved("new_hash").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDefinitionApproved_AfterHashChangeAndReapproval_ReturnsTrue()
+    {
+        var hash = new McpToolHash(ValidUserId, "tool", "hash123");
+        hash.Approve();
+        hash.UpdateHash("new_hash");
+        hash.Approve();
+
+        hash.IsDefinitionApproved("new_hash").Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements core agent safety infrastructure for issue #981
- AgentRuntime: bounded execution with per-run quotas (steps, tokens, concurrent runs), fail-closed error handling, cancellation/timeout discrimination
- AgentPolicy: tool-bundle allowlist with permanently excluded tools (GP-06: no approve_proposal, no direct board mutation)
- EgressEnvelopeHandler: DelegatingHandler blocking unauthorized HTTP egress
- McpToolDefinitionHashService: SHA-256 hash-pinning for MCP tool definitions to detect drift
- AgentTelemetry: OpenTelemetry counters (content-free metrics)
- InboxTriageDigestAgent: first bounded scheduled agent
- McpToolHash entity and EgressViolation value object in Domain layer
- EF Core migration for McpToolHashes table

## Critical fixes included (from adversarial review of #1051)
- **ParseProfileAllowlist fail-closed**: malformed JSON now denies all tools instead of allowing all
- **Result.Failure from catch blocks**: all error paths now return failure instead of falling through to Success
- **Cancellation/timeout split**: HTTP timeouts no longer conflated with user cancellation

## Test plan
- 128 tests covering all new services and domain entities
- `dotnet test backend/Taskdeck.sln -c Release --filter "FullyQualifiedName~Agent"` — all pass
- Build: 0 warnings

## Risk
- EgressEnvelopeHandler and AgentTelemetry are defined but not yet wired into active pipelines (intentional — activation in follow-up)
- TOCTOU race on concurrent-run quota (documented, needs transaction/lock in follow-up)

Closes #981
Supersedes #1051