### PR TITLE
Address remaining post-merge review findings

### DIFF
--- a/.claude/hooks/pre-commit.sh
+++ b/.claude/hooks/pre-commit.sh
@@ -2,6 +2,8 @@
 # Pre-commit hook: runs backend build and frontend typecheck
 # based on which file types are staged.
 
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
 STAGED=$(git diff --cached --name-only 2>/dev/null)
 HAS_CS=false
 HAS_VUE=false

--- a/backend/src/Taskdeck.Application/Interfaces/IAgentRunRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IAgentRunRepository.cs
@@ -7,5 +7,6 @@ public interface IAgentRunRepository : IRepository<AgentRun>
     Task<IEnumerable<AgentRun>> GetByAgentProfileIdAsync(Guid agentProfileId, int limit = 100, CancellationToken cancellationToken = default);
     Task<AgentRun?> GetByIdWithEventsAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IEnumerable<AgentRun>> GetActiveByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<int> CountRecentByUserIdAsync(Guid userId, DateTimeOffset since, CancellationToken cancellationToken = default);
     Task AddEventAsync(AgentRunEvent agentRunEvent, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Services/EgressEnvelopeHandler.cs
+++ b/backend/src/Taskdeck.Application/Services/EgressEnvelopeHandler.cs
@@ -73,15 +73,23 @@ public sealed class EgressEnvelopeHandler : DelegatingHandler
             }
 
             // Follow the redirect: create a new request preserving the method for 307/308
+            var statusCode = (int)response.StatusCode;
             var redirectRequest = new HttpRequestMessage
             {
                 RequestUri = resolvedRedirectUri,
                 Version = request.Version,
+                Method = statusCode is 307 or 308 ? request.Method : HttpMethod.Get,
             };
 
-            // 307 and 308 preserve the method; others use GET
-            var statusCode = (int)response.StatusCode;
-            redirectRequest.Method = statusCode is 307 or 308 ? request.Method : HttpMethod.Get;
+            // 307/308 require preserving the original headers and body
+            if (statusCode is 307 or 308)
+            {
+                redirectRequest.Content = request.Content;
+                foreach (var header in request.Headers)
+                {
+                    redirectRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
 
             response.Dispose();
             response = await base.SendAsync(redirectRequest, cancellationToken);

--- a/backend/src/Taskdeck.Application/Services/HybridRetrievalService.cs
+++ b/backend/src/Taskdeck.Application/Services/HybridRetrievalService.cs
@@ -235,11 +235,13 @@ public sealed class HybridRetrievalService : IHybridRetrievalService
             var ftsResults = await _ftsService.SearchAsync(
                 query, userId, boardId, limit, cancellationToken);
 
+            // FTS5 rank is negative BM25 (more negative = more relevant).
+            // Negate so higher = better, consistent with vector and RRF scores.
             return ftsResults.Select(r => new RetrievalResultDto(
                 DocumentId: r.DocumentId,
                 Title: r.Title,
                 Snippet: r.Snippet,
-                Score: r.Rank,
+                Score: -r.Rank,
                 BoardId: r.BoardId,
                 Source: RetrievalSource.Fts,
                 Tags: r.Tags,
@@ -363,11 +365,12 @@ public sealed class HybridRetrievalService : IHybridRetrievalService
         var ftsResults = await _ftsService.SearchAsync(
             query, userId, boardId, overFetchLimit, cancellationToken);
 
+        // Negate FTS5 rank so higher = better, consistent with other score sources
         return ftsResults.Select(r => new RetrievalResultDto(
             DocumentId: r.DocumentId,
             Title: r.Title,
             Snippet: r.Snippet,
-            Score: r.Rank,
+            Score: -r.Rank,
             BoardId: r.BoardId,
             Source: RetrievalSource.Fts,
             Tags: r.Tags,

--- a/backend/src/Taskdeck.Application/Services/InboxTriageDigestAgent.cs
+++ b/backend/src/Taskdeck.Application/Services/InboxTriageDigestAgent.cs
@@ -65,11 +65,9 @@ public sealed class InboxTriageDigestAgent
         if (boardId == Guid.Empty)
             return Result.Failure<InboxDigestResultDto>(ErrorCodes.ValidationError, "Board ID is required.");
 
-        // Check daily quota
-        var recentRuns = await _unitOfWork.AgentRuns.GetByAgentProfileIdAsync(agentProfileId, MaxDigestsPerDay + 1, cancellationToken);
-        var todayRuns = recentRuns.Count(r =>
-            r.TriggerType == triggerType &&
-            r.StartedAt >= DateTimeOffset.UtcNow.AddHours(-24));
+        // Check daily quota across all trigger types and profiles for this user
+        var todayRuns = await _unitOfWork.AgentRuns.CountRecentByUserIdAsync(
+            userId, DateTimeOffset.UtcNow.AddHours(-24), cancellationToken);
 
         if (todayRuns >= MaxDigestsPerDay)
         {

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AgentRunRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AgentRunRepository.cs
@@ -46,8 +46,15 @@ public class AgentRunRepository : Repository<AgentRun>, IAgentRunRepository
             .Where(ar => ar.UserId == userId
                 && ar.Status != AgentRunStatus.Completed
                 && ar.Status != AgentRunStatus.Failed
-                && ar.Status != AgentRunStatus.Cancelled)
+                && ar.Status != AgentRunStatus.Cancelled
+                && ar.Status != AgentRunStatus.ProposalCreated)
             .ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> CountRecentByUserIdAsync(Guid userId, DateTimeOffset since, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .CountAsync(ar => ar.UserId == userId && ar.StartedAt >= since, cancellationToken);
     }
 
     public async Task AddEventAsync(AgentRunEvent agentRunEvent, CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Application.Tests/Services/EgressEnvelopeHandlerTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/EgressEnvelopeHandlerTests.cs
@@ -183,6 +183,32 @@ public class EgressEnvelopeHandlerTests
         violation.ToString().Should().Contain("evil.com");
     }
 
+    [Fact]
+    public async Task SendAsync_307Redirect_PreservesHeadersAndContent()
+    {
+        var registry = CreateRegistry("trusted.example.com", "redirect-target.example.com");
+        var inner = new SingleRedirectHandler(
+            "https://redirect-target.example.com/continue",
+            System.Net.HttpStatusCode.TemporaryRedirect);
+        var handler = new EgressEnvelopeHandler(registry)
+        {
+            InnerHandler = inner
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "https://trusted.example.com/api");
+        request.Content = new StringContent("{\"key\":\"value\"}");
+        request.Headers.Add("X-Custom", "preserved");
+
+        var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        inner.LastReceivedRequest.Should().NotBeNull();
+        inner.LastReceivedRequest!.Method.Should().Be(HttpMethod.Post);
+        inner.LastReceivedRequest.Content.Should().NotBeNull();
+        inner.LastReceivedRequest.Headers.Contains("X-Custom").Should().BeTrue();
+    }
+
     // --- Test Helpers ---
 
     private sealed class StubHandler : HttpMessageHandler
@@ -216,17 +242,27 @@ public class EgressEnvelopeHandlerTests
     private sealed class SingleRedirectHandler : HttpMessageHandler
     {
         private readonly string _redirectUri;
+        private readonly System.Net.HttpStatusCode _redirectCode;
         private bool _redirected;
 
-        public SingleRedirectHandler(string redirectUri) => _redirectUri = redirectUri;
+        public HttpRequestMessage? LastReceivedRequest { get; private set; }
+
+        public SingleRedirectHandler(string redirectUri,
+            System.Net.HttpStatusCode redirectCode = System.Net.HttpStatusCode.Redirect)
+        {
+            _redirectUri = redirectUri;
+            _redirectCode = redirectCode;
+        }
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            LastReceivedRequest = request;
+
             if (!_redirected)
             {
                 _redirected = true;
-                var response = new HttpResponseMessage(System.Net.HttpStatusCode.Redirect);
+                var response = new HttpResponseMessage(_redirectCode);
                 response.Headers.Location = new Uri(_redirectUri);
                 return Task.FromResult(response);
             }


### PR DESCRIPTION
## Summary
- **307/308 redirect header preservation**: EgressEnvelopeHandler now copies headers and body when following 307/308 redirects, preventing silent request corruption
- **ProposalCreated active run exclusion**: Runs that stop at ProposalCreated no longer count against the concurrent-run quota, fixing permanent user lockout after 3 proposals
- **User-scoped daily digest quota**: Quota now counts all runs per user regardless of trigger type or profile, closing the bypass via alternating triggers
- **FTS score direction fix**: Negated SQLite FTS5 rank (lower=better) to positive scores (higher=better), fixing inverted relevance in min-max normalization
- **Pre-commit hook path resolution**: Script now resolves from git root, preventing "No such file" errors when working directory is a subdirectory

## Test plan
- [x] New test: `SendAsync_307Redirect_PreservesHeadersAndContent` verifies method, headers, and content are forwarded
- [x] All 55 targeted tests pass (EgressEnvelopeHandler + HybridRetrievalService + AgentRuntime)
- [x] Full suite: 6,224 passed, 0 failed (1 known flaky skipped)