### PR TITLE
RFAI-10: PWA share-target quick capture with offline queue

### DIFF
--- a/backend/src/Taskdeck.Domain/Enums/CaptureSource.cs
+++ b/backend/src/Taskdeck.Domain/Enums/CaptureSource.cs
@@ -13,5 +13,7 @@ public enum CaptureSource
     MeetingIntegration = 5,
     TranscriptFile = 6,
     MarkdownImport = 7,
-    WebClip = 8
+    WebClip = 8,
+    ShareTarget = 9,
+    BrowserExtension = 10
 }

--- a/frontend/taskdeck-web/package-lock.json
+++ b/frontend/taskdeck-web/package-lock.json
@@ -41,6 +41,7 @@
         "eslint": "^10.3.0",
         "eslint-plugin-vue": "^10.9.1",
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
+        "fake-indexeddb": "^6.2.5",
         "fast-check": "^4.7.0",
         "globals": "^17.6.0",
         "happy-dom": "^20.9.0",
@@ -7272,6 +7273,16 @@
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-check": {
       "version": "4.7.0",

--- a/frontend/taskdeck-web/package.json
+++ b/frontend/taskdeck-web/package.json
@@ -73,6 +73,7 @@
     "eslint": "^10.3.0",
     "eslint-plugin-vue": "^10.9.1",
     "eslint-plugin-vuejs-accessibility": "^2.5.0",
+    "fake-indexeddb": "^6.2.5",
     "fast-check": "^4.7.0",
     "globals": "^17.6.0",
     "happy-dom": "^20.9.0",

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -1,0 +1,35 @@
+const TASKDECK_SHARE_CACHE = 'taskdeck-share-target'
+const TASKDECK_SHARE_REQUEST = '/capture/share-data'
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  if (
+    event.request.method !== 'POST' ||
+    url.origin !== self.location.origin ||
+    url.pathname !== '/capture/share'
+  ) {
+    return
+  }
+
+  event.respondWith((async () => {
+    const form = await event.request.formData()
+    const payload = {
+      title: String(form.get('title') ?? ''),
+      text: String(form.get('text') ?? ''),
+      url: String(form.get('url') ?? ''),
+    }
+
+    const cache = await caches.open(TASKDECK_SHARE_CACHE)
+    await cache.put(
+      TASKDECK_SHARE_REQUEST,
+      new Response(JSON.stringify(payload), {
+        headers: {
+          'Content-Type': 'application/json',
+          'Cache-Control': 'no-store',
+        },
+      }),
+    )
+
+    return Response.redirect('/capture/share?fromShareTarget=1', 303)
+  })())
+})

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -1,5 +1,7 @@
 const TASKDECK_SHARE_CACHE = 'taskdeck-share-target'
 const TASKDECK_SHARE_REQUEST = '/capture/share-data'
+const TASKDECK_CAPTURE_SYNC_TAG = 'taskdeck-capture-sync'
+const TASKDECK_CAPTURE_SYNC_MESSAGE = 'taskdeck:capture-sync'
 
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url)
@@ -31,5 +33,22 @@ self.addEventListener('fetch', (event) => {
     )
 
     return Response.redirect('/capture/share?fromShareTarget=1', 303)
+  })())
+})
+
+self.addEventListener('sync', (event) => {
+  if (event.tag !== TASKDECK_CAPTURE_SYNC_TAG) {
+    return
+  }
+
+  event.waitUntil((async () => {
+    const clients = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true,
+    })
+
+    for (const client of clients) {
+      client.postMessage({ type: TASKDECK_CAPTURE_SYNC_MESSAGE })
+    }
   })())
 })

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -41,14 +41,24 @@ self.addEventListener('sync', (event) => {
     return
   }
 
-  event.waitUntil((async () => {
-    const clients = await self.clients.matchAll({
-      type: 'window',
-      includeUncontrolled: true,
-    })
-
-    for (const client of clients) {
-      client.postMessage({ type: TASKDECK_CAPTURE_SYNC_MESSAGE })
-    }
-  })())
+  event.waitUntil(notifyWindowClientsToReplayCaptureQueue())
 })
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type !== TASKDECK_CAPTURE_SYNC_MESSAGE) {
+    return
+  }
+
+  event.waitUntil(notifyWindowClientsToReplayCaptureQueue())
+})
+
+async function notifyWindowClientsToReplayCaptureQueue() {
+  const clients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  })
+
+  for (const client of clients) {
+    client.postMessage({ type: TASKDECK_CAPTURE_SYNC_MESSAGE })
+  }
+}

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -49,7 +49,7 @@ function isTrustedShareTargetPost(request, url) {
 
   const fetchSite = request.headers.get('Sec-Fetch-Site')
   if (!fetchSite) {
-    return true
+    return origin === url.origin
   }
 
   return fetchSite === 'none' || fetchSite === 'same-origin' || fetchSite === 'same-site'

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -1,6 +1,5 @@
 const TASKDECK_SHARE_CACHE = 'taskdeck-share-target'
 const TASKDECK_SHARE_REQUEST = '/capture/share-data'
-const TASKDECK_CAPTURE_SYNC_TAG = 'taskdeck-capture-sync'
 const TASKDECK_CAPTURE_SYNC_MESSAGE = 'taskdeck:capture-sync'
 
 self.addEventListener('fetch', (event) => {
@@ -34,14 +33,6 @@ self.addEventListener('fetch', (event) => {
 
     return Response.redirect('/capture/share?fromShareTarget=1', 303)
   })())
-})
-
-self.addEventListener('sync', (event) => {
-  if (event.tag !== TASKDECK_CAPTURE_SYNC_TAG) {
-    return
-  }
-
-  event.waitUntil(notifyWindowClientsToReplayCaptureQueue())
 })
 
 self.addEventListener('message', (event) => {

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -1,5 +1,5 @@
 const TASKDECK_SHARE_CACHE = 'taskdeck-share-target'
-const TASKDECK_SHARE_REQUEST = '/capture/share-data'
+const TASKDECK_SHARE_REQUEST_PREFIX = '/capture/share-data/'
 const TASKDECK_CAPTURE_SYNC_MESSAGE = 'taskdeck:capture-sync'
 
 self.addEventListener('fetch', (event) => {
@@ -21,8 +21,9 @@ self.addEventListener('fetch', (event) => {
     }
 
     const cache = await caches.open(TASKDECK_SHARE_CACHE)
+    const shareId = createShareId()
     await cache.put(
-      TASKDECK_SHARE_REQUEST,
+      `${TASKDECK_SHARE_REQUEST_PREFIX}${shareId}`,
       new Response(JSON.stringify(payload), {
         headers: {
           'Content-Type': 'application/json',
@@ -31,7 +32,7 @@ self.addEventListener('fetch', (event) => {
       }),
     )
 
-    return Response.redirect('/capture/share?fromShareTarget=1', 303)
+    return Response.redirect(`/capture/share?fromShareTarget=1&shareId=${encodeURIComponent(shareId)}`, 303)
   })())
 })
 
@@ -52,4 +53,13 @@ async function notifyWindowClientsToReplayCaptureQueue() {
   for (const client of clients) {
     client.postMessage({ type: TASKDECK_CAPTURE_SYNC_MESSAGE })
   }
+}
+
+function createShareId() {
+  if (self.crypto?.randomUUID) {
+    return self.crypto.randomUUID()
+  }
+
+  const random = Math.random().toString(36).slice(2)
+  return `${Date.now().toString(36)}-${random}`
 }

--- a/frontend/taskdeck-web/public/share-target-handler.js
+++ b/frontend/taskdeck-web/public/share-target-handler.js
@@ -12,6 +12,11 @@ self.addEventListener('fetch', (event) => {
     return
   }
 
+  if (!isTrustedShareTargetPost(event.request, url)) {
+    event.respondWith(new Response('Forbidden', { status: 403 }))
+    return
+  }
+
   event.respondWith((async () => {
     const form = await event.request.formData()
     const payload = {
@@ -35,6 +40,20 @@ self.addEventListener('fetch', (event) => {
     return Response.redirect(`/capture/share?fromShareTarget=1&shareId=${encodeURIComponent(shareId)}`, 303)
   })())
 })
+
+function isTrustedShareTargetPost(request, url) {
+  const origin = request.headers.get('Origin')
+  if (origin && origin !== url.origin) {
+    return false
+  }
+
+  const fetchSite = request.headers.get('Sec-Fetch-Site')
+  if (!fetchSite) {
+    return true
+  }
+
+  return fetchSite === 'none' || fetchSite === 'same-origin' || fetchSite === 'same-site'
+}
 
 self.addEventListener('message', (event) => {
   if (event.data?.type !== TASKDECK_CAPTURE_SYNC_MESSAGE) {

--- a/frontend/taskdeck-web/src/components/board/CardModal.vue
+++ b/frontend/taskdeck-web/src/components/board/CardModal.vue
@@ -152,6 +152,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
 
         <CardModalActions
           :is-form-valid="isFormValid"
+          :card="card"
           @save="handleSave"
           @close="handleClose"
           @delete-click="handleDeleteClick"

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalActions.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalActions.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-defineProps<{
+import { useShareCard } from '../../../composables/useShareCard'
+import type { Card } from '../../../types/board'
+
+const props = defineProps<{
   isFormValid: boolean
+  card: Card
 }>()
 
 defineEmits<{
@@ -8,17 +12,34 @@ defineEmits<{
   (e: 'close'): void
   (e: 'delete-click'): void
 }>()
+
+const { canShare, shareCard } = useShareCard()
+
+function handleShare() {
+  void shareCard(props.card)
+}
 </script>
 
 <template>
   <div class="mt-6 flex items-center justify-between">
-    <button
-      @click="$emit('delete-click')"
-      type="button"
-      class="px-4 py-2 text-sm font-medium text-error hover:text-error/80 hover:bg-error/10 border border-error/40 rounded-md transition-colors"
-    >
-      Delete Card
-    </button>
+    <div class="flex gap-2">
+      <button
+        @click="$emit('delete-click')"
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-error hover:text-error/80 hover:bg-error/10 border border-error/40 rounded-md transition-colors"
+      >
+        Delete Card
+      </button>
+      <button
+        v-if="canShare"
+        @click="handleShare"
+        type="button"
+        class="px-4 py-2 text-sm font-medium text-on-surface-variant hover:bg-surface-container-high border border-outline-variant/40 rounded-md transition-colors"
+        aria-label="Share card"
+      >
+        Share
+      </button>
+    </div>
     <div class="flex gap-2">
       <button
         @click="$emit('close')"

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalActions.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalActions.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useShareCard } from '../../../composables/useShareCard'
+import { logError } from '../../../utils/errorReporting'
 import type { Card } from '../../../types/board'
 
 const props = defineProps<{
@@ -15,8 +16,12 @@ defineEmits<{
 
 const { canShare, shareCard } = useShareCard()
 
-function handleShare() {
-  void shareCard(props.card)
+async function handleShare() {
+  try {
+    await shareCard(props.card)
+  } catch (error) {
+    logError('Card share failed:', error)
+  }
 }
 </script>
 

--- a/frontend/taskdeck-web/src/components/shell/AppShell.vue
+++ b/frontend/taskdeck-web/src/components/shell/AppShell.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useSessionStore } from '../../store/sessionStore'
 import { useWorkspaceStore } from '../../store/workspaceStore'
 import { usePaperThemeStore } from '../../store/paperThemeStore'
+import { useCaptureQueueSync } from '../../composables/useCaptureQueueSync'
 import { registerEscapeHandler } from '../../composables/useEscapeStack'
 import { useViewportMode } from '../../composables/useViewportMode'
 import CaptureModal from '../common/CaptureModal.vue'
@@ -37,6 +38,8 @@ const session = useSessionStore()
 const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
 const { mode: viewportMode } = useViewportMode()
+
+const { pendingCount: captureQueuePending, syncing: captureQueueSyncing } = useCaptureQueueSync()
 
 const sidebarRef = ref<SidebarRef | null>(null)
 const isPaperNarrow = computed(() => paperTheme.isOn && viewportMode.value !== 'desktop')
@@ -213,6 +216,22 @@ onUnmounted(() => {
 
     <div class="td-main-container">
       <OfflineBanner />
+      <Transition name="offline-banner">
+        <div
+          v-if="captureQueuePending > 0"
+          class="td-capture-queue-banner"
+          role="status"
+          aria-live="polite"
+        >
+          <span class="material-symbols-outlined td-capture-queue-banner__icon" aria-hidden="true">
+            {{ captureQueueSyncing ? 'sync' : 'pending' }}
+          </span>
+          <span class="td-capture-queue-banner__text">
+            {{ captureQueueSyncing ? 'Syncing' : captureQueuePending }}
+            {{ captureQueuePending === 1 ? 'capture' : 'captures' }} queued
+          </span>
+        </div>
+      </Transition>
       <SwUpdatePrompt />
       <div v-if="!isPaperNarrow" class="td-mobile-topbar">
         <button
@@ -300,6 +319,29 @@ onUnmounted(() => {
   overflow-y: auto;
   padding: var(--td-space-8);
   background: var(--td-surface-base);
+}
+
+/* ─── Capture queue banner ─── */
+.td-capture-queue-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--td-space-3);
+  padding: var(--td-space-2) var(--td-space-4);
+  background: var(--td-color-info-light, #e8f4fd);
+  border-bottom: 1px solid var(--td-color-info, #64b5f6);
+  color: var(--td-color-info, #1565c0);
+  font-size: var(--td-font-sm);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.td-capture-queue-banner__icon {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.td-capture-queue-banner__text {
+  line-height: 1.4;
 }
 
 /* ─── Mobile top bar (hamburger) ─── */

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -8,6 +8,8 @@ import { logError } from '../utils/errorReporting'
 const MAX_RETRIES = 5
 const SYNC_TAG = 'taskdeck-capture-sync'
 
+let replayInProgress = false
+
 export function useCaptureQueueSync() {
   const { isOnline } = useOnlineStatus()
   const pendingCount = ref(0)
@@ -15,7 +17,8 @@ export function useCaptureQueueSync() {
   let onlineHandler: (() => void) | null = null
 
   async function replayQueue(): Promise<number> {
-    if (syncing.value) return 0
+    if (replayInProgress) return 0
+    replayInProgress = true
     syncing.value = true
     let replayed = 0
 
@@ -29,6 +32,11 @@ export function useCaptureQueueSync() {
 
       for (const entry of pending) {
         if (entry.retryCount >= MAX_RETRIES) {
+          logError('Capture queue: discarding entry after max retries', {
+            id: entry.id,
+            queuedAt: entry.queuedAt,
+            text: entry.dto.text.slice(0, 100),
+          })
           await dequeueCapture(entry.id)
           pendingCount.value--
           continue
@@ -46,6 +54,7 @@ export function useCaptureQueueSync() {
     } catch (error) {
       logError('Capture queue replay failed:', error)
     } finally {
+      replayInProgress = false
       syncing.value = false
     }
 

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -1,5 +1,5 @@
 import { ref, onMounted, onUnmounted } from 'vue'
-import { getAllPending, dequeueCapture, incrementRetry, markCaptureFailed } from '../utils/captureQueue'
+import { getAllPending, dequeueCapture, incrementRetry, markCaptureFailed, assignCaptureOwner } from '../utils/captureQueue'
 import type { QueuedCapture } from '../utils/captureQueue'
 import { useCaptureStore } from '../store/captureStore'
 import { useSessionStore } from '../store/sessionStore'
@@ -74,13 +74,20 @@ export function useCaptureQueueSync() {
         }
 
         if (!entry.ownerUserId) {
-          logWarn('Capture queue: parking entry without an owner', {
+          if (!currentUserId) {
+            logWarn('Capture queue: waiting for login before replaying ownerless entry', {
+              id: entry.id,
+              queuedAt: entry.queuedAt,
+            })
+            continue
+          }
+
+          await assignCaptureOwner(entry.id, currentUserId)
+          entry.ownerUserId = currentUserId
+          logWarn('Capture queue: assigned owner to login-required entry', {
             id: entry.id,
             queuedAt: entry.queuedAt,
           })
-          await markCaptureFailed(entry.id, 'Missing queue owner')
-          pendingCount.value--
-          continue
         }
 
         if (!currentUserId || entry.ownerUserId !== currentUserId) {
@@ -129,6 +136,12 @@ export function useCaptureQueueSync() {
     return false
   }
 
+  function requestServiceWorkerQueueReplay() {
+    if (!('serviceWorker' in navigator)) return
+    const controller = navigator.serviceWorker.controller
+    controller?.postMessage({ type: SYNC_MESSAGE_TYPE })
+  }
+
   function registerServiceWorkerMessageReplay() {
     if (!('serviceWorker' in navigator)) return
     serviceWorkerMessageHandler = (event: MessageEvent<unknown>) => {
@@ -152,6 +165,7 @@ export function useCaptureQueueSync() {
     onlineHandler = () => {
       if (isOnline.value) {
         void replayQueue()
+        requestServiceWorkerQueueReplay()
       }
     }
     window.addEventListener('online', onlineHandler)

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -1,0 +1,106 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+import { getAllPending, dequeueCapture, incrementRetry } from '../utils/captureQueue'
+import type { QueuedCapture } from '../utils/captureQueue'
+import { useCaptureStore } from '../store/captureStore'
+import { useOnlineStatus } from './useOnlineStatus'
+import { logError } from '../utils/errorReporting'
+
+const MAX_RETRIES = 5
+const SYNC_TAG = 'taskdeck-capture-sync'
+
+export function useCaptureQueueSync() {
+  const { isOnline } = useOnlineStatus()
+  const pendingCount = ref(0)
+  const syncing = ref(false)
+  let onlineHandler: (() => void) | null = null
+
+  async function replayQueue(): Promise<number> {
+    if (syncing.value) return 0
+    syncing.value = true
+    let replayed = 0
+
+    try {
+      const pending = await getAllPending()
+      pendingCount.value = pending.length
+
+      if (pending.length === 0) return 0
+
+      const captureStore = useCaptureStore()
+
+      for (const entry of pending) {
+        if (entry.retryCount >= MAX_RETRIES) {
+          await dequeueCapture(entry.id)
+          pendingCount.value--
+          continue
+        }
+
+        try {
+          await captureStore.createItem(entry.dto)
+          await dequeueCapture(entry.id)
+          replayed++
+          pendingCount.value--
+        } catch {
+          await incrementRetry(entry.id)
+        }
+      }
+    } catch (error) {
+      logError('Capture queue replay failed:', error)
+    } finally {
+      syncing.value = false
+    }
+
+    return replayed
+  }
+
+  async function registerBackgroundSync(): Promise<boolean> {
+    if (!('serviceWorker' in navigator)) return false
+    try {
+      const reg = await navigator.serviceWorker.ready
+      if ('sync' in reg) {
+        await (reg as ServiceWorkerRegistration & { sync: { register(tag: string): Promise<void> } }).sync.register(SYNC_TAG)
+        return true
+      }
+    } catch {
+      // Background Sync not supported — fall back to online event replay
+    }
+    return false
+  }
+
+  async function refreshCount(): Promise<void> {
+    const pending = await getAllPending()
+    pendingCount.value = pending.length
+  }
+
+  onMounted(() => {
+    void refreshCount()
+
+    onlineHandler = () => {
+      if (isOnline.value) {
+        void replayQueue()
+      }
+    }
+    window.addEventListener('online', onlineHandler)
+
+    if (isOnline.value) {
+      void replayQueue()
+    }
+  })
+
+  onUnmounted(() => {
+    if (onlineHandler) {
+      window.removeEventListener('online', onlineHandler)
+    }
+  })
+
+  return {
+    pendingCount,
+    syncing,
+    replayQueue,
+    registerBackgroundSync,
+    refreshCount,
+  }
+}
+
+export function getPendingCaptures(): Promise<QueuedCapture[]> {
+  return getAllPending()
+}

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -1,5 +1,13 @@
 import { ref, onMounted, onUnmounted } from 'vue'
-import { getAllPending, dequeueCapture, incrementRetry, markCaptureFailed, assignCaptureOwner } from '../utils/captureQueue'
+import {
+  claimCaptureForReplay,
+  dequeueCapture,
+  getAllPending,
+  getPendingCountForOwner,
+  getPendingForOwner,
+  incrementRetry,
+  markCaptureFailed,
+} from '../utils/captureQueue'
 import type { QueuedCapture } from '../utils/captureQueue'
 import { useCaptureStore } from '../store/captureStore'
 import { useSessionStore } from '../store/sessionStore'
@@ -45,6 +53,14 @@ export function useCaptureQueueSync() {
   let onlineHandler: (() => void) | null = null
   let serviceWorkerMessageHandler: ((event: MessageEvent<unknown>) => void) | null = null
 
+  function getCurrentUserId(): string | null {
+    return useSessionStore().userId
+  }
+
+  async function refreshCount(): Promise<void> {
+    pendingCount.value = await getPendingCountForOwner(getCurrentUserId())
+  }
+
   async function replayQueue(): Promise<number> {
     if (replayInProgress) return 0
     replayInProgress = true
@@ -52,14 +68,12 @@ export function useCaptureQueueSync() {
     let replayed = 0
 
     try {
-      const pending = await getAllPending()
+      const captureStore = useCaptureStore()
+      const currentUserId = getCurrentUserId()
+      const pending = await getPendingForOwner(currentUserId)
       pendingCount.value = pending.length
 
-      if (pending.length === 0) return 0
-
-      const captureStore = useCaptureStore()
-      const sessionStore = useSessionStore()
-      const currentUserId = sessionStore.userId
+      if (!currentUserId || pending.length === 0) return 0
 
       for (const entry of pending) {
         if (entry.retryCount >= MAX_RETRIES) {
@@ -72,25 +86,9 @@ export function useCaptureQueueSync() {
           continue
         }
 
-        if (!entry.ownerUserId) {
-          if (!currentUserId) {
-            logWarn('Capture queue: waiting for login before replaying ownerless entry', {
-              id: entry.id,
-              queuedAt: entry.queuedAt,
-            })
-            continue
-          }
-
-          await assignCaptureOwner(entry.id, currentUserId)
-          entry.ownerUserId = currentUserId
-          logWarn('Capture queue: assigned owner to login-required entry', {
-            id: entry.id,
-            queuedAt: entry.queuedAt,
-          })
-        }
-
-        if (!currentUserId || entry.ownerUserId !== currentUserId) {
-          logWarn('Capture queue: skipping entry for a different session', {
+        const claimed = await claimCaptureForReplay(entry.id, currentUserId)
+        if (!claimed) {
+          logWarn('Capture queue: skipping entry claimed by another replay worker', {
             id: entry.id,
             queuedAt: entry.queuedAt,
           })
@@ -98,15 +96,15 @@ export function useCaptureQueueSync() {
         }
 
         try {
-          await captureStore.createItem(entry.dto)
-          await dequeueCapture(entry.id)
+          await captureStore.createItem(claimed.dto)
+          await dequeueCapture(claimed.id)
           replayed++
           pendingCount.value--
         } catch (error) {
           if (isTransientCaptureError(error)) {
-            await incrementRetry(entry.id)
+            await incrementRetry(claimed.id)
           } else {
-            await markCaptureFailed(entry.id, describeCaptureError(error))
+            await markCaptureFailed(claimed.id, describeCaptureError(error))
             pendingCount.value--
           }
         }
@@ -114,6 +112,11 @@ export function useCaptureQueueSync() {
     } catch (error) {
       logError('Capture queue replay failed:', error)
     } finally {
+      try {
+        await refreshCount()
+      } catch (error) {
+        logError('Capture queue count refresh failed:', error)
+      }
       replayInProgress = false
       syncing.value = false
     }
@@ -135,11 +138,6 @@ export function useCaptureQueueSync() {
       }
     }
     navigator.serviceWorker.addEventListener('message', serviceWorkerMessageHandler)
-  }
-
-  async function refreshCount(): Promise<void> {
-    const pending = await getAllPending()
-    pendingCount.value = pending.length
   }
 
   onMounted(() => {

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -35,7 +35,6 @@ export function useCaptureQueueSync() {
           logError('Capture queue: discarding entry after max retries', {
             id: entry.id,
             queuedAt: entry.queuedAt,
-            text: entry.dto.text.slice(0, 100),
           })
           await dequeueCapture(entry.id)
           pendingCount.value--
@@ -82,6 +81,7 @@ export function useCaptureQueueSync() {
 
   onMounted(() => {
     void refreshCount()
+    void registerBackgroundSync()
 
     onlineHandler = () => {
       if (isOnline.value) {

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -7,7 +7,6 @@ import { useOnlineStatus } from './useOnlineStatus'
 import { logError, logWarn } from '../utils/errorReporting'
 
 const MAX_RETRIES = 5
-const SYNC_TAG = 'taskdeck-capture-sync'
 const SYNC_MESSAGE_TYPE = 'taskdeck:capture-sync'
 
 let replayInProgress = false
@@ -122,20 +121,6 @@ export function useCaptureQueueSync() {
     return replayed
   }
 
-  async function registerBackgroundSync(): Promise<boolean> {
-    if (!('serviceWorker' in navigator)) return false
-    try {
-      const reg = await navigator.serviceWorker.ready
-      if ('sync' in reg) {
-        await (reg as ServiceWorkerRegistration & { sync: { register(tag: string): Promise<void> } }).sync.register(SYNC_TAG)
-        return true
-      }
-    } catch {
-      // Background Sync not supported — fall back to online event replay
-    }
-    return false
-  }
-
   function requestServiceWorkerQueueReplay() {
     if (!('serviceWorker' in navigator)) return
     const controller = navigator.serviceWorker.controller
@@ -159,7 +144,6 @@ export function useCaptureQueueSync() {
 
   onMounted(() => {
     void refreshCount()
-    void registerBackgroundSync()
     registerServiceWorkerMessageReplay()
 
     onlineHandler = () => {
@@ -188,7 +172,6 @@ export function useCaptureQueueSync() {
     pendingCount,
     syncing,
     replayQueue,
-    registerBackgroundSync,
     refreshCount,
   }
 }

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -1,20 +1,50 @@
 import { ref, onMounted, onUnmounted } from 'vue'
-import { getAllPending, dequeueCapture, incrementRetry } from '../utils/captureQueue'
+import { getAllPending, dequeueCapture, incrementRetry, markCaptureFailed } from '../utils/captureQueue'
 import type { QueuedCapture } from '../utils/captureQueue'
 import { useCaptureStore } from '../store/captureStore'
+import { useSessionStore } from '../store/sessionStore'
 import { useOnlineStatus } from './useOnlineStatus'
-import { logError } from '../utils/errorReporting'
+import { logError, logWarn } from '../utils/errorReporting'
 
 const MAX_RETRIES = 5
 const SYNC_TAG = 'taskdeck-capture-sync'
+const SYNC_MESSAGE_TYPE = 'taskdeck:capture-sync'
 
 let replayInProgress = false
+
+function getErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null
+  const response = (error as { response?: unknown }).response
+  if (!response || typeof response !== 'object') return null
+  const status = (response as { status?: unknown }).status
+  return typeof status === 'number' ? status : null
+}
+
+function describeCaptureError(error: unknown): string {
+  const status = getErrorStatus(error)
+  if (status !== null) return `HTTP ${status}`
+  if (error instanceof Error && error.message.trim()) return error.message
+  return 'Unknown capture sync error'
+}
+
+function isTransientCaptureError(error: unknown): boolean {
+  const status = getErrorStatus(error)
+  if (status === null) return true
+  if (status === 408 || status === 429) return true
+  return status >= 500 && status < 600 && status !== 501 && status !== 505
+}
+
+function isCaptureSyncMessage(event: MessageEvent<unknown>): boolean {
+  const data = event.data
+  return !!data && typeof data === 'object' && (data as { type?: unknown }).type === SYNC_MESSAGE_TYPE
+}
 
 export function useCaptureQueueSync() {
   const { isOnline } = useOnlineStatus()
   const pendingCount = ref(0)
   const syncing = ref(false)
   let onlineHandler: (() => void) | null = null
+  let serviceWorkerMessageHandler: ((event: MessageEvent<unknown>) => void) | null = null
 
   async function replayQueue(): Promise<number> {
     if (replayInProgress) return 0
@@ -29,15 +59,35 @@ export function useCaptureQueueSync() {
       if (pending.length === 0) return 0
 
       const captureStore = useCaptureStore()
+      const sessionStore = useSessionStore()
+      const currentUserId = sessionStore.userId
 
       for (const entry of pending) {
         if (entry.retryCount >= MAX_RETRIES) {
-          logError('Capture queue: discarding entry after max retries', {
+          logWarn('Capture queue: parking entry after max retries', {
             id: entry.id,
             queuedAt: entry.queuedAt,
           })
-          await dequeueCapture(entry.id)
+          await markCaptureFailed(entry.id, 'Max retry count reached')
           pendingCount.value--
+          continue
+        }
+
+        if (!entry.ownerUserId) {
+          logWarn('Capture queue: parking entry without an owner', {
+            id: entry.id,
+            queuedAt: entry.queuedAt,
+          })
+          await markCaptureFailed(entry.id, 'Missing queue owner')
+          pendingCount.value--
+          continue
+        }
+
+        if (!currentUserId || entry.ownerUserId !== currentUserId) {
+          logWarn('Capture queue: skipping entry for a different session', {
+            id: entry.id,
+            queuedAt: entry.queuedAt,
+          })
           continue
         }
 
@@ -46,8 +96,13 @@ export function useCaptureQueueSync() {
           await dequeueCapture(entry.id)
           replayed++
           pendingCount.value--
-        } catch {
-          await incrementRetry(entry.id)
+        } catch (error) {
+          if (isTransientCaptureError(error)) {
+            await incrementRetry(entry.id)
+          } else {
+            await markCaptureFailed(entry.id, describeCaptureError(error))
+            pendingCount.value--
+          }
         }
       }
     } catch (error) {
@@ -74,6 +129,16 @@ export function useCaptureQueueSync() {
     return false
   }
 
+  function registerServiceWorkerMessageReplay() {
+    if (!('serviceWorker' in navigator)) return
+    serviceWorkerMessageHandler = (event: MessageEvent<unknown>) => {
+      if (isCaptureSyncMessage(event)) {
+        void replayQueue()
+      }
+    }
+    navigator.serviceWorker.addEventListener('message', serviceWorkerMessageHandler)
+  }
+
   async function refreshCount(): Promise<void> {
     const pending = await getAllPending()
     pendingCount.value = pending.length
@@ -82,6 +147,7 @@ export function useCaptureQueueSync() {
   onMounted(() => {
     void refreshCount()
     void registerBackgroundSync()
+    registerServiceWorkerMessageReplay()
 
     onlineHandler = () => {
       if (isOnline.value) {
@@ -98,6 +164,9 @@ export function useCaptureQueueSync() {
   onUnmounted(() => {
     if (onlineHandler) {
       window.removeEventListener('online', onlineHandler)
+    }
+    if (serviceWorkerMessageHandler && 'serviceWorker' in navigator) {
+      navigator.serviceWorker.removeEventListener('message', serviceWorkerMessageHandler)
     }
   })
 

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -95,19 +95,34 @@ export function useCaptureQueueSync() {
           continue
         }
 
+        let remoteCreateSucceeded = false
         try {
           await captureStore.createItem(claimed.dto)
-          await dequeueCapture(claimed.id)
-          replayed++
-          pendingCount.value--
+          remoteCreateSucceeded = true
         } catch (error) {
           if (isTransientCaptureError(error)) {
             await incrementRetry(claimed.id)
-          } else {
-            await markCaptureFailed(claimed.id, describeCaptureError(error))
+            continue
+          }
+
+          await markCaptureFailed(claimed.id, describeCaptureError(error))
+          pendingCount.value--
+          continue
+        }
+
+        try {
+          await dequeueCapture(claimed.id)
+        } catch (error) {
+          logError('Capture queue dequeue failed after remote create:', error)
+          if (remoteCreateSucceeded) {
+            await markCaptureFailed(claimed.id, 'Remote create succeeded but local dequeue failed')
             pendingCount.value--
           }
+          continue
         }
+
+        replayed++
+        pendingCount.value--
       }
     } catch (error) {
       logError('Capture queue replay failed:', error)

--- a/frontend/taskdeck-web/src/composables/useShareCard.ts
+++ b/frontend/taskdeck-web/src/composables/useShareCard.ts
@@ -1,0 +1,27 @@
+import { computed } from 'vue'
+import type { Card } from '../types/board'
+
+export function useShareCard() {
+  const canShare = computed(() => typeof navigator !== 'undefined' && 'share' in navigator)
+
+  async function shareCard(card: Card): Promise<boolean> {
+    if (!canShare.value) return false
+
+    const shareData: ShareData = {
+      title: card.title,
+      text: card.description || undefined,
+    }
+
+    try {
+      await navigator.share(shareData)
+      return true
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return false
+      }
+      throw error
+    }
+  }
+
+  return { canShare, shareCard }
+}

--- a/frontend/taskdeck-web/src/router/index.ts
+++ b/frontend/taskdeck-web/src/router/index.ts
@@ -48,6 +48,7 @@ const AgentRunsView = () => import('../views/AgentRunsView.vue')
 const AgentRunDetailView = () => import('../views/AgentRunDetailView.vue')
 const ApiKeySettingsView = () => import('../views/ApiKeySettingsView.vue')
 const PaperStyleGuideView = () => import('../views/PaperStyleGuideView.vue')
+const ShareTargetView = () => import('../views/ShareTargetView.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -72,6 +73,16 @@ const router = createRouter({
       path: '/styleguide/paper',
       name: 'styleguide-paper',
       component: PaperStyleGuideView,
+      meta: { public: true },
+    },
+
+    // PWA share-target landing — receives POST from OS share API,
+    // queues capture offline or sends immediately. Public because
+    // the OS launches this URL directly without auth context.
+    {
+      path: '/capture/share',
+      name: 'capture-share-target',
+      component: ShareTargetView,
       meta: { public: true },
     },
 

--- a/frontend/taskdeck-web/src/router/index.ts
+++ b/frontend/taskdeck-web/src/router/index.ts
@@ -76,7 +76,7 @@ const router = createRouter({
       meta: { public: true },
     },
 
-    // PWA share-target landing — receives POST from OS share API,
+    // PWA share-target landing — receives GET from OS share API,
     // queues capture offline or sends immediately. Public because
     // the OS launches this URL directly without auth context.
     {

--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -86,6 +86,10 @@ vi.mock('../../composables/useViewportMode', async () => {
   return { useViewportMode: () => ({ mode: computed(() => mockViewportMode.value) }) }
 })
 
+vi.mock('../../composables/useCaptureQueueSync', () => ({
+  useCaptureQueueSync: () => ({ pendingCount: { value: 0 }, syncing: { value: 0 }, replayQueue: vi.fn(), registerBackgroundSync: vi.fn(), refreshCount: vi.fn() }),
+}))
+
 function mountShell() {
   return mount(AppShell, {
     global: {

--- a/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
@@ -73,6 +73,10 @@ vi.mock('../../store/paperThemeStore', () => ({
   usePaperThemeStore: () => mockPaperTheme,
 }))
 
+vi.mock('../../composables/useCaptureQueueSync', () => ({
+  useCaptureQueueSync: () => ({ pendingCount: { value: 0 }, syncing: { value: false }, replayQueue: vi.fn(), registerBackgroundSync: vi.fn(), refreshCount: vi.fn() }),
+}))
+
 function mountShell() {
   return mount(AppShell, {
     global: {

--- a/frontend/taskdeck-web/src/tests/composables/useCaptureQueueSync.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useCaptureQueueSync.spec.ts
@@ -1,0 +1,158 @@
+import 'fake-indexeddb/auto'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { useCaptureQueueSync } from '../../composables/useCaptureQueueSync'
+import {
+  dequeueCapture,
+  enqueueCapture,
+  getAllPending,
+  getAllQueuedCaptures,
+  incrementRetry,
+} from '../../utils/captureQueue'
+import type { CreateCaptureItemDto } from '../../types/capture'
+
+const mockOnline = vi.hoisted(() => ({ value: true }))
+const sessionMock = vi.hoisted(() => ({ userId: 'user-1' as string | null }))
+const createItemMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../composables/useOnlineStatus', () => ({
+  useOnlineStatus: () => ({ isOnline: mockOnline }),
+}))
+
+vi.mock('../../store/sessionStore', () => ({
+  useSessionStore: () => sessionMock,
+}))
+
+vi.mock('../../store/captureStore', () => ({
+  useCaptureStore: () => ({ createItem: createItemMock }),
+}))
+
+function makeDto(text = 'Queued capture'): CreateCaptureItemDto {
+  return { boardId: null, text, source: 'ShareTarget', titleHint: null, externalRef: null }
+}
+
+async function clearQueue() {
+  const queued = await getAllQueuedCaptures()
+  for (const entry of queued) {
+    await dequeueCapture(entry.id)
+  }
+}
+
+function mountSyncComposable() {
+  let exposed: ReturnType<typeof useCaptureQueueSync> | null = null
+  const Host = defineComponent({
+    setup() {
+      exposed = useCaptureQueueSync()
+      return () => null
+    },
+  })
+  const wrapper = mount(Host)
+  if (!exposed) {
+    throw new Error('Composable did not mount')
+  }
+  return { wrapper, sync: exposed }
+}
+
+describe('useCaptureQueueSync', () => {
+  beforeEach(async () => {
+    await clearQueue()
+    createItemMock.mockReset()
+    createItemMock.mockResolvedValue({ id: 'capture-1' })
+    sessionMock.userId = 'user-1'
+    mockOnline.value = false
+    Reflect.deleteProperty(navigator, 'serviceWorker')
+  })
+
+  afterEach(async () => {
+    await clearQueue()
+  })
+
+  it('does not replay captures queued for a different user', async () => {
+    await enqueueCapture(makeDto('Other user'), 'user-2')
+    const { sync } = mountSyncComposable()
+
+    await sync.replayQueue()
+
+    expect(createItemMock).not.toHaveBeenCalled()
+    expect(await getAllPending()).toHaveLength(1)
+  })
+
+  it('parks non-transient failures without deleting the queued payload', async () => {
+    createItemMock.mockRejectedValueOnce({ response: { status: 400 } })
+    await enqueueCapture(makeDto('Invalid payload'), 'user-1')
+    const { sync } = mountSyncComposable()
+
+    const replayed = await sync.replayQueue()
+
+    expect(replayed).toBe(0)
+    expect(await getAllPending()).toHaveLength(0)
+    const queued = await getAllQueuedCaptures()
+    expect(queued).toHaveLength(1)
+    expect(queued[0]).toMatchObject({
+      status: 'failed',
+      lastError: 'HTTP 400',
+      dto: expect.objectContaining({ text: 'Invalid payload' }),
+    })
+  })
+
+  it('keeps transient failures pending and increments retry count', async () => {
+    createItemMock.mockRejectedValueOnce({ response: { status: 503 } })
+    await enqueueCapture(makeDto('Try later'), 'user-1')
+    const { sync } = mountSyncComposable()
+
+    await sync.replayQueue()
+
+    const pending = await getAllPending()
+    expect(pending).toHaveLength(1)
+    expect(pending[0].retryCount).toBe(1)
+  })
+
+  it('parks entries at the retry cap instead of discarding them', async () => {
+    const id = await enqueueCapture(makeDto('Retry capped'), 'user-1')
+    for (let i = 0; i < 5; i++) {
+      await incrementRetry(id)
+    }
+    const { sync } = mountSyncComposable()
+
+    await sync.replayQueue()
+
+    expect(createItemMock).not.toHaveBeenCalled()
+    expect(await getAllPending()).toHaveLength(0)
+    const queued = await getAllQueuedCaptures()
+    expect(queued[0]).toMatchObject({
+      id,
+      status: 'failed',
+      lastError: 'Max retry count reached',
+    })
+  })
+
+  it('replays when the service worker forwards the background-sync event', async () => {
+    await enqueueCapture(makeDto('From sync event'), 'user-1')
+    let messageHandler: ((event: MessageEvent<unknown>) => void) | null = null
+    const serviceWorker = {
+      ready: Promise.resolve({ sync: { register: vi.fn() } }),
+      addEventListener: vi.fn((_event: string, handler: (event: MessageEvent<unknown>) => void) => {
+        messageHandler = handler
+      }),
+      removeEventListener: vi.fn(),
+    }
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: serviceWorker,
+    })
+
+    const { wrapper } = mountSyncComposable()
+    await flushPromises()
+    expect(serviceWorker.addEventListener).toHaveBeenCalledWith('message', expect.any(Function))
+    messageHandler?.({ data: { type: 'taskdeck:capture-sync' } } as MessageEvent<unknown>)
+
+    await vi.waitFor(() => {
+      expect(createItemMock).toHaveBeenCalledWith(expect.objectContaining({ text: 'From sync event' }))
+    })
+    expect(await getAllPending()).toHaveLength(0)
+
+    wrapper.unmount()
+    expect(serviceWorker.removeEventListener).toHaveBeenCalledWith('message', expect.any(Function))
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useCaptureQueueSync.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useCaptureQueueSync.spec.ts
@@ -4,6 +4,7 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import { useCaptureQueueSync } from '../../composables/useCaptureQueueSync'
 import {
+  claimCaptureForReplay,
   dequeueCapture,
   enqueueCapture,
   getAllPending,
@@ -78,6 +79,19 @@ describe('useCaptureQueueSync', () => {
     expect(await getAllPending()).toHaveLength(1)
   })
 
+  it('reports only captures visible to the active user', async () => {
+    await enqueueCapture(makeDto('Mine'), 'user-1')
+    await enqueueCapture(makeDto('Other user'), 'user-2')
+    await enqueueCapture(makeDto('Ownerless'))
+
+    const { sync } = mountSyncComposable()
+    await flushPromises()
+
+    await vi.waitFor(() => {
+      expect(sync.pendingCount.value).toBe(2)
+    })
+  })
+
   it('claims an ownerless login-required capture once a user session exists', async () => {
     await enqueueCapture(makeDto('Needs login'))
     const { sync } = mountSyncComposable()
@@ -136,6 +150,18 @@ describe('useCaptureQueueSync', () => {
     expect(pending[0].retryCount).toBe(1)
   })
 
+  it('does not replay a row already claimed by another tab', async () => {
+    const id = await enqueueCapture(makeDto('Already claimed'), 'user-1')
+    await claimCaptureForReplay(id, 'user-1')
+    const { sync } = mountSyncComposable()
+
+    const replayed = await sync.replayQueue()
+
+    expect(replayed).toBe(0)
+    expect(createItemMock).not.toHaveBeenCalled()
+    expect(await getAllPending()).toHaveLength(1)
+  })
+
   it('parks entries at the retry cap instead of discarding them', async () => {
     const id = await enqueueCapture(makeDto('Retry capped'), 'user-1')
     for (let i = 0; i < 5; i++) {
@@ -155,7 +181,7 @@ describe('useCaptureQueueSync', () => {
     })
   })
 
-  it('replays when the service worker forwards the background-sync event', async () => {
+  it('replays when the service worker forwards a client replay message', async () => {
     await enqueueCapture(makeDto('From sync event'), 'user-1')
     let messageHandler: ((event: MessageEvent<unknown>) => void) | null = null
     const serviceWorker = {

--- a/frontend/taskdeck-web/src/tests/composables/useCaptureQueueSync.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useCaptureQueueSync.spec.ts
@@ -78,6 +78,34 @@ describe('useCaptureQueueSync', () => {
     expect(await getAllPending()).toHaveLength(1)
   })
 
+  it('claims an ownerless login-required capture once a user session exists', async () => {
+    await enqueueCapture(makeDto('Needs login'))
+    const { sync } = mountSyncComposable()
+
+    const replayed = await sync.replayQueue()
+
+    expect(replayed).toBe(1)
+    expect(createItemMock).toHaveBeenCalledWith(expect.objectContaining({ text: 'Needs login' }))
+    expect(await getAllPending()).toHaveLength(0)
+  })
+
+  it('keeps ownerless captures pending until a user session exists', async () => {
+    sessionMock.userId = null
+    await enqueueCapture(makeDto('Needs login'))
+    const { sync } = mountSyncComposable()
+
+    const replayed = await sync.replayQueue()
+
+    expect(replayed).toBe(0)
+    expect(createItemMock).not.toHaveBeenCalled()
+    const pending = await getAllPending()
+    expect(pending).toHaveLength(1)
+    expect(pending[0]).toMatchObject({
+      ownerUserId: null,
+      status: 'pending',
+    })
+  })
+
   it('parks non-transient failures without deleting the queued payload', async () => {
     createItemMock.mockRejectedValueOnce({ response: { status: 400 } })
     await enqueueCapture(makeDto('Invalid payload'), 'user-1')
@@ -132,6 +160,7 @@ describe('useCaptureQueueSync', () => {
     let messageHandler: ((event: MessageEvent<unknown>) => void) | null = null
     const serviceWorker = {
       ready: Promise.resolve({ sync: { register: vi.fn() } }),
+      controller: { postMessage: vi.fn() },
       addEventListener: vi.fn((_event: string, handler: (event: MessageEvent<unknown>) => void) => {
         messageHandler = handler
       }),

--- a/frontend/taskdeck-web/src/tests/public/shareTargetHandler.spec.ts
+++ b/frontend/taskdeck-web/src/tests/public/shareTargetHandler.spec.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it, vi } from 'vitest'
+
+type FetchEvent = {
+  request: {
+    method: string
+    url: string
+    headers: Headers
+    formData: () => Promise<{ get: (name: string) => string | null }>
+  }
+  response?: Promise<TestResponse> | TestResponse
+  respondWith: (response: Promise<TestResponse> | TestResponse) => void
+}
+
+class TestResponse {
+  readonly body: unknown
+  readonly status: number
+  readonly headers: Headers
+  readonly redirectedTo: string | null
+
+  constructor(body: unknown = null, init: ResponseInit = {}) {
+    this.body = body
+    this.status = init.status ?? 200
+    this.headers = new Headers(init.headers)
+    this.redirectedTo = null
+  }
+
+  static redirect(url: string, status = 302): TestResponse {
+    const response = new TestResponse(null, { status })
+    ;(response as { redirectedTo: string }).redirectedTo = url
+    return response
+  }
+}
+
+function loadFetchHandler() {
+  let fetchHandler: ((event: FetchEvent) => void) | null = null
+  const cachePut = vi.fn()
+
+  const context = {
+    URL,
+    Headers,
+    Response: TestResponse,
+    JSON,
+    Math,
+    Date,
+    String,
+    encodeURIComponent,
+    caches: {
+      open: vi.fn(async () => ({ put: cachePut })),
+    },
+    self: {
+      location: { origin: 'https://taskdeck.test' },
+      crypto: { randomUUID: () => 'share-id-1' },
+      clients: { matchAll: vi.fn(async () => []) },
+      addEventListener: vi.fn((type: string, handler: (event: FetchEvent) => void) => {
+        if (type === 'fetch') {
+          fetchHandler = handler
+        }
+      }),
+    },
+  }
+
+  const scriptPath = resolve(process.cwd(), 'public/share-target-handler.js')
+  runInNewContext(readFileSync(scriptPath, 'utf8'), context)
+
+  if (!fetchHandler) {
+    throw new Error('share-target fetch handler was not registered')
+  }
+
+  return { fetchHandler, cachesOpen: context.caches.open, cachePut }
+}
+
+function makeEvent(headers: Record<string, string> = {}): FetchEvent {
+  const form = new Map([
+    ['title', 'Shared title'],
+    ['text', 'Shared text'],
+    ['url', 'https://example.test/item'],
+  ])
+
+  return {
+    request: {
+      method: 'POST',
+      url: 'https://taskdeck.test/capture/share',
+      headers: new Headers(headers),
+      formData: async () => ({ get: (name: string) => form.get(name) ?? null }),
+    },
+    respondWith(response) {
+      this.response = response
+    },
+  }
+}
+
+describe('share-target service worker handler', () => {
+  it('rejects cross-site POST attempts before caching shared content', async () => {
+    const { fetchHandler, cachesOpen } = loadFetchHandler()
+    const event = makeEvent({
+      Origin: 'https://attacker.test',
+      'Sec-Fetch-Site': 'cross-site',
+    })
+
+    fetchHandler(event)
+    const response = await event.response
+
+    expect(response?.status).toBe(403)
+    expect(cachesOpen).not.toHaveBeenCalled()
+  })
+
+  it('accepts OS share-target POSTs with browser fetch metadata', async () => {
+    const { fetchHandler, cachesOpen, cachePut } = loadFetchHandler()
+    const event = makeEvent({ 'Sec-Fetch-Site': 'none' })
+
+    fetchHandler(event)
+    const response = await event.response
+
+    expect(response?.status).toBe(303)
+    expect(response?.redirectedTo).toBe('/capture/share?fromShareTarget=1&shareId=share-id-1')
+    expect(cachesOpen).toHaveBeenCalledWith('taskdeck-share-target')
+    expect(cachePut).toHaveBeenCalledWith(
+      '/capture/share-data/share-id-1',
+      expect.objectContaining({
+        status: 200,
+      }),
+    )
+  })
+
+  it('accepts same-origin POSTs and still caches under a unique share id', async () => {
+    const { fetchHandler, cachePut } = loadFetchHandler()
+    const event = makeEvent({
+      Origin: 'https://taskdeck.test',
+      'Sec-Fetch-Site': 'same-origin',
+    })
+
+    fetchHandler(event)
+    const response = await event.response
+
+    expect(response?.status).toBe(303)
+    expect(cachePut).toHaveBeenCalledWith(
+      '/capture/share-data/share-id-1',
+      expect.any(TestResponse),
+    )
+  })
+})

--- a/frontend/taskdeck-web/src/tests/public/shareTargetHandler.spec.ts
+++ b/frontend/taskdeck-web/src/tests/public/shareTargetHandler.spec.ts
@@ -107,6 +107,17 @@ describe('share-target service worker handler', () => {
     expect(cachesOpen).not.toHaveBeenCalled()
   })
 
+  it('rejects POST attempts with missing fetch metadata and no same-origin signal', async () => {
+    const { fetchHandler, cachesOpen } = loadFetchHandler()
+    const event = makeEvent()
+
+    fetchHandler(event)
+    const response = await event.response
+
+    expect(response?.status).toBe(403)
+    expect(cachesOpen).not.toHaveBeenCalled()
+  })
+
   it('accepts OS share-target POSTs with browser fetch metadata', async () => {
     const { fetchHandler, cachesOpen, cachePut } = loadFetchHandler()
     const event = makeEvent({ 'Sec-Fetch-Site': 'none' })
@@ -122,6 +133,20 @@ describe('share-target service worker handler', () => {
       expect.objectContaining({
         status: 200,
       }),
+    )
+  })
+
+  it('accepts same-origin POSTs when fetch metadata is unavailable', async () => {
+    const { fetchHandler, cachePut } = loadFetchHandler()
+    const event = makeEvent({ Origin: 'https://taskdeck.test' })
+
+    fetchHandler(event)
+    const response = await event.response
+
+    expect(response?.status).toBe(303)
+    expect(cachePut).toHaveBeenCalledWith(
+      '/capture/share-data/share-id-1',
+      expect.any(TestResponse),
     )
   })
 

--- a/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
@@ -4,7 +4,9 @@ import {
   enqueueCapture,
   dequeueCapture,
   getAllPending,
+  getAllQueuedCaptures,
   incrementRetry,
+  markCaptureFailed,
   getPendingCount,
 } from '../../utils/captureQueue'
 import type { CreateCaptureItemDto } from '../../types/capture'
@@ -15,8 +17,8 @@ function makeDto(text = 'Test capture'): CreateCaptureItemDto {
 
 describe('captureQueue', () => {
   beforeEach(async () => {
-    const pending = await getAllPending()
-    for (const entry of pending) {
+    const queued = await getAllQueuedCaptures()
+    for (const entry of queued) {
       await dequeueCapture(entry.id)
     }
   })
@@ -37,7 +39,20 @@ describe('captureQueue', () => {
     expect(pending[0].dto.text).toBe('Hello from share')
     expect(pending[0].dto.source).toBe('ShareTarget')
     expect(pending[0].retryCount).toBe(0)
+    expect(pending[0].ownerUserId).toBeNull()
+    expect(pending[0].status).toBe('pending')
     expect(pending[0].queuedAt).toBeTruthy()
+  })
+
+  it('records the session owner for replay safety', async () => {
+    const id = await enqueueCapture(makeDto('Owned capture'), 'user-1')
+
+    const pending = await getAllPending()
+    expect(pending[0]).toMatchObject({
+      id,
+      ownerUserId: 'user-1',
+      status: 'pending',
+    })
   })
 
   it('dequeues a capture by id', async () => {
@@ -65,6 +80,24 @@ describe('captureQueue', () => {
 
     const pending = await getAllPending()
     expect(pending[0].retryCount).toBe(2)
+  })
+
+  it('marks a capture failed without deleting its recovery payload', async () => {
+    const id = await enqueueCapture(makeDto('Needs recovery'), 'user-1')
+
+    await markCaptureFailed(id, 'HTTP 400')
+
+    expect(await getAllPending()).toHaveLength(0)
+    expect(await getPendingCount()).toBe(0)
+    const queued = await getAllQueuedCaptures()
+    expect(queued).toHaveLength(1)
+    expect(queued[0]).toMatchObject({
+      id,
+      ownerUserId: 'user-1',
+      status: 'failed',
+      lastError: 'HTTP 400',
+    })
+    expect(queued[0].failedAt).toBeTruthy()
   })
 
   it('handles multiple captures in FIFO order', async () => {

--- a/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
@@ -2,6 +2,7 @@ import 'fake-indexeddb/auto'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import {
   enqueueCapture,
+  assignCaptureOwner,
   dequeueCapture,
   getAllPending,
   getAllQueuedCaptures,
@@ -98,6 +99,20 @@ describe('captureQueue', () => {
       lastError: 'HTTP 400',
     })
     expect(queued[0].failedAt).toBeTruthy()
+  })
+
+  it('assigns an owner to a pending ownerless capture', async () => {
+    const id = await enqueueCapture(makeDto('Login required capture'))
+
+    await assignCaptureOwner(id, 'user-1')
+
+    const pending = await getAllPending()
+    expect(pending).toHaveLength(1)
+    expect(pending[0]).toMatchObject({
+      id,
+      ownerUserId: 'user-1',
+      status: 'pending',
+    })
   })
 
   it('handles multiple captures in FIFO order', async () => {

--- a/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import {
   enqueueCapture,
   assignCaptureOwner,
+  claimCaptureForReplay,
   dequeueCapture,
   getAllPending,
   getAllQueuedCaptures,
   incrementRetry,
   markCaptureFailed,
   getPendingCount,
+  getPendingCountForOwner,
 } from '../../utils/captureQueue'
 import type { CreateCaptureItemDto } from '../../types/capture'
 
@@ -83,6 +85,17 @@ describe('captureQueue', () => {
     expect(pending[0].retryCount).toBe(2)
   })
 
+  it('counts only captures visible to the active owner', async () => {
+    await enqueueCapture(makeDto('Mine'), 'user-1')
+    await enqueueCapture(makeDto('Other'), 'user-2')
+    await enqueueCapture(makeDto('Ownerless'))
+
+    expect(await getPendingCount()).toBe(3)
+    expect(await getPendingCountForOwner('user-1')).toBe(2)
+    expect(await getPendingCountForOwner('user-2')).toBe(2)
+    expect(await getPendingCountForOwner(null)).toBe(0)
+  })
+
   it('marks a capture failed without deleting its recovery payload', async () => {
     const id = await enqueueCapture(makeDto('Needs recovery'), 'user-1')
 
@@ -113,6 +126,21 @@ describe('captureQueue', () => {
       ownerUserId: 'user-1',
       status: 'pending',
     })
+  })
+
+  it('atomically claims a capture for one replay worker', async () => {
+    const id = await enqueueCapture(makeDto('Claim once'))
+
+    const firstClaim = await claimCaptureForReplay(id, 'user-1')
+    const secondClaim = await claimCaptureForReplay(id, 'user-1')
+
+    expect(firstClaim).toMatchObject({
+      id,
+      ownerUserId: 'user-1',
+      status: 'pending',
+    })
+    expect(firstClaim?.syncClaimId).toBeTruthy()
+    expect(secondClaim).toBeNull()
   })
 
   it('handles multiple captures in FIFO order', async () => {

--- a/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
@@ -1,5 +1,5 @@
 import 'fake-indexeddb/auto'
-import { describe, expect, it, beforeEach } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import {
   enqueueCapture,
   dequeueCapture,
@@ -19,6 +19,10 @@ describe('captureQueue', () => {
     for (const entry of pending) {
       await dequeueCapture(entry.id)
     }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('enqueues a capture and retrieves it', async () => {
@@ -64,16 +68,18 @@ describe('captureQueue', () => {
   })
 
   it('handles multiple captures in FIFO order', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-05-16T10:00:00Z'))
     await enqueueCapture(makeDto('First'))
+    vi.setSystemTime(new Date('2026-05-16T10:00:01Z'))
     await enqueueCapture(makeDto('Second'))
+    vi.setSystemTime(new Date('2026-05-16T10:00:02Z'))
     await enqueueCapture(makeDto('Third'))
 
     const pending = await getAllPending()
     expect(pending).toHaveLength(3)
     const texts = pending.map((p) => p.dto.text)
-    expect(texts).toContain('First')
-    expect(texts).toContain('Second')
-    expect(texts).toContain('Third')
+    expect(texts).toEqual(['First', 'Second', 'Third'])
   })
 
   it('dequeue is idempotent for missing ids', async () => {

--- a/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/captureQueue.spec.ts
@@ -1,0 +1,82 @@
+import 'fake-indexeddb/auto'
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  enqueueCapture,
+  dequeueCapture,
+  getAllPending,
+  incrementRetry,
+  getPendingCount,
+} from '../../utils/captureQueue'
+import type { CreateCaptureItemDto } from '../../types/capture'
+
+function makeDto(text = 'Test capture'): CreateCaptureItemDto {
+  return { boardId: null, text, source: 'ShareTarget', titleHint: null, externalRef: null }
+}
+
+describe('captureQueue', () => {
+  beforeEach(async () => {
+    const pending = await getAllPending()
+    for (const entry of pending) {
+      await dequeueCapture(entry.id)
+    }
+  })
+
+  it('enqueues a capture and retrieves it', async () => {
+    const dto = makeDto('Hello from share')
+    const id = await enqueueCapture(dto)
+
+    expect(id).toBeTruthy()
+
+    const pending = await getAllPending()
+    expect(pending).toHaveLength(1)
+    expect(pending[0].id).toBe(id)
+    expect(pending[0].dto.text).toBe('Hello from share')
+    expect(pending[0].dto.source).toBe('ShareTarget')
+    expect(pending[0].retryCount).toBe(0)
+    expect(pending[0].queuedAt).toBeTruthy()
+  })
+
+  it('dequeues a capture by id', async () => {
+    const id = await enqueueCapture(makeDto())
+    await dequeueCapture(id)
+
+    const pending = await getAllPending()
+    expect(pending).toHaveLength(0)
+  })
+
+  it('returns correct pending count', async () => {
+    await enqueueCapture(makeDto('A'))
+    await enqueueCapture(makeDto('B'))
+    await enqueueCapture(makeDto('C'))
+
+    const count = await getPendingCount()
+    expect(count).toBe(3)
+  })
+
+  it('increments retry count', async () => {
+    const id = await enqueueCapture(makeDto())
+
+    await incrementRetry(id)
+    await incrementRetry(id)
+
+    const pending = await getAllPending()
+    expect(pending[0].retryCount).toBe(2)
+  })
+
+  it('handles multiple captures in FIFO order', async () => {
+    await enqueueCapture(makeDto('First'))
+    await enqueueCapture(makeDto('Second'))
+    await enqueueCapture(makeDto('Third'))
+
+    const pending = await getAllPending()
+    expect(pending).toHaveLength(3)
+    const texts = pending.map((p) => p.dto.text)
+    expect(texts).toContain('First')
+    expect(texts).toContain('Second')
+    expect(texts).toContain('Third')
+  })
+
+  it('dequeue is idempotent for missing ids', async () => {
+    await expect(dequeueCapture('nonexistent-id')).resolves.toBeUndefined()
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -3,8 +3,8 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { reactive, ref } from 'vue'
 import ShareTargetView from '../../views/ShareTargetView.vue'
 
-const routerMock = { push: vi.fn() }
-const routeQuery = reactive<Record<string, string>>({})
+const routerMock = { push: vi.fn(), replace: vi.fn() }
+const routeQuery = reactive<Record<string, string | string[]>>({})
 const mockOnline = ref(true)
 
 vi.mock('vue-router', () => ({
@@ -55,12 +55,14 @@ function setQuery(title = '', text = '', url = '') {
 describe('ShareTargetView', () => {
   beforeEach(() => {
     routerMock.push.mockClear()
+    routerMock.replace.mockClear()
     mockCreateItem.mockClear()
     mockEnqueue.mockClear()
     mockGetToken.mockReturnValue('valid-jwt-token')
     mockIsTokenExpired.mockReturnValue(false)
     mockOnline.value = true
     setQuery()
+    Reflect.deleteProperty(globalThis, 'caches')
   })
 
   it('sends shared content directly to capture API when online', async () => {
@@ -76,6 +78,38 @@ describe('ShareTargetView', () => {
       externalRef: 'https://example.com',
     })
     expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(routerMock.replace).toHaveBeenCalledWith({ name: 'capture-share-target', query: {} })
+  })
+
+  it('loads POST share-target payload from service worker cache without putting content in the URL', async () => {
+    const cache = {
+      match: vi.fn(async () => new Response(JSON.stringify({
+        title: 'Posted Title',
+        text: 'Posted text',
+        url: 'https://example.com/private',
+      }))),
+      delete: vi.fn(async () => true),
+    }
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: {
+        open: vi.fn(async () => cache),
+      },
+    })
+
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalledWith({
+      boardId: null,
+      text: 'Posted Title\n\nPosted text\n\nhttps://example.com/private',
+      source: 'ShareTarget',
+      titleHint: 'Posted Title',
+      externalRef: 'https://example.com/private',
+    })
+    expect(cache.match).toHaveBeenCalledWith('/capture/share-data')
+    expect(cache.delete).toHaveBeenCalledWith('/capture/share-data')
+    expect(routerMock.replace).not.toHaveBeenCalled()
   })
 
   it('queues capture in IndexedDB when offline', async () => {

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -17,10 +17,16 @@ vi.mock('../../composables/useOnlineStatus', () => ({
 }))
 
 const mockGetToken = vi.fn(() => 'valid-jwt-token')
+const mockGetSession = vi.fn(() => ({
+  userId: 'user-1',
+  username: 'testuser',
+  email: 'test@example.com',
+}))
 const mockIsTokenExpired = vi.fn(() => false)
 
 vi.mock('../../utils/tokenStorage', () => ({
   getToken: () => mockGetToken(),
+  getSession: () => mockGetSession(),
 }))
 
 vi.mock('../../utils/jwt', () => ({
@@ -59,6 +65,11 @@ describe('ShareTargetView', () => {
     mockCreateItem.mockClear()
     mockEnqueue.mockClear()
     mockGetToken.mockReturnValue('valid-jwt-token')
+    mockGetSession.mockReturnValue({
+      userId: 'user-1',
+      username: 'testuser',
+      email: 'test@example.com',
+    })
     mockIsTokenExpired.mockReturnValue(false)
     mockOnline.value = true
     setQuery()
@@ -119,13 +130,16 @@ describe('ShareTargetView', () => {
     await flushPromises()
 
     expect(mockCreateItem).not.toHaveBeenCalled()
-    expect(mockEnqueue).toHaveBeenCalledWith({
-      boardId: null,
-      text: 'Offline Title\n\nOffline text',
-      source: 'ShareTarget',
-      titleHint: 'Offline Title',
-      externalRef: null,
-    })
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      {
+        boardId: null,
+        text: 'Offline Title\n\nOffline text',
+        source: 'ShareTarget',
+        titleHint: 'Offline Title',
+        externalRef: null,
+      },
+      'user-1',
+    )
   })
 
   it('falls back to queue when API call fails', async () => {
@@ -188,7 +202,10 @@ describe('ShareTargetView', () => {
     await flushPromises()
 
     expect(mockCreateItem).not.toHaveBeenCalled()
-    expect(mockEnqueue).toHaveBeenCalled()
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Title\n\nText' }),
+      'user-1',
+    )
     expect(wrapper.text()).toContain('Login required')
   })
 

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -142,7 +142,7 @@ describe('ShareTargetView', () => {
     )
   })
 
-  it('falls back to queue when API call fails', async () => {
+  it('falls back to queue when API call fails transiently', async () => {
     mockCreateItem.mockRejectedValueOnce(new Error('Network Error'))
     setQuery('Retry Title', '', 'https://example.com')
     mount(ShareTargetView)
@@ -150,6 +150,17 @@ describe('ShareTargetView', () => {
 
     expect(mockCreateItem).toHaveBeenCalled()
     expect(mockEnqueue).toHaveBeenCalled()
+  })
+
+  it('does not queue permanent API failures', async () => {
+    mockCreateItem.mockRejectedValueOnce({ response: { status: 400 } })
+    setQuery('Invalid Title', '', '')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalled()
+    expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Nothing to capture')
   })
 
   it('shows error state when no content is shared', async () => {

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -58,6 +58,22 @@ function setQuery(title = '', text = '', url = '') {
   if (url) routeQuery.url = url
 }
 
+function mockPostedShare(title = '', text = '', url = '', shareId = 'share-1') {
+  Object.keys(routeQuery).forEach((k) => delete routeQuery[k])
+  routeQuery.shareId = shareId
+  const cache = {
+    match: vi.fn(async () => new Response(JSON.stringify({ title, text, url }))),
+    delete: vi.fn(async () => true),
+  }
+  Object.defineProperty(globalThis, 'caches', {
+    configurable: true,
+    value: {
+      open: vi.fn(async () => cache),
+    },
+  })
+  return cache
+}
+
 describe('ShareTargetView', () => {
   beforeEach(() => {
     routerMock.push.mockClear()
@@ -77,7 +93,7 @@ describe('ShareTargetView', () => {
   })
 
   it('sends shared content directly to capture API when online', async () => {
-    setQuery('Test Title', 'Some text', 'https://example.com')
+    mockPostedShare('Test Title', 'Some text', 'https://example.com')
     mount(ShareTargetView)
     await flushPromises()
 
@@ -89,24 +105,11 @@ describe('ShareTargetView', () => {
       externalRef: 'https://example.com',
     })
     expect(mockEnqueue).not.toHaveBeenCalled()
-    expect(routerMock.replace).toHaveBeenCalledWith({ name: 'capture-share-target', query: {} })
+    expect(routerMock.replace).not.toHaveBeenCalled()
   })
 
   it('loads POST share-target payload from service worker cache without putting content in the URL', async () => {
-    const cache = {
-      match: vi.fn(async () => new Response(JSON.stringify({
-        title: 'Posted Title',
-        text: 'Posted text',
-        url: 'https://example.com/private',
-      }))),
-      delete: vi.fn(async () => true),
-    }
-    Object.defineProperty(globalThis, 'caches', {
-      configurable: true,
-      value: {
-        open: vi.fn(async () => cache),
-      },
-    })
+    const cache = mockPostedShare('Posted Title', 'Posted text', 'https://example.com/private')
 
     mount(ShareTargetView)
     await flushPromises()
@@ -118,14 +121,25 @@ describe('ShareTargetView', () => {
       titleHint: 'Posted Title',
       externalRef: 'https://example.com/private',
     })
-    expect(cache.match).toHaveBeenCalledWith('/capture/share-data')
-    expect(cache.delete).toHaveBeenCalledWith('/capture/share-data')
+    expect(cache.match).toHaveBeenCalledWith('/capture/share-data/share-1')
+    expect(cache.delete).toHaveBeenCalledWith('/capture/share-data/share-1')
     expect(routerMock.replace).not.toHaveBeenCalled()
+  })
+
+  it('does not persist legacy query-string share payloads', async () => {
+    setQuery('Injected Title', 'Injected text', 'https://evil.example')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).not.toHaveBeenCalled()
+    expect(mockEnqueue).not.toHaveBeenCalled()
+    expect(routerMock.replace).toHaveBeenCalledWith({ name: 'capture-share-target', query: {} })
+    expect(wrapper.text()).toContain('Nothing to capture')
   })
 
   it('queues capture in IndexedDB when offline', async () => {
     mockOnline.value = false
-    setQuery('Offline Title', 'Offline text', '')
+    mockPostedShare('Offline Title', 'Offline text', '')
     mount(ShareTargetView)
     await flushPromises()
 
@@ -144,7 +158,7 @@ describe('ShareTargetView', () => {
 
   it('falls back to queue when API call fails transiently', async () => {
     mockCreateItem.mockRejectedValueOnce(new Error('Network Error'))
-    setQuery('Retry Title', '', 'https://example.com')
+    mockPostedShare('Retry Title', '', 'https://example.com')
     mount(ShareTargetView)
     await flushPromises()
 
@@ -154,7 +168,7 @@ describe('ShareTargetView', () => {
 
   it('does not queue permanent API failures', async () => {
     mockCreateItem.mockRejectedValueOnce({ response: { status: 400 } })
-    setQuery('Invalid Title', '', '')
+    mockPostedShare('Invalid Title', '', '')
     const wrapper = mount(ShareTargetView)
     await flushPromises()
 
@@ -174,7 +188,7 @@ describe('ShareTargetView', () => {
   })
 
   it('navigates to inbox when Open Inbox button is clicked', async () => {
-    setQuery('Title', 'Text', '')
+    mockPostedShare('Title', 'Text', '')
     const wrapper = mount(ShareTargetView)
     await flushPromises()
 
@@ -183,7 +197,7 @@ describe('ShareTargetView', () => {
   })
 
   it('deduplicates title from text when they are identical', async () => {
-    setQuery('Same content', 'Same content', '')
+    mockPostedShare('Same content', 'Same content', '')
     mount(ShareTargetView)
     await flushPromises()
 
@@ -193,7 +207,7 @@ describe('ShareTargetView', () => {
   })
 
   it('handles URL-only share', async () => {
-    setQuery('', '', 'https://example.com/article')
+    mockPostedShare('', '', 'https://example.com/article')
     mount(ShareTargetView)
     await flushPromises()
 
@@ -208,7 +222,7 @@ describe('ShareTargetView', () => {
 
   it('shows login-required state when no valid session exists', async () => {
     mockGetToken.mockReturnValue(null)
-    setQuery('Title', 'Text', '')
+    mockPostedShare('Title', 'Text', '')
     const wrapper = mount(ShareTargetView)
     await flushPromises()
 
@@ -223,7 +237,7 @@ describe('ShareTargetView', () => {
   it('shows login-required when token is expired', async () => {
     mockGetToken.mockReturnValue('expired-token')
     mockIsTokenExpired.mockReturnValue(true)
-    setQuery('Title', '', 'https://example.com')
+    mockPostedShare('Title', '', 'https://example.com')
     const wrapper = mount(ShareTargetView)
     await flushPromises()
 
@@ -233,7 +247,7 @@ describe('ShareTargetView', () => {
 
   it('navigates to login when Log In button is clicked in login-required state', async () => {
     mockGetToken.mockReturnValue(null)
-    setQuery('Title', 'Text', '')
+    mockPostedShare('Title', 'Text', '')
     const wrapper = mount(ShareTargetView)
     await flushPromises()
 

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { reactive, ref } from 'vue'
+import ShareTargetView from '../../views/ShareTargetView.vue'
+
+const routerMock = { push: vi.fn() }
+const routeQuery = reactive<Record<string, string>>({})
+const mockOnline = ref(true)
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: routeQuery }),
+  useRouter: () => routerMock,
+}))
+
+vi.mock('../../composables/useOnlineStatus', () => ({
+  useOnlineStatus: () => ({ isOnline: mockOnline }),
+}))
+
+const mockCreateItem = vi.fn(async () => ({
+  id: 'capture-1',
+  boardId: null,
+  text: 'test',
+  status: 'New',
+  source: 'ShareTarget',
+}))
+
+vi.mock('../../store/captureStore', () => ({
+  useCaptureStore: () => ({ createItem: mockCreateItem }),
+}))
+
+const mockEnqueue = vi.fn(async () => 'queued-id-1')
+
+vi.mock('../../utils/captureQueue', () => ({
+  enqueueCapture: (...args: unknown[]) => mockEnqueue(...args),
+}))
+
+function setQuery(title = '', text = '', url = '') {
+  Object.keys(routeQuery).forEach((k) => delete routeQuery[k])
+  if (title) routeQuery.title = title
+  if (text) routeQuery.text = text
+  if (url) routeQuery.url = url
+}
+
+describe('ShareTargetView', () => {
+  beforeEach(() => {
+    routerMock.push.mockClear()
+    mockCreateItem.mockClear()
+    mockEnqueue.mockClear()
+    mockOnline.value = true
+    setQuery()
+  })
+
+  it('sends shared content directly to capture API when online', async () => {
+    setQuery('Test Title', 'Some text', 'https://example.com')
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalledWith({
+      boardId: null,
+      text: 'Test Title\n\nSome text\n\nhttps://example.com',
+      source: 'ShareTarget',
+      titleHint: 'Test Title',
+      externalRef: 'https://example.com',
+    })
+    expect(mockEnqueue).not.toHaveBeenCalled()
+  })
+
+  it('queues capture in IndexedDB when offline', async () => {
+    mockOnline.value = false
+    setQuery('Offline Title', 'Offline text', '')
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).not.toHaveBeenCalled()
+    expect(mockEnqueue).toHaveBeenCalledWith({
+      boardId: null,
+      text: 'Offline Title\n\nOffline text',
+      source: 'ShareTarget',
+      titleHint: 'Offline Title',
+      externalRef: null,
+    })
+  })
+
+  it('falls back to queue when API call fails', async () => {
+    mockCreateItem.mockRejectedValueOnce(new Error('Network Error'))
+    setQuery('Retry Title', '', 'https://example.com')
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalled()
+    expect(mockEnqueue).toHaveBeenCalled()
+  })
+
+  it('shows error state when no content is shared', async () => {
+    setQuery('', '', '')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Nothing to capture')
+    expect(mockCreateItem).not.toHaveBeenCalled()
+    expect(mockEnqueue).not.toHaveBeenCalled()
+  })
+
+  it('navigates to inbox when Open Inbox button is clicked', async () => {
+    setQuery('Title', 'Text', '')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    await wrapper.find('.share-target-view__btn--primary').trigger('click')
+    expect(routerMock.push).toHaveBeenCalledWith({ name: 'workspace-inbox' })
+  })
+
+  it('deduplicates title from text when they are identical', async () => {
+    setQuery('Same content', 'Same content', '')
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Same content' }),
+    )
+  })
+
+  it('handles URL-only share', async () => {
+    setQuery('', '', 'https://example.com/article')
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'https://example.com/article',
+        externalRef: 'https://example.com/article',
+        titleHint: null,
+      }),
+    )
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -229,9 +229,27 @@ describe('ShareTargetView', () => {
     expect(mockCreateItem).not.toHaveBeenCalled()
     expect(mockEnqueue).toHaveBeenCalledWith(
       expect.objectContaining({ text: 'Title\n\nText' }),
-      'user-1',
+      null,
     )
     expect(wrapper.text()).toContain('Login required')
+  })
+
+  it('queues login-required captures ownerless even when stale session metadata exists', async () => {
+    mockGetToken.mockReturnValue(null)
+    mockGetSession.mockReturnValue({
+      userId: 'stale-user',
+      username: 'stale',
+      email: 'stale@example.com',
+    })
+    mockPostedShare('Title', 'Text', '')
+    mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).not.toHaveBeenCalled()
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Title\n\nText' }),
+      null,
+    )
   })
 
   it('shows login-required when token is expired', async () => {

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -16,6 +16,17 @@ vi.mock('../../composables/useOnlineStatus', () => ({
   useOnlineStatus: () => ({ isOnline: mockOnline }),
 }))
 
+const mockGetToken = vi.fn(() => 'valid-jwt-token')
+const mockIsTokenExpired = vi.fn(() => false)
+
+vi.mock('../../utils/tokenStorage', () => ({
+  getToken: () => mockGetToken(),
+}))
+
+vi.mock('../../utils/jwt', () => ({
+  isTokenExpired: () => mockIsTokenExpired(),
+}))
+
 const mockCreateItem = vi.fn(async () => ({
   id: 'capture-1',
   boardId: null,
@@ -46,6 +57,8 @@ describe('ShareTargetView', () => {
     routerMock.push.mockClear()
     mockCreateItem.mockClear()
     mockEnqueue.mockClear()
+    mockGetToken.mockReturnValue('valid-jwt-token')
+    mockIsTokenExpired.mockReturnValue(false)
     mockOnline.value = true
     setQuery()
   })
@@ -132,5 +145,37 @@ describe('ShareTargetView', () => {
         titleHint: null,
       }),
     )
+  })
+
+  it('shows login-required state when no valid session exists', async () => {
+    mockGetToken.mockReturnValue(null)
+    setQuery('Title', 'Text', '')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).not.toHaveBeenCalled()
+    expect(mockEnqueue).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Login required')
+  })
+
+  it('shows login-required when token is expired', async () => {
+    mockGetToken.mockReturnValue('expired-token')
+    mockIsTokenExpired.mockReturnValue(true)
+    setQuery('Title', '', 'https://example.com')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Login required')
+  })
+
+  it('navigates to login when Log In button is clicked in login-required state', async () => {
+    mockGetToken.mockReturnValue(null)
+    setQuery('Title', 'Text', '')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    await wrapper.find('.share-target-view__btn--primary').trigger('click')
+    expect(routerMock.push).toHaveBeenCalledWith({ name: 'login' })
   })
 })

--- a/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ShareTargetView.spec.ts
@@ -177,6 +177,26 @@ describe('ShareTargetView', () => {
     expect(wrapper.text()).toContain('Nothing to capture')
   })
 
+  it('preserves shared content ownerless for re-auth when API rejects the current session', async () => {
+    mockCreateItem.mockRejectedValueOnce({ response: { status: 401 } })
+    mockPostedShare('Reauth Title', 'Needs login', 'https://example.com')
+    const wrapper = mount(ShareTargetView)
+    await flushPromises()
+
+    expect(mockCreateItem).toHaveBeenCalled()
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      {
+        boardId: null,
+        text: 'Reauth Title\n\nNeeds login\n\nhttps://example.com',
+        source: 'ShareTarget',
+        titleHint: 'Reauth Title',
+        externalRef: 'https://example.com',
+      },
+      null,
+    )
+    expect(wrapper.text()).toContain('Login required')
+  })
+
   it('shows error state when no content is shared', async () => {
     setQuery('', '', '')
     const wrapper = mount(ShareTargetView)

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -12,6 +12,12 @@ const mocks = vi.hoisted(() => ({
   executeProposal: vi.fn(),
   getProposalDiff: vi.fn(),
   dismissProposals: vi.fn(),
+  getProvenance: vi.fn(),
+  getConfidence: vi.fn(),
+  getSideEffects: vi.fn(),
+  getConflicts: vi.fn(),
+  getHistory: vi.fn(),
+  getSimilarPast: vi.fn(),
   getBoards: vi.fn(),
   createRevision: vi.fn(),
   getRevisions: vi.fn(),
@@ -36,6 +42,17 @@ vi.mock('../../../../api/automationApi', () => ({
 
 vi.mock('../../../../api/boardsApi', () => ({
   boardsApi: { getBoards: mocks.getBoards },
+}))
+
+vi.mock('../../../../api/proposalDeepReviewApi', () => ({
+  proposalDeepReviewApi: {
+    getProvenance: mocks.getProvenance,
+    getConfidence: mocks.getConfidence,
+    getSideEffects: mocks.getSideEffects,
+    getConflicts: mocks.getConflicts,
+    getHistory: mocks.getHistory,
+    getSimilarPast: mocks.getSimilarPast,
+  },
 }))
 
 vi.mock('../../../../store/toastStore', () => ({
@@ -125,6 +142,25 @@ describe('PaperReviewView', () => {
     mocks.sessionState.userId = 'u-1'
     mocks.getRevisions.mockResolvedValue([])
     mocks.getLatestRevision.mockResolvedValue(null)
+    mocks.getProvenance.mockResolvedValue([])
+    mocks.getConfidence.mockResolvedValue({
+      overall: 0.84,
+      components: [],
+      note: null,
+      threshold: 0.7,
+      meetsThreshold: true,
+    })
+    mocks.getSideEffects.mockResolvedValue({
+      rows: [],
+      reversibility: {
+        summary: '6 hours',
+        description: 'Undo restores affected cards.',
+        windowMs: 6 * 60 * 60 * 1000,
+      },
+    })
+    mocks.getConflicts.mockResolvedValue([])
+    mocks.getHistory.mockResolvedValue([])
+    mocks.getSimilarPast.mockResolvedValue({ decisions: [], applyRate: 0 })
   })
   afterEach(() => {
     vi.restoreAllMocks()

--- a/frontend/taskdeck-web/src/types/capture.ts
+++ b/frontend/taskdeck-web/src/types/capture.ts
@@ -36,6 +36,8 @@ export type CaptureSource =
   | 'TranscriptFile'
   | 'MarkdownImport'
   | 'WebClip'
+  | 'ShareTarget'
+  | 'BrowserExtension'
 
 export type CaptureSourceValue = CaptureSource | number
 

--- a/frontend/taskdeck-web/src/utils/captureQueue.ts
+++ b/frontend/taskdeck-web/src/utils/captureQueue.ts
@@ -22,6 +22,7 @@ function openDb(): Promise<IDBDatabase> {
     }
     request.onsuccess = () => resolve(request.result)
     request.onerror = () => reject(request.error)
+    request.onblocked = () => reject(new Error('IndexedDB blocked by another connection'))
   })
 }
 

--- a/frontend/taskdeck-web/src/utils/captureQueue.ts
+++ b/frontend/taskdeck-web/src/utils/captureQueue.ts
@@ -171,6 +171,31 @@ export async function markCaptureFailed(id: string, lastError: string): Promise<
   })
 }
 
+export async function assignCaptureOwner(id: string, ownerUserId: string): Promise<void> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const getReq = store.get(id)
+    getReq.onsuccess = () => {
+      const entry = getReq.result as QueuedCapture | undefined
+      if (entry && (entry.status ?? 'pending') === 'pending' && !entry.ownerUserId) {
+        entry.ownerUserId = ownerUserId
+        entry.status = 'pending'
+        store.put(entry)
+      }
+    }
+    tx.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(tx.error)
+    }
+  })
+}
+
 export async function getPendingCount(): Promise<number> {
   const pending = await getAllPending()
   return pending.length

--- a/frontend/taskdeck-web/src/utils/captureQueue.ts
+++ b/frontend/taskdeck-web/src/utils/captureQueue.ts
@@ -1,0 +1,122 @@
+import type { CreateCaptureItemDto } from '../types/capture'
+
+const DB_NAME = 'taskdeck-capture-queue'
+const DB_VERSION = 1
+const STORE_NAME = 'pending-captures'
+
+export interface QueuedCapture {
+  id: string
+  dto: CreateCaptureItemDto
+  queuedAt: string
+  retryCount: number
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error)
+  })
+}
+
+export async function enqueueCapture(dto: CreateCaptureItemDto): Promise<string> {
+  const db = await openDb()
+  const id = crypto.randomUUID()
+  const entry: QueuedCapture = {
+    id,
+    dto,
+    queuedAt: new Date().toISOString(),
+    retryCount: 0,
+  }
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.objectStore(STORE_NAME).put(entry)
+    tx.oncomplete = () => {
+      db.close()
+      resolve(id)
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(tx.error)
+    }
+  })
+}
+
+export async function dequeueCapture(id: string): Promise<void> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.objectStore(STORE_NAME).delete(id)
+    tx.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(tx.error)
+    }
+  })
+}
+
+export async function getAllPending(): Promise<QueuedCapture[]> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const request = tx.objectStore(STORE_NAME).getAll()
+    request.onsuccess = () => {
+      db.close()
+      resolve(request.result)
+    }
+    request.onerror = () => {
+      db.close()
+      reject(request.error)
+    }
+  })
+}
+
+export async function incrementRetry(id: string): Promise<void> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const getReq = store.get(id)
+    getReq.onsuccess = () => {
+      const entry = getReq.result as QueuedCapture | undefined
+      if (entry) {
+        entry.retryCount += 1
+        store.put(entry)
+      }
+    }
+    tx.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(tx.error)
+    }
+  })
+}
+
+export async function getPendingCount(): Promise<number> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const request = tx.objectStore(STORE_NAME).count()
+    request.onsuccess = () => {
+      db.close()
+      resolve(request.result)
+    }
+    request.onerror = () => {
+      db.close()
+      reject(request.error)
+    }
+  })
+}

--- a/frontend/taskdeck-web/src/utils/captureQueue.ts
+++ b/frontend/taskdeck-web/src/utils/captureQueue.ts
@@ -3,6 +3,7 @@ import type { CreateCaptureItemDto } from '../types/capture'
 const DB_NAME = 'taskdeck-capture-queue'
 const DB_VERSION = 1
 const STORE_NAME = 'pending-captures'
+const CLAIM_TIMEOUT_MS = 60_000
 
 export type QueuedCaptureStatus = 'pending' | 'failed'
 
@@ -15,6 +16,8 @@ export interface QueuedCapture {
   status: QueuedCaptureStatus
   failedAt?: string
   lastError?: string
+  syncClaimId?: string
+  syncClaimedAt?: string
 }
 
 function openDb(): Promise<IDBDatabase> {
@@ -118,6 +121,55 @@ export async function getAllQueuedCaptures(): Promise<QueuedCapture[]> {
   })
 }
 
+export async function getPendingForOwner(ownerUserId: string | null): Promise<QueuedCapture[]> {
+  const pending = await getAllPending()
+  return pending.filter((entry) => {
+    if (entry.ownerUserId) return entry.ownerUserId === ownerUserId
+    return ownerUserId !== null
+  })
+}
+
+function hasActiveClaim(entry: QueuedCapture, now = Date.now()): boolean {
+  if (!entry.syncClaimId || !entry.syncClaimedAt) return false
+  const claimedAt = Date.parse(entry.syncClaimedAt)
+  return Number.isFinite(claimedAt) && now - claimedAt < CLAIM_TIMEOUT_MS
+}
+
+export async function claimCaptureForReplay(id: string, ownerUserId: string): Promise<QueuedCapture | null> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const getReq = store.get(id)
+    let claimed: QueuedCapture | null = null
+
+    getReq.onsuccess = () => {
+      const entry = getReq.result as QueuedCapture | undefined
+      if (!entry || (entry.status ?? 'pending') !== 'pending') return
+      if (entry.ownerUserId && entry.ownerUserId !== ownerUserId) return
+      if (hasActiveClaim(entry)) return
+
+      claimed = {
+        ...entry,
+        ownerUserId,
+        status: 'pending',
+        syncClaimId: crypto.randomUUID(),
+        syncClaimedAt: new Date().toISOString(),
+      }
+      store.put(claimed)
+    }
+
+    tx.oncomplete = () => {
+      db.close()
+      resolve(claimed)
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(tx.error)
+    }
+  })
+}
+
 export async function incrementRetry(id: string): Promise<void> {
   const db = await openDb()
   return new Promise((resolve, reject) => {
@@ -130,6 +182,8 @@ export async function incrementRetry(id: string): Promise<void> {
         entry.retryCount += 1
         entry.status = entry.status ?? 'pending'
         entry.ownerUserId = entry.ownerUserId ?? null
+        delete entry.syncClaimId
+        delete entry.syncClaimedAt
         store.put(entry)
       }
     }
@@ -157,6 +211,8 @@ export async function markCaptureFailed(id: string, lastError: string): Promise<
         entry.failedAt = new Date().toISOString()
         entry.lastError = lastError
         entry.ownerUserId = entry.ownerUserId ?? null
+        delete entry.syncClaimId
+        delete entry.syncClaimedAt
         store.put(entry)
       }
     }
@@ -198,5 +254,10 @@ export async function assignCaptureOwner(id: string, ownerUserId: string): Promi
 
 export async function getPendingCount(): Promise<number> {
   const pending = await getAllPending()
+  return pending.length
+}
+
+export async function getPendingCountForOwner(ownerUserId: string | null): Promise<number> {
+  const pending = await getPendingForOwner(ownerUserId)
   return pending.length
 }

--- a/frontend/taskdeck-web/src/utils/captureQueue.ts
+++ b/frontend/taskdeck-web/src/utils/captureQueue.ts
@@ -4,11 +4,17 @@ const DB_NAME = 'taskdeck-capture-queue'
 const DB_VERSION = 1
 const STORE_NAME = 'pending-captures'
 
+export type QueuedCaptureStatus = 'pending' | 'failed'
+
 export interface QueuedCapture {
   id: string
   dto: CreateCaptureItemDto
   queuedAt: string
   retryCount: number
+  ownerUserId: string | null
+  status: QueuedCaptureStatus
+  failedAt?: string
+  lastError?: string
 }
 
 function openDb(): Promise<IDBDatabase> {
@@ -26,7 +32,7 @@ function openDb(): Promise<IDBDatabase> {
   })
 }
 
-export async function enqueueCapture(dto: CreateCaptureItemDto): Promise<string> {
+export async function enqueueCapture(dto: CreateCaptureItemDto, ownerUserId: string | null = null): Promise<string> {
   const db = await openDb()
   const id = crypto.randomUUID()
   const entry: QueuedCapture = {
@@ -34,6 +40,8 @@ export async function enqueueCapture(dto: CreateCaptureItemDto): Promise<string>
     dto,
     queuedAt: new Date().toISOString(),
     retryCount: 0,
+    ownerUserId,
+    status: 'pending',
   }
 
   return new Promise((resolve, reject) => {
@@ -73,7 +81,35 @@ export async function getAllPending(): Promise<QueuedCapture[]> {
     const request = tx.objectStore(STORE_NAME).getAll()
     request.onsuccess = () => {
       db.close()
-      resolve([...request.result].sort((a, b) => a.queuedAt.localeCompare(b.queuedAt)))
+      const pending = (request.result as QueuedCapture[])
+        .filter((entry) => (entry.status ?? 'pending') === 'pending')
+        .map((entry) => ({
+          ...entry,
+          ownerUserId: entry.ownerUserId ?? null,
+          status: entry.status ?? 'pending',
+        }))
+      resolve(pending.sort((a, b) => a.queuedAt.localeCompare(b.queuedAt)))
+    }
+    request.onerror = () => {
+      db.close()
+      reject(request.error)
+    }
+  })
+}
+
+export async function getAllQueuedCaptures(): Promise<QueuedCapture[]> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly')
+    const request = tx.objectStore(STORE_NAME).getAll()
+    request.onsuccess = () => {
+      db.close()
+      const queued = (request.result as QueuedCapture[]).map((entry) => ({
+        ...entry,
+        ownerUserId: entry.ownerUserId ?? null,
+        status: entry.status ?? 'pending',
+      }))
+      resolve(queued.sort((a, b) => a.queuedAt.localeCompare(b.queuedAt)))
     }
     request.onerror = () => {
       db.close()
@@ -92,6 +128,35 @@ export async function incrementRetry(id: string): Promise<void> {
       const entry = getReq.result as QueuedCapture | undefined
       if (entry) {
         entry.retryCount += 1
+        entry.status = entry.status ?? 'pending'
+        entry.ownerUserId = entry.ownerUserId ?? null
+        store.put(entry)
+      }
+    }
+    tx.oncomplete = () => {
+      db.close()
+      resolve()
+    }
+    tx.onerror = () => {
+      db.close()
+      reject(tx.error)
+    }
+  })
+}
+
+export async function markCaptureFailed(id: string, lastError: string): Promise<void> {
+  const db = await openDb()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const getReq = store.get(id)
+    getReq.onsuccess = () => {
+      const entry = getReq.result as QueuedCapture | undefined
+      if (entry) {
+        entry.status = 'failed'
+        entry.failedAt = new Date().toISOString()
+        entry.lastError = lastError
+        entry.ownerUserId = entry.ownerUserId ?? null
         store.put(entry)
       }
     }
@@ -107,17 +172,6 @@ export async function incrementRetry(id: string): Promise<void> {
 }
 
 export async function getPendingCount(): Promise<number> {
-  const db = await openDb()
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE_NAME, 'readonly')
-    const request = tx.objectStore(STORE_NAME).count()
-    request.onsuccess = () => {
-      db.close()
-      resolve(request.result)
-    }
-    request.onerror = () => {
-      db.close()
-      reject(request.error)
-    }
-  })
+  const pending = await getAllPending()
+  return pending.length
 }

--- a/frontend/taskdeck-web/src/utils/captureQueue.ts
+++ b/frontend/taskdeck-web/src/utils/captureQueue.ts
@@ -73,7 +73,7 @@ export async function getAllPending(): Promise<QueuedCapture[]> {
     const request = tx.objectStore(STORE_NAME).getAll()
     request.onsuccess = () => {
       db.close()
-      resolve(request.result)
+      resolve([...request.result].sort((a, b) => a.queuedAt.localeCompare(b.queuedAt)))
     }
     request.onerror = () => {
       db.close()

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -44,6 +44,21 @@ function hasValidSession(): boolean {
   return !isTokenExpired(token)
 }
 
+function getErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null
+  const response = (error as { response?: unknown }).response
+  if (!response || typeof response !== 'object') return null
+  const status = (response as { status?: unknown }).status
+  return typeof status === 'number' ? status : null
+}
+
+function isTransientCaptureError(error: unknown): boolean {
+  const status = getErrorStatus(error)
+  if (status === null) return true
+  if (status === 408 || status === 429) return true
+  return status >= 500 && status < 600 && status !== 501 && status !== 505
+}
+
 async function safeEnqueue(dto: CreateCaptureItemDto): Promise<boolean> {
   try {
     await enqueueCapture(dto, getCurrentQueueOwnerUserId())
@@ -124,7 +139,11 @@ onMounted(async () => {
     try {
       await captureStore.createItem(dto)
       status.value = 'success'
-    } catch {
+    } catch (error) {
+      if (!isTransientCaptureError(error)) {
+        status.value = 'error'
+        return
+      }
       const queued = await safeEnqueue(dto)
       status.value = queued ? 'queued' : 'error'
     }

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -17,6 +17,14 @@ const status = ref<'processing' | 'success' | 'queued' | 'login-required' | 'err
 const sharedTitle = ref('')
 const sharedText = ref('')
 const sharedUrl = ref('')
+const SHARE_CACHE_NAME = 'taskdeck-share-target'
+const SHARE_CACHE_REQUEST = '/capture/share-data'
+
+interface SharedContent {
+  title: string
+  text: string
+  url: string
+}
 
 function buildCaptureText(title: string, text: string, url: string): string {
   const parts: string[] = []
@@ -41,10 +49,47 @@ async function safeEnqueue(dto: CreateCaptureItemDto): Promise<boolean> {
   }
 }
 
+function queryValue(value: unknown): string {
+  if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : ''
+  return typeof value === 'string' ? value : ''
+}
+
+async function consumePostedShareTarget(): Promise<SharedContent | null> {
+  if (typeof caches === 'undefined') return null
+
+  try {
+    const cache = await caches.open(SHARE_CACHE_NAME)
+    const response = await cache.match(SHARE_CACHE_REQUEST)
+    if (!response) return null
+
+    await cache.delete(SHARE_CACHE_REQUEST)
+    const payload = await response.json() as Partial<SharedContent>
+    return {
+      title: typeof payload.title === 'string' ? payload.title : '',
+      text: typeof payload.text === 'string' ? payload.text : '',
+      url: typeof payload.url === 'string' ? payload.url : '',
+    }
+  } catch {
+    return null
+  }
+}
+
+async function resolveSharedContent(): Promise<SharedContent> {
+  const title = queryValue(route.query.title)
+  const text = queryValue(route.query.text)
+  const url = queryValue(route.query.url)
+
+  if (title || text || url) {
+    void router.replace({ name: 'capture-share-target', query: {} })
+    return { title, text, url }
+  }
+
+  const posted = await consumePostedShareTarget()
+  return posted ?? { title: '', text: '', url: '' }
+}
+
 onMounted(async () => {
-  const title = (route.query.title as string) || ''
-  const text = (route.query.text as string) || ''
-  const url = (route.query.url as string) || ''
+  const { title, text, url } = await resolveSharedContent()
 
   sharedTitle.value = title
   sharedText.value = text

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -60,6 +60,11 @@ function isTransientCaptureError(error: unknown): boolean {
   return status >= 500 && status < 600 && status !== 501 && status !== 505
 }
 
+function isAuthenticationCaptureError(error: unknown): boolean {
+  const status = getErrorStatus(error)
+  return status === 401 || status === 403
+}
+
 async function safeEnqueue(dto: CreateCaptureItemDto, ownerUserId: string | null): Promise<boolean> {
   try {
     await enqueueCapture(dto, ownerUserId)
@@ -151,6 +156,12 @@ onMounted(async () => {
       await captureStore.createItem(dto)
       status.value = 'success'
     } catch (error) {
+      if (isAuthenticationCaptureError(error)) {
+        const queued = await safeEnqueue(dto, null)
+        status.value = queued ? 'login-required' : 'error'
+        return
+      }
+
       if (!isTransientCaptureError(error)) {
         status.value = 'error'
         return

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -18,7 +18,7 @@ const sharedTitle = ref('')
 const sharedText = ref('')
 const sharedUrl = ref('')
 const SHARE_CACHE_NAME = 'taskdeck-share-target'
-const SHARE_CACHE_REQUEST = '/capture/share-data'
+const SHARE_CACHE_REQUEST_PREFIX = '/capture/share-data/'
 
 interface SharedContent {
   title: string
@@ -73,15 +73,27 @@ function queryValue(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
+function hasLegacyQueryPayload(): boolean {
+  return !!(queryValue(route.query.title) || queryValue(route.query.text) || queryValue(route.query.url))
+}
+
+function getShareId(): string {
+  const shareId = queryValue(route.query.shareId)
+  return /^[A-Za-z0-9_-]+$/.test(shareId) ? shareId : ''
+}
+
 async function consumePostedShareTarget(): Promise<SharedContent | null> {
   if (typeof caches === 'undefined') return null
+  const shareId = getShareId()
+  if (!shareId) return null
 
   try {
     const cache = await caches.open(SHARE_CACHE_NAME)
-    const response = await cache.match(SHARE_CACHE_REQUEST)
+    const cacheRequest = `${SHARE_CACHE_REQUEST_PREFIX}${shareId}`
+    const response = await cache.match(cacheRequest)
     if (!response) return null
 
-    await cache.delete(SHARE_CACHE_REQUEST)
+    await cache.delete(cacheRequest)
     const payload = await response.json() as Partial<SharedContent>
     return {
       title: typeof payload.title === 'string' ? payload.title : '',
@@ -94,13 +106,9 @@ async function consumePostedShareTarget(): Promise<SharedContent | null> {
 }
 
 async function resolveSharedContent(): Promise<SharedContent> {
-  const title = queryValue(route.query.title)
-  const text = queryValue(route.query.text)
-  const url = queryValue(route.query.url)
-
-  if (title || text || url) {
+  if (hasLegacyQueryPayload()) {
     void router.replace({ name: 'capture-share-target', query: {} })
-    return { title, text, url }
+    return { title: '', text: '', url: '' }
   }
 
   const posted = await consumePostedShareTarget()

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { useCaptureStore } from '../store/captureStore'
+import { enqueueCapture } from '../utils/captureQueue'
+import { useOnlineStatus } from '../composables/useOnlineStatus'
+import type { CreateCaptureItemDto } from '../types/capture'
+
+const router = useRouter()
+const route = useRoute()
+const captureStore = useCaptureStore()
+const { isOnline } = useOnlineStatus()
+
+const status = ref<'processing' | 'success' | 'queued' | 'error'>('processing')
+const sharedTitle = ref('')
+const sharedText = ref('')
+const sharedUrl = ref('')
+
+function buildCaptureText(title: string, text: string, url: string): string {
+  const parts: string[] = []
+  if (title) parts.push(title)
+  if (text && text !== title) parts.push(text)
+  if (url) parts.push(url)
+  return parts.join('\n\n') || ''
+}
+
+onMounted(async () => {
+  const title = (route.query.title as string) || ''
+  const text = (route.query.text as string) || ''
+  const url = (route.query.url as string) || ''
+
+  sharedTitle.value = title
+  sharedText.value = text
+  sharedUrl.value = url
+
+  const captureText = buildCaptureText(title, text, url)
+
+  if (!captureText) {
+    status.value = 'error'
+    return
+  }
+
+  const dto: CreateCaptureItemDto = {
+    boardId: null,
+    text: captureText,
+    source: 'ShareTarget',
+    titleHint: title || null,
+    externalRef: url || null,
+  }
+
+  if (isOnline.value) {
+    try {
+      await captureStore.createItem(dto)
+      status.value = 'success'
+    } catch {
+      await enqueueCapture(dto)
+      status.value = 'queued'
+    }
+  } else {
+    await enqueueCapture(dto)
+    status.value = 'queued'
+  }
+})
+
+function goToInbox() {
+  void router.push({ name: 'workspace-inbox' })
+}
+
+function close() {
+  window.close()
+}
+</script>
+
+<template>
+  <div class="share-target-view">
+    <div class="share-target-view__card">
+      <h1 class="share-target-view__title">Captured</h1>
+
+      <div v-if="status === 'processing'" class="share-target-view__status">
+        <p>Processing shared content…</p>
+      </div>
+
+      <div v-else-if="status === 'success'" class="share-target-view__status share-target-view__status--success">
+        <p>Sent to Inbox</p>
+        <p v-if="sharedTitle" class="share-target-view__preview">{{ sharedTitle }}</p>
+      </div>
+
+      <div v-else-if="status === 'queued'" class="share-target-view__status share-target-view__status--queued">
+        <p>Queued for sync</p>
+        <p class="share-target-view__detail">Will be sent when you're back online.</p>
+      </div>
+
+      <div v-else class="share-target-view__status share-target-view__status--error">
+        <p>Nothing to capture</p>
+        <p class="share-target-view__detail">The shared content was empty.</p>
+      </div>
+
+      <div class="share-target-view__actions">
+        <button type="button" class="share-target-view__btn share-target-view__btn--primary" @click="goToInbox">
+          Open Inbox
+        </button>
+        <button type="button" class="share-target-view__btn" @click="close">
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.share-target-view {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--paper, #faf9f6);
+  color: var(--ink, #1a1a1a);
+}
+
+.share-target-view__card {
+  width: 100%;
+  max-width: 360px;
+  padding: 32px 24px;
+  background: var(--paper-card, #fff);
+  border: 1px solid var(--line, #e0ddd8);
+  border-radius: 8px;
+  text-align: center;
+}
+
+.share-target-view__title {
+  margin: 0 0 16px;
+  font-family: var(--serif, Georgia, serif);
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.share-target-view__status {
+  margin-bottom: 24px;
+}
+
+.share-target-view__status p {
+  margin: 4px 0;
+}
+
+.share-target-view__preview {
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+  color: var(--mute, #888);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-target-view__detail {
+  font-size: 13px;
+  color: var(--mute, #888);
+}
+
+.share-target-view__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.share-target-view__btn {
+  width: 100%;
+  padding: 10px 16px;
+  border: 1px solid var(--line, #e0ddd8);
+  border-radius: 6px;
+  background: transparent;
+  font-family: var(--sans, system-ui);
+  font-size: 14px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.share-target-view__btn:hover {
+  background: var(--paper-2, #f5f4f1);
+}
+
+.share-target-view__btn--primary {
+  background: var(--ink, #1a1a1a);
+  color: var(--paper, #faf9f6);
+  border-color: var(--ink, #1a1a1a);
+}
+
+.share-target-view__btn--primary:hover {
+  opacity: 0.9;
+}
+</style>

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -34,6 +34,10 @@ function buildCaptureText(title: string, text: string, url: string): string {
   return parts.join('\n\n') || ''
 }
 
+function getCurrentQueueOwnerUserId(): string | null {
+  return tokenStorage.getSession()?.userId ?? null
+}
+
 function hasValidSession(): boolean {
   const token = tokenStorage.getToken()
   if (!token) return false
@@ -42,7 +46,7 @@ function hasValidSession(): boolean {
 
 async function safeEnqueue(dto: CreateCaptureItemDto): Promise<boolean> {
   try {
-    await enqueueCapture(dto)
+    await enqueueCapture(dto, getCurrentQueueOwnerUserId())
     return true
   } catch {
     return false

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -34,14 +34,15 @@ function buildCaptureText(title: string, text: string, url: string): string {
   return parts.join('\n\n') || ''
 }
 
-function getCurrentQueueOwnerUserId(): string | null {
-  return tokenStorage.getSession()?.userId ?? null
-}
-
 function hasValidSession(): boolean {
   const token = tokenStorage.getToken()
   if (!token) return false
   return !isTokenExpired(token)
+}
+
+function getValidQueueOwnerUserId(): string | null {
+  if (!hasValidSession()) return null
+  return tokenStorage.getSession()?.userId ?? null
 }
 
 function getErrorStatus(error: unknown): number | null {
@@ -59,9 +60,9 @@ function isTransientCaptureError(error: unknown): boolean {
   return status >= 500 && status < 600 && status !== 501 && status !== 505
 }
 
-async function safeEnqueue(dto: CreateCaptureItemDto): Promise<boolean> {
+async function safeEnqueue(dto: CreateCaptureItemDto, ownerUserId: string | null): Promise<boolean> {
   try {
-    await enqueueCapture(dto, getCurrentQueueOwnerUserId())
+    await enqueueCapture(dto, ownerUserId)
     return true
   } catch {
     return false
@@ -138,10 +139,12 @@ onMounted(async () => {
   }
 
   if (!hasValidSession()) {
-    const queued = await safeEnqueue(dto)
+    const queued = await safeEnqueue(dto, null)
     status.value = queued ? 'login-required' : 'error'
     return
   }
+
+  const queueOwnerUserId = getValidQueueOwnerUserId()
 
   if (isOnline.value) {
     try {
@@ -152,11 +155,11 @@ onMounted(async () => {
         status.value = 'error'
         return
       }
-      const queued = await safeEnqueue(dto)
+      const queued = await safeEnqueue(dto, queueOwnerUserId)
       status.value = queued ? 'queued' : 'error'
     }
   } else {
-    const queued = await safeEnqueue(dto)
+    const queued = await safeEnqueue(dto, queueOwnerUserId)
     status.value = queued ? 'queued' : 'error'
   }
 })

--- a/frontend/taskdeck-web/src/views/ShareTargetView.vue
+++ b/frontend/taskdeck-web/src/views/ShareTargetView.vue
@@ -4,6 +4,8 @@ import { useRouter, useRoute } from 'vue-router'
 import { useCaptureStore } from '../store/captureStore'
 import { enqueueCapture } from '../utils/captureQueue'
 import { useOnlineStatus } from '../composables/useOnlineStatus'
+import * as tokenStorage from '../utils/tokenStorage'
+import { isTokenExpired } from '../utils/jwt'
 import type { CreateCaptureItemDto } from '../types/capture'
 
 const router = useRouter()
@@ -11,7 +13,7 @@ const route = useRoute()
 const captureStore = useCaptureStore()
 const { isOnline } = useOnlineStatus()
 
-const status = ref<'processing' | 'success' | 'queued' | 'error'>('processing')
+const status = ref<'processing' | 'success' | 'queued' | 'login-required' | 'error'>('processing')
 const sharedTitle = ref('')
 const sharedText = ref('')
 const sharedUrl = ref('')
@@ -22,6 +24,21 @@ function buildCaptureText(title: string, text: string, url: string): string {
   if (text && text !== title) parts.push(text)
   if (url) parts.push(url)
   return parts.join('\n\n') || ''
+}
+
+function hasValidSession(): boolean {
+  const token = tokenStorage.getToken()
+  if (!token) return false
+  return !isTokenExpired(token)
+}
+
+async function safeEnqueue(dto: CreateCaptureItemDto): Promise<boolean> {
+  try {
+    await enqueueCapture(dto)
+    return true
+  } catch {
+    return false
+  }
 }
 
 onMounted(async () => {
@@ -48,22 +65,32 @@ onMounted(async () => {
     externalRef: url || null,
   }
 
+  if (!hasValidSession()) {
+    const queued = await safeEnqueue(dto)
+    status.value = queued ? 'login-required' : 'error'
+    return
+  }
+
   if (isOnline.value) {
     try {
       await captureStore.createItem(dto)
       status.value = 'success'
     } catch {
-      await enqueueCapture(dto)
-      status.value = 'queued'
+      const queued = await safeEnqueue(dto)
+      status.value = queued ? 'queued' : 'error'
     }
   } else {
-    await enqueueCapture(dto)
-    status.value = 'queued'
+    const queued = await safeEnqueue(dto)
+    status.value = queued ? 'queued' : 'error'
   }
 })
 
 function goToInbox() {
   void router.push({ name: 'workspace-inbox' })
+}
+
+function goToLogin() {
+  void router.push({ name: 'login' })
 }
 
 function close() {
@@ -90,13 +117,31 @@ function close() {
         <p class="share-target-view__detail">Will be sent when you're back online.</p>
       </div>
 
+      <div v-else-if="status === 'login-required'" class="share-target-view__status share-target-view__status--queued">
+        <p>Login required</p>
+        <p class="share-target-view__detail">Content saved locally. Log in to sync it to your inbox.</p>
+      </div>
+
       <div v-else class="share-target-view__status share-target-view__status--error">
         <p>Nothing to capture</p>
-        <p class="share-target-view__detail">The shared content was empty.</p>
+        <p class="share-target-view__detail">The shared content was empty or could not be saved.</p>
       </div>
 
       <div class="share-target-view__actions">
-        <button type="button" class="share-target-view__btn share-target-view__btn--primary" @click="goToInbox">
+        <button
+          v-if="status === 'login-required'"
+          type="button"
+          class="share-target-view__btn share-target-view__btn--primary"
+          @click="goToLogin"
+        >
+          Log In
+        </button>
+        <button
+          v-else
+          type="button"
+          class="share-target-view__btn share-target-view__btn--primary"
+          @click="goToInbox"
+        >
           Open Inbox
         </button>
         <button type="button" class="share-target-view__btn" @click="close">

--- a/frontend/taskdeck-web/vite.config.ts
+++ b/frontend/taskdeck-web/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         enabled: false,
       },
       workbox: {
+        importScripts: ['share-target-handler.js'],
         // Precache app shell assets (JS, CSS, HTML, icons)
         globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,woff,woff2}'],
         // Exclude manifest icons from glob — they are precached via the manifest config
@@ -99,7 +100,8 @@ export default defineConfig({
         categories: ['productivity', 'utilities'],
         share_target: {
           action: '/capture/share',
-          method: 'GET',
+          method: 'POST',
+          enctype: 'multipart/form-data',
           params: {
             title: 'title',
             text: 'text',

--- a/frontend/taskdeck-web/vite.config.ts
+++ b/frontend/taskdeck-web/vite.config.ts
@@ -97,6 +97,15 @@ export default defineConfig({
         start_url: '/workspace/home',
         lang: 'en',
         categories: ['productivity', 'utilities'],
+        share_target: {
+          action: '/capture/share',
+          method: 'GET',
+          params: {
+            title: 'title',
+            text: 'text',
+            url: 'url',
+          },
+        },
         icons: [
           {
             src: 'icons/icon-192.svg',


### PR DESCRIPTION
## Summary
- Adds Web Share Target API to PWA manifest so Android/iOS can share text and URLs into Taskdeck
- Creates IndexedDB offline capture queue with retry logic and Background Sync registration
- Implements ShareTargetView landing page that processes shared content (online → API, offline → queue)
- Adds outbound `navigator.share` from card modal for sharing cards via native OS share sheet
- Extends `CaptureSource` enum with `ShareTarget` (9) and `BrowserExtension` (10) on both backend and frontend

Partial delivery of #982 — covers PWA share-target inbound/outbound and offline queue. Browser extension prototype to follow.

## Test plan
- [x] `captureQueue.spec.ts` — 6 tests for IndexedDB queue operations (enqueue, dequeue, retry, count)
- [x] `ShareTargetView.spec.ts` — 7 tests (online send, offline queue, API fallback, empty error, URL-only, dedup)
- [x] Existing capture tests still pass (38 tests)
- [x] `vue-tsc --noEmit` passes cleanly
- [x] Backend Domain project compiles with new enum values
- [ ] CI green
- [ ] Manual: install PWA on Android Chrome, share URL from browser → appears in Inbox