### PR TITLE
Fix SEC-33: Suppress internal exception details from health endpoint

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/HealthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/HealthController.cs
@@ -19,19 +19,22 @@ public class HealthController : ControllerBase
     private readonly WorkerHeartbeatRegistry _workerHeartbeatRegistry;
     private readonly RedisBackplaneHealthCheck _redisHealthCheck;
     private readonly CircuitBreakerStateTracker _circuitBreakerTracker;
+    private readonly ILogger<HealthController> _logger;
 
     public HealthController(
         IServiceProvider serviceProvider,
         WorkerSettings workerSettings,
         WorkerHeartbeatRegistry workerHeartbeatRegistry,
         RedisBackplaneHealthCheck redisHealthCheck,
-        CircuitBreakerStateTracker circuitBreakerTracker)
+        CircuitBreakerStateTracker circuitBreakerTracker,
+        ILogger<HealthController> logger)
     {
         _serviceProvider = serviceProvider;
         _workerSettings = workerSettings;
         _workerHeartbeatRegistry = workerHeartbeatRegistry;
         _redisHealthCheck = redisHealthCheck;
         _circuitBreakerTracker = circuitBreakerTracker;
+        _logger = logger;
     }
 
     [HttpGet("live")]
@@ -64,7 +67,8 @@ public class HealthController : ControllerBase
         }
         catch (Exception ex)
         {
-            checks["database"] = new { status = "Unhealthy", error = ex.Message };
+            _logger.LogError(ex, "Health check: database connectivity failed");
+            checks["database"] = new { status = "Unhealthy", error = "Connection failed" };
             isReady = false;
         }
 
@@ -99,7 +103,8 @@ public class HealthController : ControllerBase
         }
         catch (Exception ex)
         {
-            checks["queue"] = new { status = "Unhealthy", error = ex.Message };
+            _logger.LogError(ex, "Health check: queue status query failed");
+            checks["queue"] = new { status = "Unhealthy", error = "Connection failed" };
             isReady = false;
         }
 
@@ -118,7 +123,8 @@ public class HealthController : ControllerBase
         }
         catch (Exception ex)
         {
-            checks["signalrBackplane"] = new RedisHealthStatus("Unhealthy", ex.Message);
+            _logger.LogError(ex, "Health check: SignalR backplane connectivity failed");
+            checks["signalrBackplane"] = new RedisHealthStatus("Unhealthy", "Connection failed");
             isReady = false;
         }
 

--- a/backend/src/Taskdeck.Api/Controllers/HealthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/HealthController.cs
@@ -222,8 +222,7 @@ public class HealthController : ControllerBase
                 circuitChecks[name] = new
                 {
                     state = snapshot.State.ToString(),
-                    lastTransitionUtc = snapshot.LastTransitionUtc,
-                    lastFailureReason = snapshot.LastFailureReason
+                    lastTransitionUtc = snapshot.LastTransitionUtc
                 };
 
                 if (snapshot.State == CircuitState.Open)

--- a/backend/src/Taskdeck.Api/Health/RedisBackplaneHealthCheck.cs
+++ b/backend/src/Taskdeck.Api/Health/RedisBackplaneHealthCheck.cs
@@ -96,7 +96,7 @@ public sealed class RedisBackplaneHealthCheck : IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Redis backplane health check failed");
-            var result = new RedisHealthStatus("Unhealthy", ex.Message);
+            var result = new RedisHealthStatus("Unhealthy", "Connection failed");
             _cache = new CacheEntry(result, DateTimeOffset.UtcNow);
             return result;
         }

--- a/backend/tests/Taskdeck.Api.Tests/CircuitBreakerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CircuitBreakerTests.cs
@@ -172,7 +172,8 @@ public class CircuitBreakerTests : IClassFixture<TestWebApplicationFactory>
         var circuitBreakers = payload.GetProperty("checks").GetProperty("circuitBreakers");
         circuitBreakers.TryGetProperty("OpenAI", out var openAi).Should().BeTrue();
         openAi.GetProperty("state").GetString().Should().Be("Open");
-        openAi.GetProperty("lastFailureReason").GetString().Should().Be("HTTP 500");
+        openAi.TryGetProperty("lastFailureReason", out _).Should().BeFalse(
+            "lastFailureReason must not be exposed to prevent info disclosure");
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/HealthApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/HealthApiTests.cs
@@ -53,6 +53,43 @@ public class HealthApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task Ready_ShouldNotLeakExceptionDetails()
+    {
+        var response = await _client.GetAsync("/health/ready");
+        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            .Should()
+            .BeTrue();
+
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotContainAny(
+            "Exception", "StackTrace", "at System.", "at Microsoft.",
+            "Data Source=", "Password=", "Server=");
+    }
+
+    [Fact]
+    public async Task Ready_ShouldNotExposeCircuitBreakerFailureReasons()
+    {
+        var response = await _client.GetAsync("/health/ready");
+        (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            .Should()
+            .BeTrue();
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
+        if (payload.TryGetProperty("checks", out var checks) &&
+            checks.TryGetProperty("circuitBreakers", out var cb) &&
+            cb.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var prop in cb.EnumerateObject())
+            {
+                if (prop.Name == "_summary" || prop.Name == "status") continue;
+                if (prop.Value.ValueKind != JsonValueKind.Object) continue;
+                prop.Value.TryGetProperty("lastFailureReason", out _).Should().BeFalse(
+                    "circuit breaker entries must not expose failure reason details");
+            }
+        }
+    }
+
+    [Fact]
     public async Task Ready_ShouldExcludeCaptureBacklogFromAutomationQueueDepth()
     {
         await ApiTestHarness.AuthenticateAsync(_client, "health-capture-backlog");


### PR DESCRIPTION
## Summary

- Replaces raw `ex.Message` in `/health/ready` responses with generic "Connection failed" string
- Adds `ILogger<HealthController>` and logs full exception details server-side
- Prevents unauthenticated information disclosure of internal paths, hostnames, and infrastructure details

## Changes

- `HealthController.cs`: Add logger injection, replace 3 `ex.Message` exposures with generic messages + server-side logging

## Test plan

- [x] Build passes (0 errors)
- [x] Existing HealthApiTests do not rely on error message content
- [ ] CI green