### PR TITLE
Add privacy insights API for proposal outcome cohorts (RFAI-08)

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/InsightsController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/InsightsController.cs
@@ -1,0 +1,74 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/insights")]
+[Produces("application/json")]
+public class InsightsController : AuthenticatedControllerBase
+{
+    private readonly IInsightsService _insightsService;
+
+    public InsightsController(IInsightsService insightsService, IUserContext userContext)
+        : base(userContext)
+    {
+        _insightsService = insightsService;
+    }
+
+    [HttpGet("cohort")]
+    [ProducesResponseType(typeof(InsightCohortResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetCohort([FromQuery] int periodDays = 30, CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var userId, out var errorResult))
+            return errorResult!;
+
+        var cohort = await _insightsService.GetProposalCohortAsync(userId, periodDays, cancellationToken);
+
+        return Ok(new InsightCohortResponse(
+            cohort.AcceptedCount,
+            cohort.EditedCount,
+            cohort.RejectedCount,
+            cohort.TotalCount,
+            cohort.AcceptanceRate));
+    }
+
+    [HttpGet("metrics")]
+    [ProducesResponseType(typeof(InsightMetricsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetMetrics([FromQuery] int periodDays = 30, CancellationToken cancellationToken = default)
+    {
+        if (!TryGetCurrentUserId(out var userId, out var errorResult))
+            return errorResult!;
+
+        var metrics = await _insightsService.GetMetricsAsync(userId, periodDays, cancellationToken);
+
+        var dtos = metrics.Select(m => new InsightMetricDto(
+            m.MetricName,
+            m.BucketedCount,
+            m.TimePeriodDays,
+            m.PromptVersion)).ToList();
+
+        return Ok(new InsightMetricsResponse(dtos));
+    }
+}
+
+public sealed record InsightCohortResponse(
+    int AcceptedCount,
+    int EditedCount,
+    int RejectedCount,
+    int TotalCount,
+    double AcceptanceRate);
+
+public sealed record InsightMetricsResponse(
+    IReadOnlyList<InsightMetricDto> Metrics);
+
+public sealed record InsightMetricDto(
+    string MetricName,
+    int BucketedCount,
+    int TimePeriodDays,
+    string PromptVersion);

--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -47,6 +47,7 @@ public static class ApplicationServiceRegistration
         services.AddScoped<ICaptureTriageService, CaptureTriageService>();
         services.AddScoped<HistoryService>();
         services.AddScoped<IHistoryService>(sp => sp.GetRequiredService<HistoryService>());
+        services.AddScoped<IInsightsService, InsightsService>();
         services.AddScoped<IAutomationProposalService, AutomationProposalService>();
         services.AddScoped<IProposalConflictDetector, ProposalConflictDetector>();
         services.AddScoped<IProvenanceQueryService, ProvenanceQueryService>();

--- a/backend/src/Taskdeck.Application/Interfaces/IProposalOutcomeRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IProposalOutcomeRepository.cs
@@ -19,4 +19,9 @@ public interface IProposalOutcomeRepository : IRepository<ProposalOutcome>
     /// Gets outcomes filtered by decision type.
     /// </summary>
     Task<IReadOnlyList<ProposalOutcome>> GetByDecisionAsync(OutcomeDecision decision, int limit = 100, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets all outcomes for a user without server-side ordering (safe for SQLite).
+    /// </summary>
+    Task<IReadOnlyList<ProposalOutcome>> GetAllByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Interfaces/IProposalOutcomeRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IProposalOutcomeRepository.cs
@@ -21,7 +21,8 @@ public interface IProposalOutcomeRepository : IRepository<ProposalOutcome>
     Task<IReadOnlyList<ProposalOutcome>> GetByDecisionAsync(OutcomeDecision decision, int limit = 100, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets all outcomes for a user without server-side ordering (safe for SQLite).
+    /// Gets outcomes for a user without server-side ordering (safe for SQLite).
+    /// Capped at 1000 rows as a safety bound for the local-first use case.
     /// </summary>
     Task<IReadOnlyList<ProposalOutcome>> GetAllByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Services/IInsightsService.cs
+++ b/backend/src/Taskdeck.Application/Services/IInsightsService.cs
@@ -1,0 +1,10 @@
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Application.Services;
+
+public interface IInsightsService
+{
+    Task<InsightCohort> GetProposalCohortAsync(Guid userId, int periodDays, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InsightMetric>> GetMetricsAsync(Guid userId, int periodDays, CancellationToken cancellationToken = default);
+}

--- a/backend/src/Taskdeck.Application/Services/IInsightsService.cs
+++ b/backend/src/Taskdeck.Application/Services/IInsightsService.cs
@@ -1,5 +1,3 @@
-using Taskdeck.Application.Services;
-
 namespace Taskdeck.Application.Services;
 
 public interface IInsightsService

--- a/backend/src/Taskdeck.Application/Services/InsightsService.cs
+++ b/backend/src/Taskdeck.Application/Services/InsightsService.cs
@@ -1,0 +1,97 @@
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Enums;
+
+namespace Taskdeck.Application.Services;
+
+public sealed class InsightsService : IInsightsService
+{
+    private readonly IProposalOutcomeRepository _outcomeRepository;
+
+    private const int MaxPeriodDays = 365;
+    private const int DefaultPeriodDays = 30;
+
+    public InsightsService(IProposalOutcomeRepository outcomeRepository)
+    {
+        _outcomeRepository = outcomeRepository;
+    }
+
+    public async Task<InsightCohort> GetProposalCohortAsync(
+        Guid userId,
+        int periodDays,
+        CancellationToken cancellationToken = default)
+    {
+        var bounded = BoundPeriod(periodDays);
+        var cutoff = DateTimeOffset.UtcNow.AddDays(-bounded);
+
+        var outcomes = await _outcomeRepository.GetAllByUserIdAsync(userId, cancellationToken);
+
+        var filtered = outcomes.Where(o => o.DecidedAt >= cutoff).ToList();
+
+        var accepted = filtered.Count(o => o.Decision == OutcomeDecision.Approved);
+        var edited = filtered.Count(o => o.Decision == OutcomeDecision.EditedThenApproved);
+        var rejected = filtered.Count(o => o.Decision == OutcomeDecision.Rejected);
+
+        return new InsightCohort(accepted, edited, rejected);
+    }
+
+    public async Task<IReadOnlyList<InsightMetric>> GetMetricsAsync(
+        Guid userId,
+        int periodDays,
+        CancellationToken cancellationToken = default)
+    {
+        var cohort = await GetProposalCohortAsync(userId, periodDays, cancellationToken);
+        var bounded = BoundPeriod(periodDays);
+
+        var metrics = new List<InsightMetric>();
+
+        if (cohort.TotalCount > 0)
+        {
+            var bucketedTotal = BucketCount(cohort.TotalCount);
+
+            metrics.Add(new InsightMetric(
+                "proposal.acceptance_rate",
+                BucketCount(cohort.AcceptedCount),
+                bounded,
+                "v1.0"));
+
+            metrics.Add(new InsightMetric(
+                "proposal.edit_rate",
+                BucketCount(cohort.EditedCount),
+                bounded,
+                "v1.0"));
+
+            metrics.Add(new InsightMetric(
+                "proposal.rejection_rate",
+                BucketCount(cohort.RejectedCount),
+                bounded,
+                "v1.0"));
+
+            metrics.Add(new InsightMetric(
+                "proposal.generated_count",
+                bucketedTotal,
+                bounded,
+                "v1.0"));
+        }
+
+        return metrics.AsReadOnly();
+    }
+
+    private static int BoundPeriod(int periodDays)
+    {
+        return periodDays <= 0 ? DefaultPeriodDays : Math.Min(periodDays, MaxPeriodDays);
+    }
+
+    private static int BucketCount(int count)
+    {
+        return count switch
+        {
+            0 => 0,
+            <= 5 => 5,
+            <= 10 => 10,
+            <= 25 => 25,
+            <= 50 => 50,
+            <= 100 => 100,
+            _ => (count / 50) * 50
+        };
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Repositories/ProposalOutcomeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/ProposalOutcomeRepository.cs
@@ -50,6 +50,7 @@ public class ProposalOutcomeRepository : Repository<ProposalOutcome>, IProposalO
         return await _dbSet
             .AsNoTracking()
             .Where(o => o.DecidedByUserId == userId)
+            .Take(MaxLimit)
             .ToListAsync(cancellationToken);
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/ProposalOutcomeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/ProposalOutcomeRepository.cs
@@ -44,4 +44,12 @@ public class ProposalOutcomeRepository : Repository<ProposalOutcome>, IProposalO
             .Take(boundedLimit)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<IReadOnlyList<ProposalOutcome>> GetAllByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .AsNoTracking()
+            .Where(o => o.DecidedByUserId == userId)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/backend/tests/Taskdeck.Api.Tests/InsightsApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/InsightsApiTests.cs
@@ -1,0 +1,170 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public class InsightsApiTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public InsightsApiTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetCohort_ShouldReturnUnauthorized_WhenNoToken()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/insights/cohort");
+
+        await ApiTestHarness.AssertUnauthorizedAsync(response);
+    }
+
+    [Fact]
+    public async Task GetCohort_ShouldReturnOk_ForAuthenticatedUser()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-cohort");
+
+        var response = await client.GetAsync("/api/insights/cohort");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("acceptedCount").GetInt32().Should().BeGreaterOrEqualTo(0);
+        doc.RootElement.GetProperty("editedCount").GetInt32().Should().BeGreaterOrEqualTo(0);
+        doc.RootElement.GetProperty("rejectedCount").GetInt32().Should().BeGreaterOrEqualTo(0);
+        doc.RootElement.GetProperty("totalCount").GetInt32().Should().BeGreaterOrEqualTo(0);
+        doc.RootElement.GetProperty("acceptanceRate").GetDouble().Should().BeGreaterOrEqualTo(0.0);
+    }
+
+    [Fact]
+    public async Task GetCohort_TotalCountMatchesSumOfParts()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-sum");
+
+        var response = await client.GetAsync("/api/insights/cohort");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var accepted = doc.RootElement.GetProperty("acceptedCount").GetInt32();
+        var edited = doc.RootElement.GetProperty("editedCount").GetInt32();
+        var rejected = doc.RootElement.GetProperty("rejectedCount").GetInt32();
+        var total = doc.RootElement.GetProperty("totalCount").GetInt32();
+        total.Should().Be(accepted + edited + rejected);
+    }
+
+    [Fact]
+    public async Task GetCohort_AcceptsCustomPeriodDays()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-period");
+
+        var response = await client.GetAsync("/api/insights/cohort?periodDays=7");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("totalCount").GetInt32().Should().BeGreaterOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task GetCohort_AcceptanceRateIsZeroWhenNoOutcomes()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-empty");
+
+        var response = await client.GetAsync("/api/insights/cohort?periodDays=1");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var rate = doc.RootElement.GetProperty("acceptanceRate").GetDouble();
+        rate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task GetMetrics_ShouldReturnUnauthorized_WhenNoToken()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/insights/metrics");
+
+        await ApiTestHarness.AssertUnauthorizedAsync(response);
+    }
+
+    [Fact]
+    public async Task GetMetrics_ShouldReturnOk_WithMetricsArray()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-metrics");
+
+        var response = await client.GetAsync("/api/insights/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("metrics", out var metrics).Should().BeTrue();
+        metrics.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact]
+    public async Task GetMetrics_MetricsHaveRequiredFields()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-fields");
+
+        var response = await client.GetAsync("/api/insights/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var metrics = doc.RootElement.GetProperty("metrics");
+
+        foreach (var metric in metrics.EnumerateArray())
+        {
+            metric.TryGetProperty("metricName", out _).Should().BeTrue();
+            metric.TryGetProperty("bucketedCount", out _).Should().BeTrue();
+            metric.TryGetProperty("timePeriodDays", out _).Should().BeTrue();
+            metric.TryGetProperty("promptVersion", out _).Should().BeTrue();
+            metric.GetProperty("metricName").GetString().Should().NotBeNullOrWhiteSpace();
+            metric.GetProperty("bucketedCount").GetInt32().Should().BeGreaterOrEqualTo(0);
+            metric.GetProperty("timePeriodDays").GetInt32().Should().BeGreaterThan(0);
+            metric.GetProperty("promptVersion").GetString().Should().NotBeNullOrWhiteSpace();
+        }
+    }
+
+    [Fact]
+    public async Task GetMetrics_NoUserContentInResponse()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-privacy");
+
+        var response = await client.GetAsync("/api/insights/metrics");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().NotContainEquivalentOf("Bearer ",
+            "Bearer tokens must not appear in insight metrics");
+        body.Should().NotMatchRegex(@"sk-[A-Za-z0-9]{20,}",
+            "API keys must not appear in insight metrics");
+    }
+
+    [Fact]
+    public async Task GetCohort_NegativePeriodDaysDefaultsTo30()
+    {
+        using var client = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(client, "insights-negperiod");
+
+        var response = await client.GetAsync("/api/insights/cohort?periodDays=-5");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/InsightsServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/InsightsServiceTests.cs
@@ -112,6 +112,28 @@ public class InsightsServiceTests
     }
 
     [Fact]
+    public async Task GetProposalCohortAsync_IgnoredOutcomesExcludedFromCounts()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 1),
+            CreateOutcome(OutcomeType.Ignored, daysAgo: 2),
+            CreateOutcome(OutcomeType.Ignored, daysAgo: 3),
+            CreateOutcome(OutcomeType.Rejected, daysAgo: 4),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var cohort = await _sut.GetProposalCohortAsync(_userId, 30);
+
+        cohort.AcceptedCount.Should().Be(1);
+        cohort.RejectedCount.Should().Be(1);
+        cohort.EditedCount.Should().Be(0);
+        cohort.TotalCount.Should().Be(2, "Ignored outcomes should not contribute to TotalCount");
+    }
+
+    [Fact]
     public async Task GetMetricsAsync_EmptyOutcomes_ReturnsEmptyList()
     {
         _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
@@ -198,7 +220,8 @@ public class InsightsServiceTests
 
     private static void SetDecidedAt(ProposalOutcome outcome, DateTimeOffset value)
     {
-        var prop = typeof(ProposalOutcome).GetProperty(nameof(ProposalOutcome.DecidedAt));
-        prop!.SetValue(outcome, value);
+        var prop = typeof(ProposalOutcome).GetProperty(nameof(ProposalOutcome.DecidedAt))
+            ?? throw new InvalidOperationException($"Property {nameof(ProposalOutcome.DecidedAt)} not found on {nameof(ProposalOutcome)}");
+        prop.SetValue(outcome, value);
     }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/InsightsServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/InsightsServiceTests.cs
@@ -145,6 +145,23 @@ public class InsightsServiceTests
     }
 
     [Fact]
+    public async Task GetMetricsAsync_OnlyIgnoredOutcomes_ReturnsEmptyList()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Ignored, daysAgo: 1),
+            CreateOutcome(OutcomeType.Ignored, daysAgo: 5),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var metrics = await _sut.GetMetricsAsync(_userId, 30);
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GetMetricsAsync_WithOutcomes_ReturnsBucketedMetrics()
     {
         var outcomes = new List<ProposalOutcome>

--- a/backend/tests/Taskdeck.Application.Tests/Services/InsightsServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/InsightsServiceTests.cs
@@ -1,0 +1,204 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+public class InsightsServiceTests
+{
+    private readonly Mock<IProposalOutcomeRepository> _repository;
+    private readonly InsightsService _sut;
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public InsightsServiceTests()
+    {
+        _repository = new Mock<IProposalOutcomeRepository>();
+        _sut = new InsightsService(_repository.Object);
+    }
+
+    [Fact]
+    public async Task GetProposalCohortAsync_EmptyOutcomes_ReturnsZeroCohort()
+    {
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ProposalOutcome>());
+
+        var cohort = await _sut.GetProposalCohortAsync(_userId, 30);
+
+        cohort.AcceptedCount.Should().Be(0);
+        cohort.EditedCount.Should().Be(0);
+        cohort.RejectedCount.Should().Be(0);
+        cohort.TotalCount.Should().Be(0);
+        cohort.AcceptanceRate.Should().Be(0.0);
+    }
+
+    [Fact]
+    public async Task GetProposalCohortAsync_MixedOutcomes_CountsCorrectly()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 2),
+            CreateOutcome(OutcomeType.Approved, daysAgo: 5),
+            CreateOutcome(OutcomeType.EditedThenApproved, daysAgo: 3),
+            CreateOutcome(OutcomeType.Rejected, daysAgo: 1),
+            CreateOutcome(OutcomeType.Rejected, daysAgo: 40),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var cohort = await _sut.GetProposalCohortAsync(_userId, 30);
+
+        cohort.AcceptedCount.Should().Be(2);
+        cohort.EditedCount.Should().Be(1);
+        cohort.RejectedCount.Should().Be(1);
+        cohort.TotalCount.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GetProposalCohortAsync_FiltersOutOldOutcomes()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 5),
+            CreateOutcome(OutcomeType.Rejected, daysAgo: 35),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var cohort = await _sut.GetProposalCohortAsync(_userId, 30);
+
+        cohort.AcceptedCount.Should().Be(1);
+        cohort.RejectedCount.Should().Be(0);
+        cohort.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetProposalCohortAsync_NegativePeriodDefaultsTo30()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 25),
+            CreateOutcome(OutcomeType.Approved, daysAgo: 35),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var cohort = await _sut.GetProposalCohortAsync(_userId, -1);
+
+        cohort.AcceptedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetProposalCohortAsync_LargePeriodClampedTo365()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 360),
+            CreateOutcome(OutcomeType.Approved, daysAgo: 370),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var cohort = await _sut.GetProposalCohortAsync(_userId, 9999);
+
+        cohort.AcceptedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetMetricsAsync_EmptyOutcomes_ReturnsEmptyList()
+    {
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ProposalOutcome>());
+
+        var metrics = await _sut.GetMetricsAsync(_userId, 30);
+
+        metrics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMetricsAsync_WithOutcomes_ReturnsBucketedMetrics()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 1),
+            CreateOutcome(OutcomeType.Approved, daysAgo: 2),
+            CreateOutcome(OutcomeType.Approved, daysAgo: 3),
+            CreateOutcome(OutcomeType.EditedThenApproved, daysAgo: 1),
+            CreateOutcome(OutcomeType.Rejected, daysAgo: 2),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var metrics = await _sut.GetMetricsAsync(_userId, 30);
+
+        metrics.Should().HaveCount(4);
+        metrics.Should().Contain(m => m.MetricName == "proposal.acceptance_rate");
+        metrics.Should().Contain(m => m.MetricName == "proposal.edit_rate");
+        metrics.Should().Contain(m => m.MetricName == "proposal.rejection_rate");
+        metrics.Should().Contain(m => m.MetricName == "proposal.generated_count");
+
+        var totalMetric = metrics.First(m => m.MetricName == "proposal.generated_count");
+        totalMetric.BucketedCount.Should().Be(5);
+        totalMetric.TimePeriodDays.Should().Be(30);
+        totalMetric.PromptVersion.Should().Be("v1.0");
+    }
+
+    [Fact]
+    public async Task GetMetricsAsync_BucketingQuantizesSmallCounts()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 1),
+            CreateOutcome(OutcomeType.Approved, daysAgo: 2),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var metrics = await _sut.GetMetricsAsync(_userId, 30);
+
+        var acceptanceMetric = metrics.First(m => m.MetricName == "proposal.acceptance_rate");
+        acceptanceMetric.BucketedCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task GetMetricsAsync_AllMetricsAreValid()
+    {
+        var outcomes = new List<ProposalOutcome>
+        {
+            CreateOutcome(OutcomeType.Approved, daysAgo: 1),
+        };
+
+        _repository.Setup(r => r.GetAllByUserIdAsync(_userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(outcomes);
+
+        var metrics = await _sut.GetMetricsAsync(_userId, 30);
+
+        foreach (var metric in metrics)
+        {
+            metric.IsValid().Should().BeTrue($"metric {metric.MetricName} should pass validation");
+        }
+    }
+
+    private ProposalOutcome CreateOutcome(OutcomeType outcomeType, int daysAgo)
+    {
+        var proposalId = Guid.NewGuid();
+        var outcome = new ProposalOutcome(proposalId, outcomeType, _userId);
+        SetDecidedAt(outcome, DateTimeOffset.UtcNow.AddDays(-daysAgo));
+        return outcome;
+    }
+
+    private static void SetDecidedAt(ProposalOutcome outcome, DateTimeOffset value)
+    {
+        var prop = typeof(ProposalOutcome).GetProperty(nameof(ProposalOutcome.DecidedAt));
+        prop!.SetValue(outcome, value);
+    }
+}


### PR DESCRIPTION
## Summary

- **New service**: `IInsightsService` / `InsightsService` computes content-free proposal outcome cohort metrics (accepted/edited/rejected counts within configurable time windows). Uses quantized bucketing to prevent individual user fingerprinting.
- **New endpoints**: `GET /api/insights/cohort` (returns acceptance rate and counts) and `GET /api/insights/metrics` (returns bucketed `InsightMetric` entries for analytics dashboards).
- **SQLite fix**: Added `GetAllByUserIdAsync` to `IProposalOutcomeRepository` to avoid SQLite's `DateTimeOffset` ORDER BY limitation.
- **19 tests**: 9 unit tests (cohort computation, filtering, bucketing, metric validity) + 10 API integration tests (auth, shape, fields, privacy).

## Test plan

- [x] All 9 `InsightsServiceTests` pass
- [x] All 10 `InsightsApiTests` pass
- [x] Full backend suite green (6,496 tests, 0 failures)
- [ ] Adversarial review round 1
- [ ] Adversarial review round 2