### PR TITLE
RFAI-05: Wire Paper Review deep-dive to real backend APIs

### DIFF
--- a/frontend/taskdeck-web/src/api/proposalDeepReviewApi.ts
+++ b/frontend/taskdeck-web/src/api/proposalDeepReviewApi.ts
@@ -62,49 +62,59 @@ export interface SimilarPastResultDto {
   applyRate: number
 }
 
+export interface RequestOptions {
+  signal?: AbortSignal
+}
+
 function encodedId(id: string): string {
   return encodeURIComponent(id)
 }
 
 export const proposalDeepReviewApi = {
-  async getProvenance(proposalId: string): Promise<ProvenanceRowDto[]> {
+  async getProvenance(proposalId: string, options?: RequestOptions): Promise<ProvenanceRowDto[]> {
     const { data } = await http.get<ProvenanceRowDto[]>(
       `/automation/proposals/${encodedId(proposalId)}/provenance`,
+      { signal: options?.signal },
     )
     return data
   },
 
-  async getConfidence(proposalId: string): Promise<ConfidenceBreakdownDto> {
+  async getConfidence(proposalId: string, options?: RequestOptions): Promise<ConfidenceBreakdownDto> {
     const { data } = await http.get<ConfidenceBreakdownDto>(
       `/automation/proposals/${encodedId(proposalId)}/confidence`,
+      { signal: options?.signal },
     )
     return data
   },
 
-  async getSideEffects(proposalId: string): Promise<ProposalSideEffectsDto> {
+  async getSideEffects(proposalId: string, options?: RequestOptions): Promise<ProposalSideEffectsDto> {
     const { data } = await http.get<ProposalSideEffectsDto>(
       `/automation/proposals/${encodedId(proposalId)}/side-effects`,
+      { signal: options?.signal },
     )
     return data
   },
 
-  async getConflicts(proposalId: string): Promise<ConflictRowDto[]> {
+  async getConflicts(proposalId: string, options?: RequestOptions): Promise<ConflictRowDto[]> {
     const { data } = await http.get<ConflictRowDto[]>(
       `/automation/proposals/${encodedId(proposalId)}/conflicts`,
+      { signal: options?.signal },
     )
     return data
   },
 
-  async getHistory(proposalId: string): Promise<CardHistoryRowDto[]> {
+  async getHistory(proposalId: string, options?: RequestOptions): Promise<CardHistoryRowDto[]> {
     const { data } = await http.get<CardHistoryRowDto[]>(
       `/automation/proposals/${encodedId(proposalId)}/history`,
+      { signal: options?.signal },
     )
     return data
   },
 
-  async getSimilarPast(proposalId: string): Promise<SimilarPastResultDto> {
+  async getSimilarPast(proposalId: string, options?: RequestOptions): Promise<SimilarPastResultDto> {
     const { data } = await http.get<SimilarPastResultDto>(
       `/automation/proposals/${encodedId(proposalId)}/similar-past`,
+      { signal: options?.signal },
     )
     return data
   },

--- a/frontend/taskdeck-web/src/api/proposalDeepReviewApi.ts
+++ b/frontend/taskdeck-web/src/api/proposalDeepReviewApi.ts
@@ -1,0 +1,111 @@
+import http from './http'
+
+export interface ProvenanceRowDto {
+  icon: string
+  key: string
+  value: string
+  weight: string
+}
+
+export interface ConfidenceComponentDto {
+  key: string
+  value: number
+}
+
+export interface ConfidenceBreakdownDto {
+  overall: number
+  components: ConfidenceComponentDto[]
+  note: string | null
+  threshold: number
+  meetsThreshold: boolean
+}
+
+export interface SideEffectRowDto {
+  key: string
+  value: string
+  tone: 'active' | 'passive'
+}
+
+export interface ReversibilityDto {
+  summary: string
+  description: string
+  windowMs: number
+}
+
+export interface ProposalSideEffectsDto {
+  rows: SideEffectRowDto[]
+  reversibility: ReversibilityDto
+}
+
+export interface ConflictRowDto {
+  tone: 'Warn' | 'Info' | 'Ok'
+  key: string
+  value: string
+}
+
+export interface CardHistoryRowDto {
+  serial: string
+  event: string
+  age: string
+  status: 'Pending' | 'Applied' | 'Past'
+}
+
+export interface SimilarPastDecisionDto {
+  serial: string
+  title: string
+  verdict: string
+  date: string
+}
+
+export interface SimilarPastResultDto {
+  decisions: SimilarPastDecisionDto[]
+  applyRate: number
+}
+
+function encodedId(id: string): string {
+  return encodeURIComponent(id)
+}
+
+export const proposalDeepReviewApi = {
+  async getProvenance(proposalId: string): Promise<ProvenanceRowDto[]> {
+    const { data } = await http.get<ProvenanceRowDto[]>(
+      `/automation/proposals/${encodedId(proposalId)}/provenance`,
+    )
+    return data
+  },
+
+  async getConfidence(proposalId: string): Promise<ConfidenceBreakdownDto> {
+    const { data } = await http.get<ConfidenceBreakdownDto>(
+      `/automation/proposals/${encodedId(proposalId)}/confidence`,
+    )
+    return data
+  },
+
+  async getSideEffects(proposalId: string): Promise<ProposalSideEffectsDto> {
+    const { data } = await http.get<ProposalSideEffectsDto>(
+      `/automation/proposals/${encodedId(proposalId)}/side-effects`,
+    )
+    return data
+  },
+
+  async getConflicts(proposalId: string): Promise<ConflictRowDto[]> {
+    const { data } = await http.get<ConflictRowDto[]>(
+      `/automation/proposals/${encodedId(proposalId)}/conflicts`,
+    )
+    return data
+  },
+
+  async getHistory(proposalId: string): Promise<CardHistoryRowDto[]> {
+    const { data } = await http.get<CardHistoryRowDto[]>(
+      `/automation/proposals/${encodedId(proposalId)}/history`,
+    )
+    return data
+  },
+
+  async getSimilarPast(proposalId: string): Promise<SimilarPastResultDto> {
+    const { data } = await http.get<SimilarPastResultDto>(
+      `/automation/proposals/${encodedId(proposalId)}/similar-past`,
+    )
+    return data
+  },
+}

--- a/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
+++ b/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
@@ -70,26 +70,27 @@ export interface PaperReviewSelectors {
   history: ComputedRef<HistoryRow[]>
   similarPast: ComputedRef<SimilarPastRow[]>
   similarPastApplyRate: ComputedRef<{ applied: number; total: number; ratio: number }>
+  loading: ComputedRef<boolean>
 }
 
-const EMPTY_PROVENANCE: ProvenanceRow[] = []
-const EMPTY_CONFLICTS: ConflictRow[] = []
-const EMPTY_HISTORY: HistoryRow[] = []
-const EMPTY_SIMILAR: SimilarPastRow[] = []
-const EMPTY_SIDE_EFFECTS: SideEffects = {
-  rows: [],
-  reversibility: {
+const EMPTY_PROVENANCE: ProvenanceRow[] = Object.freeze([] as ProvenanceRow[]) as ProvenanceRow[]
+const EMPTY_CONFLICTS: ConflictRow[] = Object.freeze([] as ConflictRow[]) as ConflictRow[]
+const EMPTY_HISTORY: HistoryRow[] = Object.freeze([] as HistoryRow[]) as HistoryRow[]
+const EMPTY_SIMILAR: SimilarPastRow[] = Object.freeze([] as SimilarPastRow[]) as SimilarPastRow[]
+const EMPTY_SIDE_EFFECTS: SideEffects = Object.freeze({
+  rows: Object.freeze([] as SideEffectRow[]) as SideEffectRow[],
+  reversibility: Object.freeze({
     summary: '6 hours · single keystroke',
     description: 'Undo restores the prior state. Nothing is lost.',
     windowMs: 6 * 60 * 60 * 1000,
     appliedAt: null,
-  },
-}
-const EMPTY_CONFIDENCE: ConfidenceBreakdown = {
+  }) as SideEffects['reversibility'],
+}) as SideEffects
+const EMPTY_CONFIDENCE: ConfidenceBreakdown = Object.freeze({
   overall: 0,
-  components: [],
+  components: Object.freeze([] as ConfidenceBreakdown['components']) as ConfidenceBreakdown['components'],
   threshold: 0.7,
-}
+}) as ConfidenceBreakdown
 
 const VALID_WEIGHTS = new Set<ProvenanceWeight>(['primary', 'contextual', 'excluded', 'inferred'])
 
@@ -125,10 +126,14 @@ function mapHistoryStatus(status: string): 'pending' | 'applied' | 'past' {
   }
 }
 
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v))
+}
+
 function mapConfidence(dto: ConfidenceBreakdownDto): ConfidenceBreakdown {
   return {
-    overall: dto.overall,
-    components: dto.components.map((c) => ({ key: c.key, value: c.value })),
+    overall: clamp01(dto.overall),
+    components: dto.components.map((c) => ({ key: c.key, value: clamp01(c.value) })),
     note: dto.note ?? undefined,
     threshold: dto.threshold,
   }
@@ -177,13 +182,22 @@ export function usePaperReviewSelectors(
   const conflictsData: Ref<ConflictRow[]> = ref([])
   const historyData: Ref<HistoryRow[]> = ref([])
   const similarPastData: Ref<SimilarPastRow[]> = ref([])
+  const isLoading = ref(false)
 
   let fetchGeneration = 0
+  let abortController: AbortController | null = null
 
   watch(
     () => activeProposal.value?.id,
     async (proposalId) => {
+      // Abort any in-flight requests from the previous watcher invocation
+      if (abortController) {
+        abortController.abort()
+        abortController = null
+      }
+
       if (!proposalId) {
+        isLoading.value = false
         provenanceData.value = EMPTY_PROVENANCE
         sideEffectsData.value = EMPTY_SIDE_EFFECTS
         confidenceData.value = EMPTY_CONFIDENCE
@@ -194,19 +208,27 @@ export function usePaperReviewSelectors(
       }
 
       const generation = ++fetchGeneration
+      const controller = new AbortController()
+      abortController = controller
+      const signal = controller.signal
+
       const proposal = activeProposal.value
       const appliedAt = proposal?.appliedAt ? new Date(proposal.appliedAt).getTime() : null
 
+      isLoading.value = true
+
       const results = await Promise.allSettled([
-        proposalDeepReviewApi.getProvenance(proposalId),
-        proposalDeepReviewApi.getConfidence(proposalId),
-        proposalDeepReviewApi.getSideEffects(proposalId),
-        proposalDeepReviewApi.getConflicts(proposalId),
-        proposalDeepReviewApi.getHistory(proposalId),
-        proposalDeepReviewApi.getSimilarPast(proposalId),
+        proposalDeepReviewApi.getProvenance(proposalId, { signal }),
+        proposalDeepReviewApi.getConfidence(proposalId, { signal }),
+        proposalDeepReviewApi.getSideEffects(proposalId, { signal }),
+        proposalDeepReviewApi.getConflicts(proposalId, { signal }),
+        proposalDeepReviewApi.getHistory(proposalId, { signal }),
+        proposalDeepReviewApi.getSimilarPast(proposalId, { signal }),
       ])
 
       if (generation !== fetchGeneration) return
+
+      isLoading.value = false
 
       const [prov, conf, side, confl, hist, sim] = results
 
@@ -244,6 +266,8 @@ export function usePaperReviewSelectors(
     return { applied, total, ratio: total === 0 ? 0 : applied / total }
   })
 
+  const loading = computed(() => isLoading.value)
+
   return {
     provenance,
     sideEffects,
@@ -252,5 +276,6 @@ export function usePaperReviewSelectors(
     history,
     similarPast,
     similarPastApplyRate,
+    loading,
   }
 }

--- a/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
+++ b/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
@@ -1,23 +1,14 @@
-import { computed, type ComputedRef } from 'vue'
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
 import type { Proposal as ApiProposal } from '../types/automation'
-
-/**
- * usePaperReviewSelectors — extends `useReviewProposals` output with the
- * Paper deep-Review selectors (provenance, side-effects, confidence
- * breakdown, conflicts, history, similar past).
- *
- * Backend gaps: as of 2026-04 the API does not yet expose these fields on
- * `Proposal`. Until the backend lands the corresponding shape, we feed the
- * surface from a feature-flagged demo stub so the Paper deep-Review view is
- * complete and reviewable. Each gap has an open follow-up issue (see
- * `paper-review-backend-gap-*` and references to PAPER-06 / #1002).
- *
- * The flag `PAPER_REVIEW_DEMO_FILL` defaults to `true`. When the backend
- * starts returning real data on the proposal payload, switch the selector to
- * read from there and flip the flag off (or wire to `featureFlagStore`).
- */
-
-const PAPER_REVIEW_DEMO_FILL = true
+import { proposalDeepReviewApi } from '../api/proposalDeepReviewApi'
+import type {
+  ProvenanceRowDto,
+  ConfidenceBreakdownDto,
+  ProposalSideEffectsDto,
+  ConflictRowDto,
+  CardHistoryRowDto,
+  SimilarPastResultDto,
+} from '../api/proposalDeepReviewApi'
 
 export type ProvenanceWeight = 'primary' | 'contextual' | 'excluded' | 'inferred'
 
@@ -31,7 +22,6 @@ export interface ProvenanceRow {
 export interface SideEffectRow {
   key: string
   value: string
-  /** `active` rows are styled in serif italic with ember eyebrow. */
   tone: 'active' | 'passive'
 }
 
@@ -40,21 +30,15 @@ export interface SideEffects {
   reversibility: {
     summary: string
     description: string
-    /** Window in milliseconds for the undo timeline. Defaults to 6 h. */
     windowMs: number
-    /** When the apply happened (ms epoch). Pending proposals do not have a running undo window. */
     appliedAt: number | null
   }
 }
 
 export interface ConfidenceBreakdown {
-  /** Aggregate value used by the dial (0..1). */
   overall: number
-  /** Per-component bars; rendered in the right rail. */
   components: Array<{ key: string; value: number }>
-  /** Footer note explaining a low component, when present. */
   note?: string
-  /** Apply threshold from settings, used for the dial caption. */
   threshold: number
 }
 
@@ -85,7 +69,6 @@ export interface PaperReviewSelectors {
   conflicts: ComputedRef<ConflictRow[]>
   history: ComputedRef<HistoryRow[]>
   similarPast: ComputedRef<SimilarPastRow[]>
-  /** Aggregate apply rate of the similar-past list. */
   similarPastApplyRate: ComputedRef<{ applied: number; total: number; ratio: number }>
 }
 
@@ -108,128 +91,151 @@ const EMPTY_CONFIDENCE: ConfidenceBreakdown = {
   threshold: 0.7,
 }
 
-// TODO(#1002): Replace each demo block with backend-driven data once the
-// gap-* issues land. The shape is stable; only the source changes.
-const DEMO_PROVENANCE: ProvenanceRow[] = [
-  {
-    icon: '📄',
-    key: 'card body',
-    value: 'Card description · 178 words · last edited yesterday',
-    weight: 'primary',
-  },
-  {
-    icon: '🔗',
-    key: 'design-doc',
-    value: 'Dark Mode QA checklist · 5 items · attached last week',
-    weight: 'primary',
-  },
-  {
-    icon: '📜',
-    key: 'board activity · 7 entries',
-    value: 'Recent moves on this card and adjacent cards · last 14 days',
-    weight: 'contextual',
-  },
-  {
-    icon: '⊘',
-    key: 'not read',
-    value: 'Other boards · private cards · captures with different scope',
-    weight: 'excluded',
-  },
-  {
-    icon: '✦',
-    key: 'inferred',
-    value: 'Splitting threshold = 5+ subtasks OR >2 days estimated.',
-    weight: 'inferred',
-  },
-]
+const VALID_WEIGHTS = new Set<ProvenanceWeight>(['primary', 'contextual', 'excluded', 'inferred'])
 
-const DEMO_SIDE_EFFECT_ROWS: SideEffectRow[] = [
-  { key: 'Cards', value: '3 created · 1 archived (30 days)', tone: 'active' },
-  { key: 'Subtasks', value: '8 distributed · none lost · checkmarks preserved', tone: 'active' },
-  { key: 'Comments', value: 'Original 4 comments stay on the archived parent', tone: 'passive' },
-  { key: 'Activity log', value: "Single entry: 'applied #014'", tone: 'active' },
-  { key: 'Notifications', value: 'Author only · no team notify (solo board)', tone: 'passive' },
-  { key: 'Webhooks', value: 'None · no integrations active on this board', tone: 'passive' },
-  { key: 'Calendar', value: 'Untouched · due dates preserved or blank', tone: 'passive' },
-]
+function mapProvenanceRow(dto: ProvenanceRowDto): ProvenanceRow {
+  const weight = dto.weight.toLowerCase() as ProvenanceWeight
+  return {
+    icon: dto.icon,
+    key: dto.key,
+    value: dto.value,
+    weight: VALID_WEIGHTS.has(weight) ? weight : 'contextual',
+  }
+}
 
-const DEMO_CONFLICTS: ConflictRow[] = [
-  {
-    tone: 'warn',
-    key: 'Stale assignment',
-    value: 'Assignee was last active 9 days ago. Confirm before applying or reassign.',
-  },
-  {
-    tone: 'info',
-    key: 'Linked capture is older',
-    value: 'Source capture is 2 days old. Still relevant?',
-  },
-  { tone: 'ok', key: 'No collisions', value: 'No other proposals touch this card right now.' },
-]
+function mapConflictTone(tone: string): 'warn' | 'info' | 'ok' {
+  switch (tone.toLowerCase()) {
+    case 'warn':
+      return 'warn'
+    case 'ok':
+      return 'ok'
+    default:
+      return 'info'
+  }
+}
 
-const DEMO_HISTORY: HistoryRow[] = [
-  { serial: '#014', event: 'haiku proposed split into 3', age: '11:42', status: 'pending' },
-  { serial: '#011', event: 'subtask checked · audit AA', age: '09:18', status: 'applied' },
-  { serial: '#009', event: "capture linked: 'Paper at Night QA'", age: 'yest 16:04', status: 'past' },
-  { serial: '#007', event: 'body rewritten', age: 'yest 14:22', status: 'past' },
-  { serial: '#003', event: 'label · theme added', age: 'Mon 11:00', status: 'past' },
-  { serial: '#001', event: 'card created', age: 'wk 17 Mon', status: 'past' },
-]
+function mapHistoryStatus(status: string): 'pending' | 'applied' | 'past' {
+  switch (status.toLowerCase()) {
+    case 'pending':
+      return 'pending'
+    case 'applied':
+      return 'applied'
+    default:
+      return 'past'
+  }
+}
 
-const DEMO_SIMILAR: SimilarPastRow[] = [
-  { serial: '#984', title: "Split 'Auth flow' → 4 cards", verdict: 'applied', date: 'wk 14' },
-  { serial: '#962', title: "Split 'Onboarding' → 3", verdict: 'rejected', date: 'wk 13' },
-  { serial: '#941', title: 'Merge dupes (C-082, C-083)', verdict: 'applied', date: 'wk 12' },
-]
+function mapConfidence(dto: ConfidenceBreakdownDto): ConfidenceBreakdown {
+  return {
+    overall: dto.overall,
+    components: dto.components.map((c) => ({ key: c.key, value: c.value })),
+    note: dto.note ?? undefined,
+    threshold: dto.threshold,
+  }
+}
 
-const DEMO_CONFIDENCE: ConfidenceBreakdown = {
-  overall: 0.84,
-  components: [
-    { key: 'Pattern match', value: 0.92 },
-    { key: 'Reach', value: 0.88 },
-    { key: 'Reversibility', value: 0.99 },
-    { key: 'Recency · ctx', value: 0.61 },
-  ],
-  note: 'Lower-than-average on recency: source capture is 2 days old. Consider double-checking before apply.',
-  threshold: 0.7,
+function mapSideEffects(dto: ProposalSideEffectsDto, appliedAt: number | null): SideEffects {
+  return {
+    rows: dto.rows.map((r) => ({ key: r.key, value: r.value, tone: r.tone })),
+    reversibility: {
+      summary: dto.reversibility.summary,
+      description: dto.reversibility.description,
+      windowMs: dto.reversibility.windowMs,
+      appliedAt,
+    },
+  }
+}
+
+function mapConflicts(dtos: ConflictRowDto[]): ConflictRow[] {
+  return dtos.map((d) => ({ tone: mapConflictTone(d.tone), key: d.key, value: d.value }))
+}
+
+function mapHistory(dtos: CardHistoryRowDto[]): HistoryRow[] {
+  return dtos.map((d) => ({
+    serial: d.serial,
+    event: d.event,
+    age: d.age,
+    status: mapHistoryStatus(d.status),
+  }))
+}
+
+function mapSimilarPast(dto: SimilarPastResultDto): SimilarPastRow[] {
+  return dto.decisions.map((d) => ({
+    serial: d.serial,
+    title: d.title,
+    verdict: d.verdict.toLowerCase() === 'applied' ? 'applied' : 'rejected',
+    date: d.date,
+  }))
 }
 
 export function usePaperReviewSelectors(
   activeProposal: ComputedRef<ApiProposal | null>,
 ): PaperReviewSelectors {
-  const useDemo = computed(() => PAPER_REVIEW_DEMO_FILL && activeProposal.value !== null)
+  const provenanceData: Ref<ProvenanceRow[]> = ref([])
+  const sideEffectsData: Ref<SideEffects> = ref(EMPTY_SIDE_EFFECTS)
+  const confidenceData: Ref<ConfidenceBreakdown> = ref(EMPTY_CONFIDENCE)
+  const conflictsData: Ref<ConflictRow[]> = ref([])
+  const historyData: Ref<HistoryRow[]> = ref([])
+  const similarPastData: Ref<SimilarPastRow[]> = ref([])
 
-  const provenance = computed<ProvenanceRow[]>(() =>
-    useDemo.value ? DEMO_PROVENANCE : EMPTY_PROVENANCE,
+  let fetchGeneration = 0
+
+  watch(
+    () => activeProposal.value?.id,
+    async (proposalId) => {
+      if (!proposalId) {
+        provenanceData.value = EMPTY_PROVENANCE
+        sideEffectsData.value = EMPTY_SIDE_EFFECTS
+        confidenceData.value = EMPTY_CONFIDENCE
+        conflictsData.value = EMPTY_CONFLICTS
+        historyData.value = EMPTY_HISTORY
+        similarPastData.value = EMPTY_SIMILAR
+        return
+      }
+
+      const generation = ++fetchGeneration
+      const proposal = activeProposal.value
+      const appliedAt = proposal?.appliedAt ? new Date(proposal.appliedAt).getTime() : null
+
+      const results = await Promise.allSettled([
+        proposalDeepReviewApi.getProvenance(proposalId),
+        proposalDeepReviewApi.getConfidence(proposalId),
+        proposalDeepReviewApi.getSideEffects(proposalId),
+        proposalDeepReviewApi.getConflicts(proposalId),
+        proposalDeepReviewApi.getHistory(proposalId),
+        proposalDeepReviewApi.getSimilarPast(proposalId),
+      ])
+
+      if (generation !== fetchGeneration) return
+
+      const [prov, conf, side, confl, hist, sim] = results
+
+      provenanceData.value =
+        prov.status === 'fulfilled' ? prov.value.map(mapProvenanceRow) : EMPTY_PROVENANCE
+
+      confidenceData.value =
+        conf.status === 'fulfilled' ? mapConfidence(conf.value) : EMPTY_CONFIDENCE
+
+      sideEffectsData.value =
+        side.status === 'fulfilled' ? mapSideEffects(side.value, appliedAt) : EMPTY_SIDE_EFFECTS
+
+      conflictsData.value =
+        confl.status === 'fulfilled' ? mapConflicts(confl.value) : EMPTY_CONFLICTS
+
+      historyData.value = hist.status === 'fulfilled' ? mapHistory(hist.value) : EMPTY_HISTORY
+
+      similarPastData.value =
+        sim.status === 'fulfilled' ? mapSimilarPast(sim.value) : EMPTY_SIMILAR
+    },
+    { immediate: true },
   )
 
-  const sideEffects = computed<SideEffects>(() => {
-    if (!useDemo.value) return EMPTY_SIDE_EFFECTS
-    const proposal = activeProposal.value
-    const appliedAt = proposal?.appliedAt ? new Date(proposal.appliedAt).getTime() : null
-    return {
-      rows: DEMO_SIDE_EFFECT_ROWS,
-      reversibility: {
-        summary: '6 hours · single keystroke',
-        description:
-          'Undo restores all affected cards to their prior state with original body, subtasks, comments, and activity log. Nothing is lost.',
-        windowMs: 6 * 60 * 60 * 1000,
-        appliedAt,
-      },
-    }
-  })
-
-  const confidenceBreakdown = computed<ConfidenceBreakdown>(() =>
-    useDemo.value ? DEMO_CONFIDENCE : EMPTY_CONFIDENCE,
-  )
-
-  const conflicts = computed<ConflictRow[]>(() => (useDemo.value ? DEMO_CONFLICTS : EMPTY_CONFLICTS))
-
-  const history = computed<HistoryRow[]>(() => (useDemo.value ? DEMO_HISTORY : EMPTY_HISTORY))
-
-  const similarPast = computed<SimilarPastRow[]>(() =>
-    useDemo.value ? DEMO_SIMILAR : EMPTY_SIMILAR,
-  )
+  const provenance = computed<ProvenanceRow[]>(() => provenanceData.value)
+  const sideEffects = computed<SideEffects>(() => sideEffectsData.value)
+  const confidenceBreakdown = computed<ConfidenceBreakdown>(() => confidenceData.value)
+  const conflicts = computed<ConflictRow[]>(() => conflictsData.value)
+  const history = computed<HistoryRow[]>(() => historyData.value)
+  const similarPast = computed<SimilarPastRow[]>(() => similarPastData.value)
 
   const similarPastApplyRate = computed(() => {
     const rows = similarPast.value

--- a/frontend/taskdeck-web/src/tests/api/proposalDeepReviewApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/proposalDeepReviewApi.spec.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import http from '../../api/http'
+import { proposalDeepReviewApi } from '../../api/proposalDeepReviewApi'
+
+vi.mock('../../api/http', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}))
+
+describe('proposalDeepReviewApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('fetches provenance rows for a proposal', async () => {
+    const rows = [{ icon: '📄', key: 'card', value: 'test', weight: 'primary' }]
+    vi.mocked(http.get).mockResolvedValue({ data: rows })
+
+    const result = await proposalDeepReviewApi.getProvenance('p-1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/provenance')
+    expect(result).toEqual(rows)
+  })
+
+  it('fetches confidence breakdown for a proposal', async () => {
+    const breakdown = { overall: 0.84, components: [], note: null, threshold: 0.7, meetsThreshold: true }
+    vi.mocked(http.get).mockResolvedValue({ data: breakdown })
+
+    const result = await proposalDeepReviewApi.getConfidence('p-1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/confidence')
+    expect(result).toEqual(breakdown)
+  })
+
+  it('fetches side effects for a proposal', async () => {
+    const effects = { rows: [], reversibility: { summary: 's', description: 'd', windowMs: 1000 } }
+    vi.mocked(http.get).mockResolvedValue({ data: effects })
+
+    const result = await proposalDeepReviewApi.getSideEffects('p-1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/side-effects')
+    expect(result).toEqual(effects)
+  })
+
+  it('fetches conflicts for a proposal', async () => {
+    const conflicts = [{ tone: 'Warn', key: 'stale', value: 'desc' }]
+    vi.mocked(http.get).mockResolvedValue({ data: conflicts })
+
+    const result = await proposalDeepReviewApi.getConflicts('p-1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/conflicts')
+    expect(result).toEqual(conflicts)
+  })
+
+  it('fetches card history for a proposal', async () => {
+    const history = [{ serial: '#1', event: 'created', age: '2h', status: 'Applied' }]
+    vi.mocked(http.get).mockResolvedValue({ data: history })
+
+    const result = await proposalDeepReviewApi.getHistory('p-1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/history')
+    expect(result).toEqual(history)
+  })
+
+  it('fetches similar past decisions for a proposal', async () => {
+    const similar = { decisions: [], applyRate: 0.67 }
+    vi.mocked(http.get).mockResolvedValue({ data: similar })
+
+    const result = await proposalDeepReviewApi.getSimilarPast('p-1')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/similar-past')
+    expect(result).toEqual(similar)
+  })
+
+  it('encodes special characters in proposal IDs', async () => {
+    vi.mocked(http.get).mockResolvedValue({ data: [] })
+
+    await proposalDeepReviewApi.getProvenance('id/with spaces')
+
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/id%2Fwith%20spaces/provenance')
+  })
+
+  it('propagates HTTP errors', async () => {
+    vi.mocked(http.get).mockRejectedValue(new Error('Network error'))
+
+    await expect(proposalDeepReviewApi.getConfidence('p-1')).rejects.toThrow('Network error')
+  })
+})

--- a/frontend/taskdeck-web/src/tests/api/proposalDeepReviewApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/proposalDeepReviewApi.spec.ts
@@ -19,7 +19,7 @@ describe('proposalDeepReviewApi', () => {
 
     const result = await proposalDeepReviewApi.getProvenance('p-1')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/provenance')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/provenance', { signal: undefined })
     expect(result).toEqual(rows)
   })
 
@@ -29,7 +29,7 @@ describe('proposalDeepReviewApi', () => {
 
     const result = await proposalDeepReviewApi.getConfidence('p-1')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/confidence')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/confidence', { signal: undefined })
     expect(result).toEqual(breakdown)
   })
 
@@ -39,7 +39,7 @@ describe('proposalDeepReviewApi', () => {
 
     const result = await proposalDeepReviewApi.getSideEffects('p-1')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/side-effects')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/side-effects', { signal: undefined })
     expect(result).toEqual(effects)
   })
 
@@ -49,7 +49,7 @@ describe('proposalDeepReviewApi', () => {
 
     const result = await proposalDeepReviewApi.getConflicts('p-1')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/conflicts')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/conflicts', { signal: undefined })
     expect(result).toEqual(conflicts)
   })
 
@@ -59,7 +59,7 @@ describe('proposalDeepReviewApi', () => {
 
     const result = await proposalDeepReviewApi.getHistory('p-1')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/history')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/history', { signal: undefined })
     expect(result).toEqual(history)
   })
 
@@ -69,7 +69,7 @@ describe('proposalDeepReviewApi', () => {
 
     const result = await proposalDeepReviewApi.getSimilarPast('p-1')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/similar-past')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/p-1/similar-past', { signal: undefined })
     expect(result).toEqual(similar)
   })
 
@@ -78,7 +78,7 @@ describe('proposalDeepReviewApi', () => {
 
     await proposalDeepReviewApi.getProvenance('id/with spaces')
 
-    expect(http.get).toHaveBeenCalledWith('/automation/proposals/id%2Fwith%20spaces/provenance')
+    expect(http.get).toHaveBeenCalledWith('/automation/proposals/id%2Fwith%20spaces/provenance', { signal: undefined })
   })
 
   it('propagates HTTP errors', async () => {

--- a/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
@@ -83,21 +83,17 @@ describe('usePaperReviewSelectors', () => {
     proposal.value = makeProposal()
     await nextTick()
     await vi.waitFor(() => {
-      expect(proposalDeepReviewApi.getProvenance).toHaveBeenCalledWith('p-1')
+      expect(proposalDeepReviewApi.getProvenance).toHaveBeenCalledWith('p-1', expect.objectContaining({ signal: expect.any(AbortSignal) }))
     })
 
-    expect(proposalDeepReviewApi.getConfidence).toHaveBeenCalledWith('p-1')
-    expect(proposalDeepReviewApi.getSideEffects).toHaveBeenCalledWith('p-1')
-    expect(proposalDeepReviewApi.getConflicts).toHaveBeenCalledWith('p-1')
-    expect(proposalDeepReviewApi.getHistory).toHaveBeenCalledWith('p-1')
-    expect(proposalDeepReviewApi.getSimilarPast).toHaveBeenCalledWith('p-1')
+    expect(proposalDeepReviewApi.getConfidence).toHaveBeenCalledWith('p-1', expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(proposalDeepReviewApi.getSideEffects).toHaveBeenCalledWith('p-1', expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(proposalDeepReviewApi.getConflicts).toHaveBeenCalledWith('p-1', expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(proposalDeepReviewApi.getHistory).toHaveBeenCalledWith('p-1', expect.objectContaining({ signal: expect.any(AbortSignal) }))
+    expect(proposalDeepReviewApi.getSimilarPast).toHaveBeenCalledWith('p-1', expect.objectContaining({ signal: expect.any(AbortSignal) }))
   })
 
   it('maps provenance weight to lowercase', async () => {
-    vi.mocked(proposalDeepReviewApi.getProvenance).mockResolvedValue([
-      { icon: '📄', key: 'body', value: 'val', weight: 'Primary' },
-      { icon: '⊘', key: 'excl', value: 'val', weight: 'Excluded' },
-    ])
     mockAllEndpointsEmpty()
     vi.mocked(proposalDeepReviewApi.getProvenance).mockResolvedValue([
       { icon: '📄', key: 'body', value: 'val', weight: 'Primary' },

--- a/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, computed, nextTick } from 'vue'
+import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
+import { proposalDeepReviewApi } from '../../api/proposalDeepReviewApi'
+import type { Proposal as ApiProposal } from '../../types/automation'
+
+vi.mock('../../api/proposalDeepReviewApi', () => ({
+  proposalDeepReviewApi: {
+    getProvenance: vi.fn(),
+    getConfidence: vi.fn(),
+    getSideEffects: vi.fn(),
+    getConflicts: vi.fn(),
+    getHistory: vi.fn(),
+    getSimilarPast: vi.fn(),
+  },
+}))
+
+function makeProposal(overrides: Partial<ApiProposal> = {}): ApiProposal {
+  return {
+    id: 'p-1',
+    status: 'Pending',
+    riskLevel: 'Low',
+    title: 'Test',
+    description: 'desc',
+    captureItemId: 'c-1',
+    boardId: 'b-1',
+    operations: [],
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    requestedByUserId: 'u-1',
+    appliedAt: null,
+    expiresAt: null,
+    ...overrides,
+  } as ApiProposal
+}
+
+function mockAllEndpointsEmpty() {
+  vi.mocked(proposalDeepReviewApi.getProvenance).mockResolvedValue([])
+  vi.mocked(proposalDeepReviewApi.getConfidence).mockResolvedValue({
+    overall: 0.5,
+    components: [{ key: 'Pattern', value: 0.5 }],
+    note: null,
+    threshold: 0.7,
+    meetsThreshold: false,
+  })
+  vi.mocked(proposalDeepReviewApi.getSideEffects).mockResolvedValue({
+    rows: [],
+    reversibility: { summary: '6h', description: 'Safe', windowMs: 21600000 },
+  })
+  vi.mocked(proposalDeepReviewApi.getConflicts).mockResolvedValue([])
+  vi.mocked(proposalDeepReviewApi.getHistory).mockResolvedValue([])
+  vi.mocked(proposalDeepReviewApi.getSimilarPast).mockResolvedValue({
+    decisions: [],
+    applyRate: 0,
+  })
+}
+
+describe('usePaperReviewSelectors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty state when no proposal is active', async () => {
+    const activeProposal = computed(() => null)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await nextTick()
+
+    expect(selectors.provenance.value).toEqual([])
+    expect(selectors.confidenceBreakdown.value.overall).toBe(0)
+    expect(selectors.conflicts.value).toEqual([])
+    expect(selectors.history.value).toEqual([])
+    expect(selectors.similarPast.value).toEqual([])
+  })
+
+  it('fetches all endpoints when proposal becomes active', async () => {
+    mockAllEndpointsEmpty()
+
+    const proposal = ref<ApiProposal | null>(null)
+    const activeProposal = computed(() => proposal.value)
+    usePaperReviewSelectors(activeProposal)
+
+    proposal.value = makeProposal()
+    await nextTick()
+    await vi.waitFor(() => {
+      expect(proposalDeepReviewApi.getProvenance).toHaveBeenCalledWith('p-1')
+    })
+
+    expect(proposalDeepReviewApi.getConfidence).toHaveBeenCalledWith('p-1')
+    expect(proposalDeepReviewApi.getSideEffects).toHaveBeenCalledWith('p-1')
+    expect(proposalDeepReviewApi.getConflicts).toHaveBeenCalledWith('p-1')
+    expect(proposalDeepReviewApi.getHistory).toHaveBeenCalledWith('p-1')
+    expect(proposalDeepReviewApi.getSimilarPast).toHaveBeenCalledWith('p-1')
+  })
+
+  it('maps provenance weight to lowercase', async () => {
+    vi.mocked(proposalDeepReviewApi.getProvenance).mockResolvedValue([
+      { icon: '📄', key: 'body', value: 'val', weight: 'Primary' },
+      { icon: '⊘', key: 'excl', value: 'val', weight: 'Excluded' },
+    ])
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getProvenance).mockResolvedValue([
+      { icon: '📄', key: 'body', value: 'val', weight: 'Primary' },
+      { icon: '⊘', key: 'excl', value: 'val', weight: 'Excluded' },
+    ])
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.provenance.value.length).toBe(2)
+    })
+
+    expect(selectors.provenance.value[0].weight).toBe('primary')
+    expect(selectors.provenance.value[1].weight).toBe('excluded')
+  })
+
+  it('maps conflict tones to lowercase', async () => {
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getConflicts).mockResolvedValue([
+      { tone: 'Warn', key: 'stale', value: 'v' },
+      { tone: 'Ok', key: 'clear', value: 'v' },
+      { tone: 'Info', key: 'note', value: 'v' },
+    ])
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.conflicts.value.length).toBe(3)
+    })
+
+    expect(selectors.conflicts.value[0].tone).toBe('warn')
+    expect(selectors.conflicts.value[1].tone).toBe('ok')
+    expect(selectors.conflicts.value[2].tone).toBe('info')
+  })
+
+  it('maps history status to lowercase', async () => {
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getHistory).mockResolvedValue([
+      { serial: '#1', event: 'created', age: '2h', status: 'Pending' },
+      { serial: '#2', event: 'applied', age: '1d', status: 'Applied' },
+      { serial: '#3', event: 'old', age: '5d', status: 'Past' },
+    ])
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.history.value.length).toBe(3)
+    })
+
+    expect(selectors.history.value[0].status).toBe('pending')
+    expect(selectors.history.value[1].status).toBe('applied')
+    expect(selectors.history.value[2].status).toBe('past')
+  })
+
+  it('computes similarPastApplyRate from decisions', async () => {
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getSimilarPast).mockResolvedValue({
+      decisions: [
+        { serial: '#1', title: 'A', verdict: 'Applied', date: 'wk1' },
+        { serial: '#2', title: 'B', verdict: 'Rejected', date: 'wk2' },
+        { serial: '#3', title: 'C', verdict: 'Applied', date: 'wk3' },
+      ],
+      applyRate: 0.67,
+    })
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.similarPast.value.length).toBe(3)
+    })
+
+    expect(selectors.similarPastApplyRate.value.applied).toBe(2)
+    expect(selectors.similarPastApplyRate.value.total).toBe(3)
+    expect(selectors.similarPastApplyRate.value.ratio).toBeCloseTo(0.667, 2)
+  })
+
+  it('gracefully handles individual endpoint failures', async () => {
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getProvenance).mockRejectedValue(new Error('fail'))
+    vi.mocked(proposalDeepReviewApi.getHistory).mockRejectedValue(new Error('fail'))
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.confidenceBreakdown.value.overall).toBe(0.5)
+    })
+
+    expect(selectors.provenance.value).toEqual([])
+    expect(selectors.history.value).toEqual([])
+    expect(selectors.conflicts.value).toEqual([])
+  })
+
+  it('discards stale responses when proposal changes rapidly', async () => {
+    let resolveFirst: (v: never[]) => void
+    const firstCall = new Promise<never[]>((r) => { resolveFirst = r })
+    vi.mocked(proposalDeepReviewApi.getProvenance)
+      .mockImplementationOnce(() => firstCall)
+      .mockResolvedValueOnce([{ icon: '✦', key: 'new', value: 'v', weight: 'inferred' }])
+    mockAllEndpointsEmpty()
+
+    const proposal = ref<ApiProposal | null>(makeProposal({ id: 'p-1' }))
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await nextTick()
+    proposal.value = makeProposal({ id: 'p-2' })
+    await nextTick()
+
+    resolveFirst!([{ icon: '📄', key: 'stale', value: 'v', weight: 'primary' }] as never[])
+    await nextTick()
+
+    await vi.waitFor(() => {
+      expect(selectors.provenance.value.length).toBeGreaterThanOrEqual(0)
+    })
+
+    const hasStale = selectors.provenance.value.some((r) => r.key === 'stale')
+    expect(hasStale).toBe(false)
+  })
+
+  it('maps confidence note from null to undefined', async () => {
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getConfidence).mockResolvedValue({
+      overall: 0.9,
+      components: [],
+      note: null,
+      threshold: 0.7,
+      meetsThreshold: true,
+    })
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.confidenceBreakdown.value.overall).toBe(0.9)
+    })
+
+    expect(selectors.confidenceBreakdown.value.note).toBeUndefined()
+  })
+
+  it('maps side effects with appliedAt from proposal', async () => {
+    mockAllEndpointsEmpty()
+    vi.mocked(proposalDeepReviewApi.getSideEffects).mockResolvedValue({
+      rows: [{ key: 'Cards', value: '1 created', tone: 'active' }],
+      reversibility: { summary: '6h', description: 'Undo works', windowMs: 21600000 },
+    })
+
+    const proposal = ref<ApiProposal | null>(
+      makeProposal({ appliedAt: '2026-05-01T10:00:00Z' }),
+    )
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.sideEffects.value.rows.length).toBe(1)
+    })
+
+    expect(selectors.sideEffects.value.reversibility.appliedAt).toBe(
+      new Date('2026-05-01T10:00:00Z').getTime(),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Add `proposalDeepReviewApi.ts` with typed HTTP client for all 6 deep-review endpoints (provenance, confidence, side-effects, conflicts, history, similar-past)
- Rewrite `usePaperReviewSelectors` composable to fetch real data from backend instead of hardcoded demo stubs
- Graceful per-endpoint failure handling via `Promise.allSettled` — individual endpoint failures don't break the whole Review surface
- Generation counter prevents stale API responses from overwriting current proposal data on rapid switching
- DTO-to-frontend type mapping normalizes backend enum casing (PascalCase → lowercase)

## Test plan
- [x] 8 API module tests (endpoint calls, ID encoding, error propagation)
- [x] 10 composable tests (empty state, fetch on activate, weight/tone/status mapping, stale discard, failure isolation, apply rate computation)
- [x] 45 existing Paper Review view tests continue to pass
- [x] `vue-tsc --noEmit` typecheck passes clean
- [ ] CI (pending)

Refs #977