### PR TITLE
Add Claude workflow skills and hooks for automated PR review

### DIFF
--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Pre-commit hook: runs backend build and frontend typecheck
+# based on which file types are staged.
+
+STAGED=$(git diff --cached --name-only 2>/dev/null)
+HAS_CS=false
+HAS_VUE=false
+
+if echo "$STAGED" | grep -qE '\.cs$'; then
+  HAS_CS=true
+fi
+if echo "$STAGED" | grep -qE '\.(vue|ts)$'; then
+  HAS_VUE=true
+fi
+
+ERRORS=""
+
+if [ "$HAS_CS" = true ]; then
+  RESULT=$(dotnet build backend/Taskdeck.sln -c Release --nologo -v q 2>&1)
+  if [ $? -ne 0 ]; then
+    ERRORS="Backend build failed:\n$RESULT"
+  fi
+fi
+
+if [ "$HAS_VUE" = true ]; then
+  RESULT=$(cd frontend/taskdeck-web && npx vue-tsc --noEmit 2>&1)
+  if [ $? -ne 0 ]; then
+    ERRORS="$ERRORS\nFrontend typecheck failed:\n$RESULT"
+  fi
+fi
+
+if [ -n "$ERRORS" ]; then
+  echo "PRE-COMMIT CHECK FAILED:" >&2
+  echo -e "$ERRORS" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -77,7 +77,18 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit *)",
+            "if": "Bash(git push*)",
+            "command": "bash -c 'echo \"{\\\"hookSpecificOutput\\\": {\\\"hookEventName\\\": \\\"PreToolUse\\\", \\\"additionalContext\\\": \\\"[PRE-PUSH] Verify: tests passed, build clean, no secrets staged, commit messages are descriptive.\\\"}}\"; exit 0'",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
             "command": "bash -c 'INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r \".tool_input.command // empty\"); STAGED=$(git diff --cached --name-only 2>/dev/null); HAS_CS=false; HAS_VUE=false; if echo \"$STAGED\" | grep -qE \"\\.cs$\"; then HAS_CS=true; fi; if echo \"$STAGED\" | grep -qE \"\\.(vue|ts)$\"; then HAS_VUE=true; fi; ERRORS=\"\"; if [ \"$HAS_CS\" = true ]; then RESULT=$(dotnet build backend/Taskdeck.sln -c Release --nologo -v q 2>&1); if [ $? -ne 0 ]; then ERRORS=\"Backend build failed:\\n$RESULT\"; fi; fi; if [ \"$HAS_VUE\" = true ]; then RESULT=$(cd frontend/taskdeck-web && npx vue-tsc --noEmit 2>&1); if [ $? -ne 0 ]; then ERRORS=\"$ERRORS\\nFrontend typecheck failed:\\n$RESULT\"; fi; fi; if [ -n \"$ERRORS\" ]; then echo \"PRE-COMMIT CHECK FAILED:\" >&2; echo -e \"$ERRORS\" >&2; exit 2; fi; exit 0'",
             "timeout": 120,
             "statusMessage": "Running pre-commit checks..."
@@ -92,6 +103,16 @@
           {
             "type": "command",
             "command": "bash -c 'INPUT=$(cat); FILE=$(echo \"$INPUT\" | jq -r \".tool_input.file_path // empty\"); if echo \"$FILE\" | grep -qE \"\\.(vue|ts)$\"; then if echo \"$FILE\" | grep -q \"frontend/taskdeck-web\"; then echo \"{\\\"hookSpecificOutput\\\": {\\\"hookEventName\\\": \\\"PostToolUse\\\", \\\"additionalContext\\\": \\\"Vue/TS file edited: $FILE -- consider running typecheck if making multiple related edits.\\\"}}\"; fi; fi; exit 0'",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r \".tool_input.command // empty\"); if echo \"$CMD\" | grep -q \"gh pr create\"; then echo \"{\\\"hookSpecificOutput\\\": {\\\"hookEventName\\\": \\\"PostToolUse\\\", \\\"additionalContext\\\": \\\"PR created. MANDATORY: Run /adversarial-review on this PR now. Post findings as PR comment, fix ALL severities, push fixes, check bot comments, post follow-up.\\\"}}\"; fi; exit 0'",
             "timeout": 5
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,7 +89,7 @@
           {
             "type": "command",
             "if": "Bash(git commit*)",
-            "command": "bash -c 'INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r \".tool_input.command // empty\"); STAGED=$(git diff --cached --name-only 2>/dev/null); HAS_CS=false; HAS_VUE=false; if echo \"$STAGED\" | grep -qE \"\\.cs$\"; then HAS_CS=true; fi; if echo \"$STAGED\" | grep -qE \"\\.(vue|ts)$\"; then HAS_VUE=true; fi; ERRORS=\"\"; if [ \"$HAS_CS\" = true ]; then RESULT=$(dotnet build backend/Taskdeck.sln -c Release --nologo -v q 2>&1); if [ $? -ne 0 ]; then ERRORS=\"Backend build failed:\\n$RESULT\"; fi; fi; if [ \"$HAS_VUE\" = true ]; then RESULT=$(cd frontend/taskdeck-web && npx vue-tsc --noEmit 2>&1); if [ $? -ne 0 ]; then ERRORS=\"$ERRORS\\nFrontend typecheck failed:\\n$RESULT\"; fi; fi; if [ -n \"$ERRORS\" ]; then echo \"PRE-COMMIT CHECK FAILED:\" >&2; echo -e \"$ERRORS\" >&2; exit 2; fi; exit 0'",
+            "command": "bash .claude/hooks/pre-commit.sh",
             "timeout": 120,
             "statusMessage": "Running pre-commit checks..."
           }
@@ -112,7 +112,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r \".tool_input.command // empty\"); if echo \"$CMD\" | grep -q \"gh pr create\"; then echo \"{\\\"hookSpecificOutput\\\": {\\\"hookEventName\\\": \\\"PostToolUse\\\", \\\"additionalContext\\\": \\\"PR created. MANDATORY: Run /adversarial-review on this PR now. Post findings as PR comment, fix ALL severities, push fixes, check bot comments, post follow-up.\\\"}}\"; fi; exit 0'",
+            "if": "Bash(gh pr create*)",
+            "command": "bash -c 'echo \"{\\\"hookSpecificOutput\\\": {\\\"hookEventName\\\": \\\"PostToolUse\\\", \\\"additionalContext\\\": \\\"PR created. MANDATORY: Run /adversarial-review on this PR now. Post findings as PR comment, fix ALL severities, push fixes, check bot comments, post follow-up.\\\"}}\"'",
             "timeout": 5
           }
         ]

--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -40,7 +40,7 @@ Read the full diff with `gh pr diff <number>`. Analyze for:
 
 ## Step 3: Check existing PR comments
 
-Read ALL comments on the PR with `gh api repos/{owner}/{repo}/pulls/{number}/comments` and `gh pr view <number> --comments`.
+Read ALL comments on the PR with `gh api repos/{owner}/{repo}/pulls/{number}/comments`, `gh api repos/{owner}/{repo}/issues/{number}/comments`, and `gh pr view <number> --comments`.
 Check for:
 - Bot comments (Dependabot, CodeQL, CI bots) — address any actionable findings
 - Previous review comments not yet resolved

--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: adversarial-review
+description: "Full adversarial review pipeline: review → post PR comment → fix ALL severities → push → verify. Use when reviewing PRs. NEVER stop between steps."
+user-invocable: true
+---
+
+# Adversarial Code Review Pipeline
+
+Execute this as ONE atomic task. Do not pause between steps to ask for approval.
+
+## Arguments
+
+`$ARGUMENTS` is a PR number, comma-separated PR numbers, or empty (auto-detect from current branch).
+
+## Step 1: Identify targets
+
+If `$ARGUMENTS` is empty, detect the current branch's open PR with `gh pr view --json number`.
+If multiple PRs, process each in parallel via worktree-isolated subagents.
+
+## Step 2: Review (per PR)
+
+Read the full diff with `gh pr diff <number>`. Analyze for:
+
+- **CRITICAL**: Logic errors, security flaws, auth bypasses, data corruption, crashes, resource leaks, clean architecture violations (domain referencing infrastructure)
+- **HIGH**: Race conditions, wrong algorithms, performance issues, API contract breaks, missing validation, TOCTOU bugs, silent failures, fail-open where fail-closed is needed
+- **MEDIUM**: Code quality, maintainability, test gaps, error handling, logging violations, dead code/unused dependencies
+- **LOW**: Style, naming, comments, docs drift, minor inefficiencies
+
+### Review focus (Taskdeck-specific)
+
+- auth/authz and cross-user data exposure (claims-first identity)
+- review-first automation safety (GP-06: no agent can approve proposals or directly mutate boards)
+- egress envelope enforcement and policy compliance
+- migration correctness and idempotency (EF Core + SQLite)
+- agent quota and runtime hardening boundaries
+- HTTP semantics (401/403/404/409 stable codes)
+- SignalR contract correctness
+- Frontend: Vue 3 composition API, Pinia store boundaries, Tailwind conventions
+- Test coverage: behavior changes must ship with tests
+
+## Step 3: Check existing PR comments
+
+Read ALL comments on the PR with `gh api repos/{owner}/{repo}/pulls/{number}/comments` and `gh pr view <number> --comments`.
+Check for:
+- Bot comments (Dependabot, CodeQL, CI bots) — address any actionable findings
+- Previous review comments not yet resolved
+- Stale conversations needing response
+
+Include bot-comment findings in the review output.
+
+## Step 4: Post PR comment
+
+Post immediately using `gh pr comment <number>` (not `gh pr review`). Format:
+
+```
+## Adversarial Code Review
+
+### CRITICAL
+- [findings or "None"]
+
+### HIGH
+- [findings]
+
+### MEDIUM
+- [findings]
+
+### LOW
+- [findings]
+
+### Bot Comments Addressed
+- [bot findings that need action, or "None"]
+
+### Summary
+[count by severity, merge-blocking assessment]
+```
+
+## Step 5: Fix ALL findings
+
+For EACH finding at EVERY severity level:
+
+1. Check out the PR branch (use worktree isolation if not already on it)
+2. Make the minimal targeted fix
+3. Verify with the narrowest relevant test:
+   - Backend .cs change → `dotnet test backend/Taskdeck.sln -c Release --filter "FullyQualifiedName~RelevantTest"`
+   - Frontend .vue/.ts change → `cd frontend/taskdeck-web && npx vitest --run -t "relevant test"`
+   - Migration → `dotnet ef migrations script` dry run
+4. Commit with: `fix(<scope>): <severity> <description>`
+
+Only skip a fix if it would cause worse problems. Explain that in the PR comment.
+
+## Step 6: Push and verify
+
+```bash
+git push
+```
+
+Run `gh pr checks <number>` to verify CI status after push.
+
+## Step 7: Post follow-up comment
+
+Post a follow-up comment mapping findings to fix commits:
+
+```
+## Adversarial Review — Fixes Applied
+
+| Finding | Severity | Fix Commit | Verified |
+|---------|----------|-----------|----------|
+| ... | ... | `abc1234` | tests pass |
+
+All findings addressed. CI status: [GREEN/PENDING/RED]
+```
+
+## Rules
+
+- **NEVER** pause between steps to ask "want me to continue?" or "should I fix these?"
+- **NEVER** skip MEDIUM or LOW findings by default
+- All seven steps are one atomic operation
+- Use worktree isolation when fixing branches you didn't create
+- For multiple PRs: spawn parallel agents, each running the full pipeline independently
+- If a finding requires understanding the broader codebase, use the Explore agent first
+- Always check bot comments and address them alongside code findings

--- a/.claude/skills/docs-sweep/SKILL.md
+++ b/.claude/skills/docs-sweep/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: docs-sweep
+description: "Update live documents (STATUS.md, IMPLEMENTATION_MASTERPLAN.md) after PR merges or batch work. Triggered after merges or manually."
+user-invocable: true
+---
+
+# Docs Sweep
+
+Update all live project documents to reflect current state after work completes.
+
+## Arguments
+
+`$ARGUMENTS` is one of:
+- PR range (e.g., "#1048-#1052") — triggers full audit + docs update
+- "update" or empty — just refresh live docs from git state
+- "audit #N-#M" — write audit summary only
+
+## Phase 1: Gather State
+
+```bash
+git log --oneline -30
+gh pr list --state merged --limit 20 --json number,title,mergedAt,headRefName
+gh pr list --state open --json number,title,headRefName
+```
+
+Read:
+- `docs/STATUS.md`
+- `docs/IMPLEMENTATION_MASTERPLAN.md`
+
+## Phase 2: Update Live Documents
+
+### 2.1 — `docs/STATUS.md`
+
+Update:
+- Feature completion status (what is now shipped)
+- Known gaps section (what was fixed, what remains)
+- Architecture state (new layers, services, entities added)
+
+### 2.2 — `docs/IMPLEMENTATION_MASTERPLAN.md`
+
+Update:
+- Delivery history (add rows for newly merged PRs)
+- Planned work (mark completed items, update sequencing)
+- Move "in progress" items that have landed to "shipped"
+
+### 2.3 — ADR Index (if architecture decisions were made)
+
+If any merged PRs introduced architecture decisions, verify `docs/decisions/INDEX.md` is current.
+
+## Phase 3: Verify
+
+Run consistency checks:
+```bash
+dotnet build backend/Taskdeck.sln -c Release --nologo
+```
+
+Ensure docs reference real files/features that exist in the codebase.
+
+## Phase 4: Report
+
+Output a summary:
+
+```
+## Docs Sweep Complete
+
+### Updated
+- docs/STATUS.md: [what changed]
+- docs/IMPLEMENTATION_MASTERPLAN.md: [what changed]
+
+### Newly Shipped
+- [list of features/fixes now reflected in STATUS.md]
+
+### Open Work
+- [list of open PRs and their state]
+```
+
+## Rules
+
+- This is ONE continuous operation — do not pause between phases
+- Always update STATUS.md when shipped state changes (it is the source of truth)
+- Never delete historical delivery entries — add new ones
+- Verify that referenced files/features actually exist before documenting them
+- If no meaningful changes to document, report "no updates needed" and exit

--- a/.claude/skills/pre-merge-gate/SKILL.md
+++ b/.claude/skills/pre-merge-gate/SKILL.md
@@ -25,6 +25,7 @@ If mergeable is "CONFLICTING", stop and report — do not auto-resolve.
 Read ALL comments on the PR:
 ```bash
 gh api repos/{owner}/{repo}/pulls/{number}/comments
+gh api repos/{owner}/{repo}/issues/{number}/comments
 gh pr view $ARGUMENTS --comments
 ```
 
@@ -38,8 +39,7 @@ Run ALL of these:
 ```bash
 dotnet build backend/Taskdeck.sln -c Release
 dotnet test backend/Taskdeck.sln -c Release -m:1
-cd frontend/taskdeck-web && npm run build
-cd frontend/taskdeck-web && npx vitest --run --reporter=verbose
+cd frontend/taskdeck-web && npm run build && npx vitest --run --reporter=verbose
 ```
 
 Report any failures immediately — do not proceed to merge.

--- a/.claude/skills/pre-merge-gate/SKILL.md
+++ b/.claude/skills/pre-merge-gate/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: pre-merge-gate
+description: "Final validation gate before merging a PR: tests, lint, type-check, build, self-review, CI green check. Use before merging."
+user-invocable: true
+---
+
+# Pre-Merge Gate
+
+Run all validation checks before a PR can be merged. Execute as one atomic operation.
+
+## Arguments
+
+`$ARGUMENTS` is a PR number or empty (current branch's PR).
+
+## Step 1: Identify PR and branch
+
+```bash
+gh pr view $ARGUMENTS --json number,headRefName,baseRefName,mergeable,statusCheckRollup
+```
+
+If mergeable is "CONFLICTING", stop and report — do not auto-resolve.
+
+## Step 2: Check bot comments
+
+Read ALL comments on the PR:
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments
+gh pr view $ARGUMENTS --comments
+```
+
+Check for unaddressed bot findings (Dependabot, CodeQL, CI bots, previous adversarial reviews).
+If actionable bot comments exist, fix them before proceeding.
+
+## Step 3: Run local checks
+
+Run ALL of these:
+
+```bash
+dotnet build backend/Taskdeck.sln -c Release
+dotnet test backend/Taskdeck.sln -c Release -m:1
+cd frontend/taskdeck-web && npm run build
+cd frontend/taskdeck-web && npx vitest --run --reporter=verbose
+```
+
+Report any failures immediately — do not proceed to merge.
+
+## Step 4: Self-review
+
+Read the full diff (`gh pr diff $ARGUMENTS`) and check for:
+
+- Secrets accidentally committed (.env, tokens, keys, connection strings)
+- Debug code left in (console.log, Console.WriteLine used for debugging, breakpoints)
+- TODO comments without issue references
+- Hardcoded values that violate conventions
+- Missing tests for behavior changes
+- Clean architecture violations (Domain referencing Infrastructure)
+- Agent safety violations (GP-06: no approve_proposal or direct board mutation)
+- HTTP semantics violations (wrong status codes)
+- Unused `using` statements or dead code
+
+If any issues found, fix them, commit, and push before proceeding.
+
+## Step 5: CI status
+
+```bash
+gh pr checks $ARGUMENTS
+```
+
+All checks must be green. If any are failing, diagnose and fix.
+
+## Step 6: Report
+
+Output a merge-readiness summary:
+
+```
+## Merge Readiness: PR #XXX
+
+- [ ] Backend build: PASS/FAIL
+- [ ] Backend tests: PASS/FAIL (N passed, M failed)
+- [ ] Frontend build: PASS/FAIL
+- [ ] Frontend tests: PASS/FAIL
+- [ ] CI checks: GREEN/RED
+- [ ] Self-review: CLEAN/ISSUES FIXED
+- [ ] Bot comments: ADDRESSED/NONE
+- [ ] Secrets scan: CLEAN
+
+**Verdict**: READY TO MERGE / BLOCKED (reason)
+```
+
+## Rules
+
+- Do NOT merge the PR — only validate and report readiness
+- Fix any self-review issues found (commit + push)
+- If CI is red, attempt to fix — only report "blocked" if the fix is non-trivial
+- Always check and address bot comments

--- a/.claude/skills/taskdeck-pr-review-loop/SKILL.md
+++ b/.claude/skills/taskdeck-pr-review-loop/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: taskdeck-pr-review-loop
-description: Perform Taskdeck PR self-review or fresh adversarial review, inspect comments, post actionable findings, and verify fixes.
+description: "Perform Taskdeck PR self-review or fresh adversarial review, inspect ALL comments (including bots), post actionable findings, fix everything, and verify."
+user-invocable: true
 ---
 
 # Taskdeck PR Review Loop
 
 Use this skill for PR self-review, fresh adversarial review, and review-comment follow-up.
+This is the Taskdeck-specific wrapper around `/adversarial-review` with domain knowledge baked in.
 
 ## Read First
 
@@ -21,19 +23,66 @@ Use this skill for PR self-review, fresh adversarial review, and review-comment 
 Prioritize actionable findings:
 
 - behavioral regressions
-- security/authz gaps
+- security/authz gaps (cross-user data exposure, claims bypass)
+- agent safety violations (GP-06: no approve_proposal or direct board mutation by agents)
+- egress envelope enforcement gaps
 - migration/data-loss risk
+- race conditions (especially in quota/concurrent-run tracking)
+- fail-open patterns where fail-closed is needed
 - missing tests or weak assertions
-- docs drift
+- docs drift (STATUS.md, IMPLEMENTATION_MASTERPLAN.md)
 - CI, scripts, or project automation breakage
-- product-thesis violations around review-first automation
+- clean architecture violations (Domain referencing Infrastructure)
+- HTTP semantics violations (wrong status codes)
 
 Use severities: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. All accepted findings need a fix, invalidation evidence, or an explicit tracked follow-up.
 
+## Bot Comment Check (MANDATORY)
+
+Before posting findings, check ALL existing PR comments:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/comments
+gh pr view <number> --comments
+gh api repos/{owner}/{repo}/issues/{number}/comments
+```
+
+Look for:
+- Dependabot alerts or suggestions
+- CodeQL / security scanning findings
+- CI bot failure messages
+- Previous adversarial review comments not yet resolved
+- Any automated tool output needing action
+
+Include bot findings in the review output under "### Bot Comments Addressed".
+
 ## Review Output
 
-For each finding include:
+Post as a PR comment (`gh pr comment <number>`):
 
+```
+## Adversarial Code Review
+
+### CRITICAL
+- [findings or "None"]
+
+### HIGH
+- [findings]
+
+### MEDIUM
+- [findings]
+
+### LOW
+- [findings]
+
+### Bot Comments Addressed
+- [bot findings or "None"]
+
+### Summary
+[count by severity, merge-blocking assessment]
+```
+
+For each finding include:
 - severity
 - file and line
 - what can go wrong
@@ -46,9 +95,29 @@ If no findings, say so and still name residual risk and test gaps.
 
 When addressing findings:
 
-1. map every finding to a fix, invalidation, or tracked follow-up
-2. make focused commits
-3. run targeted checks
-4. re-review the changed diff
-5. comment with fix evidence and verification results
+1. Map every finding to a fix, invalidation, or tracked follow-up
+2. Make focused commits: `fix(<scope>): <severity> <description>`
+3. Run targeted checks:
+   - Backend: `dotnet test backend/Taskdeck.sln -c Release --filter "FullyQualifiedName~RelevantTest"`
+   - Frontend: `cd frontend/taskdeck-web && npx vitest --run -t "relevant test"`
+4. Push fixes
+5. Re-review the changed diff
+6. Post follow-up comment with fix evidence:
 
+```
+## Adversarial Review — Fixes Applied
+
+| Finding | Severity | Fix Commit | Verified |
+|---------|----------|-----------|----------|
+| ... | ... | `abc1234` | tests pass |
+
+All findings addressed. CI status: [GREEN/PENDING/RED]
+```
+
+## Rules
+
+- NEVER pause between review, post, fix, push — it is one atomic operation
+- NEVER skip MEDIUM or LOW findings
+- Always check bot comments before posting findings
+- Always post a follow-up comment after fixes are pushed
+- Verify CI is green after pushing with `gh pr checks`


### PR DESCRIPTION
## Summary
- Adds 3 new Claude Code skills adapted from options_limits_backtest project
- Enhances existing PR review skill with mandatory bot-comment checking
- Adds PostToolUse hook to auto-trigger adversarial review after `gh pr create`

## New skills
- **adversarial-review**: Standalone atomic 7-step pipeline (review → bot-check → post comment → fix all → push → verify CI → post follow-up)
- **pre-merge-gate**: Final validation gate (build, test, self-review, CI status, bot comments)
- **docs-sweep**: Batch post-merge docs update for STATUS.md and IMPLEMENTATION_MASTERPLAN.md

## Updated
- **taskdeck-pr-review-loop**: Enhanced with mandatory bot-comment checking, structured fix-loop, follow-up comment template, explicit severity handling

## Hooks added
- PostToolUse: triggers mandatory adversarial review instruction after PR creation
- PreToolUse: git push safety verification reminder

## Cleanup
- Removed redundant `implement-and-ship` (duplicates `issue-to-pr`)
- Removed redundant `batch-parallel-work` (duplicates `taskdeck-issue-batch-orchestrator`)

## Test plan
- Skills are declarative markdown — no runtime tests needed
- Hooks validated by JSON parse of settings.json
- Verified no conflicts with existing skill names or descriptions