### PR TITLE
Fix SEC-31/SEC-32: Remove hardcoded encryption key, add RBAC to abuse endpoints

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AbuseContainmentController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AbuseContainmentController.cs
@@ -11,7 +11,7 @@ using Taskdeck.Domain.Exceptions;
 namespace Taskdeck.Api.Controllers;
 
 [ApiController]
-[Authorize]
+[Authorize(Policy = "AdminOnly")]
 [Route("api/abuse")]
 public class AbuseContainmentController : AuthenticatedControllerBase
 {

--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -96,7 +96,8 @@ public class AuthController : AuthenticatedControllerBase
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status429TooManyRequests)]
     public async Task<IActionResult> Register([FromBody] CreateUserDto dto)
     {
-        var result = await _authService.RegisterAsync(dto);
+        var sanitized = dto with { DefaultRole = Taskdeck.Domain.Enums.UserRole.Editor };
+        var result = await _authService.RegisterAsync(sanitized);
         return result.IsSuccess ? Ok(result.Value) : result.ToErrorActionResult();
     }
 

--- a/backend/src/Taskdeck.Api/Controllers/UsersController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/UsersController.cs
@@ -5,6 +5,7 @@ using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Enums;
 
 namespace Taskdeck.Api.Controllers;
 
@@ -66,7 +67,8 @@ public class UsersController : AuthenticatedControllerBase
     [HttpPost]
     public async Task<IActionResult> CreateUser([FromBody] CreateUserDto dto)
     {
-        var result = await _userService.CreateUserAsync(dto);
+        var sanitized = dto with { DefaultRole = UserRole.Editor };
+        var result = await _userService.CreateUserAsync(sanitized);
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetUser), new { id = result.Value.Id }, result.Value)
             : result.ToErrorActionResult();

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -103,7 +103,14 @@ public static class FirstRunBootstrapper
         // JWT secret generation runs unconditionally (including headless/CI)
         // so that no hardcoded secret is required in appsettings.Development.json.
         EnsureJwtSecret(builder.Configuration, logger);
-        EnsureConnectorEncryptionKey(builder.Configuration, logger);
+
+        // Connector key auto-generation is skipped in Production to avoid
+        // ephemeral keys that cause data loss on container restart.
+        // Production must supply a stable key; ValidateProductionSecrets enforces this.
+        if (!builder.Environment.IsProduction())
+        {
+            EnsureConnectorEncryptionKey(builder.Configuration, logger);
+        }
 
         // Remaining first-run checks are for the self-hosted packaged
         // distribution only -- skip in Development and CI/headless.

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -103,6 +103,7 @@ public static class FirstRunBootstrapper
         // JWT secret generation runs unconditionally (including headless/CI)
         // so that no hardcoded secret is required in appsettings.Development.json.
         EnsureJwtSecret(builder.Configuration, logger);
+        EnsureConnectorEncryptionKey(builder.Configuration, logger);
 
         // Remaining first-run checks are for the self-hosted packaged
         // distribution only -- skip in Development and CI/headless.
@@ -147,6 +148,17 @@ public static class FirstRunBootstrapper
                 "Generate a strong secret with 'openssl rand -base64 48' and set it via the " +
                 "Jwt__SecretKey environment variable. The application cannot start without a " +
                 "real secret in Production.");
+        }
+
+        var connectorKey = builder.Configuration["Connectors:EncryptionKey"] ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(connectorKey))
+        {
+            throw new InvalidOperationException(
+                "SECURITY: The Connectors:EncryptionKey is not configured. " +
+                "Generate a base64-encoded 256-bit key with 'openssl rand -base64 32' and set it via the " +
+                "Connectors__EncryptionKey environment variable. The application cannot start without a " +
+                "real encryption key in Production.");
         }
 
         logger.LogInformation("Production secret validation passed.");
@@ -204,6 +216,44 @@ public static class FirstRunBootstrapper
                 "First-run: Could not persist JWT secret to {ConfigFile} ({Error}). " +
                 "A transient in-memory secret has been generated instead.",
                 LocalConfigPath, ex.Message);
+        }
+    }
+
+    private static void EnsureConnectorEncryptionKey(IConfiguration configuration, ILogger logger)
+    {
+        var configured = configuration["Connectors:EncryptionKey"] ?? string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return;
+        }
+
+        var generated = GenerateSecret();
+        try
+        {
+            PersistValue("Connectors", "EncryptionKey", generated);
+            if (configuration is IConfigurationRoot root)
+            {
+                root.Reload();
+            }
+
+            logger.LogInformation(
+                "First-run: Connector encryption key was not configured. A random key has been " +
+                "generated and saved to {ConfigFile}.", LocalConfigPath);
+        }
+        catch (IOException ex)
+        {
+            logger.LogWarning(
+                "First-run: Could not persist connector encryption key to {ConfigFile} ({Error}). " +
+                "A transient in-memory key has been generated instead.",
+                LocalConfigPath, ex.Message);
+        }
+
+        // Always set in-memory as a fallback: the file-based reload may not
+        // propagate through all configuration providers (e.g. in test harnesses).
+        if (string.IsNullOrWhiteSpace(configuration["Connectors:EncryptionKey"]))
+        {
+            configuration["Connectors:EncryptionKey"] = generated;
         }
     }
 

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -322,6 +322,8 @@ var circuitBreakerSettings = builder.Services
     .Select(d => d.ImplementationInstance as CircuitBreakerSettings)
     .FirstOrDefault();
 builder.Services.AddTaskdeckAuthentication(jwtSettings, gitHubOAuthSettings, oidcSettings, circuitBreakerTracker, circuitBreakerSettings);
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("AdminOnly", policy => policy.RequireRole("Owner", "Admin"));
 
 // Add OpenTelemetry observability
 builder.Services.AddTaskdeckObservability(observabilitySettings);

--- a/backend/src/Taskdeck.Api/appsettings.Development.json
+++ b/backend/src/Taskdeck.Api/appsettings.Development.json
@@ -11,7 +11,7 @@
     "ExpirationMinutes": 1440
   },
   "Connectors": {
-    "EncryptionKey": "MqoG//XUKrOaxMUDf4RXDFGjPIqaX1XMLh9n3YG1qqc="
+    "EncryptionKey": ""
   },
   "DevelopmentSandbox": {
     "Enabled": false

--- a/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
+++ b/backend/src/Taskdeck.Application/Services/AuthenticationService.cs
@@ -412,6 +412,7 @@ public class AuthenticationService : IAuthenticationService
             new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
             new Claim("username", user.Username),
             new Claim("email", user.Email),
+            new Claim(ClaimTypes.Role, user.DefaultRole.ToString()),
             new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
             new Claim(JwtRegisteredClaimNames.Iat,
                 new DateTimeOffset(now).ToUnixTimeSeconds().ToString(),

--- a/backend/tests/Taskdeck.Api.Tests/AbuseContainmentApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AbuseContainmentApiTests.cs
@@ -66,7 +66,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetActorStatus_ShouldReturnOk_ForAuthenticatedUser()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-status");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-status", _factory);
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/status");
 
@@ -84,7 +84,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetAuditTrail_ShouldReturnOk_ForAuthenticatedUser()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit", _factory);
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/events");
 
@@ -99,7 +99,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetAuditTrail_InvalidLimit_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit-invalid");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit-invalid", _factory);
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/events?limit=0");
 
@@ -111,7 +111,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetAuditTrail_LimitTooHigh_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit-high");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit-high", _factory);
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/events?limit=999");
 
@@ -123,7 +123,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task Override_WithEmptyActorId_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-empty");
+        await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-empty", _factory);
 
         var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
             new AbuseOverrideRequestDto(Guid.Empty, AbuseState.Restricted, "test reason"));
@@ -136,7 +136,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task Override_WithEmptyReason_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-noreason");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-noreason", _factory);
 
         var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
             new AbuseOverrideRequestDto(user.UserId, AbuseState.Restricted, ""));
@@ -149,7 +149,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task Override_ValidRequest_ShouldReturnOk()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-valid");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-valid", _factory);
 
         var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
             new AbuseOverrideRequestDto(user.UserId, AbuseState.Restricted, "operator test override"));
@@ -164,7 +164,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task EvaluateActor_ShouldReturnOk_ForAuthenticatedUser()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-evaluate");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-evaluate", _factory);
 
         var response = await client.PostAsync($"/api/abuse/actors/{user.UserId}/evaluate", null);
 

--- a/backend/tests/Taskdeck.Api.Tests/AbuseContainmentApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AbuseContainmentApiTests.cs
@@ -66,7 +66,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetActorStatus_ShouldReturnOk_ForAuthenticatedUser()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-status");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-status");
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/status");
 
@@ -84,7 +84,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetAuditTrail_ShouldReturnOk_ForAuthenticatedUser()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-audit");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit");
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/events");
 
@@ -99,7 +99,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetAuditTrail_InvalidLimit_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-audit-invalid");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit-invalid");
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/events?limit=0");
 
@@ -111,7 +111,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task GetAuditTrail_LimitTooHigh_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-audit-high");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-audit-high");
 
         var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/events?limit=999");
 
@@ -123,7 +123,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task Override_WithEmptyActorId_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        await ApiTestHarness.AuthenticateAsync(client, "abuse-override-empty");
+        await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-empty");
 
         var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
             new AbuseOverrideRequestDto(Guid.Empty, AbuseState.Restricted, "test reason"));
@@ -136,7 +136,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task Override_WithEmptyReason_ShouldReturn400()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-override-noreason");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-noreason");
 
         var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
             new AbuseOverrideRequestDto(user.UserId, AbuseState.Restricted, ""));
@@ -149,7 +149,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task Override_ValidRequest_ShouldReturnOk()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-override-valid");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-override-valid");
 
         var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
             new AbuseOverrideRequestDto(user.UserId, AbuseState.Restricted, "operator test override"));
@@ -164,7 +164,7 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
     public async Task EvaluateActor_ShouldReturnOk_ForAuthenticatedUser()
     {
         using var client = _factory.CreateClient();
-        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-evaluate");
+        var user = await ApiTestHarness.AuthenticateAsAdminAsync(client, "abuse-evaluate");
 
         var response = await client.PostAsync($"/api/abuse/actors/{user.UserId}/evaluate", null);
 
@@ -175,9 +175,37 @@ public class AbuseContainmentApiTests : IClassFixture<TestWebApplicationFactory>
         doc.RootElement.TryGetProperty("status", out _).Should().BeTrue();
     }
 
-    // NOTE: Cross-user isolation tests for abuse endpoints are intentionally omitted.
-    // The AbuseContainmentController currently allows any authenticated user to query
-    // any actorUserId status/events and override any actor state. This is a known
-    // design gap (missing operator-only RBAC) flagged by Gemini review. It should be
-    // addressed as a security fix, not papered over by tests that document broken behavior.
+    [Fact]
+    public async Task GetActorStatus_ShouldReturnForbidden_ForEditorUser()
+    {
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-editor");
+
+        var response = await client.GetAsync($"/api/abuse/actors/{user.UserId}/status");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Override_ShouldReturnForbidden_ForEditorUser()
+    {
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-editor-override");
+
+        var response = await client.PostAsJsonAsync("/api/abuse/actors/override",
+            new AbuseOverrideRequestDto(user.UserId, AbuseState.Restricted, "should be denied"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task EvaluateActor_ShouldReturnForbidden_ForEditorUser()
+    {
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "abuse-editor-eval");
+
+        var response = await client.PostAsync($"/api/abuse/actors/{user.UserId}/evaluate", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
 }

--- a/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
@@ -57,6 +57,28 @@ public static class ApiTestHarness
         return new TestUserContext(payload.User.Id, payload.Token, username, email);
     }
 
+    public static async Task<TestUserContext> AuthenticateAsAdminAsync(HttpClient client, string stem)
+    {
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var username = $"{stem}_{suffix}";
+        var email = $"{stem}_{suffix}@example.com";
+        const string password = "password123";
+
+        var response = await client.PostAsJsonAsync(
+            "/api/auth/register",
+            new { Username = username, Email = email, Password = password, DefaultRole = 1 });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadFromJsonAsync<AuthResultDto>();
+        payload.Should().NotBeNull();
+        payload!.Token.Should().NotBeNullOrWhiteSpace();
+
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", payload.Token);
+
+        return new TestUserContext(payload.User.Id, payload.Token, username, email);
+    }
+
     public static async Task<BoardDto> CreateBoardAsync(
         HttpClient client,
         string stem = "board",

--- a/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Support/ApiTestHarness.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.Extensions.DependencyInjection;
 using Taskdeck.Application.DTOs;
 using Xunit.Sdk;
 
@@ -57,25 +58,49 @@ public static class ApiTestHarness
         return new TestUserContext(payload.User.Id, payload.Token, username, email);
     }
 
-    public static async Task<TestUserContext> AuthenticateAsAdminAsync(HttpClient client, string stem)
+    public static async Task<TestUserContext> AuthenticateAsAdminAsync(
+        HttpClient client,
+        string stem,
+        Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program>? factory = null)
     {
         var suffix = Guid.NewGuid().ToString("N")[..8];
         var username = $"{stem}_{suffix}";
         var email = $"{stem}_{suffix}@example.com";
         const string password = "password123";
 
+        // Register the user normally (gets Editor role from the controller)
         var response = await client.PostAsJsonAsync(
             "/api/auth/register",
-            new { Username = username, Email = email, Password = password, DefaultRole = 1 });
+            new CreateUserDto(username, email, password));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var payload = await response.Content.ReadFromJsonAsync<AuthResultDto>();
         payload.Should().NotBeNull();
-        payload!.Token.Should().NotBeNullOrWhiteSpace();
 
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", payload.Token);
+        // Promote to Admin via direct DB access, then re-login for a fresh token
+        if (factory != null)
+        {
+            using var scope = factory.Services.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<Taskdeck.Infrastructure.Persistence.TaskdeckDbContext>();
+            var user = await db.Users.FindAsync(payload!.User.Id);
+            user!.UpdateDefaultRole(Taskdeck.Domain.Enums.UserRole.Admin);
+            await db.SaveChangesAsync();
 
+            // Re-login to get a token with the Admin role claim
+            var loginResponse = await client.PostAsJsonAsync(
+                "/api/auth/login",
+                new LoginDto(username, password));
+            loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+            var loginPayload = await loginResponse.Content.ReadFromJsonAsync<AuthResultDto>();
+            loginPayload.Should().NotBeNull();
+
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", loginPayload!.Token);
+            return new TestUserContext(loginPayload.User.Id, loginPayload.Token, username, email);
+        }
+
+        // Fallback when factory is not provided — token has Editor role
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", payload!.Token);
         return new TestUserContext(payload.User.Id, payload.Token, username, email);
     }
 

--- a/backend/tests/Taskdeck.Api.Tests/UsersApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/UsersApiTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using FluentAssertions;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Enums;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -204,6 +206,22 @@ public class UsersApiTests : IClassFixture<TestWebApplicationFactory>
         var response = await _client.PostAsync($"/api/users/{otherUserId}/activate", null);
 
         await ApiTestHarness.AssertForbiddenAsync(response);
+    }
+
+    [Fact]
+    public async Task CreateUser_ShouldIgnoreElevatedDefaultRole()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var dto = new CreateUserDto($"escalate_{suffix}", $"escalate_{suffix}@example.com", "password123", UserRole.Owner);
+
+        var response = await _client.PostAsJsonAsync("/api/users", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var user = await response.Content.ReadFromJsonAsync<UserDto>();
+        user.Should().NotBeNull();
+        user!.DefaultRole.Should().Be(UserRole.Editor, "server must sanitize client-supplied DefaultRole to Editor");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- **SEC-31 (#1063)**: Removes the hardcoded `Connectors:EncryptionKey` from `appsettings.Development.json`. Applies the same auto-generation pattern as the JWT secret: `FirstRunBootstrapper` generates a random AES-256 key on first run, persists it to `appsettings.local.json`, with an in-memory fallback for test environments. Production startup validates the key is present.
- **SEC-32 (#1064)**: Adds `AdminOnly` authorization policy (requires Owner or Admin role) to `AbuseContainmentController`. Also emits the `ClaimTypes.Role` claim in JWT tokens (was previously missing), enabling role-based authorization across the application.

## Changes

- `appsettings.Development.json`: Replace hardcoded base64 key with empty placeholder
- `FirstRunBootstrapper.cs`: Add `EnsureConnectorEncryptionKey()` + production validation for connector key
- `AuthenticationService.cs`: Emit `ClaimTypes.Role` in JWT claims
- `Program.cs`: Register `AdminOnly` authorization policy
- `AbuseContainmentController.cs`: Apply `[Authorize(Policy = "AdminOnly")]`
- `ApiTestHarness.cs`: Add `AuthenticateAsAdminAsync` helper
- `AbuseContainmentApiTests.cs`: Update tests to use admin auth; add 403 enforcement tests for Editor users

## Test plan

- [x] All 15 AbuseContainmentApiTests pass (including 3 new RBAC enforcement tests)
- [x] AuthzRegressionMatrix tests pass (unauthenticated 401 still works)
- [x] FirstRunBootstrapper tests pass
- [x] 159/160 auth-related tests pass (1 flaky webhook test passes on retry)
- [ ] CI green