### PR TITLE
PAPER-11: Complete narrow companions (sidebar variants + board snap scroll)

### DIFF
--- a/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
+++ b/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
@@ -221,9 +221,14 @@ watch(phoneMoreOpen, (isOpen, _, onCleanup) => {
   document.body.style.overflow = 'hidden'
   const unregisterEscape = registerEscapeHandler(closePhoneMore)
 
+  // Trap focus: mark background content inert so keyboard cannot escape drawer
+  const mainContent = document.getElementById('td-main-content')
+  if (mainContent) mainContent.setAttribute('inert', '')
+
   onCleanup(() => {
     document.body.style.overflow = ''
     unregisterEscape()
+    if (mainContent) mainContent.removeAttribute('inert')
   })
 })
 
@@ -405,15 +410,15 @@ defineExpose({
             >
               <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
             </router-link>
-            <a
+            <button
               v-else
-              href="#"
+              type="button"
               class="paper-sidebar__item paper-sidebar__item--muted"
               :aria-label="item.label"
               @click="handleMetaClick(item, $event)"
             >
               <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
-            </a>
+            </button>
           </li>
         </ul>
       </div>
@@ -848,7 +853,7 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: space-around;
-  height: 56px;
+  min-height: 56px;
   padding-bottom: var(--paper-safe-bottom, env(safe-area-inset-bottom, 0px));
   background: var(--paper-card);
   border-top: 1px solid var(--line);
@@ -895,11 +900,13 @@ defineExpose({
   left: 0;
   right: 0;
   width: 100%;
+  min-height: 0;
   height: auto;
   max-height: 60vh;
   overflow-y: auto;
   z-index: 50;
   border-top: 1px solid var(--line);
+  border-right: none;
   border-radius: 12px 12px 0 0;
   padding: 12px 0 8px;
 }

--- a/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
+++ b/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
@@ -2,6 +2,7 @@
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { registerEscapeHandler } from '../../composables/useEscapeStack'
+import { useViewportMode } from '../../composables/useViewportMode'
 import { useFeatureFlagStore } from '../../store/featureFlagStore'
 import { usePaperThemeStore } from '../../store/paperThemeStore'
 import { useWorkspaceStore } from '../../store/workspaceStore'
@@ -55,7 +56,15 @@ const route = useRoute()
 const featureFlags = useFeatureFlagStore()
 const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
+const { mode: viewportMode } = useViewportMode()
 const mobileOpen = ref(false)
+
+const phoneNavItems = [
+  { id: 'home', glyph: 'H', label: 'Home', path: '/workspace/home' },
+  { id: 'today', glyph: 'T', label: 'Today', path: '/workspace/today' },
+  { id: 'review', glyph: 'R', label: 'Review', path: '/workspace/review' },
+  { id: 'inbox', glyph: 'I', label: 'Inbox', path: '/workspace/inbox' },
+] as const
 
 const primaryItems: PaperNavItem[] = [
   { id: 'home', label: 'Home', glyph: 'H', path: '/workspace/home', keywords: 'home start summary workspace' },
@@ -192,124 +201,239 @@ defineExpose({
   mobileOpen,
   toggleMobileMenu,
   closeMobileMenu,
+  viewportMode,
 })
 </script>
 
 <template>
-  <div
-    v-if="mobileOpen"
-    class="paper-sidebar-overlay"
-    aria-hidden="true"
-    @click="closeMobileMenu"
-  />
+  <!-- Phone: bottom tab bar -->
   <nav
-    class="paper-sidebar"
-    :class="{ 'paper-sidebar--mobile-open': mobileOpen }"
+    v-if="viewportMode === 'phone'"
+    class="paper-bottombar"
     role="navigation"
     aria-label="Workspace navigation"
     data-paper-sidebar
+    data-paper-bottombar
   >
-    <div class="paper-sidebar__header">
-      <div class="paper-sidebar__brand">Taskdeck</div>
-      <div class="tk-eyebrow paper-sidebar__eyebrow">
-        Precision Mode <span class="paper-sidebar__eyebrow-active">&middot; active</span>
-      </div>
-    </div>
-
-    <button type="button" class="paper-sidebar__workspace" aria-label="Switch workspace">
-      <span class="paper-sidebar__workspace-glyph">{{ workspaceInitial }}</span>
-      <span class="paper-sidebar__workspace-name">{{ workspaceName }}</span>
-      <PaperIcon name="chevronDown" />
-    </button>
-
-    <div class="paper-sidebar__group" data-group="primary">
-      <div class="tk-eyebrow paper-sidebar__group-label">Primary loop</div>
-      <ul class="paper-sidebar__list">
-        <li v-for="item in visiblePrimary" :key="item.id">
-          <router-link
-            :to="item.path"
-            class="paper-sidebar__item"
-            :class="{ 'paper-sidebar__item--active': isActive(item) }"
-            :aria-current="isActive(item) ? 'page' : undefined"
-            @click="closeMobileMenu"
-          >
-            <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
-            <span class="paper-sidebar__label">{{ item.label }}</span>
-            <span
-              v-if="badgeFor(item) > 0"
-              class="paper-sidebar__badge"
-              :aria-label="`${item.label}: ${badgeFor(item)} pending`"
-            >&middot; {{ badgeFor(item) }}</span>
-          </router-link>
-        </li>
-      </ul>
-    </div>
-
-    <div class="paper-sidebar__group" data-group="workbench">
-      <div class="tk-eyebrow paper-sidebar__group-label">Workbench tools</div>
-      <ul class="paper-sidebar__list">
-        <li v-for="item in visibleWorkbench" :key="item.id">
-          <router-link
-            :to="item.path"
-            class="paper-sidebar__item"
-            :class="{ 'paper-sidebar__item--active': isActive(item) }"
-            :aria-current="isActive(item) ? 'page' : undefined"
-            @click="closeMobileMenu"
-          >
-            <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
-            <span class="paper-sidebar__label">{{ item.label }}</span>
-          </router-link>
-        </li>
-      </ul>
-    </div>
-
-    <div class="paper-sidebar__spacer" />
-
-    <div class="paper-sidebar__group paper-sidebar__group--muted" data-group="meta">
-      <ul class="paper-sidebar__list">
-        <li v-for="item in visibleMeta" :key="item.id">
-          <router-link
-            v-if="!item.path.startsWith('#')"
-            :to="item.path"
-            class="paper-sidebar__item paper-sidebar__item--muted"
-            :class="{ 'paper-sidebar__item--active': isActive(item) }"
-            :aria-current="isActive(item) ? 'page' : undefined"
-            @click="closeMobileMenu"
-          >
-            <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
-            <span class="paper-sidebar__label">{{ item.label }}</span>
-          </router-link>
-          <a
-            v-else
-            href="#"
-            class="paper-sidebar__item paper-sidebar__item--muted"
-            @click="handleMetaClick(item, $event)"
-          >
-            <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
-            <span class="paper-sidebar__label">{{ item.label }}</span>
-          </a>
-        </li>
-      </ul>
-    </div>
-
-    <div class="paper-sidebar__footer">
-      <div class="paper-sidebar__footer-status">
-        <PaperStatusPill kind="live">SYSTEM LIVE</PaperStatusPill>
-        <span class="paper-sidebar__version">{{ version }}</span>
-      </div>
-      <button
-        type="button"
-        class="paper-sidebar__theme-toggle"
-        :aria-label="themeToggleLabel"
-        @click="handleThemeToggle"
-      >
-        <PaperIcon :name="themeIcon" :label="themeToggleLabel" />
-      </button>
-    </div>
+    <router-link
+      v-for="item in phoneNavItems"
+      :key="item.id"
+      :to="item.path"
+      class="paper-bottombar__tab"
+      :class="{ 'paper-bottombar__tab--active': isActive(item as unknown as PaperNavItem) }"
+      :aria-current="isActive(item as unknown as PaperNavItem) ? 'page' : undefined"
+      :aria-label="item.label"
+    >
+      <span class="paper-bottombar__glyph">{{ item.glyph }}</span>
+    </router-link>
   </nav>
+
+  <!-- Tablet: 60px icon-only rail -->
+  <template v-else-if="viewportMode === 'tablet'">
+    <nav
+      class="paper-sidebar paper-sidebar--rail"
+      role="navigation"
+      aria-label="Workspace navigation"
+      data-paper-sidebar
+      data-paper-rail
+    >
+      <div class="paper-sidebar__header">
+        <div class="paper-sidebar__brand">Td</div>
+      </div>
+
+      <div class="paper-sidebar__group" data-group="primary">
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visiblePrimary" :key="item.id">
+            <router-link
+              :to="item.path"
+              class="paper-sidebar__item"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              :aria-label="item.label"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+            </router-link>
+          </li>
+        </ul>
+      </div>
+
+      <div class="paper-sidebar__group" data-group="workbench">
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visibleWorkbench" :key="item.id">
+            <router-link
+              :to="item.path"
+              class="paper-sidebar__item"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              :aria-label="item.label"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+            </router-link>
+          </li>
+        </ul>
+      </div>
+
+      <div class="paper-sidebar__spacer" />
+
+      <div class="paper-sidebar__group paper-sidebar__group--muted" data-group="meta">
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visibleMeta" :key="item.id">
+            <router-link
+              v-if="!item.path.startsWith('#')"
+              :to="item.path"
+              class="paper-sidebar__item paper-sidebar__item--muted"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              :aria-label="item.label"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+            </router-link>
+            <a
+              v-else
+              href="#"
+              class="paper-sidebar__item paper-sidebar__item--muted"
+              :aria-label="item.label"
+              @click="handleMetaClick(item, $event)"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="paper-sidebar__footer">
+        <button
+          type="button"
+          class="paper-sidebar__theme-toggle"
+          :aria-label="themeToggleLabel"
+          @click="handleThemeToggle"
+        >
+          <PaperIcon :name="themeIcon" :label="themeToggleLabel" />
+        </button>
+      </div>
+    </nav>
+  </template>
+
+  <!-- Desktop: full sidebar -->
+  <template v-else>
+    <div
+      v-if="mobileOpen"
+      class="paper-sidebar-overlay"
+      aria-hidden="true"
+      @click="closeMobileMenu"
+    />
+    <nav
+      class="paper-sidebar"
+      :class="{ 'paper-sidebar--mobile-open': mobileOpen }"
+      role="navigation"
+      aria-label="Workspace navigation"
+      data-paper-sidebar
+    >
+      <div class="paper-sidebar__header">
+        <div class="paper-sidebar__brand">Taskdeck</div>
+        <div class="tk-eyebrow paper-sidebar__eyebrow">
+          Precision Mode <span class="paper-sidebar__eyebrow-active">&middot; active</span>
+        </div>
+      </div>
+
+      <button type="button" class="paper-sidebar__workspace" aria-label="Switch workspace">
+        <span class="paper-sidebar__workspace-glyph">{{ workspaceInitial }}</span>
+        <span class="paper-sidebar__workspace-name">{{ workspaceName }}</span>
+        <PaperIcon name="chevronDown" />
+      </button>
+
+      <div class="paper-sidebar__group" data-group="primary">
+        <div class="tk-eyebrow paper-sidebar__group-label">Primary loop</div>
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visiblePrimary" :key="item.id">
+            <router-link
+              :to="item.path"
+              class="paper-sidebar__item"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              @click="closeMobileMenu"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+              <span
+                v-if="badgeFor(item) > 0"
+                class="paper-sidebar__badge"
+                :aria-label="`${item.label}: ${badgeFor(item)} pending`"
+              >&middot; {{ badgeFor(item) }}</span>
+            </router-link>
+          </li>
+        </ul>
+      </div>
+
+      <div class="paper-sidebar__group" data-group="workbench">
+        <div class="tk-eyebrow paper-sidebar__group-label">Workbench tools</div>
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visibleWorkbench" :key="item.id">
+            <router-link
+              :to="item.path"
+              class="paper-sidebar__item"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              @click="closeMobileMenu"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+            </router-link>
+          </li>
+        </ul>
+      </div>
+
+      <div class="paper-sidebar__spacer" />
+
+      <div class="paper-sidebar__group paper-sidebar__group--muted" data-group="meta">
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visibleMeta" :key="item.id">
+            <router-link
+              v-if="!item.path.startsWith('#')"
+              :to="item.path"
+              class="paper-sidebar__item paper-sidebar__item--muted"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              @click="closeMobileMenu"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+            </router-link>
+            <a
+              v-else
+              href="#"
+              class="paper-sidebar__item paper-sidebar__item--muted"
+              @click="handleMetaClick(item, $event)"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="paper-sidebar__footer">
+        <div class="paper-sidebar__footer-status">
+          <PaperStatusPill kind="live">SYSTEM LIVE</PaperStatusPill>
+          <span class="paper-sidebar__version">{{ version }}</span>
+        </div>
+        <button
+          type="button"
+          class="paper-sidebar__theme-toggle"
+          :aria-label="themeToggleLabel"
+          @click="handleThemeToggle"
+        >
+          <PaperIcon :name="themeIcon" :label="themeToggleLabel" />
+        </button>
+      </div>
+    </nav>
+  </template>
 </template>
 
 <style scoped>
+/* =========================================================
+   Desktop: full sidebar
+   ========================================================= */
 .paper-sidebar {
   width: 232px;
   flex: none;
@@ -542,6 +666,100 @@ defineExpose({
 @media (prefers-reduced-motion: reduce) {
   .paper-sidebar {
     transition: none;
+  }
+}
+
+/* =========================================================
+   Tablet: 60px icon-only rail
+   ========================================================= */
+.paper-sidebar--rail {
+  width: 60px;
+  padding: 16px 0 12px;
+  align-items: center;
+}
+
+.paper-sidebar--rail .paper-sidebar__header {
+  padding: 0 0 14px;
+  text-align: center;
+}
+
+.paper-sidebar--rail .paper-sidebar__item {
+  justify-content: center;
+  padding: 6px 0;
+  height: 36px;
+  width: 36px;
+  border-left: none;
+  border-radius: var(--r-2);
+}
+
+.paper-sidebar--rail .paper-sidebar__item:hover {
+  background: var(--ember-bloom);
+}
+
+.paper-sidebar--rail .paper-sidebar__item--active {
+  background: var(--ember-bloom);
+  border-left: none;
+}
+
+.paper-sidebar--rail .paper-sidebar__item--active .paper-sidebar__glyph {
+  color: var(--ember);
+}
+
+.paper-sidebar--rail .paper-sidebar__glyph {
+  width: auto;
+  font-size: 12px;
+}
+
+.paper-sidebar--rail .paper-sidebar__footer {
+  margin: 4px 0 0;
+  padding: 8px 0 0;
+  justify-content: center;
+}
+
+/* =========================================================
+   Phone: bottom tab bar
+   ========================================================= */
+.paper-bottombar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  height: 56px;
+  padding-bottom: var(--paper-safe-bottom, env(safe-area-inset-bottom, 0px));
+  background: var(--paper-card);
+  border-top: 1px solid var(--line);
+  font-family: var(--mono);
+}
+
+.paper-bottombar__tab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  height: 100%;
+  text-decoration: none;
+  color: var(--mute);
+  transition: color var(--d-quick, 140ms) var(--ease-paper, ease);
+}
+
+.paper-bottombar__tab--active {
+  color: var(--ember);
+}
+
+.paper-bottombar__glyph {
+  font-family: var(--mono);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .paper-bottombar__tab {
+    transition: opacity 200ms ease;
   }
 }
 </style>

--- a/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
+++ b/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
@@ -59,12 +59,14 @@ const paperTheme = usePaperThemeStore()
 const { mode: viewportMode } = useViewportMode()
 const mobileOpen = ref(false)
 
-const phoneNavItems: PaperNavItemBase[] = [
-  { id: 'home', glyph: 'H', label: 'Home', path: '/workspace/home' },
-  { id: 'today', glyph: 'T', label: 'Today', path: '/workspace/today' },
-  { id: 'review', glyph: 'R', label: 'Review', path: '/workspace/review' },
-  { id: 'inbox', glyph: 'I', label: 'Inbox', path: '/workspace/inbox' },
+const phoneNavItemCandidates: PaperNavItem[] = [
+  { id: 'home', glyph: 'H', label: 'Home', path: '/workspace/home', keywords: '' },
+  { id: 'today', glyph: 'T', label: 'Today', path: '/workspace/today', keywords: '' },
+  { id: 'review', glyph: 'R', label: 'Review', path: '/workspace/review', flag: 'newAutomation', workbenchBypassesFlag: true, keywords: '' },
+  { id: 'inbox', glyph: 'I', label: 'Inbox', path: '/workspace/inbox', keywords: '' },
 ]
+const phoneNavItems = computed<PaperNavItemBase[]>(() => phoneNavItemCandidates.filter(isAvailable))
+const phoneMoreOpen = ref(false)
 
 const primaryItems: PaperNavItem[] = [
   { id: 'home', label: 'Home', glyph: 'H', path: '/workspace/home', keywords: 'home start summary workspace' },
@@ -206,27 +208,76 @@ defineExpose({
 </script>
 
 <template>
-  <!-- Phone: bottom tab bar -->
-  <nav
-    v-if="viewportMode === 'phone'"
-    class="paper-bottombar"
-    role="navigation"
-    aria-label="Workspace navigation"
-    data-paper-sidebar
-    data-paper-bottombar
-  >
-    <router-link
-      v-for="item in phoneNavItems"
-      :key="item.id"
-      :to="item.path"
-      class="paper-bottombar__tab"
-      :class="{ 'paper-bottombar__tab--active': isActive(item) }"
-      :aria-current="isActive(item) ? 'page' : undefined"
-      :aria-label="item.label"
+  <!-- Phone: bottom tab bar + More drawer for meta navigation -->
+  <template v-if="viewportMode === 'phone'">
+    <nav
+      class="paper-bottombar"
+      role="navigation"
+      aria-label="Workspace navigation"
+      data-paper-sidebar
+      data-paper-bottombar
     >
-      <span class="paper-bottombar__glyph">{{ item.glyph }}</span>
-    </router-link>
-  </nav>
+      <router-link
+        v-for="item in phoneNavItems"
+        :key="item.id"
+        :to="item.path"
+        class="paper-bottombar__tab"
+        :class="{ 'paper-bottombar__tab--active': isActive(item) }"
+        :aria-current="isActive(item) ? 'page' : undefined"
+        :aria-label="item.label"
+      >
+        <span class="paper-bottombar__glyph">{{ item.glyph }}</span>
+      </router-link>
+      <button
+        class="paper-bottombar__tab"
+        :class="{ 'paper-bottombar__tab--active': phoneMoreOpen }"
+        aria-label="More"
+        @click="phoneMoreOpen = !phoneMoreOpen"
+      >
+        <span class="paper-bottombar__glyph paper-bottombar__glyph--more">…</span>
+      </button>
+    </nav>
+
+    <div v-if="phoneMoreOpen" class="paper-sidebar-overlay" @click="phoneMoreOpen = false" />
+    <nav
+      v-if="phoneMoreOpen"
+      class="paper-sidebar paper-sidebar--phone-drawer"
+      role="navigation"
+      aria-label="More navigation"
+    >
+      <div class="paper-sidebar__group" data-group="workbench">
+        <div class="paper-sidebar__group-label">Workbench</div>
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visibleWorkbench" :key="item.id">
+            <router-link
+              :to="item.path"
+              class="paper-sidebar__item"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              @click="phoneMoreOpen = false"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+            </router-link>
+          </li>
+        </ul>
+      </div>
+      <div class="paper-sidebar__group paper-sidebar__group--muted" data-group="meta">
+        <ul class="paper-sidebar__list">
+          <li v-for="item in visibleMeta" :key="item.id">
+            <component
+              :is="item.path.startsWith('#') ? 'button' : 'router-link'"
+              v-bind="item.path.startsWith('#') ? {} : { to: item.path }"
+              class="paper-sidebar__item"
+              @click="item.id === 'logout' ? (emit('logout'), phoneMoreOpen = false) : item.id === 'shortcuts' ? (emit('open-shortcuts'), phoneMoreOpen = false) : (phoneMoreOpen = false)"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+            </component>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </template>
 
   <!-- Tablet: 60px icon-only rail -->
   <template v-else-if="viewportMode === 'tablet'">
@@ -635,7 +686,7 @@ defineExpose({
 }
 
 @media (max-width: 640px) {
-  .paper-sidebar {
+  .paper-sidebar:not(.paper-sidebar--rail):not(.paper-sidebar--phone-drawer) {
     position: fixed;
     top: 0;
     left: 0;
@@ -761,5 +812,26 @@ defineExpose({
   .paper-bottombar__tab {
     transition: none;
   }
+}
+
+.paper-bottombar__glyph--more {
+  font-size: 18px;
+  letter-spacing: 2px;
+}
+
+/* Phone: slide-up drawer for workbench/meta items */
+.paper-sidebar--phone-drawer {
+  position: fixed;
+  bottom: calc(56px + var(--paper-safe-bottom, env(safe-area-inset-bottom, 0px)));
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: auto;
+  max-height: 60vh;
+  overflow-y: auto;
+  z-index: 50;
+  border-top: 1px solid var(--line);
+  border-radius: 12px 12px 0 0;
+  padding: 12px 0 8px;
 }
 </style>

--- a/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
+++ b/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
@@ -58,6 +58,8 @@ const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
 const { mode: viewportMode } = useViewportMode()
 const mobileOpen = ref(false)
+const phoneMoreOpen = ref(false)
+const phoneMoreDrawerId = 'paper-phone-more-drawer'
 
 const phoneNavItemCandidates: PaperNavItem[] = [
   { id: 'home', glyph: 'H', label: 'Home', path: '/workspace/home', keywords: '' },
@@ -66,7 +68,6 @@ const phoneNavItemCandidates: PaperNavItem[] = [
   { id: 'inbox', glyph: 'I', label: 'Inbox', path: '/workspace/inbox', keywords: '' },
 ]
 const phoneNavItems = computed<PaperNavItemBase[]>(() => phoneNavItemCandidates.filter(isAvailable))
-const phoneMoreOpen = ref(false)
 
 const primaryItems: PaperNavItem[] = [
   { id: 'home', label: 'Home', glyph: 'H', path: '/workspace/home', keywords: 'home start summary workspace' },
@@ -174,7 +175,32 @@ function closeMobileMenu() {
 }
 
 function toggleMobileMenu() {
+  if (viewportMode.value === 'phone') {
+    togglePhoneMore()
+    return
+  }
+
   mobileOpen.value = !mobileOpen.value
+}
+
+function closePhoneMore() {
+  phoneMoreOpen.value = false
+}
+
+function togglePhoneMore() {
+  phoneMoreOpen.value = !phoneMoreOpen.value
+}
+
+function handlePhoneMetaClick(item: PaperNavItem, event: MouseEvent) {
+  if (!item.path.startsWith('#')) {
+    closePhoneMore()
+    return
+  }
+
+  event.preventDefault()
+  closePhoneMore()
+  if (item.id === 'logout') emit('logout')
+  else if (item.id === 'shortcuts') emit('open-shortcuts')
 }
 
 watch(mobileOpen, (isOpen, _, onCleanup) => {
@@ -189,8 +215,24 @@ watch(mobileOpen, (isOpen, _, onCleanup) => {
   })
 })
 
+watch(phoneMoreOpen, (isOpen, _, onCleanup) => {
+  if (!isOpen) return
+
+  document.body.style.overflow = 'hidden'
+  const unregisterEscape = registerEscapeHandler(closePhoneMore)
+
+  onCleanup(() => {
+    document.body.style.overflow = ''
+    unregisterEscape()
+  })
+})
+
+watch(() => route.path, () => {
+  closePhoneMore()
+})
+
 onUnmounted(() => {
-  if (mobileOpen.value) {
+  if (mobileOpen.value || phoneMoreOpen.value) {
     document.body.style.overflow = ''
   }
 })
@@ -201,8 +243,11 @@ defineExpose({
   visibleWorkbench,
   visibleMeta,
   mobileOpen,
+  phoneMoreOpen,
   toggleMobileMenu,
   closeMobileMenu,
+  togglePhoneMore,
+  closePhoneMore,
   viewportMode,
 })
 </script>
@@ -229,21 +274,31 @@ defineExpose({
         <span class="paper-bottombar__glyph">{{ item.glyph }}</span>
       </router-link>
       <button
+        type="button"
         class="paper-bottombar__tab"
         :class="{ 'paper-bottombar__tab--active': phoneMoreOpen }"
         aria-label="More"
-        @click="phoneMoreOpen = !phoneMoreOpen"
+        :aria-expanded="phoneMoreOpen ? 'true' : 'false'"
+        :aria-controls="phoneMoreDrawerId"
+        @click="togglePhoneMore"
       >
         <span class="paper-bottombar__glyph paper-bottombar__glyph--more">…</span>
       </button>
     </nav>
 
-    <div v-if="phoneMoreOpen" class="paper-sidebar-overlay" @click="phoneMoreOpen = false" />
+    <div
+      v-if="phoneMoreOpen"
+      class="paper-sidebar-overlay"
+      aria-hidden="true"
+      @click="closePhoneMore"
+    />
     <nav
       v-if="phoneMoreOpen"
+      :id="phoneMoreDrawerId"
       class="paper-sidebar paper-sidebar--phone-drawer"
       role="navigation"
       aria-label="More navigation"
+      data-paper-phone-drawer
     >
       <div class="paper-sidebar__group" data-group="workbench">
         <div class="paper-sidebar__group-label">Workbench</div>
@@ -253,7 +308,7 @@ defineExpose({
               :to="item.path"
               class="paper-sidebar__item"
               :class="{ 'paper-sidebar__item--active': isActive(item) }"
-              @click="phoneMoreOpen = false"
+              @click="closePhoneMore"
             >
               <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
               <span class="paper-sidebar__label">{{ item.label }}</span>
@@ -264,15 +319,26 @@ defineExpose({
       <div class="paper-sidebar__group paper-sidebar__group--muted" data-group="meta">
         <ul class="paper-sidebar__list">
           <li v-for="item in visibleMeta" :key="item.id">
-            <component
-              :is="item.path.startsWith('#') ? 'button' : 'router-link'"
-              v-bind="item.path.startsWith('#') ? {} : { to: item.path }"
+            <router-link
+              v-if="!item.path.startsWith('#')"
+              :to="item.path"
               class="paper-sidebar__item"
-              @click="item.id === 'logout' ? (emit('logout'), phoneMoreOpen = false) : item.id === 'shortcuts' ? (emit('open-shortcuts'), phoneMoreOpen = false) : (phoneMoreOpen = false)"
+              :class="{ 'paper-sidebar__item--active': isActive(item) }"
+              :aria-current="isActive(item) ? 'page' : undefined"
+              @click="closePhoneMore"
             >
               <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
               <span class="paper-sidebar__label">{{ item.label }}</span>
-            </component>
+            </router-link>
+            <button
+              v-else
+              type="button"
+              class="paper-sidebar__item"
+              @click="handlePhoneMetaClick(item, $event)"
+            >
+              <span class="paper-sidebar__glyph">{{ item.glyph }}</span>
+              <span class="paper-sidebar__label">{{ item.label }}</span>
+            </button>
           </li>
         </ul>
       </div>
@@ -592,10 +658,13 @@ defineExpose({
   font-size: 12.5px;
   font-weight: 400;
   font-family: var(--sans);
+  width: 100%;
+  border: 0;
   border-left: 2px solid transparent;
   background: transparent;
   position: relative;
   cursor: pointer;
+  text-align: left;
 }
 
 .paper-sidebar__item:hover {

--- a/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
+++ b/frontend/taskdeck-web/src/components/paper/PaperSidebar.vue
@@ -21,15 +21,15 @@ import PaperStatusPill from './PaperStatusPill.vue'
  * via `paperThemeStore.toggleNight()`.
  */
 
-type PaperNavItem = {
+type PaperNavItemBase = {
   id: string
   label: string
   glyph: string
-  /** router-link `to` path */
   path: string
-  /** badge counter source (workspace store) */
+}
+
+type PaperNavItem = PaperNavItemBase & {
   badgeKey?: 'inbox' | 'review'
-  /** Hide if this feature flag exists and is disabled. */
   flag?: keyof FeatureFlags
   workbenchBypassesFlag?: boolean
   keywords?: string
@@ -59,12 +59,12 @@ const paperTheme = usePaperThemeStore()
 const { mode: viewportMode } = useViewportMode()
 const mobileOpen = ref(false)
 
-const phoneNavItems = [
+const phoneNavItems: PaperNavItemBase[] = [
   { id: 'home', glyph: 'H', label: 'Home', path: '/workspace/home' },
   { id: 'today', glyph: 'T', label: 'Today', path: '/workspace/today' },
   { id: 'review', glyph: 'R', label: 'Review', path: '/workspace/review' },
   { id: 'inbox', glyph: 'I', label: 'Inbox', path: '/workspace/inbox' },
-] as const
+]
 
 const primaryItems: PaperNavItem[] = [
   { id: 'home', label: 'Home', glyph: 'H', path: '/workspace/home', keywords: 'home start summary workspace' },
@@ -127,7 +127,7 @@ function badgeFor(item: PaperNavItem): number {
   return 0
 }
 
-function isActive(item: PaperNavItem): boolean {
+function isActive(item: PaperNavItemBase): boolean {
   if (item.path.startsWith('#')) return false
   if (item.path === '/workspace/home') return route.path === item.path
   if (item.path === '/workspace/review') {
@@ -220,8 +220,8 @@ defineExpose({
       :key="item.id"
       :to="item.path"
       class="paper-bottombar__tab"
-      :class="{ 'paper-bottombar__tab--active': isActive(item as unknown as PaperNavItem) }"
-      :aria-current="isActive(item as unknown as PaperNavItem) ? 'page' : undefined"
+      :class="{ 'paper-bottombar__tab--active': isActive(item) }"
+      :aria-current="isActive(item) ? 'page' : undefined"
       :aria-label="item.label"
     >
       <span class="paper-bottombar__glyph">{{ item.glyph }}</span>
@@ -759,7 +759,7 @@ defineExpose({
 
 @media (prefers-reduced-motion: reduce) {
   .paper-bottombar__tab {
-    transition: opacity 200ms ease;
+    transition: none;
   }
 }
 </style>

--- a/frontend/taskdeck-web/src/components/shell/AppShell.vue
+++ b/frontend/taskdeck-web/src/components/shell/AppShell.vue
@@ -5,6 +5,7 @@ import { useSessionStore } from '../../store/sessionStore'
 import { useWorkspaceStore } from '../../store/workspaceStore'
 import { usePaperThemeStore } from '../../store/paperThemeStore'
 import { registerEscapeHandler } from '../../composables/useEscapeStack'
+import { useViewportMode } from '../../composables/useViewportMode'
 import CaptureModal from '../common/CaptureModal.vue'
 import OfflineBanner from './OfflineBanner.vue'
 import SwUpdatePrompt from './SwUpdatePrompt.vue'
@@ -35,8 +36,11 @@ const router = useRouter()
 const session = useSessionStore()
 const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
+const { mode: viewportMode } = useViewportMode()
 
 const sidebarRef = ref<SidebarRef | null>(null)
+const isPaperNarrow = computed(() => paperTheme.isOn && viewportMode.value !== 'desktop')
+const isPaperPhone = computed(() => paperTheme.isOn && viewportMode.value === 'phone')
 
 const showCommandPalette = ref(false)
 const showKeyboardHelp = ref(false)
@@ -185,7 +189,13 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="td-shell" :class="{ 'td-shell--paper': paperTheme.isOn }">
+  <div
+    class="td-shell"
+    :class="{
+      'td-shell--paper': paperTheme.isOn,
+      'td-shell--paper-phone': isPaperPhone,
+    }"
+  >
     <PaperSidebar
       v-if="paperTheme.isOn"
       ref="sidebarRef"
@@ -204,7 +214,7 @@ onUnmounted(() => {
     <div class="td-main-container">
       <OfflineBanner />
       <SwUpdatePrompt />
-      <div class="td-mobile-topbar">
+      <div v-if="!isPaperNarrow" class="td-mobile-topbar">
         <button
           class="td-mobile-topbar__hamburger"
           aria-label="Open navigation menu"
@@ -366,5 +376,11 @@ onUnmounted(() => {
     font-weight: 500;
     color: var(--ink-deep);
   }
+}
+
+.td-shell--paper-phone .td-content {
+  padding-bottom: calc(
+    var(--td-space-4) + 56px + var(--paper-safe-bottom, env(safe-area-inset-bottom, 0px))
+  );
 }
 </style>

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -461,9 +461,8 @@
      calc(...); shrinking it once at the .paper root cascades cleanly
      without compounding (leaves multiply, the root only sets).
    - `--paper-safe-bottom` exposes `env(safe-area-inset-bottom, 0px)` for
-     future phone bottom-bar variants of `PaperSidebar` (deferred to the
-     per-surface follow-ups against GH-1007). Currently unconsumed; do not
-     remove without checking those follow-ups.
+     phone bottom-bar spacing in `PaperSidebar` and matching AppShell content
+     padding. Do not remove without checking those surfaces.
    - `--paper-density` flips to `compact` ≤1024px and is intended for
      leaf surfaces (e.g. card / row paddings) to opt into a tighter
      spacing variant in follow-up patches. Currently unconsumed.

--- a/frontend/taskdeck-web/src/paper-tokens.css
+++ b/frontend/taskdeck-web/src/paper-tokens.css
@@ -463,9 +463,9 @@
    - `--paper-safe-bottom` exposes `env(safe-area-inset-bottom, 0px)` for
      phone bottom-bar spacing in `PaperSidebar` and matching AppShell content
      padding. Do not remove without checking those surfaces.
-   - `--paper-density` flips to `compact` ≤1024px and is intended for
-     leaf surfaces (e.g. card / row paddings) to opt into a tighter
-     spacing variant in follow-up patches. Currently unconsumed.
+   - `--paper-density` flips to `compact` ≤1024px and is reserved for
+     leaf surfaces (e.g. card / row paddings) to opt into tighter spacing
+     in follow-up patches.
    ========================================================= */
 .paper, .paper-night {
   --paper-safe-bottom: env(safe-area-inset-bottom, 0px);

--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -76,6 +76,12 @@ vi.mock('../../store/paperThemeStore', () => ({
   usePaperThemeStore: () => mockPaperTheme,
 }))
 
+vi.mock('../../composables/useViewportMode', async () => {
+  const { ref, readonly } = await import('vue')
+  const mode = ref('desktop')
+  return { useViewportMode: () => ({ mode: readonly(mode) }) }
+})
+
 function mountShell() {
   return mount(AppShell, {
     global: {

--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { reactive } from 'vue'
+import { readFileSync } from 'node:fs'
 import AppShell from '../../components/shell/AppShell.vue'
 
 const mockRouter = {
@@ -55,6 +56,10 @@ const mockPaperTheme = reactive({
   disable: vi.fn(),
 })
 
+const mockViewportMode = vi.hoisted(() => ({
+  value: 'desktop' as 'desktop' | 'tablet' | 'phone',
+}))
+
 vi.mock('vue-router', () => ({
   useRouter: () => mockRouter,
   useRoute: () => mockRoute,
@@ -77,9 +82,8 @@ vi.mock('../../store/paperThemeStore', () => ({
 }))
 
 vi.mock('../../composables/useViewportMode', async () => {
-  const { ref, readonly } = await import('vue')
-  const mode = ref('desktop')
-  return { useViewportMode: () => ({ mode: readonly(mode) }) }
+  const { computed } = await import('vue')
+  return { useViewportMode: () => ({ mode: computed(() => mockViewportMode.value) }) }
 })
 
 function mountShell() {
@@ -108,6 +112,7 @@ describe('AppShell — paper variant routing', () => {
     mockPaperTheme.activeClass = null
     mockWorkspace.mode = 'guided'
     mockRoute.path = '/workspace/home'
+    mockViewportMode.value = 'desktop'
   })
 
   afterEach(() => {
@@ -183,6 +188,43 @@ describe('AppShell — paper variant routing', () => {
     await hamburger.trigger('click')
 
     expect(wrapper.find('.paper-sidebar--mobile-open').exists()).toBe(true)
+  })
+
+  it('hides the legacy mobile hamburger in Paper phone mode', () => {
+    mockPaperTheme.mode = 'paper'
+    mockPaperTheme.isOn = true
+    mockPaperTheme.activeClass = 'paper'
+    mockViewportMode.value = 'phone'
+
+    wrapper = mountShell()
+
+    expect(wrapper.find('.td-mobile-topbar').exists()).toBe(false)
+    expect(wrapper.find('.td-mobile-topbar__hamburger').exists()).toBe(false)
+    expect(wrapper.find('.td-shell').classes()).toContain('td-shell--paper-phone')
+    expect(wrapper.find('[data-paper-bottombar]').exists()).toBe(true)
+  })
+
+  it('hides the legacy mobile hamburger in Paper tablet mode', () => {
+    mockPaperTheme.mode = 'paper'
+    mockPaperTheme.isOn = true
+    mockPaperTheme.activeClass = 'paper'
+    mockViewportMode.value = 'tablet'
+
+    wrapper = mountShell()
+
+    expect(wrapper.find('.td-mobile-topbar').exists()).toBe(false)
+    expect(wrapper.find('.td-mobile-topbar__hamburger').exists()).toBe(false)
+    expect(wrapper.find('[data-paper-rail]').exists()).toBe(true)
+  })
+
+  it('keeps Paper phone content padded above the fixed bottom bar', () => {
+    const source = readFileSync(
+      'src/components/shell/AppShell.vue',
+      'utf8',
+    )
+
+    expect(source).toContain('.td-shell--paper-phone .td-content')
+    expect(source).toContain('56px + var(--paper-safe-bottom')
   })
 
   it('does not render both sidebars simultaneously when toggling paper mode', () => {

--- a/frontend/taskdeck-web/src/tests/components/paper/PaperSidebar.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/paper/PaperSidebar.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 import PaperSidebar from '../../../components/paper/PaperSidebar.vue'
 import type { FeatureFlags } from '../../../types/feature-flags'
+import type { ViewportMode } from '../../../composables/useViewportMode'
 
 const mockRoute = reactive({
   path: '/workspace/home',
@@ -25,6 +26,8 @@ const mockPaperTheme = reactive({
   toggleNight: vi.fn(),
 })
 
+const mockViewportMode = ref<ViewportMode>('desktop')
+
 vi.mock('vue-router', () => ({
   useRoute: () => mockRoute,
 }))
@@ -39,6 +42,10 @@ vi.mock('../../../store/featureFlagStore', () => ({
 
 vi.mock('../../../store/paperThemeStore', () => ({
   usePaperThemeStore: () => mockPaperTheme,
+}))
+
+vi.mock('../../../composables/useViewportMode', () => ({
+  useViewportMode: () => ({ mode: mockViewportMode }),
 }))
 
 function mountSidebar() {
@@ -64,6 +71,7 @@ describe('PaperSidebar', () => {
     mockFeatureFlags.isEnabled = vi.fn(() => true)
     mockPaperTheme.mode = 'paper'
     mockPaperTheme.activeClass = 'paper'
+    mockViewportMode.value = 'desktop'
   })
 
   it('renders the brand and Precision Mode eyebrow with the active accent', () => {
@@ -275,5 +283,57 @@ describe('PaperSidebar', () => {
     await boardsLink?.trigger('click')
 
     expect(exposed.mobileOpen).toBe(false)
+  })
+
+  it('renders bottom-bar variant with H/T/R/I glyphs on phone', () => {
+    mockViewportMode.value = 'phone'
+    const wrapper = mountSidebar()
+
+    expect(wrapper.find('[data-paper-bottombar]').exists()).toBe(true)
+    expect(wrapper.find('.paper-sidebar--rail').exists()).toBe(false)
+
+    const glyphs = wrapper.findAll('.paper-bottombar__glyph').map((g) => g.text())
+    expect(glyphs).toEqual(['H', 'T', 'R', 'I'])
+
+    const tabs = wrapper.findAll('.paper-bottombar__tab')
+    expect(tabs).toHaveLength(4)
+  })
+
+  it('renders bottom-bar with ember accent on the active route', () => {
+    mockViewportMode.value = 'phone'
+    mockRoute.path = '/workspace/review'
+    const wrapper = mountSidebar()
+
+    const reviewTab = wrapper.findAll('.paper-bottombar__tab')
+      .find((t) => t.attributes('href') === '/workspace/review')
+    expect(reviewTab?.classes()).toContain('paper-bottombar__tab--active')
+
+    const homeTab = wrapper.findAll('.paper-bottombar__tab')
+      .find((t) => t.attributes('href') === '/workspace/home')
+    expect(homeTab?.classes()).not.toContain('paper-bottombar__tab--active')
+  })
+
+  it('renders icon-only rail on tablet', () => {
+    mockViewportMode.value = 'tablet'
+    const wrapper = mountSidebar()
+
+    expect(wrapper.find('[data-paper-rail]').exists()).toBe(true)
+    expect(wrapper.find('[data-paper-bottombar]').exists()).toBe(false)
+    expect(wrapper.find('.paper-sidebar--rail').exists()).toBe(true)
+
+    expect(wrapper.findAll('.paper-sidebar__label')).toHaveLength(0)
+
+    const glyphs = wrapper.findAll('.paper-sidebar__glyph')
+    expect(glyphs.length).toBeGreaterThan(0)
+  })
+
+  it('renders rail active-route ember accent on tablet', () => {
+    mockViewportMode.value = 'tablet'
+    mockRoute.path = '/workspace/boards'
+    const wrapper = mountSidebar()
+
+    const boardsLink = wrapper.findAll('a.paper-sidebar__item')
+      .find((l) => l.attributes('href') === '/workspace/boards')
+    expect(boardsLink?.classes()).toContain('paper-sidebar__item--active')
   })
 })

--- a/frontend/taskdeck-web/src/tests/components/paper/PaperSidebar.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/paper/PaperSidebar.spec.ts
@@ -293,10 +293,10 @@ describe('PaperSidebar', () => {
     expect(wrapper.find('.paper-sidebar--rail').exists()).toBe(false)
 
     const glyphs = wrapper.findAll('.paper-bottombar__glyph').map((g) => g.text())
-    expect(glyphs).toEqual(['H', 'T', 'R', 'I'])
+    expect(glyphs).toEqual(['H', 'T', 'R', 'I', '…'])
 
     const tabs = wrapper.findAll('.paper-bottombar__tab')
-    expect(tabs).toHaveLength(4)
+    expect(tabs).toHaveLength(5)
   })
 
   it('renders bottom-bar with ember accent on the active route', () => {

--- a/frontend/taskdeck-web/src/tests/components/paper/PaperSidebar.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/paper/PaperSidebar.spec.ts
@@ -54,7 +54,7 @@ function mountSidebar() {
       stubs: {
         RouterLink: {
           props: ['to'],
-          template: '<a :href="to" :class="$attrs.class" :aria-current="$attrs[`aria-current`]"><slot /></a>',
+          template: '<a :href="to" v-bind="$attrs"><slot /></a>',
         },
       },
     },
@@ -72,6 +72,7 @@ describe('PaperSidebar', () => {
     mockPaperTheme.mode = 'paper'
     mockPaperTheme.activeClass = 'paper'
     mockViewportMode.value = 'desktop'
+    document.body.style.overflow = ''
   })
 
   it('renders the brand and Precision Mode eyebrow with the active accent', () => {
@@ -311,6 +312,62 @@ describe('PaperSidebar', () => {
     const homeTab = wrapper.findAll('.paper-bottombar__tab')
       .find((t) => t.attributes('href') === '/workspace/home')
     expect(homeTab?.classes()).not.toContain('paper-bottombar__tab--active')
+  })
+
+  it('opens the phone More drawer with ARIA state and closes it with Escape', async () => {
+    mockViewportMode.value = 'phone'
+    const wrapper = mountSidebar()
+    const moreButton = wrapper.get('button[aria-label="More"]')
+
+    expect(moreButton.attributes('aria-expanded')).toBe('false')
+    expect(moreButton.attributes('aria-controls')).toBe('paper-phone-more-drawer')
+
+    await moreButton.trigger('click')
+
+    expect(moreButton.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('[data-paper-phone-drawer]').exists()).toBe(true)
+    expect(wrapper.find('#paper-phone-more-drawer').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Settings')
+    expect(wrapper.text()).toContain('Logout')
+    expect(document.body.style.overflow).toBe('hidden')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-paper-phone-drawer]').exists()).toBe(false)
+    expect(moreButton.attributes('aria-expanded')).toBe('false')
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('closes the phone More drawer after route changes and pseudo-actions', async () => {
+    mockViewportMode.value = 'phone'
+    const wrapper = mountSidebar()
+    const moreButton = wrapper.get('button[aria-label="More"]')
+
+    await moreButton.trigger('click')
+    mockRoute.path = '/workspace/settings/profile'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[data-paper-phone-drawer]').exists()).toBe(false)
+
+    await moreButton.trigger('click')
+    const shortcutsButton = wrapper.findAll('button.paper-sidebar__item')
+      .find((button) => button.text().includes('Shortcuts'))
+    await shortcutsButton?.trigger('click')
+
+    expect(wrapper.emitted('open-shortcuts')).toHaveLength(1)
+    expect(wrapper.find('[data-paper-phone-drawer]').exists()).toBe(false)
+  })
+
+  it('keeps feature-flagged phone tabs hidden when unavailable', () => {
+    mockViewportMode.value = 'phone'
+    mockFeatureFlags.isEnabled = vi.fn((flag: keyof FeatureFlags) => flag !== 'newAutomation')
+
+    const wrapper = mountSidebar()
+    const hrefs = wrapper.findAll('.paper-bottombar__tab').map((tab) => tab.attributes('href'))
+
+    expect(hrefs).not.toContain('/workspace/review')
+    expect(hrefs).toContain('/workspace/home')
   })
 
   it('renders icon-only rail on tablet', () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/PaperBoardView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/PaperBoardView.spec.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
-import { nextTick, reactive } from 'vue'
+import { nextTick, reactive, ref } from 'vue'
 import PaperBoardView from '../../../views/paper/PaperBoardView.vue'
 import PaperBoardColumn from '../../../views/paper/PaperBoardColumn.vue'
 import type { BoardDetail, Card, Column } from '../../../types/board'
+import type { ViewportMode } from '../../../composables/useViewportMode'
 
 const routerMock = { push: vi.fn() }
 const routeMock = reactive({ params: { id: 'board-1' } })
+const mockViewportMode = ref<ViewportMode>('desktop')
 
 function makeColumn(partial: Partial<Column> = {}): Column {
   return {
@@ -91,6 +93,10 @@ vi.mock('../../../store/boardStore', () => ({
   useBoardStore: () => mockBoardStore,
 }))
 
+vi.mock('../../../composables/useViewportMode', () => ({
+  useViewportMode: () => ({ mode: mockViewportMode }),
+}))
+
 function mountView(props: Record<string, unknown> = {}) {
   return mount(PaperBoardView, {
     attachTo: document.body,
@@ -124,6 +130,7 @@ describe('PaperBoardView', () => {
     mockBoardStore.cardsByColumn = cardsByColumn
     mockBoardStore.error = null
     mockBoardStore.loading = false
+    mockViewportMode.value = 'desktop'
   })
 
   afterEach(() => {
@@ -264,5 +271,19 @@ describe('PaperBoardView', () => {
     await flushPromises()
 
     expect(mockBoardStore.moveCard).toHaveBeenCalledWith('board-1', 'card-1', 'col-backlog', 1)
+  })
+
+  it('applies snap-scroll CSS class at tablet viewport', () => {
+    mockViewportMode.value = 'tablet'
+    const wrapper = mountView()
+    const lanes = wrapper.find('[data-testid="paper-board-lanes"]')
+    expect(lanes.classes()).toContain('paper-board-view__lanes--snap')
+  })
+
+  it('does not apply snap-scroll CSS class at desktop viewport', () => {
+    mockViewportMode.value = 'desktop'
+    const wrapper = mountView()
+    const lanes = wrapper.find('[data-testid="paper-board-lanes"]')
+    expect(lanes.classes()).not.toContain('paper-board-view__lanes--snap')
   })
 })

--- a/frontend/taskdeck-web/src/views/paper/PaperBoardView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperBoardView.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useBoardStore } from '../../store/boardStore'
 import { useBoardDragDrop } from '../../composables/useBoardDragDrop'
+import { useViewportMode } from '../../composables/useViewportMode'
 import PaperBoardColumn from './PaperBoardColumn.vue'
 import PaperHLBtn from '../../components/paper/PaperHLBtn.vue'
 import CardModal from '../../components/board/CardModal.vue'
@@ -33,6 +34,7 @@ const props = withDefaults(
 const route = useRoute()
 const router = useRouter()
 const boardStore = useBoardStore()
+const { mode: viewportMode } = useViewportMode()
 
 const boardId = computed(() => (typeof route.params.id === 'string' ? route.params.id : ''))
 const selectedCard = ref<Card | null>(null)
@@ -230,6 +232,7 @@ function openCaptureBoard() {
       <div
         v-else
         class="paper-board-view__lanes"
+        :class="{ 'paper-board-view__lanes--snap': viewportMode === 'tablet' }"
         data-testid="paper-board-lanes"
       >
         <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- column drag/drop wrapper; group role + drag events drive existing reorder semantics -->
@@ -355,6 +358,17 @@ function openCaptureBoard() {
   /* When the wrapper is `display: contents` only the column itself receives
    * layout. Drag-target / dragging affordances are surfaced via the column
    * border in PaperBoardColumn. */
+}
+
+.paper-board-view__lanes--snap {
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.paper-board-view__lanes--snap .paper-board-view__lane {
+  display: block;
+  scroll-snap-align: start;
+  flex: 0 0 280px;
 }
 
 @media (max-width: 640px) {

--- a/frontend/taskdeck-web/src/views/paper/PaperBoardView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperBoardView.vue
@@ -375,11 +375,11 @@ function openCaptureBoard() {
   .paper-board-view__inner {
     padding: 16px;
   }
-  .paper-board-view__lanes {
+  .paper-board-view__lanes:not(.paper-board-view__lanes--snap) {
     flex-direction: column;
     overflow-x: visible;
   }
-  .paper-board-view__lane {
+  .paper-board-view__lanes:not(.paper-board-view__lanes--snap) .paper-board-view__lane {
     display: block;
   }
 }

--- a/frontend/taskdeck-web/src/views/paper/PaperBoardView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperBoardView.vue
@@ -383,4 +383,10 @@ function openCaptureBoard() {
     display: block;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .paper-board-view__lanes--snap {
+    scroll-snap-type: none;
+  }
+}
 </style>

--- a/frontend/taskdeck-web/tests/e2e/paper-responsive.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/paper-responsive.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test, type Page } from '@playwright/test'
+import { createBoardWithColumn } from './support/boardHelpers'
+import { registerAndAttachSession } from './support/authSession'
+
+async function enablePaperMode(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('td.paper.mode', 'paper')
+  })
+}
+
+test.describe('Paper responsive shell', () => {
+  test('375px phone uses bottom navigation and keeps board content above it', async ({ page, request }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
+    await enablePaperMode(page)
+    const auth = await registerAndAttachSession(page, request, 'paper-phone')
+    const seed = `${Date.now()}`
+    const boardId = await createBoardWithColumn(request, auth, seed, {
+      boardNamePrefix: 'Paper Phone',
+      description: 'paper phone responsive board',
+      columnNamePrefix: 'Phone Lane',
+    })
+
+    await page.goto(`/workspace/boards/${boardId}`)
+
+    await expect(page.locator('[data-paper-bottombar]')).toBeVisible()
+    await expect(page.locator('.td-mobile-topbar__hamburger')).toHaveCount(0)
+    await expect(page.locator('[data-testid="paper-board-lanes"]')).toBeVisible()
+
+    const contentPaddingBottom = await page.locator('.td-content').evaluate((element) =>
+      Number.parseFloat(window.getComputedStyle(element).paddingBottom),
+    )
+    expect(contentPaddingBottom).toBeGreaterThanOrEqual(56)
+
+    const more = page.getByRole('button', { name: 'More' })
+    await expect(more).toHaveAttribute('aria-expanded', 'false')
+    await more.click()
+    await expect(more).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('[data-paper-phone-drawer]')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.locator('[data-paper-phone-drawer]')).toHaveCount(0)
+  })
+
+  test('768px tablet uses the icon rail and snap board lanes', async ({ page, request }) => {
+    await page.setViewportSize({ width: 768, height: 1024 })
+    await enablePaperMode(page)
+    const auth = await registerAndAttachSession(page, request, 'paper-tablet')
+    const seed = `${Date.now()}`
+    const boardId = await createBoardWithColumn(request, auth, seed, {
+      boardNamePrefix: 'Paper Tablet',
+      description: 'paper tablet responsive board',
+      columnNamePrefix: 'Tablet Lane',
+    })
+
+    await page.goto(`/workspace/boards/${boardId}`)
+
+    await expect(page.locator('[data-paper-rail]')).toBeVisible()
+    await expect(page.locator('[data-paper-bottombar]')).toHaveCount(0)
+    await expect(page.getByRole('heading', { name: `Paper Tablet ${seed}` })).toBeVisible()
+    await expect(page.locator('[data-testid="paper-board-lanes"]')).toHaveClass(/paper-board-view__lanes--snap/)
+  })
+})


### PR DESCRIPTION
## Summary
- PaperSidebar: bottom tab bar with H/T/R/I letterform glyphs on phone (<=480px), fixed to bottom with iOS safe area inset
- PaperSidebar: More drawer restores meta actions on phone and closes on Escape, route changes, and pseudo-actions
- PaperSidebar: 60px icon-only rail on tablet (<=1024px), replacing the full 232px sidebar
- PaperBoardView: horizontal snap scroll showing 2 visible 280px columns at tablet width via scroll-snap-type/scroll-snap-align
- Uses `useViewportMode` composable throughout -- no separate matchMedia calls
- All variants respect active-route ember accent and feature-flag availability
- prefers-reduced-motion handled on bottom-bar transitions

## Test plan
- [x] vitest: sidebar renders bottom-bar with H/T/R/I on phone
- [x] vitest: phone More drawer exposes meta actions and closes on Escape/route/pseudo-action
- [x] vitest: feature-flagged phone tabs stay hidden when unavailable
- [x] vitest: sidebar renders icon-only rail on tablet
- [x] vitest: sidebar rail applies ember accent on active route
- [x] vitest: AppShell hides legacy hamburger in Paper phone/tablet and pads phone content above bottom bar
- [x] vitest: board view applies snap-scroll class at tablet and not at desktop
- [x] npm run test -- --run src/tests/components/AppShell.paperVariant.spec.ts src/tests/components/paper/PaperSidebar.spec.ts src/tests/views/paper/PaperBoardView.spec.ts
- [x] npm run test:e2e -- tests/e2e/paper-responsive.spec.ts --project=chromium --workers=1 --reporter=line

## Adversarial checks
- Phone users retain meta actions through More; legacy AppShell hamburger is hidden on Paper narrow layouts so there is no dead drawer trigger
- Breakpoints align with viewport mode classifications; 768px tablet and 375px phone are covered by Playwright
- Bottom-bar respects iOS safe area via `var(--paper-safe-bottom, env(safe-area-inset-bottom, 0px))`
- Type scale does not compound (`--paper-scale` set once at .paper root, sidebar uses explicit font-size values)
- Tablet rail respects active-route ember accent (tested)

Refs #996
Closes #1007