### PR TITLE
TST-63: Add MFA setup 409-Conflict integration test

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/MfaApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/MfaApiTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Infrastructure.Persistence;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -161,5 +163,25 @@ public class MfaApiWithSetupEnabledTests : IClassFixture<MfaEnabledWebApplicatio
         var response = await client.PostAsJsonAsync("/api/auth/mfa/confirm", new MfaVerifyRequest("000000"));
 
         response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Setup_ShouldReturnConflict_WhenMfaAlreadyEnabled()
+    {
+        using var client = _factory.CreateClient();
+        var userContext = await ApiTestHarness.AuthenticateAsync(client, "mfa-setup-conflict");
+
+        // Directly enable MFA on the user via DB to simulate a completed setup
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+            var user = await db.Users.FindAsync(userContext.UserId);
+            user!.EnableMfa();
+            await db.SaveChangesAsync();
+        }
+
+        var response = await client.PostAsync("/api/auth/mfa/setup", null);
+
+        await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.Conflict, "Conflict");
     }
 }


### PR DESCRIPTION
## Summary
- Adds integration test for `POST /api/auth/mfa/setup` returning 409 when MFA is already enabled
- Uses DB-level `EnableMfa()` to simulate completed setup (avoids need for TOTP generator in test harness)
- Covers the gap identified in PR #1069 R2 adversarial review

Closes #1070

## Test plan
- [x] New test passes locally: `dotnet test --filter "FullyQualifiedName~MfaApiWithSetupEnabledTests.Setup_ShouldReturnConflict"` (1 passed)
- [x] All existing MFA tests still pass (11 total, 0 failures)
- [ ] CI green