### PR TITLE
Add ConnectorProviders API tests and useAutomationChat composable tests

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/ConnectorProvidersApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConnectorProvidersApiTests.cs
@@ -44,10 +44,11 @@ public class ConnectorProvidersApiTests : IClassFixture<TestWebApplicationFactor
         doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
         doc.RootElement.GetArrayLength().Should().BeGreaterOrEqualTo(1);
 
-        var firstProvider = doc.RootElement[0];
-        firstProvider.GetProperty("providerId").GetString().Should().Be("github");
-        firstProvider.GetProperty("displayName").GetString().Should().NotBeNullOrWhiteSpace();
-        firstProvider.GetProperty("description").GetString().Should().NotBeNullOrWhiteSpace();
+        var githubProvider = doc.RootElement.EnumerateArray()
+            .FirstOrDefault(p => p.GetProperty("providerId").GetString() == "github");
+        githubProvider.ValueKind.Should().NotBe(JsonValueKind.Undefined, "github provider should be present");
+        githubProvider.GetProperty("displayName").GetString().Should().NotBeNullOrWhiteSpace();
+        githubProvider.GetProperty("description").GetString().Should().NotBeNullOrWhiteSpace();
     }
 
     [Fact]
@@ -149,6 +150,22 @@ public class ConnectorProvidersApiTests : IClassFixture<TestWebApplicationFactor
     }
 
     [Fact]
+    public async Task StoreCredential_ShouldPassValidation_WhenLabelIsExactly100Chars()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-maxlabel");
+        var fakeConnectorId = Guid.NewGuid();
+        var maxLabel = new string('x', 100);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{fakeConnectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, maxLabel, "ghp_test_value"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "validation passes for 100-char label; 404 because connector doesn't exist");
+    }
+
+    [Fact]
     public async Task StoreCredential_ShouldReturn400_WhenValueEmpty()
     {
         using var client = _factory.CreateClient();
@@ -181,6 +198,9 @@ public class ConnectorProvidersApiTests : IClassFixture<TestWebApplicationFactor
         doc.RootElement.GetProperty("label").GetString().Should().Be("My Token");
         doc.RootElement.GetProperty("hasCredential").GetBoolean().Should().BeTrue();
         doc.RootElement.GetProperty("authMethod").GetInt32().Should().Be((int)ConnectorAuthMethod.PersonalAccessToken);
+        doc.RootElement.TryGetProperty("value", out _).Should().BeFalse("credential value must never be returned");
+        doc.RootElement.TryGetProperty("encryptedValue", out _).Should().BeFalse("encrypted value must never be returned");
+        doc.RootElement.TryGetProperty("plaintextValue", out _).Should().BeFalse("plaintext must never be returned");
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/ConnectorProvidersApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConnectorProvidersApiTests.cs
@@ -1,0 +1,280 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.Connectors;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Connectors;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public class ConnectorProvidersApiTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public ConnectorProvidersApiTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task ListProviders_ShouldReturnUnauthorized_WhenNoToken()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/connectors/providers");
+
+        await ApiTestHarness.AssertUnauthorizedAsync(response);
+    }
+
+    [Fact]
+    public async Task ListProviders_ShouldReturnOk_ForAuthenticatedUser()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-list");
+
+        var response = await client.GetAsync("/api/connectors/providers");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+        doc.RootElement.GetArrayLength().Should().BeGreaterOrEqualTo(1);
+
+        var firstProvider = doc.RootElement[0];
+        firstProvider.GetProperty("providerId").GetString().Should().Be("github");
+        firstProvider.GetProperty("displayName").GetString().Should().NotBeNullOrWhiteSpace();
+        firstProvider.GetProperty("description").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task CheckProviderHealth_ShouldReturnUnauthorized_WhenNoToken()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/connectors/providers/github/health");
+
+        await ApiTestHarness.AssertUnauthorizedAsync(response);
+    }
+
+    [Fact]
+    public async Task CheckProviderHealth_ShouldReturnOk_ForRegisteredProvider()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-health");
+
+        var response = await client.GetAsync("/api/connectors/providers/github/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("providerId").GetString().Should().Be("github");
+        doc.RootElement.TryGetProperty("status", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("message", out _).Should().BeTrue();
+        doc.RootElement.TryGetProperty("checkedAt", out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckProviderHealth_ShouldReturn404_ForUnknownProvider()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-health-unknown");
+
+        var response = await client.GetAsync("/api/connectors/providers/nonexistent-provider/health");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task StoreCredential_ShouldReturnUnauthorized_WhenNoToken()
+    {
+        using var client = _factory.CreateClient();
+        var connectorId = Guid.NewGuid();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "My Token", "ghp_fake_token_value"));
+
+        await ApiTestHarness.AssertUnauthorizedAsync(response);
+    }
+
+    [Fact]
+    public async Task StoreCredential_ShouldReturn404_WhenConnectorNotFound()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-noconn");
+        var fakeConnectorId = Guid.NewGuid();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{fakeConnectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "My Token", "ghp_test_value"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task StoreCredential_ShouldReturn400_WhenLabelEmpty()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-nolabel");
+        var connectorId = Guid.NewGuid();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "", "ghp_test_value"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.BadRequest, "ValidationError");
+    }
+
+    [Fact]
+    public async Task StoreCredential_ShouldReturn400_WhenLabelTooLong()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-longlabel");
+        var connectorId = Guid.NewGuid();
+        var longLabel = new string('x', 101);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, longLabel, "ghp_test_value"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.BadRequest, "ValidationError");
+    }
+
+    [Fact]
+    public async Task StoreCredential_ShouldReturn400_WhenValueEmpty()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-noval");
+        var connectorId = Guid.NewGuid();
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "My Token", ""));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.BadRequest, "ValidationError");
+    }
+
+    [Fact]
+    public async Task StoreCredential_ShouldReturn201_WhenConnectorOwned()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-store");
+        var connectorId = await CreateConnectorAsync(client);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "My Token", "ghp_live_value_abc"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("connectorId").GetGuid().Should().Be(connectorId);
+        doc.RootElement.GetProperty("label").GetString().Should().Be("My Token");
+        doc.RootElement.GetProperty("hasCredential").GetBoolean().Should().BeTrue();
+        doc.RootElement.GetProperty("authMethod").GetInt32().Should().Be((int)ConnectorAuthMethod.PersonalAccessToken);
+    }
+
+    [Fact]
+    public async Task DeleteCredential_ShouldReturnUnauthorized_WhenNoToken()
+    {
+        using var client = _factory.CreateClient();
+        var connectorId = Guid.NewGuid();
+
+        var response = await client.DeleteAsync($"/api/connectors/{connectorId}/credentials");
+
+        await ApiTestHarness.AssertUnauthorizedAsync(response);
+    }
+
+    [Fact]
+    public async Task DeleteCredential_ShouldReturn404_WhenNoCredentialExists()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-del404");
+        var connectorId = await CreateConnectorAsync(client);
+
+        var response = await client.DeleteAsync($"/api/connectors/{connectorId}/credentials");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteCredential_ShouldReturn204_AfterStoring()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-del204");
+        var connectorId = await CreateConnectorAsync(client);
+
+        await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "My Token", "ghp_to_delete"));
+
+        var response = await client.DeleteAsync($"/api/connectors/{connectorId}/credentials");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task CredentialLifecycle_CrossUserIsolation()
+    {
+        using var clientA = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(clientA, "conn-iso-a");
+        var connectorId = await CreateConnectorAsync(clientA);
+
+        var storeResponse = await clientA.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "User A Token", "ghp_user_a_secret"));
+        storeResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using var clientB = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(clientB, "conn-iso-b");
+
+        var deleteResponse = await clientB.DeleteAsync($"/api/connectors/{connectorId}/credentials");
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task StoreCredential_Replaces_ExistingCredential()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "conn-cred-replace");
+        var connectorId = await CreateConnectorAsync(client);
+
+        var firstStore = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.PersonalAccessToken, "First Token", "ghp_first"));
+        firstStore.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var secondStore = await client.PostAsJsonAsync(
+            $"/api/connectors/{connectorId}/credentials",
+            new StoreConnectorCredentialDto(ConnectorAuthMethod.OAuth2, "OAuth Token", "oauth_second"));
+        secondStore.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await secondStore.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("label").GetString().Should().Be("OAuth Token");
+        doc.RootElement.GetProperty("authMethod").GetInt32().Should().Be((int)ConnectorAuthMethod.OAuth2);
+    }
+
+    private static async Task<Guid> CreateConnectorAsync(HttpClient client)
+    {
+        var response = await client.PostAsJsonAsync("/api/integrations",
+            new CreateIntegrationConnectorDto(
+                $"test-connector-{Guid.NewGuid():N}",
+                ConnectorType.Custom,
+                ConnectorDirection.Inbound));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("id").GetGuid();
+    }
+}

--- a/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
-import { ref } from 'vue'
 
 const routerMocks = vi.hoisted(() => ({
   push: vi.fn(),

--- a/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
@@ -61,6 +61,9 @@ describe('useAutomationChat', () => {
     vi.clearAllMocks()
     routeMocks.query = {}
     chatApiMocks.getMySessions.mockResolvedValue([])
+    chatApiMocks.getSession.mockResolvedValue(undefined)
+    chatApiMocks.createSession.mockResolvedValue(undefined)
+    chatApiMocks.sendMessage.mockResolvedValue(undefined)
     chatApiMocks.getHealth.mockResolvedValue({ status: 'healthy' })
     boardsApiMocks.getBoards.mockResolvedValue([])
   })
@@ -352,6 +355,7 @@ describe('useAutomationChat', () => {
 
       await vi.waitFor(() => {
         expect(chat.chatHealthLoadError.value).not.toBeNull()
+        expect(toastMocks.error).toHaveBeenCalled()
       })
     })
   })

--- a/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+}))
+
+const routeMocks = vi.hoisted(() => ({
+  query: {} as Record<string, string | undefined>,
+}))
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}))
+
+const chatApiMocks = vi.hoisted(() => ({
+  getMySessions: vi.fn().mockResolvedValue([]),
+  getSession: vi.fn(),
+  createSession: vi.fn(),
+  sendMessage: vi.fn(),
+  getHealth: vi.fn().mockResolvedValue({ status: 'healthy' }),
+}))
+
+const boardsApiMocks = vi.hoisted(() => ({
+  getBoards: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => routerMocks,
+  useRoute: () => routeMocks,
+}))
+
+vi.mock('../../store/toastStore', () => ({
+  useToastStore: () => toastMocks,
+}))
+
+vi.mock('../../api/chatApi', () => ({
+  chatApi: chatApiMocks,
+}))
+
+vi.mock('../../api/boardsApi', () => ({
+  boardsApi: boardsApiMocks,
+}))
+
+vi.mock('vue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue')>()
+  return {
+    ...actual,
+    onMounted: (fn: () => void) => fn(),
+    watch: vi.fn(),
+  }
+})
+
+async function loadComposable() {
+  vi.resetModules()
+  return import('../../composables/useAutomationChat')
+}
+
+describe('useAutomationChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    routeMocks.query = {}
+    chatApiMocks.getMySessions.mockResolvedValue([])
+    chatApiMocks.getHealth.mockResolvedValue({ status: 'healthy' })
+    boardsApiMocks.getBoards.mockResolvedValue([])
+  })
+
+  describe('initial state', () => {
+    it('starts with empty sessions and no selected session', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.sessions.value).toEqual([])
+      })
+      expect(chat.selectedSession.value).toBeNull()
+      expect(chat.messageContent.value).toBe('')
+      expect(chat.requestProposal.value).toBe(false)
+    })
+
+    it('loads sessions and provider health on mount', async () => {
+      const { useAutomationChat } = await loadComposable()
+      useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chatApiMocks.getMySessions).toHaveBeenCalledTimes(1)
+        expect(chatApiMocks.getHealth).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('sortedMessages', () => {
+    it('returns empty when no session selected', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      expect(chat.sortedMessages.value).toEqual([])
+    })
+
+    it('sorts messages by createdAt', async () => {
+      chatApiMocks.getMySessions.mockResolvedValue([
+        {
+          id: 's1',
+          title: 'Test',
+          boardId: null,
+          recentMessages: [
+            { id: 'm2', content: 'second', role: 0, messageType: 'chat', createdAt: '2026-05-16T10:01:00Z' },
+            { id: 'm1', content: 'first', role: 0, messageType: 'chat', createdAt: '2026-05-16T10:00:00Z' },
+          ],
+        },
+      ])
+      chatApiMocks.getSession.mockResolvedValue({
+        id: 's1',
+        title: 'Test',
+        boardId: null,
+        recentMessages: [
+          { id: 'm2', content: 'second', role: 0, messageType: 'chat', createdAt: '2026-05-16T10:01:00Z' },
+          { id: 'm1', content: 'first', role: 0, messageType: 'chat', createdAt: '2026-05-16T10:00:00Z' },
+        ],
+      })
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.selectedSession.value).not.toBeNull()
+      })
+      expect(chat.sortedMessages.value[0].content).toBe('first')
+      expect(chat.sortedMessages.value[1].content).toBe('second')
+    })
+  })
+
+  describe('lastMessageIsClarification', () => {
+    it('returns false when no messages', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      expect(chat.lastMessageIsClarification.value).toBe(false)
+    })
+
+    it('returns true when last message is assistant clarification', async () => {
+      chatApiMocks.getMySessions.mockResolvedValue([
+        {
+          id: 's1',
+          title: 'Test',
+          boardId: null,
+          recentMessages: [
+            { id: 'm1', content: 'What do you mean?', role: 1, messageType: 'clarification', createdAt: '2026-05-16T10:00:00Z' },
+          ],
+        },
+      ])
+      chatApiMocks.getSession.mockResolvedValue({
+        id: 's1',
+        title: 'Test',
+        boardId: null,
+        recentMessages: [
+          { id: 'm1', content: 'What do you mean?', role: 1, messageType: 'clarification', createdAt: '2026-05-16T10:00:00Z' },
+        ],
+      })
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.selectedSession.value).not.toBeNull()
+      })
+      expect(chat.lastMessageIsClarification.value).toBe(true)
+    })
+  })
+
+  describe('handleCreateSession', () => {
+    it('shows error toast when title is empty', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      chat.newSessionTitle.value = '   '
+      await chat.handleCreateSession()
+
+      expect(toastMocks.error).toHaveBeenCalledWith('Session title is required')
+      expect(chatApiMocks.createSession).not.toHaveBeenCalled()
+    })
+
+    it('creates session when title provided without board', async () => {
+      chatApiMocks.createSession.mockResolvedValue({ id: 'new-session' })
+      chatApiMocks.getSession.mockResolvedValue({
+        id: 'new-session',
+        title: 'My Session',
+        boardId: null,
+        recentMessages: [],
+      })
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      chat.newSessionTitle.value = 'My Session'
+      await chat.handleCreateSession()
+
+      expect(chatApiMocks.createSession).toHaveBeenCalledWith({
+        title: 'My Session',
+        boardId: null,
+      })
+    })
+
+    it('shows error when board name does not resolve', async () => {
+      boardsApiMocks.getBoards.mockResolvedValue([
+        { id: 'b1', name: 'Project Alpha', description: null, isArchived: false },
+      ])
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(boardsApiMocks.getBoards).toHaveBeenCalled()
+      })
+
+      chat.newSessionTitle.value = 'Test Session'
+      chat.newSessionBoardId.value = 'nonexistent board'
+      await chat.handleCreateSession()
+
+      expect(toastMocks.error).toHaveBeenCalledWith(
+        'Choose a board from the list or leave board context blank.',
+      )
+      expect(chatApiMocks.createSession).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handleSendMessage', () => {
+    it('does nothing when message content is empty', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      chat.messageContent.value = ''
+      await chat.handleSendMessage()
+
+      expect(chatApiMocks.sendMessage).not.toHaveBeenCalled()
+    })
+
+    it('shows error toast when no session is selected', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      chat.messageContent.value = 'Hello'
+      await chat.handleSendMessage()
+
+      expect(toastMocks.error).toHaveBeenCalledWith('Select a session first')
+    })
+  })
+
+  describe('applyHintSuggestion', () => {
+    it('sets message content and enables requestProposal', async () => {
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      chat.applyHintSuggestion('Move card X to Done')
+
+      expect(chat.messageContent.value).toBe('Move card X to Done')
+      expect(chat.requestProposal.value).toBe(true)
+    })
+  })
+
+  describe('selectedSessionBoardName', () => {
+    it('returns "No board context" when session has no board', async () => {
+      chatApiMocks.getMySessions.mockResolvedValue([
+        { id: 's1', title: 'Test', boardId: null, recentMessages: [] },
+      ])
+      chatApiMocks.getSession.mockResolvedValue({
+        id: 's1',
+        title: 'Test',
+        boardId: null,
+        recentMessages: [],
+      })
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.selectedSession.value).not.toBeNull()
+      })
+      expect(chat.selectedSessionBoardName.value).toBe('No board context')
+    })
+
+    it('returns board name when board is loaded', async () => {
+      boardsApiMocks.getBoards.mockResolvedValue([
+        { id: 'b1', name: 'Project Alpha', description: null, isArchived: false },
+      ])
+      chatApiMocks.getMySessions.mockResolvedValue([
+        { id: 's1', title: 'Test', boardId: 'b1', recentMessages: [] },
+      ])
+      chatApiMocks.getSession.mockResolvedValue({
+        id: 's1',
+        title: 'Test',
+        boardId: 'b1',
+        recentMessages: [],
+      })
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.selectedSession.value).not.toBeNull()
+      })
+      expect(chat.selectedSessionBoardName.value).toBe('Project Alpha')
+    })
+  })
+
+  describe('openProposalReview', () => {
+    it('navigates to workspace review with proposal hash', async () => {
+      chatApiMocks.getMySessions.mockResolvedValue([
+        { id: 's1', title: 'Test', boardId: 'b1', recentMessages: [] },
+      ])
+      chatApiMocks.getSession.mockResolvedValue({
+        id: 's1',
+        title: 'Test',
+        boardId: 'b1',
+        recentMessages: [],
+      })
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.selectedSession.value).not.toBeNull()
+      })
+
+      chat.openProposalReview('proposal-abc-123')
+
+      expect(routerMocks.push).toHaveBeenCalledWith({
+        name: 'workspace-review',
+        query: { boardId: 'b1' },
+        hash: '#proposal-proposal-abc-123',
+      })
+    })
+  })
+
+  describe('error handling', () => {
+    it('shows toast when loadSessions fails', async () => {
+      chatApiMocks.getMySessions.mockRejectedValue(new Error('Network error'))
+
+      const { useAutomationChat } = await loadComposable()
+      useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(toastMocks.error).toHaveBeenCalled()
+      })
+    })
+
+    it('shows toast when loadProviderHealth fails', async () => {
+      chatApiMocks.getHealth.mockRejectedValue(new Error('Health check failed'))
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      await vi.waitFor(() => {
+        expect(chat.chatHealthLoadError.value).not.toBeNull()
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 16 integration tests for `ConnectorProvidersController` covering auth, provider listing, health checks, credential CRUD lifecycle, validation, and cross-user isolation
- Adds 17 unit tests for `useAutomationChat` composable covering state management, session creation, message sending, board resolution, error handling, and navigation

Closes partial scope of #1066 (ConnectorProviders HIGH + frontend composable gap).

## Test plan
- [x] `dotnet test --filter ConnectorProvidersApiTests` — 16/16 pass
- [x] `npx vitest --run src/tests/composables/useAutomationChat.spec.ts` — 17/17 pass
- [ ] Full CI gate passes