### PR TITLE
RFAI-04: Add revision endpoints and edit-before-approve flow

### DIFF
--- a/backend/src/Taskdeck.Api/Contracts/CreateRevisionRequest.cs
+++ b/backend/src/Taskdeck.Api/Contracts/CreateRevisionRequest.cs
@@ -1,0 +1,7 @@
+namespace Taskdeck.Api.Contracts;
+
+public sealed class CreateRevisionRequest
+{
+    public string RevisedPayload { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+}

--- a/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
@@ -404,60 +404,69 @@ public class AutomationProposalsController : AuthenticatedControllerBase
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 
-    [HttpPost("{proposalId}/revisions")]
+    /// <summary>
+    /// Creates a new revision for a pending proposal, capturing the edited payload and reason.
+    /// </summary>
+    [HttpPost("{id}/revisions")]
     public async Task<IActionResult> CreateRevision(
-        Guid proposalId,
+        Guid id,
         [FromBody] CreateRevisionRequest request,
         CancellationToken cancellationToken = default)
     {
         if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
             return errorResult!;
 
-        var auth = await AuthorizeProposalAsync(proposalId, callerUserId, requireWriteAccess: true, cancellationToken);
+        var auth = await AuthorizeProposalAsync(id, callerUserId, requireWriteAccess: true, cancellationToken);
         if (auth.ErrorResult is not null)
             return auth.ErrorResult;
 
         var dto = new CreateProposalRevisionDto(
-            proposalId,
+            id,
             callerUserId,
             request.RevisedPayload,
             request.Reason);
 
         var result = await _revisionService.CreateRevisionAsync(dto, cancellationToken);
         return result.IsSuccess
-            ? CreatedAtAction(nameof(GetLatestRevision), new { proposalId }, result.Value)
+            ? CreatedAtAction(nameof(GetLatestRevision), new { id }, result.Value)
             : result.ToErrorActionResult();
     }
 
-    [HttpGet("{proposalId}/revisions")]
+    /// <summary>
+    /// Gets all revisions for a proposal, ordered by revision number ascending.
+    /// </summary>
+    [HttpGet("{id}/revisions")]
     public async Task<IActionResult> GetRevisions(
-        Guid proposalId,
+        Guid id,
         CancellationToken cancellationToken = default)
     {
         if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
             return errorResult!;
 
-        var auth = await AuthorizeProposalAsync(proposalId, callerUserId, requireWriteAccess: false, cancellationToken);
+        var auth = await AuthorizeProposalAsync(id, callerUserId, requireWriteAccess: false, cancellationToken);
         if (auth.ErrorResult is not null)
             return auth.ErrorResult;
 
-        var result = await _revisionService.GetRevisionsForProposalAsync(proposalId, cancellationToken);
+        var result = await _revisionService.GetRevisionsForProposalAsync(id, cancellationToken);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 
-    [HttpGet("{proposalId}/revisions/latest")]
+    /// <summary>
+    /// Gets the latest revision for a proposal. Returns 404 when no revisions exist.
+    /// </summary>
+    [HttpGet("{id}/revisions/latest")]
     public async Task<IActionResult> GetLatestRevision(
-        Guid proposalId,
+        Guid id,
         CancellationToken cancellationToken = default)
     {
         if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
             return errorResult!;
 
-        var auth = await AuthorizeProposalAsync(proposalId, callerUserId, requireWriteAccess: false, cancellationToken);
+        var auth = await AuthorizeProposalAsync(id, callerUserId, requireWriteAccess: false, cancellationToken);
         if (auth.ErrorResult is not null)
             return auth.ErrorResult;
 
-        var result = await _revisionService.GetLatestRevisionAsync(proposalId, cancellationToken);
+        var result = await _revisionService.GetLatestRevisionAsync(id, cancellationToken);
         if (!result.IsSuccess)
             return result.ToErrorActionResult();
 

--- a/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AutomationProposalsController.cs
@@ -34,6 +34,7 @@ public class AutomationProposalsController : AuthenticatedControllerBase
     private readonly IConfidenceBreakdownService _confidenceBreakdownService;
     private readonly ICardHistoryService _cardHistoryService;
     private readonly ISideEffectAnalyzer _sideEffectAnalyzer;
+    private readonly IProposalRevisionService _revisionService;
 
     public AutomationProposalsController(
         IAutomationProposalService proposalService,
@@ -45,6 +46,7 @@ public class AutomationProposalsController : AuthenticatedControllerBase
         IConfidenceBreakdownService confidenceBreakdownService,
         ICardHistoryService cardHistoryService,
         ISideEffectAnalyzer sideEffectAnalyzer,
+        IProposalRevisionService revisionService,
         IUserContext userContext) : base(userContext)
     {
         _proposalService = proposalService;
@@ -56,6 +58,7 @@ public class AutomationProposalsController : AuthenticatedControllerBase
         _confidenceBreakdownService = confidenceBreakdownService;
         _cardHistoryService = cardHistoryService;
         _sideEffectAnalyzer = sideEffectAnalyzer;
+        _revisionService = revisionService;
     }
 
     /// <summary>
@@ -399,6 +402,68 @@ public class AutomationProposalsController : AuthenticatedControllerBase
 
         var result = await _similarDecisionService.GetSimilarPastAsync(id, callerUserId, cancellationToken);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
+    }
+
+    [HttpPost("{proposalId}/revisions")]
+    public async Task<IActionResult> CreateRevision(
+        Guid proposalId,
+        [FromBody] CreateRevisionRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var auth = await AuthorizeProposalAsync(proposalId, callerUserId, requireWriteAccess: true, cancellationToken);
+        if (auth.ErrorResult is not null)
+            return auth.ErrorResult;
+
+        var dto = new CreateProposalRevisionDto(
+            proposalId,
+            callerUserId,
+            request.RevisedPayload,
+            request.Reason);
+
+        var result = await _revisionService.CreateRevisionAsync(dto, cancellationToken);
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetLatestRevision), new { proposalId }, result.Value)
+            : result.ToErrorActionResult();
+    }
+
+    [HttpGet("{proposalId}/revisions")]
+    public async Task<IActionResult> GetRevisions(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var auth = await AuthorizeProposalAsync(proposalId, callerUserId, requireWriteAccess: false, cancellationToken);
+        if (auth.ErrorResult is not null)
+            return auth.ErrorResult;
+
+        var result = await _revisionService.GetRevisionsForProposalAsync(proposalId, cancellationToken);
+        return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
+    }
+
+    [HttpGet("{proposalId}/revisions/latest")]
+    public async Task<IActionResult> GetLatestRevision(
+        Guid proposalId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var callerUserId, out var errorResult))
+            return errorResult!;
+
+        var auth = await AuthorizeProposalAsync(proposalId, callerUserId, requireWriteAccess: false, cancellationToken);
+        if (auth.ErrorResult is not null)
+            return auth.ErrorResult;
+
+        var result = await _revisionService.GetLatestRevisionAsync(proposalId, cancellationToken);
+        if (!result.IsSuccess)
+            return result.ToErrorActionResult();
+
+        return result.Value is not null
+            ? Ok(result.Value)
+            : NotFound(new ApiErrorResponse(ErrorCodes.NotFound, "No revisions exist for this proposal"));
     }
 
     private async Task<(ProposalDto? Proposal, IActionResult? ErrorResult)> AuthorizeProposalAsync(

--- a/backend/src/Taskdeck.Application/Services/AutomationExecutorService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationExecutorService.cs
@@ -107,8 +107,22 @@ public class AutomationExecutorService : IAutomationExecutorService
             return Result.Failure(ErrorCodes.InvalidOperation, $"Cannot execute proposal in status {proposal.Status}");
         }
 
+        var effectiveProposalResult = await MaterializeEffectiveProposalAsync(proposal, cancellationToken);
+        if (!effectiveProposalResult.IsSuccess)
+        {
+            _logger?.LogWarning(
+                "Automation proposal execution rejected for proposal {ProposalId} after {DurationMs}ms because revised payload is invalid: {ErrorCode} {ErrorMessage}",
+                proposalId,
+                (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds,
+                effectiveProposalResult.ErrorCode,
+                effectiveProposalResult.ErrorMessage);
+            return Result.Failure(effectiveProposalResult.ErrorCode, effectiveProposalResult.ErrorMessage);
+        }
+
+        var effectiveProposal = effectiveProposalResult.Value;
+
         // Revalidate policy before execution
-        var policyResult = _policyEngine.ValidatePolicy(proposal);
+        var policyResult = _policyEngine.ValidatePolicy(effectiveProposal);
         if (!policyResult.IsSuccess)
         {
             _logger?.LogWarning(
@@ -122,9 +136,9 @@ public class AutomationExecutorService : IAutomationExecutorService
 
         // Revalidate permissions
         var permissionResult = await _policyEngine.ValidatePermissionsAsync(
-            proposal.RequestedByUserId,
-            proposal.BoardId,
-            proposal.Operations,
+            effectiveProposal.RequestedByUserId,
+            effectiveProposal.BoardId,
+            effectiveProposal.Operations,
             cancellationToken);
         if (!permissionResult.IsSuccess)
         {
@@ -142,7 +156,7 @@ public class AutomationExecutorService : IAutomationExecutorService
             await _unitOfWork.BeginTransactionAsync(cancellationToken);
 
             // Execute operations in sequence order
-            var orderedOperations = proposal.Operations.OrderBy(o => o.Sequence).ToList();
+            var orderedOperations = effectiveProposal.Operations.OrderBy(o => o.Sequence).ToList();
             var failedOperation = -1;
             var failedResult = Result.Success();
             var failureReason = "";
@@ -159,7 +173,7 @@ public class AutomationExecutorService : IAutomationExecutorService
                 }
 
                 // Create audit log for the operation
-                await _auditRecorder.RecordAsync(operation, proposal, cancellationToken);
+                await _auditRecorder.RecordAsync(operation, effectiveProposal, cancellationToken);
             }
 
             if (failedOperation >= 0)
@@ -189,7 +203,7 @@ public class AutomationExecutorService : IAutomationExecutorService
                 return Result.Failure(markResult.ErrorCode, markResult.ErrorMessage);
 
             var captureSyncResult = await SyncLinkedCaptureConversionAsync(
-                proposal with
+                effectiveProposal with
                 {
                     Status = ProposalStatus.Applied,
                     AppliedAt = DateTime.UtcNow
@@ -222,6 +236,28 @@ public class AutomationExecutorService : IAutomationExecutorService
                 (DateTimeOffset.UtcNow - startedAt).TotalMilliseconds);
             return Result.Failure(ErrorCodes.UnexpectedError, $"Failed to execute proposal: {ex.Message}");
         }
+    }
+
+    private async Task<Result<ProposalDto>> MaterializeEffectiveProposalAsync(
+        ProposalDto proposal,
+        CancellationToken cancellationToken)
+    {
+        var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(
+            proposal.Id,
+            cancellationToken);
+        if (latestRevision is null)
+            return Result.Success(proposal);
+
+        if (!ProposalRevisionPayload.TryParseOperations(
+                proposal.Id,
+                latestRevision.RevisedPayload,
+                out var revisedOperations,
+                out var errorMessage))
+        {
+            return Result.Failure<ProposalDto>(ErrorCodes.ValidationError, errorMessage);
+        }
+
+        return Result.Success(proposal with { Operations = revisedOperations });
     }
 
     private async Task<Result> SyncLinkedCaptureConversionAsync(ProposalDto proposal, CancellationToken cancellationToken)

--- a/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
@@ -29,6 +30,11 @@ public class ProposalRevisionService : IProposalRevisionService
                 return Result.Failure<ProposalRevisionDto>(
                     ErrorCodes.InvalidOperation,
                     $"Cannot create revision for proposal in status {proposal.Status}");
+
+            if (!IsValidJson(dto.RevisedPayload))
+                return Result.Failure<ProposalRevisionDto>(
+                    ErrorCodes.ValidationError,
+                    "RevisedPayload must be valid JSON");
 
             var nextRevisionNumber = await _unitOfWork.ProposalRevisions
                 .GetNextRevisionNumberAsync(dto.ProposalId, cancellationToken);
@@ -97,5 +103,18 @@ public class ProposalRevisionService : IProposalRevisionService
             revision.RevisedAt,
             revision.Reason,
             revision.CreatedAt);
+    }
+
+    private static bool IsValidJson(string payload)
+    {
+        try
+        {
+            using var _ = JsonDocument.Parse(payload);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
@@ -31,10 +31,15 @@ public class ProposalRevisionService : IProposalRevisionService
                     ErrorCodes.InvalidOperation,
                     $"Cannot create revision for proposal in status {proposal.Status}");
 
-            if (!IsValidJson(dto.RevisedPayload))
+            var payloadValidation = ProposalRevisionPayload.TryParseOperations(
+                dto.ProposalId,
+                dto.RevisedPayload,
+                out _,
+                out var validationError);
+            if (!payloadValidation)
                 return Result.Failure<ProposalRevisionDto>(
                     ErrorCodes.ValidationError,
-                    "RevisedPayload must be valid JSON");
+                    validationError);
 
             var nextRevisionNumber = await _unitOfWork.ProposalRevisions
                 .GetNextRevisionNumberAsync(dto.ProposalId, cancellationToken);
@@ -105,12 +110,194 @@ public class ProposalRevisionService : IProposalRevisionService
             revision.CreatedAt);
     }
 
-    private static bool IsValidJson(string payload)
+}
+
+internal static class ProposalRevisionPayload
+{
+    public static bool TryParseOperations(
+        Guid proposalId,
+        string payload,
+        out List<ProposalOperationDto> operations,
+        out string errorMessage)
+    {
+        operations = new List<ProposalOperationDto>();
+        errorMessage = string.Empty;
+
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                errorMessage = "RevisedPayload must be a JSON object";
+                return false;
+            }
+
+            if (!document.RootElement.TryGetProperty("operations", out var operationsElement))
+            {
+                errorMessage = "RevisedPayload must contain an operations array";
+                return false;
+            }
+
+            if (operationsElement.ValueKind != JsonValueKind.Array)
+            {
+                errorMessage = "RevisedPayload operations must be an array";
+                return false;
+            }
+
+            foreach (var operationElement in operationsElement.EnumerateArray())
+            {
+                if (!TryParseOperation(proposalId, operationElement, out var operation, out errorMessage))
+                    return false;
+
+                operations.Add(operation);
+            }
+
+            if (operations.Count == 0)
+            {
+                errorMessage = "RevisedPayload operations must contain at least one operation";
+                return false;
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            errorMessage = "RevisedPayload must be valid JSON";
+            return false;
+        }
+    }
+
+    private static bool TryParseOperation(
+        Guid proposalId,
+        JsonElement operationElement,
+        out ProposalOperationDto operation,
+        out string errorMessage)
+    {
+        operation = default!;
+        errorMessage = string.Empty;
+
+        if (operationElement.ValueKind != JsonValueKind.Object)
+        {
+            errorMessage = "Each revised operation must be a JSON object";
+            return false;
+        }
+
+        if (!TryGetInt32(operationElement, "sequence", out var sequence, out errorMessage))
+            return false;
+
+        if (sequence < 0)
+        {
+            errorMessage = "Revised operation sequence must be non-negative";
+            return false;
+        }
+
+        if (!TryGetRequiredString(operationElement, "actionType", out var actionType, out errorMessage))
+            return false;
+
+        if (!TryGetRequiredString(operationElement, "targetType", out var targetType, out errorMessage))
+            return false;
+
+        if (!TryGetRequiredString(operationElement, "parameters", out var parameters, out errorMessage))
+            return false;
+
+        if (!IsValidJsonObject(parameters))
+        {
+            errorMessage = "Revised operation parameters must be a JSON object string";
+            return false;
+        }
+
+        if (!TryGetRequiredString(operationElement, "idempotencyKey", out var idempotencyKey, out errorMessage))
+            return false;
+
+        var operationId = TryGetOptionalGuid(operationElement, "id") ?? Guid.Empty;
+        var targetId = TryGetOptionalString(operationElement, "targetId");
+        var expectedVersion = TryGetOptionalString(operationElement, "expectedVersion");
+
+        operation = new ProposalOperationDto(
+            operationId,
+            proposalId,
+            sequence,
+            actionType,
+            targetType,
+            targetId,
+            parameters,
+            idempotencyKey,
+            expectedVersion);
+        return true;
+    }
+
+    private static bool TryGetInt32(
+        JsonElement element,
+        string propertyName,
+        out int value,
+        out string errorMessage)
+    {
+        value = default;
+        errorMessage = string.Empty;
+
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.Number ||
+            !property.TryGetInt32(out value))
+        {
+            errorMessage = $"Revised operation {propertyName} must be an integer";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryGetRequiredString(
+        JsonElement element,
+        string propertyName,
+        out string value,
+        out string errorMessage)
+    {
+        value = string.Empty;
+        errorMessage = string.Empty;
+
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind != JsonValueKind.String)
+        {
+            errorMessage = $"Revised operation {propertyName} must be a string";
+            return false;
+        }
+
+        value = property.GetString()?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errorMessage = $"Revised operation {propertyName} cannot be empty";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string? TryGetOptionalString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var property) ||
+            property.ValueKind == JsonValueKind.Null ||
+            property.ValueKind == JsonValueKind.Undefined)
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : null;
+    }
+
+    private static Guid? TryGetOptionalGuid(JsonElement element, string propertyName)
+    {
+        var value = TryGetOptionalString(element, propertyName);
+        return Guid.TryParse(value, out var guid) ? guid : null;
+    }
+
+    private static bool IsValidJsonObject(string value)
     {
         try
         {
-            using var _ = JsonDocument.Parse(payload);
-            return true;
+            using var document = JsonDocument.Parse(value);
+            return document.RootElement.ValueKind == JsonValueKind.Object;
         }
         catch (JsonException)
         {

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -1,0 +1,197 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public ProposalRevisionApiTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task CreateRevision_HappyPath_ShouldReturnCreated()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-happy");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-create-happy-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"title\":\"Edited Card\"}", reason = "Adjusted title" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var revision = await response.Content.ReadFromJsonAsync<ProposalRevisionDto>();
+        revision.Should().NotBeNull();
+        revision!.ProposalId.Should().Be(proposal.Id);
+        revision.RevisionNumber.Should().Be(1);
+        revision.EditorUserId.Should().Be(user.UserId);
+        revision.RevisedPayload.Should().Be("{\"title\":\"Edited Card\"}");
+        revision.Reason.Should().Be("Adjusted title");
+    }
+
+    [Fact]
+    public async Task CreateRevision_OnNonExistentProposal_ShouldReturn404()
+    {
+        var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "rev-create-notfound");
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{Guid.NewGuid()}/revisions",
+            new { revisedPayload = "{}", reason = "test" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var error = await response.Content.ReadFromJsonAsync<JsonElement>();
+        error.GetProperty("errorCode").GetString().Should().Be("NotFound");
+    }
+
+    [Fact]
+    public async Task CreateRevision_OnApprovedProposal_ShouldReturnConflict()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-conflict");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-create-conflict-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{}", reason = "too late" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task GetRevisions_Empty_ShouldReturnEmptyList()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-list-empty");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-list-empty-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var revisions = await response.Content.ReadFromJsonAsync<List<ProposalRevisionDto>>();
+        revisions.Should().NotBeNull();
+        revisions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetRevisions_Populated_ShouldReturnAll()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-list-pop");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-list-pop-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"v\":1}", reason = "first edit" });
+        await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"v\":2}", reason = "second edit" });
+
+        var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var revisions = await response.Content.ReadFromJsonAsync<List<ProposalRevisionDto>>();
+        revisions.Should().NotBeNull();
+        revisions.Should().HaveCount(2);
+        revisions![0].RevisionNumber.Should().BeLessThan(revisions[1].RevisionNumber);
+    }
+
+    [Fact]
+    public async Task GetLatestRevision_WhenNoneExist_ShouldReturn404()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-latest-none");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-latest-none-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions/latest");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetLatestRevision_WhenRevisionsExist_ShouldReturnLatest()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-latest-exists");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-latest-exists-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"v\":1}", reason = "first" });
+        await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"v\":2}", reason = "second" });
+
+        var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions/latest");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var revision = await response.Content.ReadFromJsonAsync<ProposalRevisionDto>();
+        revision.Should().NotBeNull();
+        revision!.RevisedPayload.Should().Be("{\"v\":2}");
+        revision.RevisionNumber.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateRevision_ShouldReturnForbidden_WhenCallerCannotWriteProposalBoard()
+    {
+        var ownerClient = _factory.CreateClient();
+        var outsiderClient = _factory.CreateClient();
+
+        var owner = await ApiTestHarness.AuthenticateAsync(ownerClient, "rev-authz-owner");
+        _ = await ApiTestHarness.AuthenticateAsync(outsiderClient, "rev-authz-outsider");
+        var board = await ApiTestHarness.CreateBoardAsync(ownerClient, "rev-authz-board");
+        var proposal = await CreateTestProposalAsync(ownerClient, owner.UserId, board.Id);
+
+        var response = await outsiderClient.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{}", reason = "unauthorized" });
+
+        await ApiTestHarness.AssertForbiddenAsync(response);
+    }
+
+    private static async Task<ProposalDto> CreateTestProposalAsync(
+        HttpClient client,
+        Guid userId,
+        Guid boardId)
+    {
+        var createRequest = new CreateProposalDto(
+            SourceType: ProposalSourceType.Chat,
+            RequestedByUserId: userId,
+            Summary: $"Revision test proposal {Guid.NewGuid()}",
+            RiskLevel: RiskLevel.Low,
+            CorrelationId: Guid.NewGuid().ToString(),
+            BoardId: boardId,
+            Operations: new List<CreateProposalOperationDto>
+            {
+                new(
+                    Sequence: 1,
+                    ActionType: "CreateCard",
+                    TargetType: "Card",
+                    Parameters: "{\"title\":\"Test Card\"}",
+                    IdempotencyKey: Guid.NewGuid().ToString())
+            });
+
+        var response = await client.PostAsJsonAsync("/api/automation/proposals", createRequest);
+        response.EnsureSuccessStatusCode();
+        return (await response.Content.ReadFromJsonAsync<ProposalDto>())!;
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -24,12 +24,12 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-happy");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-create-happy-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-create-happy-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         var response = await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{\"title\":\"Edited Card\"}", reason = "Adjusted title" });
+            new { revisedPayload = BuildRevisionPayload("Edited Card", board.Id, column.Id), reason = "Adjusted title" });
 
         response.StatusCode.Should().Be(HttpStatusCode.Created);
         var revision = await response.Content.ReadFromJsonAsync<ProposalRevisionDto>();
@@ -37,7 +37,7 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         revision!.ProposalId.Should().Be(proposal.Id);
         revision.RevisionNumber.Should().Be(1);
         revision.EditorUserId.Should().Be(user.UserId);
-        revision.RevisedPayload.Should().Be("{\"title\":\"Edited Card\"}");
+        revision.RevisedPayload.Should().Contain("Edited Card");
         revision.Reason.Should().Be("Adjusted title");
     }
 
@@ -49,7 +49,7 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
 
         var response = await client.PostAsJsonAsync(
             $"/api/automation/proposals/{Guid.NewGuid()}/revisions",
-            new { revisedPayload = "{}", reason = "test" });
+            new { revisedPayload = BuildRevisionPayload("Edited Card", Guid.NewGuid(), Guid.NewGuid()), reason = "test" });
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
@@ -61,14 +61,14 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-conflict");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-create-conflict-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-create-conflict-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
 
         var response = await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{}", reason = "too late" });
+            new { revisedPayload = BuildRevisionPayload("Edited Card", board.Id, column.Id), reason = "too late" });
 
         response.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
@@ -78,8 +78,8 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-invalid-json");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-create-invalid-json-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-create-invalid-json-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         var response = await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
@@ -92,12 +92,30 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task CreateRevision_WithNonArrayOperations_ShouldReturnValidationError()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-invalid-shape");
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-create-invalid-shape-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"operations\":\"not an array\"}", reason = "broken snapshot" });
+
+        await ApiTestHarness.AssertErrorContractAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "ValidationError");
+    }
+
+    [Fact]
     public async Task GetRevisions_Empty_ShouldReturnEmptyList()
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-list-empty");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-list-empty-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-list-empty-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions");
 
@@ -112,15 +130,15 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-list-pop");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-list-pop-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-list-pop-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{\"v\":1}", reason = "first edit" });
+            new { revisedPayload = BuildRevisionPayload("First Edit", board.Id, column.Id), reason = "first edit" });
         await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{\"v\":2}", reason = "second edit" });
+            new { revisedPayload = BuildRevisionPayload("Second Edit", board.Id, column.Id), reason = "second edit" });
 
         var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions");
 
@@ -136,8 +154,8 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-latest-none");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-latest-none-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-latest-none-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions/latest");
 
@@ -149,23 +167,53 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-latest-exists");
-        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-latest-exists-board");
-        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-latest-exists-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id);
 
         await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{\"v\":1}", reason = "first" });
+            new { revisedPayload = BuildRevisionPayload("First Edit", board.Id, column.Id), reason = "first" });
         await client.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{\"v\":2}", reason = "second" });
+            new { revisedPayload = BuildRevisionPayload("Second Edit", board.Id, column.Id), reason = "second" });
 
         var response = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/revisions/latest");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var revision = await response.Content.ReadFromJsonAsync<ProposalRevisionDto>();
         revision.Should().NotBeNull();
-        revision!.RevisedPayload.Should().Be("{\"v\":2}");
+        revision!.RevisedPayload.Should().Contain("Second Edit");
         revision.RevisionNumber.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ExecuteProposal_WithLatestRevision_ShouldApplyRevisedOperations()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-execute-latest");
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-execute-latest-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id, "Original Card");
+
+        var revisionResponse = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = BuildRevisionPayload("Edited Card", board.Id, column.Id), reason = "Use edited title" });
+        revisionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var executeRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/automation/proposals/{proposal.Id}/execute");
+        executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        var executeResponse = await client.SendAsync(executeRequest);
+        executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var cardsResponse = await client.GetAsync($"/api/boards/{board.Id}/cards");
+        cardsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var cards = await cardsResponse.Content.ReadFromJsonAsync<List<CardDto>>();
+
+        cards.Should().NotBeNull();
+        cards!.Should().ContainSingle(card => card.Title == "Edited Card");
+        cards.Should().NotContain(card => card.Title == "Original Card");
     }
 
     [Fact]
@@ -176,12 +224,12 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
 
         var owner = await ApiTestHarness.AuthenticateAsync(ownerClient, "rev-authz-owner");
         _ = await ApiTestHarness.AuthenticateAsync(outsiderClient, "rev-authz-outsider");
-        var board = await ApiTestHarness.CreateBoardAsync(ownerClient, "rev-authz-board");
-        var proposal = await CreateTestProposalAsync(ownerClient, owner.UserId, board.Id);
+        var (board, column) = await CreateBoardWithColumnAsync(ownerClient, "rev-authz-board");
+        var proposal = await CreateTestProposalAsync(ownerClient, owner.UserId, board.Id, column.Id);
 
         var response = await outsiderClient.PostAsJsonAsync(
             $"/api/automation/proposals/{proposal.Id}/revisions",
-            new { revisedPayload = "{}", reason = "unauthorized" });
+            new { revisedPayload = BuildRevisionPayload("Edited Card", board.Id, column.Id), reason = "unauthorized" });
 
         await ApiTestHarness.AssertForbiddenAsync(response);
     }
@@ -189,7 +237,9 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     private static async Task<ProposalDto> CreateTestProposalAsync(
         HttpClient client,
         Guid userId,
-        Guid boardId)
+        Guid boardId,
+        Guid columnId,
+        string title = "Test Card")
     {
         var createRequest = new CreateProposalDto(
             SourceType: ProposalSourceType.Chat,
@@ -202,14 +252,61 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
             {
                 new(
                     Sequence: 1,
-                    ActionType: "CreateCard",
-                    TargetType: "Card",
-                    Parameters: "{\"title\":\"Test Card\"}",
+                    ActionType: "create",
+                    TargetType: "card",
+                    Parameters: BuildCreateCardParameters(title, boardId, columnId),
                     IdempotencyKey: Guid.NewGuid().ToString())
             });
 
         var response = await client.PostAsJsonAsync("/api/automation/proposals", createRequest);
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<ProposalDto>())!;
+    }
+
+    private static async Task<(BoardDto Board, ColumnDto Column)> CreateBoardWithColumnAsync(
+        HttpClient client,
+        string stem)
+    {
+        var board = await ApiTestHarness.CreateBoardAsync(client, stem);
+        var columnResponse = await client.PostAsJsonAsync(
+            $"/api/boards/{board.Id}/columns",
+            new CreateColumnDto(board.Id, "To Do", 0, null));
+        columnResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var column = await columnResponse.Content.ReadFromJsonAsync<ColumnDto>();
+        column.Should().NotBeNull();
+        return (board, column!);
+    }
+
+    private static string BuildRevisionPayload(string title, Guid boardId, Guid columnId)
+    {
+        var payload = new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 1,
+                    actionType = "create",
+                    targetType = "card",
+                    targetId = (string?)null,
+                    parameters = BuildCreateCardParameters(title, boardId, columnId),
+                    idempotencyKey = Guid.NewGuid().ToString(),
+                    expectedVersion = (string?)null
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    private static string BuildCreateCardParameters(string title, Guid boardId, Guid columnId)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            title,
+            boardId,
+            columnId
+        });
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -74,6 +74,24 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task CreateRevision_WithInvalidRevisedPayloadJson_ShouldReturnValidationError()
+    {
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-invalid-json");
+        var board = await ApiTestHarness.CreateBoardAsync(client, "rev-create-invalid-json-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = "{\"operations\":[", reason = "malformed edit" });
+
+        await ApiTestHarness.AssertErrorContractAsync(
+            response,
+            HttpStatusCode.BadRequest,
+            "ValidationError");
+    }
+
+    [Fact]
     public async Task GetRevisions_Empty_ShouldReturnEmptyList()
     {
         var client = _factory.CreateClient();

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationExecutorServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationExecutorServiceTests.cs
@@ -26,6 +26,7 @@ public class AutomationExecutorServiceTests
     private readonly Mock<IColumnRepository> _columnRepoMock;
     private readonly Mock<ICardRepository> _cardRepoMock;
     private readonly Mock<ILlmQueueRepository> _llmQueueRepoMock;
+    private readonly Mock<IProposalRevisionRepository> _proposalRevisionRepoMock;
     private readonly AutomationExecutorService _service;
 
     public AutomationExecutorServiceTests()
@@ -39,6 +40,7 @@ public class AutomationExecutorServiceTests
         _columnRepoMock = new Mock<IColumnRepository>();
         _cardRepoMock = new Mock<ICardRepository>();
         _llmQueueRepoMock = new Mock<ILlmQueueRepository>();
+        _proposalRevisionRepoMock = new Mock<IProposalRevisionRepository>();
 
         _unitOfWorkMock.Setup(u => u.AutomationProposals).Returns(_proposalRepoMock.Object);
         _unitOfWorkMock.Setup(u => u.AuditLogs).Returns(_auditLogRepoMock.Object);
@@ -46,6 +48,7 @@ public class AutomationExecutorServiceTests
         _unitOfWorkMock.Setup(u => u.Columns).Returns(_columnRepoMock.Object);
         _unitOfWorkMock.Setup(u => u.Cards).Returns(_cardRepoMock.Object);
         _unitOfWorkMock.Setup(u => u.LlmQueue).Returns(_llmQueueRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.ProposalRevisions).Returns(_proposalRevisionRepoMock.Object);
         _unitOfWorkMock.Setup(u => u.BeginTransactionAsync(default)).Returns(Task.CompletedTask);
         _unitOfWorkMock.Setup(u => u.CommitTransactionAsync(default)).Returns(Task.CompletedTask);
         _unitOfWorkMock.Setup(u => u.RollbackTransactionAsync(default)).Returns(Task.CompletedTask);

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Moq;
 using Taskdeck.Application.DTOs;
@@ -32,7 +33,7 @@ public class ProposalRevisionServiceTests
         var dto = new CreateProposalRevisionDto(
             proposal.Id,
             Guid.NewGuid(),
-            """{"operations":[]}""",
+            BuildRevisionPayload(proposal.BoardId!.Value, Guid.NewGuid()),
             "Edited before approval");
 
         _proposals
@@ -66,5 +67,28 @@ public class ProposalRevisionServiceTests
             RiskLevel.Low,
             Guid.NewGuid().ToString("N"),
             Guid.NewGuid());
+    }
+
+    private static string BuildRevisionPayload(Guid boardId, Guid columnId)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 1,
+                    actionType = "create",
+                    targetType = "card",
+                    parameters = JsonSerializer.Serialize(new
+                    {
+                        title = "Edited Card",
+                        boardId,
+                        columnId
+                    }),
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
     }
 }

--- a/frontend/taskdeck-web/src/api/proposalRevisionsApi.ts
+++ b/frontend/taskdeck-web/src/api/proposalRevisionsApi.ts
@@ -1,0 +1,50 @@
+import http from './http'
+
+export interface ProposalRevision {
+  id: string
+  proposalId: string
+  revisionNumber: number
+  editorUserId: string
+  revisedPayload: string
+  revisedAt: string
+  reason: string
+  createdAt: string
+}
+
+export interface CreateRevisionPayload {
+  revisedPayload: string
+  reason: string
+}
+
+export const proposalRevisionsApi = {
+  async createRevision(
+    proposalId: string,
+    payload: CreateRevisionPayload,
+  ): Promise<ProposalRevision> {
+    const { data } = await http.post<ProposalRevision>(
+      `/automation/proposals/${encodeURIComponent(proposalId)}/revisions`,
+      payload,
+    )
+    return data
+  },
+
+  async getRevisions(proposalId: string): Promise<ProposalRevision[]> {
+    const { data } = await http.get<ProposalRevision[]>(
+      `/automation/proposals/${encodeURIComponent(proposalId)}/revisions`,
+    )
+    return data
+  },
+
+  async getLatestRevision(proposalId: string): Promise<ProposalRevision | null> {
+    try {
+      const { data } = await http.get<ProposalRevision>(
+        `/automation/proposals/${encodeURIComponent(proposalId)}/revisions/latest`,
+      )
+      return data
+    } catch (e: unknown) {
+      const err = e as { response?: { status?: number } }
+      if (err?.response?.status === 404) return null
+      throw e
+    }
+  },
+}

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -15,16 +15,20 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
   const saving = ref(false)
   const revisionCount = ref(0)
   const latestRevision = ref<ProposalRevision | null>(null)
+  let loadGeneration = 0
 
   async function loadRevisionState(proposalId: string) {
+    const gen = ++loadGeneration
     try {
       const revisions = await proposalRevisionsApi.getRevisions(proposalId)
+      if (gen !== loadGeneration) return
       revisionCount.value = revisions.length
       latestRevision.value =
         revisions.length > 0
           ? revisions.reduce((a, b) => (a.revisionNumber > b.revisionNumber ? a : b))
           : null
     } catch (e: unknown) {
+      if (gen !== loadGeneration) return
       revisionCount.value = 0
       latestRevision.value = null
       toast.error(getErrorDisplay(e, 'Failed to load revision history').message)

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -16,19 +16,20 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
   const revisionCount = ref(0)
   const latestRevision = ref<ProposalRevision | null>(null)
   let loadGeneration = 0
+  let saveGeneration = 0
 
   async function loadRevisionState(proposalId: string) {
     const gen = ++loadGeneration
     try {
       const revisions = await proposalRevisionsApi.getRevisions(proposalId)
-      if (gen !== loadGeneration) return
+      if (gen !== loadGeneration || activeProposal.value?.id !== proposalId) return
       revisionCount.value = revisions.length
       latestRevision.value =
         revisions.length > 0
           ? revisions.reduce((a, b) => (a.revisionNumber > b.revisionNumber ? a : b))
           : null
     } catch (e: unknown) {
-      if (gen !== loadGeneration) return
+      if (gen !== loadGeneration || activeProposal.value?.id !== proposalId) return
       revisionCount.value = 0
       latestRevision.value = null
       toast.error(getErrorDisplay(e, 'Failed to load revision history').message)
@@ -38,12 +39,14 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
   watch(
     () => activeProposal.value?.id,
     (id) => {
+      loadGeneration += 1
+      saveGeneration += 1
       editing.value = false
+      saving.value = false
+      revisionCount.value = 0
+      latestRevision.value = null
       if (id) {
         void loadRevisionState(id)
-      } else {
-        revisionCount.value = 0
-        latestRevision.value = null
       }
     },
     { immediate: true },
@@ -62,17 +65,23 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
     const proposal = activeProposal.value
     if (!proposal) return
 
+    const proposalId = proposal.id
+    const gen = ++saveGeneration
     try {
       saving.value = true
-      const revision = await proposalRevisionsApi.createRevision(proposal.id, payload)
+      const revision = await proposalRevisionsApi.createRevision(proposalId, payload)
+      if (gen !== saveGeneration || activeProposal.value?.id !== proposalId) return
       latestRevision.value = revision
       revisionCount.value += 1
       editing.value = false
       toast.success('Revision saved')
     } catch (e: unknown) {
+      if (gen !== saveGeneration || activeProposal.value?.id !== proposalId) return
       toast.error(getErrorDisplay(e, 'Failed to save revision').message)
     } finally {
-      saving.value = false
+      if (gen === saveGeneration && activeProposal.value?.id === proposalId) {
+        saving.value = false
+      }
     }
   }
 

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -24,9 +24,10 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
         revisions.length > 0
           ? revisions.reduce((a, b) => (a.revisionNumber > b.revisionNumber ? a : b))
           : null
-    } catch {
+    } catch (e: unknown) {
       revisionCount.value = 0
       latestRevision.value = null
+      toast.error(getErrorDisplay(e, 'Failed to load revision history').message)
     }
   }
 

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -1,0 +1,84 @@
+import { ref, watch, type Ref } from 'vue'
+import {
+  proposalRevisionsApi,
+  type ProposalRevision,
+  type CreateRevisionPayload,
+} from '../api/proposalRevisionsApi'
+import { useToastStore } from '../store/toastStore'
+import { getErrorDisplay } from './useErrorMapper'
+import type { Proposal as ApiProposal } from '../types/automation'
+
+export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
+  const toast = useToastStore()
+
+  const editing = ref(false)
+  const saving = ref(false)
+  const revisionCount = ref(0)
+  const latestRevision = ref<ProposalRevision | null>(null)
+
+  async function loadRevisionState(proposalId: string) {
+    try {
+      const revisions = await proposalRevisionsApi.getRevisions(proposalId)
+      revisionCount.value = revisions.length
+      latestRevision.value =
+        revisions.length > 0
+          ? revisions.reduce((a, b) => (a.revisionNumber > b.revisionNumber ? a : b))
+          : null
+    } catch {
+      revisionCount.value = 0
+      latestRevision.value = null
+    }
+  }
+
+  watch(
+    () => activeProposal.value?.id,
+    (id) => {
+      editing.value = false
+      if (id) {
+        void loadRevisionState(id)
+      } else {
+        revisionCount.value = 0
+        latestRevision.value = null
+      }
+    },
+    { immediate: true },
+  )
+
+  function startEditing() {
+    if (!activeProposal.value) return
+    editing.value = true
+  }
+
+  function cancelEditing() {
+    editing.value = false
+  }
+
+  async function saveRevision(payload: CreateRevisionPayload) {
+    const proposal = activeProposal.value
+    if (!proposal) return
+
+    try {
+      saving.value = true
+      const revision = await proposalRevisionsApi.createRevision(proposal.id, payload)
+      latestRevision.value = revision
+      revisionCount.value += 1
+      editing.value = false
+      toast.success('Revision saved')
+    } catch (e: unknown) {
+      toast.error(getErrorDisplay(e, 'Failed to save revision').message)
+    } finally {
+      saving.value = false
+    }
+  }
+
+  return {
+    editing,
+    saving,
+    revisionCount,
+    latestRevision,
+    startEditing,
+    cancelEditing,
+    saveRevision,
+    loadRevisionState,
+  }
+}

--- a/frontend/taskdeck-web/src/tests/api/proposalRevisionsApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/proposalRevisionsApi.spec.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import http from '../../api/http'
+import { proposalRevisionsApi } from '../../api/proposalRevisionsApi'
+
+vi.mock('../../api/http', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+describe('proposalRevisionsApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a revision with payload and reason', async () => {
+    const mockRevision = {
+      id: 'rev-1',
+      proposalId: 'p1',
+      revisionNumber: 1,
+      editorUserId: 'u1',
+      revisedPayload: '{"title":"Edited"}',
+      revisedAt: '2026-01-01T00:00:00Z',
+      reason: 'Fix title',
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(http.post).mockResolvedValue({ data: mockRevision })
+
+    const result = await proposalRevisionsApi.createRevision('p1', {
+      revisedPayload: '{"title":"Edited"}',
+      reason: 'Fix title',
+    })
+
+    expect(http.post).toHaveBeenCalledWith(
+      '/automation/proposals/p1/revisions',
+      { revisedPayload: '{"title":"Edited"}', reason: 'Fix title' },
+    )
+    expect(result).toEqual(mockRevision)
+  })
+
+  it('lists revisions for a proposal', async () => {
+    vi.mocked(http.get).mockResolvedValue({ data: [] })
+
+    const result = await proposalRevisionsApi.getRevisions('p1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p1/revisions')
+    expect(result).toEqual([])
+  })
+
+  it('returns latest revision when one exists', async () => {
+    const mockRevision = {
+      id: 'rev-2',
+      proposalId: 'p1',
+      revisionNumber: 2,
+      editorUserId: 'u1',
+      revisedPayload: '{"v":2}',
+      revisedAt: '2026-01-01T00:00:00Z',
+      reason: 'second',
+      createdAt: '2026-01-01T00:00:00Z',
+    }
+    vi.mocked(http.get).mockResolvedValue({ data: mockRevision })
+
+    const result = await proposalRevisionsApi.getLatestRevision('p1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p1/revisions/latest')
+    expect(result).toEqual(mockRevision)
+  })
+
+  it('returns null when no latest revision (404)', async () => {
+    vi.mocked(http.get).mockRejectedValue({ response: { status: 404 } })
+
+    const result = await proposalRevisionsApi.getLatestRevision('p1')
+
+    expect(result).toBeNull()
+  })
+
+  it('rethrows non-404 errors from getLatestRevision', async () => {
+    const error = { response: { status: 500 } }
+    vi.mocked(http.get).mockRejectedValue(error)
+
+    await expect(proposalRevisionsApi.getLatestRevision('p1')).rejects.toEqual(error)
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
@@ -149,4 +149,36 @@ describe('useProposalRevisions', () => {
 
     expect(editing.value).toBe(false)
   })
+
+  it('discards stale load responses when proposal switches quickly', async () => {
+    const staleRevisions = [makeRevision({ proposalId: 'p-1', revisionNumber: 1 })]
+    const freshRevisions = [
+      makeRevision({ proposalId: 'p-2', revisionNumber: 1 }),
+      makeRevision({ proposalId: 'p-2', revisionNumber: 2 }),
+    ]
+
+    let resolveStale!: (v: typeof staleRevisions) => void
+    vi.mocked(proposalRevisionsApi.getRevisions)
+      .mockImplementationOnce(() => new Promise((r) => { resolveStale = r }))
+      .mockResolvedValueOnce(freshRevisions)
+
+    const proposal = ref<ApiProposal | null>(null)
+    const { revisionCount, latestRevision } = useProposalRevisions(proposal)
+
+    proposal.value = makeProposal({ id: 'p-1' })
+    await nextTick()
+
+    proposal.value = makeProposal({ id: 'p-2' })
+    await nextTick()
+
+    await vi.waitFor(() => {
+      expect(revisionCount.value).toBe(2)
+    })
+
+    resolveStale(staleRevisions)
+    await nextTick()
+
+    expect(revisionCount.value).toBe(2)
+    expect(latestRevision.value?.proposalId).toBe('p-2')
+  })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
@@ -150,6 +150,56 @@ describe('useProposalRevisions', () => {
     expect(editing.value).toBe(false)
   })
 
+  it('clears revision state immediately when proposal changes', async () => {
+    vi.mocked(proposalRevisionsApi.getRevisions)
+      .mockResolvedValueOnce([makeRevision()])
+      .mockImplementationOnce(() => new Promise(() => undefined))
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { editing, revisionCount, latestRevision, startEditing } = useProposalRevisions(proposal)
+
+    await vi.waitFor(() => {
+      expect(revisionCount.value).toBe(1)
+    })
+
+    startEditing()
+    proposal.value = makeProposal({ id: 'p-2' })
+    await nextTick()
+
+    expect(editing.value).toBe(false)
+    expect(revisionCount.value).toBe(0)
+    expect(latestRevision.value).toBeNull()
+  })
+
+  it('ignores stale save responses after switching proposals', async () => {
+    let resolveSave!: (revision: ProposalRevision) => void
+    vi.mocked(proposalRevisionsApi.createRevision).mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveSave = resolve
+      }),
+    )
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { saving, revisionCount, latestRevision, startEditing, saveRevision } =
+      useProposalRevisions(proposal)
+
+    startEditing()
+    const savePromise = saveRevision({ revisedPayload: '{"title":"Edited"}', reason: 'Fix' })
+    await nextTick()
+
+    expect(saving.value).toBe(true)
+
+    proposal.value = makeProposal({ id: 'p-2' })
+    await nextTick()
+
+    expect(saving.value).toBe(false)
+
+    resolveSave(makeRevision({ proposalId: 'p-1' }))
+    await savePromise
+
+    expect(revisionCount.value).toBe(0)
+    expect(latestRevision.value).toBeNull()
+  })
+
   it('discards stale load responses when proposal switches quickly', async () => {
     const staleRevisions = [makeRevision({ proposalId: 'p-1', revisionNumber: 1 })]
     const freshRevisions = [

--- a/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useProposalRevisions } from '../../composables/useProposalRevisions'
+import { proposalRevisionsApi } from '../../api/proposalRevisionsApi'
+import type { Proposal as ApiProposal } from '../../types/automation'
+import type { ProposalRevision } from '../../api/proposalRevisionsApi'
+
+vi.mock('../../api/proposalRevisionsApi', () => ({
+  proposalRevisionsApi: {
+    createRevision: vi.fn(),
+    getRevisions: vi.fn(),
+    getLatestRevision: vi.fn(),
+  },
+}))
+
+vi.mock('../../store/toastStore', () => ({
+  useToastStore: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  }),
+}))
+
+function makeProposal(overrides: Partial<ApiProposal> = {}): ApiProposal {
+  return {
+    id: 'p-1',
+    sourceType: 'Chat',
+    sourceReferenceId: null,
+    boardId: 'b-1',
+    requestedByUserId: 'u-1',
+    status: 'PendingReview',
+    riskLevel: 'Low',
+    summary: 'Test',
+    diffPreview: null,
+    validationIssues: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 3600000).toISOString(),
+    decidedAt: null,
+    decidedByUserId: null,
+    appliedAt: null,
+    failureReason: null,
+    correlationId: 'c-1',
+    operations: [
+      {
+        id: 'op-1',
+        proposalId: 'p-1',
+        sequence: 1,
+        actionType: 'CreateCard',
+        targetType: 'Card',
+        targetId: null,
+        parameters: '{"title":"Test"}',
+        idempotencyKey: 'ik-1',
+        expectedVersion: null,
+      },
+    ],
+    ...overrides,
+  } as ApiProposal
+}
+
+function makeRevision(overrides: Partial<ProposalRevision> = {}): ProposalRevision {
+  return {
+    id: 'rev-1',
+    proposalId: 'p-1',
+    revisionNumber: 1,
+    editorUserId: 'u-1',
+    revisedPayload: '{"title":"Edited"}',
+    revisedAt: '2026-01-01T00:00:00Z',
+    reason: 'Fix',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('useProposalRevisions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([])
+  })
+
+  it('starts with editing false and zero revision count', async () => {
+    const proposal = ref<ApiProposal | null>(null)
+    const { editing, revisionCount } = useProposalRevisions(proposal)
+
+    expect(editing.value).toBe(false)
+    expect(revisionCount.value).toBe(0)
+  })
+
+  it('loads revisions when activeProposal changes', async () => {
+    const revisions = [makeRevision()]
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue(revisions)
+
+    const proposal = ref<ApiProposal | null>(null)
+    const { revisionCount, latestRevision } = useProposalRevisions(proposal)
+
+    proposal.value = makeProposal()
+    await nextTick()
+    await vi.waitFor(() => {
+      expect(revisionCount.value).toBe(1)
+    })
+    expect(latestRevision.value).toEqual(revisions[0])
+  })
+
+  it('opens and closes editing mode', () => {
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([])
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { editing, startEditing, cancelEditing } = useProposalRevisions(proposal)
+
+    startEditing()
+    expect(editing.value).toBe(true)
+
+    cancelEditing()
+    expect(editing.value).toBe(false)
+  })
+
+  it('saves a revision and updates state', async () => {
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([])
+    const newRevision = makeRevision({ revisionNumber: 1 })
+    vi.mocked(proposalRevisionsApi.createRevision).mockResolvedValue(newRevision)
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { editing, revisionCount, latestRevision, startEditing, saveRevision } =
+      useProposalRevisions(proposal)
+
+    startEditing()
+    expect(editing.value).toBe(true)
+
+    await saveRevision({ revisedPayload: '{"title":"Edited"}', reason: 'Fix' })
+
+    expect(proposalRevisionsApi.createRevision).toHaveBeenCalledWith('p-1', {
+      revisedPayload: '{"title":"Edited"}',
+      reason: 'Fix',
+    })
+    expect(editing.value).toBe(false)
+    expect(revisionCount.value).toBe(1)
+    expect(latestRevision.value).toEqual(newRevision)
+  })
+
+  it('resets editing when proposal changes', async () => {
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([])
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { editing, startEditing } = useProposalRevisions(proposal)
+
+    startEditing()
+    expect(editing.value).toBe(true)
+
+    proposal.value = makeProposal({ id: 'p-2' })
+    await nextTick()
+
+    expect(editing.value).toBe(false)
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -13,6 +13,9 @@ const mocks = vi.hoisted(() => ({
   getProposalDiff: vi.fn(),
   dismissProposals: vi.fn(),
   getBoards: vi.fn(),
+  createRevision: vi.fn(),
+  getRevisions: vi.fn(),
+  getLatestRevision: vi.fn(),
   successToast: vi.fn(),
   errorToast: vi.fn(),
   infoToast: vi.fn(),
@@ -49,9 +52,9 @@ vi.mock('../../../../store/sessionStore', () => ({
 
 vi.mock('../../../../api/proposalRevisionsApi', () => ({
   proposalRevisionsApi: {
-    createRevision: vi.fn(),
-    getRevisions: vi.fn().mockResolvedValue([]),
-    getLatestRevision: vi.fn().mockResolvedValue(null),
+    createRevision: mocks.createRevision,
+    getRevisions: mocks.getRevisions,
+    getLatestRevision: mocks.getLatestRevision,
   },
 }))
 
@@ -120,6 +123,8 @@ describe('PaperReviewView', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.sessionState.userId = 'u-1'
+    mocks.getRevisions.mockResolvedValue([])
+    mocks.getLatestRevision.mockResolvedValue(null)
   })
   afterEach(() => {
     vi.restoreAllMocks()
@@ -417,6 +422,63 @@ describe('PaperReviewView', () => {
     await flushPromises()
 
     expect(wrapper.find('[data-testid="revision-editor"]').exists()).toBe(true)
+  })
+
+  it('opens revision editing for multi-operation proposals with all operations present', async () => {
+    const wrapper = await mountView([
+      makeProposal({
+        operations: [
+          {
+            id: 'op-1',
+            proposalId: 'proposal-001',
+            sequence: 2,
+            actionType: 'MoveCard',
+            targetType: 'Card',
+            targetId: 'card-1',
+            parameters: '{"columnId":"done"}',
+            idempotencyKey: 'k-2',
+            expectedVersion: 7,
+          },
+          {
+            id: 'op-2',
+            proposalId: 'proposal-001',
+            sequence: 1,
+            actionType: 'CreateCard',
+            targetType: 'Card',
+            targetId: null,
+            parameters: '{"title":"Draft"}',
+            idempotencyKey: 'k-1',
+            expectedVersion: null,
+          },
+        ],
+      }),
+    ])
+
+    await wrapper.find('[data-testid="decision-edit"]').trigger('click')
+    await flushPromises()
+
+    const operationsField = wrapper.get('[data-testid="revision-field-operations"]')
+    const value = JSON.parse((operationsField.element as HTMLTextAreaElement).value)
+
+    expect(value).toHaveLength(2)
+    expect(value.map((operation: { sequence: number }) => operation.sequence)).toEqual([1, 2])
+  })
+
+  it('disables apply and reject while a revision edit is open', async () => {
+    const wrapper = await mountView([makeProposal()])
+
+    await wrapper.find('[data-testid="decision-edit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="decision-apply"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('[data-testid="decision-reject"]').attributes('disabled')).toBeDefined()
+
+    await wrapper.get('[data-testid="decision-apply"]').trigger('click')
+    await wrapper.get('[data-testid="decision-reject"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.rejectProposal).not.toHaveBeenCalled()
   })
 
   it('surfaces feedback when provenance toggle is invoked before collapsible mode exists', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -47,6 +47,14 @@ vi.mock('../../../../store/sessionStore', () => ({
   useSessionStore: () => mocks.sessionState,
 }))
 
+vi.mock('../../../../api/proposalRevisionsApi', () => ({
+  proposalRevisionsApi: {
+    createRevision: vi.fn(),
+    getRevisions: vi.fn().mockResolvedValue([]),
+    getLatestRevision: vi.fn().mockResolvedValue(null),
+  },
+}))
+
 function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
   const now = new Date().toISOString()
   return {
@@ -400,16 +408,15 @@ describe('PaperReviewView', () => {
     )
   })
 
-  it('surfaces feedback when request edit is invoked before backend support exists', async () => {
+  it('opens the revision editor when request edit is clicked', async () => {
     const wrapper = await mountView([makeProposal()])
+
+    expect(wrapper.find('[data-testid="revision-editor"]').exists()).toBe(false)
 
     await wrapper.find('[data-testid="decision-edit"]').trigger('click')
     await flushPromises()
 
-    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
-    expect(mocks.infoToast).toHaveBeenCalledWith(
-      'Request edit is not wired yet; no proposal changes were sent.',
-    )
+    expect(wrapper.find('[data-testid="revision-editor"]').exists()).toBe(true)
   })
 
   it('surfaces feedback when provenance toggle is invoked before collapsible mode exists', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewRevisionEditor.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewRevisionEditor.spec.ts
@@ -40,4 +40,18 @@ describe('ReviewRevisionEditor', () => {
     })
     expect(payload.reason).toBe('Clarify title')
   })
+
+  it('blocks save when an editable JSON field is invalid', async () => {
+    const wrapper = mountEditor('{"operations":[{"sequence":1,"actionType":"CreateCard"}]}')
+
+    await wrapper.get('[data-testid="revision-field-operations"]').setValue('not valid json')
+    await wrapper.get('[data-testid="revision-reason"]').setValue('Break operations')
+
+    expect(wrapper.get('[data-testid="revision-field-operations-error"]').text()).toContain('valid JSON')
+    expect(wrapper.get('[data-testid="revision-save"]').attributes('disabled')).toBeDefined()
+
+    await wrapper.get('[data-testid="revision-save"]').trigger('click')
+
+    expect(wrapper.emitted('save')).toBeUndefined()
+  })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewRevisionEditor.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewRevisionEditor.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ReviewRevisionEditor from '../../../../views/paper/review/ReviewRevisionEditor.vue'
+
+function mountEditor(operationsPayload: string) {
+  return mount(ReviewRevisionEditor, {
+    props: {
+      operationsPayload,
+      saving: false,
+    },
+  })
+}
+
+describe('ReviewRevisionEditor', () => {
+  it('reparses the editable fields when the proposal payload changes', async () => {
+    const wrapper = mountEditor('{"title":"First"}')
+
+    expect(wrapper.get('[data-testid="revision-field-title"]').element).toHaveProperty('value', 'First')
+
+    await wrapper.setProps({ operationsPayload: '{"title":"Second"}' })
+
+    expect(wrapper.get('[data-testid="revision-field-title"]').element).toHaveProperty('value', 'Second')
+  })
+
+  it('preserves original string fields as strings when saving', async () => {
+    const wrapper = mountEditor('{"title":"Original","labels":["bug"]}')
+
+    await wrapper.get('[data-testid="revision-field-title"]').setValue('{"not":"json"}')
+    await wrapper.get('[data-testid="revision-field-labels"]').setValue('["bug","urgent"]')
+    await wrapper.get('[data-testid="revision-reason"]').setValue('Clarify title')
+    await wrapper.get('[data-testid="revision-save"]').trigger('click')
+
+    const saveEvents = wrapper.emitted('save')
+    expect(saveEvents).toHaveLength(1)
+    const payload = saveEvents![0][0] as { revisedPayload: string; reason: string }
+
+    expect(JSON.parse(payload.revisedPayload)).toEqual({
+      title: '{"not":"json"}',
+      labels: ['bug', 'urgent'],
+    })
+    expect(payload.reason).toBe('Clarify title')
+  })
+})

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -6,11 +6,13 @@ import ReviewQueueRail, {
 } from './review/ReviewQueueRail.vue'
 import type { RecentlyAppliedRow } from './review/ReviewRecentApplied.vue'
 import ReviewMain from './review/ReviewMain.vue'
+import ReviewRevisionEditor from './review/ReviewRevisionEditor.vue'
 import ReviewRightRail from './review/ReviewRightRail.vue'
 import { useReviewProposals } from '../../composables/useReviewProposals'
 import { useReviewActions } from '../../composables/useReviewActions'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
 import { useReviewKeymap } from '../../composables/useReviewKeymap'
+import { useProposalRevisions } from '../../composables/useProposalRevisions'
 import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
 import { normalizeProposalSourceType, normalizeProposalStatus } from '../../utils/automation'
@@ -153,6 +155,26 @@ watch(
 )
 
 const selectors = usePaperReviewSelectors(activeProposal)
+
+const {
+  editing: revisionEditing,
+  saving: revisionSaving,
+  revisionCount,
+  latestRevision,
+  startEditing: startRevisionEditing,
+  cancelEditing: cancelRevisionEditing,
+  saveRevision,
+} = useProposalRevisions(activeProposal)
+
+const editablePayload = computed(() => {
+  const p = activeProposal.value
+  if (!p) return '{}'
+  if (latestRevision.value) return latestRevision.value.revisedPayload
+  const ops = p.operations ?? []
+  if (ops.length === 0) return '{}'
+  const firstOp = ops[0]
+  return firstOp.parameters ?? '{}'
+})
 
 // --- Queue rail data ---------------------------------------------------
 
@@ -469,7 +491,7 @@ function onReject() {
 function onRequestEdit() {
   const p = activeProposal.value
   if (!p) return
-  toast.info('Request edit is not wired yet; no proposal changes were sent.')
+  startRevisionEditing()
 }
 
 function onDefer() {
@@ -538,28 +560,43 @@ function onQueueFilterChange(filter: QueueFilter) {
       @select="selectProposal"
     />
 
-    <ReviewMain
-      v-if="activeProposal"
-      :serial="headerSerial"
-      :meta="headerMeta"
-      :title-parts="titleParts"
-      :lede="lede"
-      :decision-summary="decisionSummary"
-      :busy="busy"
-      :confidence="selectors.confidenceBreakdown.value"
-      :before="before"
-      :after="after"
-      :fields="fields"
-      :change-sub-title="changeSubTitle"
-      :provenance="selectors.provenance.value"
-      :side-effects="selectors.sideEffects.value"
-      :conflicts="selectors.conflicts.value"
-      :history="selectors.history.value"
-      @apply="onApply"
-      @reject="onReject"
-      @request-edit="onRequestEdit"
-      @defer="onDefer"
-    />
+    <div v-if="activeProposal" class="paper-review-deep__main-col">
+      <div
+        v-if="revisionCount > 0"
+        class="paper-review-deep__revision-badge"
+        data-testid="revision-badge"
+      >
+        {{ revisionCount }} {{ revisionCount === 1 ? 'revision' : 'revisions' }}
+      </div>
+      <ReviewMain
+        :serial="headerSerial"
+        :meta="headerMeta"
+        :title-parts="titleParts"
+        :lede="lede"
+        :decision-summary="decisionSummary"
+        :busy="busy"
+        :confidence="selectors.confidenceBreakdown.value"
+        :before="before"
+        :after="after"
+        :fields="fields"
+        :change-sub-title="changeSubTitle"
+        :provenance="selectors.provenance.value"
+        :side-effects="selectors.sideEffects.value"
+        :conflicts="selectors.conflicts.value"
+        :history="selectors.history.value"
+        @apply="onApply"
+        @reject="onReject"
+        @request-edit="onRequestEdit"
+        @defer="onDefer"
+      />
+      <ReviewRevisionEditor
+        v-if="revisionEditing"
+        :operations-payload="editablePayload"
+        :saving="revisionSaving"
+        @save="saveRevision"
+        @cancel="cancelRevisionEditing"
+      />
+    </div>
     <div v-else class="paper-review-deep__empty" data-testid="paper-review-empty">
       <template v-if="hasFilterEmptyState">
         <div class="tk-eyebrow">Queue · {{ awaitingCount }} awaiting</div>
@@ -602,6 +639,21 @@ function onQueueFilterChange(filter: QueueFilter) {
   background: var(--paper);
   height: 100%;
   font-family: var(--sans);
+}
+.paper-review-deep__main-col {
+  overflow: auto;
+  min-width: 0;
+}
+.paper-review-deep__revision-badge {
+  padding: 4px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ember, #c2410c);
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  text-align: right;
 }
 .paper-review-deep__empty {
   padding: 80px 56px;

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -491,6 +491,14 @@ function onReject() {
 function onRequestEdit() {
   const p = activeProposal.value
   if (!p) return
+  if (normalizeProposalStatus(p.status) !== 'PendingReview' || isProposalExpired(p)) {
+    toast.info('This proposal can no longer be edited.')
+    return
+  }
+  if ((p.operations?.length ?? 0) > 1) {
+    toast.info('Editing multi-operation proposals is not yet supported.')
+    return
+  }
   startRevisionEditing()
 }
 

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -172,8 +172,19 @@ const editablePayload = computed(() => {
   if (latestRevision.value) return latestRevision.value.revisedPayload
   const ops = p.operations ?? []
   if (ops.length === 0) return '{}'
-  const firstOp = ops[0]
-  return firstOp.parameters ?? '{}'
+  return JSON.stringify({
+    operations: [...ops]
+      .sort((a, b) => a.sequence - b.sequence)
+      .map((operation) => ({
+        sequence: operation.sequence,
+        actionType: operation.actionType,
+        targetType: operation.targetType,
+        targetId: operation.targetId,
+        parameters: operation.parameters,
+        idempotencyKey: operation.idempotencyKey,
+        expectedVersion: operation.expectedVersion,
+      })),
+  })
 })
 
 // --- Queue rail data ---------------------------------------------------
@@ -452,7 +463,8 @@ const whyNowBody = computed(() => {
 
 // --- Action wiring -----------------------------------------------------
 
-const busy = computed(() => proposalActionBusyId.value !== null)
+const revisionBusy = computed(() => revisionEditing.value || revisionSaving.value)
+const busy = computed(() => proposalActionBusyId.value !== null || revisionBusy.value)
 
 function isApplyActionable(proposal: ApiProposal): boolean {
   const status = normalizeProposalStatus(proposal.status)
@@ -466,6 +478,10 @@ function isRejectActionable(proposal: ApiProposal): boolean {
 function onApply() {
   const p = activeProposal.value
   if (!p) return
+  if (revisionBusy.value) {
+    toast.info('Save or cancel the revision before applying this proposal.')
+    return
+  }
   if (!isApplyActionable(p)) {
     toast.info('This proposal is no longer actionable. Refresh review to see current status.')
     return
@@ -481,6 +497,10 @@ function onApply() {
 function onReject() {
   const p = activeProposal.value
   if (!p) return
+  if (revisionBusy.value) {
+    toast.info('Save or cancel the revision before rejecting this proposal.')
+    return
+  }
   if (!isRejectActionable(p)) {
     toast.info('This proposal can no longer be rejected. Refresh review to see current status.')
     return
@@ -491,12 +511,9 @@ function onReject() {
 function onRequestEdit() {
   const p = activeProposal.value
   if (!p) return
+  if (revisionSaving.value) return
   if (normalizeProposalStatus(p.status) !== 'PendingReview' || isProposalExpired(p)) {
     toast.info('This proposal can no longer be edited.')
-    return
-  }
-  if ((p.operations?.length ?? 0) > 1) {
-    toast.info('Editing multi-operation proposals is not yet supported.')
     return
   }
   startRevisionEditing()

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewRevisionEditor.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewRevisionEditor.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import PaperHLBtn from '../../../components/paper/PaperHLBtn.vue'
+import PaperTagstamp from '../../../components/paper/PaperTagstamp.vue'
+
+const props = defineProps<{
+  operationsPayload: string
+  saving?: boolean
+}>()
+
+const emit = defineEmits<{
+  (event: 'save', payload: { revisedPayload: string; reason: string }): void
+  (event: 'cancel'): void
+}>()
+
+interface EditableField {
+  key: string
+  value: string
+}
+
+const fields = ref<EditableField[]>([])
+const reason = ref('')
+const parseError = ref(false)
+
+onMounted(() => {
+  try {
+    const parsed = JSON.parse(props.operationsPayload) as Record<string, unknown>
+    fields.value = Object.entries(parsed).map(([key, value]) => ({
+      key,
+      value: typeof value === 'string' ? value : JSON.stringify(value),
+    }))
+    parseError.value = false
+  } catch {
+    fields.value = [{ key: 'payload', value: props.operationsPayload }]
+    parseError.value = true
+  }
+})
+
+const canSave = computed(() => {
+  return reason.value.trim().length > 0 && !props.saving
+})
+
+function onSave() {
+  if (!canSave.value) return
+
+  let revisedPayload: string
+  if (parseError.value) {
+    revisedPayload = fields.value[0]?.value ?? ''
+  } else {
+    const obj: Record<string, unknown> = {}
+    for (const field of fields.value) {
+      try {
+        obj[field.key] = JSON.parse(field.value) as unknown
+      } catch {
+        obj[field.key] = field.value
+      }
+    }
+    revisedPayload = JSON.stringify(obj)
+  }
+
+  emit('save', { revisedPayload, reason: reason.value.trim() })
+}
+</script>
+
+<template>
+  <div class="revision-editor card" data-testid="revision-editor">
+    <div class="revision-editor__header">
+      <PaperTagstamp tone="ember">EDIT BEFORE APPROVE</PaperTagstamp>
+    </div>
+
+    <div class="revision-editor__fields">
+      <div v-for="field in fields" :key="field.key" class="revision-editor__field">
+        <label :for="`revision-field-${field.key}`" class="revision-editor__label">{{ field.key }}</label>
+        <textarea
+          :id="`revision-field-${field.key}`"
+          v-model="field.value"
+          class="revision-editor__input"
+          rows="2"
+          :data-testid="`revision-field-${field.key}`"
+        />
+      </div>
+    </div>
+
+    <div class="revision-editor__reason">
+      <label for="revision-reason" class="revision-editor__label">Reason for edit</label>
+      <input
+        id="revision-reason"
+        v-model="reason"
+        type="text"
+        class="revision-editor__reason-input"
+        placeholder="Why are you editing this proposal?"
+        data-testid="revision-reason"
+      />
+    </div>
+
+    <div class="revision-editor__actions">
+      <PaperHLBtn
+        label="Cancel"
+        :disabled="saving"
+        data-testid="revision-cancel"
+        @click="emit('cancel')"
+      />
+      <PaperHLBtn
+        label="Save revision"
+        variant="ember"
+        :disabled="!canSave"
+        data-testid="revision-save"
+        @click="onSave"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.revision-editor {
+  margin-top: 16px;
+  padding: 16px;
+}
+.revision-editor__header {
+  margin-bottom: 12px;
+}
+.revision-editor__fields {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.revision-editor__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.revision-editor__label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-2);
+}
+.revision-editor__input {
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--paper);
+  color: var(--text);
+  resize: vertical;
+}
+.revision-editor__reason {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.revision-editor__reason-input {
+  font-size: 13px;
+  padding: 8px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--paper);
+  color: var(--text);
+}
+.revision-editor__actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewRevisionEditor.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewRevisionEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch } from 'vue'
 import PaperHLBtn from '../../../components/paper/PaperHLBtn.vue'
 import PaperTagstamp from '../../../components/paper/PaperTagstamp.vue'
 
@@ -16,25 +16,29 @@ const emit = defineEmits<{
 interface EditableField {
   key: string
   value: string
+  valueKind: 'string' | 'json'
 }
 
 const fields = ref<EditableField[]>([])
 const reason = ref('')
 const parseError = ref(false)
 
-onMounted(() => {
+function parsePayload() {
   try {
     const parsed = JSON.parse(props.operationsPayload) as Record<string, unknown>
     fields.value = Object.entries(parsed).map(([key, value]) => ({
       key,
       value: typeof value === 'string' ? value : JSON.stringify(value),
+      valueKind: typeof value === 'string' ? 'string' : 'json',
     }))
     parseError.value = false
   } catch {
-    fields.value = [{ key: 'payload', value: props.operationsPayload }]
+    fields.value = [{ key: 'payload', value: props.operationsPayload, valueKind: 'string' }]
     parseError.value = true
   }
-})
+}
+
+watch(() => props.operationsPayload, parsePayload, { immediate: true })
 
 const canSave = computed(() => {
   return reason.value.trim().length > 0 && !props.saving
@@ -49,6 +53,11 @@ function onSave() {
   } else {
     const obj: Record<string, unknown> = {}
     for (const field of fields.value) {
+      if (field.valueKind === 'string') {
+        obj[field.key] = field.value
+        continue
+      }
+
       try {
         obj[field.key] = JSON.parse(field.value) as unknown
       } catch {

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewRevisionEditor.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewRevisionEditor.vue
@@ -23,6 +23,23 @@ const fields = ref<EditableField[]>([])
 const reason = ref('')
 const parseError = ref(false)
 
+const jsonFieldErrors = computed(() => {
+  const errors: Record<string, string> = {}
+  for (const field of fields.value) {
+    if (field.valueKind !== 'json') continue
+
+    try {
+      JSON.parse(field.value)
+    } catch {
+      errors[field.key] = 'Enter valid JSON before saving.'
+    }
+  }
+
+  return errors
+})
+
+const hasJsonFieldErrors = computed(() => Object.keys(jsonFieldErrors.value).length > 0)
+
 function parsePayload() {
   try {
     const parsed = JSON.parse(props.operationsPayload) as Record<string, unknown>
@@ -41,7 +58,7 @@ function parsePayload() {
 watch(() => props.operationsPayload, parsePayload, { immediate: true })
 
 const canSave = computed(() => {
-  return reason.value.trim().length > 0 && !props.saving
+  return reason.value.trim().length > 0 && !props.saving && !hasJsonFieldErrors.value
 })
 
 function onSave() {
@@ -61,7 +78,7 @@ function onSave() {
       try {
         obj[field.key] = JSON.parse(field.value) as unknown
       } catch {
-        obj[field.key] = field.value
+        return
       }
     }
     revisedPayload = JSON.stringify(obj)
@@ -87,6 +104,13 @@ function onSave() {
           rows="2"
           :data-testid="`revision-field-${field.key}`"
         />
+        <p
+          v-if="jsonFieldErrors[field.key]"
+          class="revision-editor__error"
+          :data-testid="`revision-field-${field.key}-error`"
+        >
+          {{ jsonFieldErrors[field.key] }}
+        </p>
       </div>
     </div>
 
@@ -154,6 +178,11 @@ function onSave() {
   background: var(--paper);
   color: var(--text);
   resize: vertical;
+}
+.revision-editor__error {
+  margin: 0;
+  font-size: 12px;
+  color: var(--td-color-error);
 }
 .revision-editor__reason {
   margin-top: 12px;


### PR DESCRIPTION
## Summary
- Add 3 proposal revision API endpoints (create/list/latest) as sub-resources on AutomationProposalsController, with EditorUserId derived from JWT claims
- Create proposalRevisionsApi.ts frontend HTTP client with typed interfaces
- Add edit-before-approve UI in PaperReviewView: Request edit opens an inline revision editor with reason tracking
- Store full sorted proposal operation snapshots for edits, including multi-operation proposals
- Harden revision editing against stale loads/saves, payload prop changes, string type coercion, invalid JSON, and apply/reject races while editing

## Scope note
- This PR stores and reviews revision payloads, but approval/execution still applies the original proposal operations. The remaining apply-revised-payload wiring is follow-up work before #976 can be closed.

## Test plan
- [x] 9 backend integration tests for revision endpoints, including invalid RevisedPayload JSON returning ValidationError
- [x] 5 frontend proposalRevisionsApi unit tests (create, list, latest, 404 handling, error rethrow)
- [x] frontend revision lifecycle/editor/view regressions: reparse on payload changes, preserve string field types, clear stale state on proposal switch, ignore stale saves, multi-op editable payload, and disable decisions while editing
- [x] dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release --filter "FullyQualifiedName~ProposalRevisionApiTests"
- [x] npm run test -- --run src/tests/views/paper/review/ReviewRevisionEditor.spec.ts src/tests/composables/useProposalRevisions.spec.ts src/tests/views/paper/review/PaperReviewView.spec.ts
- [x] npm run typecheck

Refs #976