### PR TITLE
TST-64: Add unit tests for untested composables (inkBleed, reviewKeymap)

### DIFF
--- a/frontend/taskdeck-web/src/tests/composables/inkBleedMotion.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/inkBleedMotion.spec.ts
@@ -65,5 +65,23 @@ describe('inkBleedMotion', () => {
       expect(detectInkBleedReducedMotion()).toBe(true)
       globalThis.matchMedia = original
     })
+
+    it('returns false when matchMedia throws', () => {
+      const original = globalThis.matchMedia
+      globalThis.matchMedia = (() => {
+        throw new Error('matchMedia exploded')
+      }) as unknown as typeof matchMedia
+      expect(detectInkBleedReducedMotion()).toBe(false)
+      globalThis.matchMedia = original
+    })
+
+    it('passes the correct media query string', () => {
+      const original = globalThis.matchMedia
+      const spy = vi.fn(() => ({ matches: false }))
+      globalThis.matchMedia = spy as unknown as typeof matchMedia
+      detectInkBleedReducedMotion()
+      expect(spy).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)')
+      globalThis.matchMedia = original
+    })
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/inkBleedMotion.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/inkBleedMotion.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   INK_BLEED_PHASE_SCHEDULE,
   INK_BLEED_TOTAL_MS,

--- a/frontend/taskdeck-web/src/tests/composables/inkBleedMotion.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/inkBleedMotion.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INK_BLEED_PHASE_SCHEDULE,
+  INK_BLEED_TOTAL_MS,
+  detectInkBleedReducedMotion,
+} from '../../composables/inkBleedMotion'
+
+describe('inkBleedMotion', () => {
+  describe('INK_BLEED_PHASE_SCHEDULE', () => {
+    it('has 6 phases in correct order', () => {
+      expect(INK_BLEED_PHASE_SCHEDULE).toHaveLength(6)
+      expect(INK_BLEED_PHASE_SCHEDULE.map((p) => p.phase)).toEqual([
+        'drop',
+        'bloom',
+        'compose',
+        'settle',
+        'stamp',
+        'dried',
+      ])
+    })
+
+    it('starts at time 0', () => {
+      expect(INK_BLEED_PHASE_SCHEDULE[0].at).toBe(0)
+    })
+
+    it('has monotonically increasing timestamps', () => {
+      for (let i = 1; i < INK_BLEED_PHASE_SCHEDULE.length; i++) {
+        expect(INK_BLEED_PHASE_SCHEDULE[i].at).toBeGreaterThan(
+          INK_BLEED_PHASE_SCHEDULE[i - 1].at,
+        )
+      }
+    })
+
+    it('last phase matches INK_BLEED_TOTAL_MS', () => {
+      const last = INK_BLEED_PHASE_SCHEDULE[INK_BLEED_PHASE_SCHEDULE.length - 1]
+      expect(last.at).toBe(INK_BLEED_TOTAL_MS)
+    })
+  })
+
+  describe('INK_BLEED_TOTAL_MS', () => {
+    it('is 4600ms as specified', () => {
+      expect(INK_BLEED_TOTAL_MS).toBe(4600)
+    })
+  })
+
+  describe('detectInkBleedReducedMotion', () => {
+    it('returns false when matchMedia is not available', () => {
+      const original = globalThis.matchMedia
+      // @ts-expect-error removing matchMedia for test
+      delete globalThis.matchMedia
+      expect(detectInkBleedReducedMotion()).toBe(false)
+      globalThis.matchMedia = original
+    })
+
+    it('returns false when prefers-reduced-motion does not match', () => {
+      const original = globalThis.matchMedia
+      globalThis.matchMedia = (() => ({ matches: false })) as unknown as typeof matchMedia
+      expect(detectInkBleedReducedMotion()).toBe(false)
+      globalThis.matchMedia = original
+    })
+
+    it('returns true when prefers-reduced-motion matches', () => {
+      const original = globalThis.matchMedia
+      globalThis.matchMedia = (() => ({ matches: true })) as unknown as typeof matchMedia
+      expect(detectInkBleedReducedMotion()).toBe(true)
+      globalThis.matchMedia = original
+    })
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useInkBleed.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useInkBleed.spec.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 
+let unmountCallback: (() => void) | null = null
+
 vi.mock('vue', () => ({
   ref: (val: unknown) => ({ value: val }),
   readonly: (r: unknown) => r,
-  onBeforeUnmount: vi.fn(),
+  onBeforeUnmount: (fn: () => void) => { unmountCallback = fn },
 }))
+
+const mockDetectReducedMotion = vi.fn(() => false)
 
 vi.mock('../../composables/inkBleedMotion', () => ({
   INK_BLEED_PHASE_SCHEDULE: [
@@ -16,7 +20,7 @@ vi.mock('../../composables/inkBleedMotion', () => ({
     { at: 4600, phase: 'dried' },
   ],
   INK_BLEED_TOTAL_MS: 4600,
-  detectInkBleedReducedMotion: () => false,
+  detectInkBleedReducedMotion: () => mockDetectReducedMotion(),
 }))
 
 import { useInkBleed } from '../../composables/useInkBleed'
@@ -141,5 +145,48 @@ describe('useInkBleed', () => {
     const id1 = start()
     const id2 = start()
     expect(id2).toBeGreaterThan(id1)
+  })
+
+  describe('reduced motion', () => {
+    beforeEach(() => {
+      mockDetectReducedMotion.mockReturnValue(true)
+    })
+
+    afterEach(() => {
+      mockDetectReducedMotion.mockReturnValue(false)
+    })
+
+    it('start() stays in dried phase and skips timers', () => {
+      const { start, phase } = useInkBleed()
+      start()
+      expect(phase.value).toBe('dried')
+
+      vi.advanceTimersByTime(5000)
+      expect(phase.value).toBe('dried')
+    })
+
+    it('finish() fires onDone immediately in reduced-motion mode', () => {
+      const onDone = vi.fn()
+      const { start, finish } = useInkBleed({ onDone })
+      const runId = start()
+
+      finish(runId)
+      expect(onDone).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('onBeforeUnmount cleanup', () => {
+    it('clears timers and prevents onDone after unmount', () => {
+      const onDone = vi.fn()
+      const { start, finish } = useInkBleed({ onDone })
+      const runId = start()
+
+      vi.advanceTimersByTime(1000)
+      unmountCallback?.()
+
+      finish(runId)
+      vi.advanceTimersByTime(5000)
+      expect(onDone).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useInkBleed.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useInkBleed.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('vue', () => ({
+  ref: (val: unknown) => ({ value: val }),
+  readonly: (r: unknown) => r,
+  onBeforeUnmount: vi.fn(),
+}))
+
+vi.mock('../../composables/inkBleedMotion', () => ({
+  INK_BLEED_PHASE_SCHEDULE: [
+    { at: 0, phase: 'drop' },
+    { at: 400, phase: 'bloom' },
+    { at: 1400, phase: 'compose' },
+    { at: 3400, phase: 'settle' },
+    { at: 4200, phase: 'stamp' },
+    { at: 4600, phase: 'dried' },
+  ],
+  INK_BLEED_TOTAL_MS: 4600,
+  detectInkBleedReducedMotion: () => false,
+}))
+
+import { useInkBleed } from '../../composables/useInkBleed'
+
+describe('useInkBleed', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts in dried phase', () => {
+    const { phase } = useInkBleed()
+    expect(phase.value).toBe('dried')
+  })
+
+  it('start() transitions to drop phase', () => {
+    const { start, phase } = useInkBleed()
+    start()
+    expect(phase.value).toBe('drop')
+  })
+
+  it('advances through phases on schedule', () => {
+    const { start, phase } = useInkBleed()
+    start()
+
+    expect(phase.value).toBe('drop')
+
+    vi.advanceTimersByTime(400)
+    expect(phase.value).toBe('bloom')
+
+    vi.advanceTimersByTime(1000)
+    expect(phase.value).toBe('compose')
+
+    vi.advanceTimersByTime(2000)
+    expect(phase.value).toBe('settle')
+
+    vi.advanceTimersByTime(800)
+    expect(phase.value).toBe('stamp')
+
+    vi.advanceTimersByTime(400)
+    expect(phase.value).toBe('dried')
+  })
+
+  it('fires onDone when finish() called before schedule ends (early finish)', () => {
+    const onDone = vi.fn()
+    const { start, finish } = useInkBleed({ onDone })
+    const runId = start()
+
+    finish(runId)
+    expect(onDone).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(4600)
+    expect(onDone).toHaveBeenCalledOnce()
+  })
+
+  it('fires onDone immediately when finish() called after schedule ends (late finish)', () => {
+    const onDone = vi.fn()
+    const { start, finish, loop } = useInkBleed({ onDone })
+    const runId = start()
+
+    vi.advanceTimersByTime(4600)
+    expect(loop.value).toBe(true)
+    expect(onDone).not.toHaveBeenCalled()
+
+    finish(runId)
+    expect(onDone).toHaveBeenCalledOnce()
+    expect(loop.value).toBe(false)
+  })
+
+  it('sets loop=true when dried phase is reached without finish()', () => {
+    const { start, loop } = useInkBleed()
+    start()
+
+    vi.advanceTimersByTime(4600)
+    expect(loop.value).toBe(true)
+  })
+
+  it('cancel() resets to dried and does not fire onDone', () => {
+    const onDone = vi.fn()
+    const { start, cancel, phase } = useInkBleed({ onDone })
+    start()
+
+    vi.advanceTimersByTime(1000)
+    cancel()
+
+    expect(phase.value).toBe('dried')
+    vi.advanceTimersByTime(5000)
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('start() cancels previous bleed (singleton guard)', () => {
+    const onDone = vi.fn()
+    const { start, finish } = useInkBleed({ onDone })
+    const runId1 = start()
+
+    vi.advanceTimersByTime(1000)
+    const runId2 = start()
+
+    finish(runId1)
+    vi.advanceTimersByTime(5000)
+    expect(onDone).not.toHaveBeenCalled()
+
+    finish(runId2)
+    expect(onDone).toHaveBeenCalledOnce()
+  })
+
+  it('finish() with wrong runId is a no-op', () => {
+    const onDone = vi.fn()
+    const { start, finish } = useInkBleed({ onDone })
+    start()
+
+    finish(999)
+    vi.advanceTimersByTime(5000)
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('returns incrementing runIds', () => {
+    const { start } = useInkBleed()
+    const id1 = start()
+    const id2 = start()
+    expect(id2).toBeGreaterThan(id1)
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useReviewKeymap.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewKeymap.spec.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isEditableTarget,
+  isInteractiveTarget,
+  useReviewKeymap,
+  type ReviewKeymapHandlers,
+} from '../../composables/useReviewKeymap'
+
+vi.mock('vue', () => ({
+  onMounted: (fn: () => void) => fn(),
+  onBeforeUnmount: vi.fn(),
+}))
+
+function makeKeyEvent(
+  key: string,
+  overrides: Partial<KeyboardEvent> = {},
+): KeyboardEvent {
+  return {
+    key,
+    code: key === ' ' ? 'Space' : `Key${key.toUpperCase()}`,
+    isComposing: false,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    target: document.createElement('div'),
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...overrides,
+  } as unknown as KeyboardEvent
+}
+
+describe('useReviewKeymap', () => {
+  describe('key bindings', () => {
+    it('Enter triggers onApply', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('Enter'))
+      expect(handlers.onApply).toHaveBeenCalledOnce()
+    })
+
+    it('Backspace triggers onReject', () => {
+      const handlers: ReviewKeymapHandlers = { onReject: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('Backspace'))
+      expect(handlers.onReject).toHaveBeenCalledOnce()
+    })
+
+    it('Space triggers onPreviewDiff', () => {
+      const handlers: ReviewKeymapHandlers = { onPreviewDiff: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent(' '))
+      expect(handlers.onPreviewDiff).toHaveBeenCalledOnce()
+    })
+
+    it('E triggers onRequestEdit', () => {
+      const handlers: ReviewKeymapHandlers = { onRequestEdit: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('e'))
+      expect(handlers.onRequestEdit).toHaveBeenCalledOnce()
+    })
+
+    it('D triggers onDefer', () => {
+      const handlers: ReviewKeymapHandlers = { onDefer: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('d'))
+      expect(handlers.onDefer).toHaveBeenCalledOnce()
+    })
+
+    it('P triggers onToggleProvenance', () => {
+      const handlers: ReviewKeymapHandlers = { onToggleProvenance: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('p'))
+      expect(handlers.onToggleProvenance).toHaveBeenCalledOnce()
+    })
+
+    it('unbound keys are ignored', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      const event = makeKeyEvent('x')
+      handleKeyDown(event)
+      expect(handlers.onApply).not.toHaveBeenCalled()
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('guards', () => {
+    it('does not fire when enabled returns false', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers, { enabled: () => false })
+      handleKeyDown(makeKeyEvent('Enter'))
+      expect(handlers.onApply).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when isComposing is true (IME)', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('Enter', { isComposing: true } as Partial<KeyboardEvent>))
+      expect(handlers.onApply).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when target is a text input', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      const input = document.createElement('input')
+      input.type = 'text'
+      handleKeyDown(makeKeyEvent('Enter', { target: input } as unknown as Partial<KeyboardEvent>))
+      expect(handlers.onApply).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when target is a textarea', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      const textarea = document.createElement('textarea')
+      handleKeyDown(makeKeyEvent('Enter', { target: textarea } as unknown as Partial<KeyboardEvent>))
+      expect(handlers.onApply).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when modifier key is held', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('Enter', { ctrlKey: true } as Partial<KeyboardEvent>))
+      expect(handlers.onApply).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when handler is not provided for the key', () => {
+      const handlers: ReviewKeymapHandlers = {}
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      const event = makeKeyEvent('Enter')
+      handleKeyDown(event)
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('preventDefault', () => {
+    it('calls preventDefault and stopPropagation when handler fires', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      const event = makeKeyEvent('Enter')
+      handleKeyDown(event)
+      expect(event.preventDefault).toHaveBeenCalledOnce()
+      expect(event.stopPropagation).toHaveBeenCalledOnce()
+    })
+  })
+})
+
+describe('isEditableTarget', () => {
+  it('returns false for null', () => {
+    expect(isEditableTarget(null)).toBe(false)
+  })
+
+  it('returns true for textarea', () => {
+    expect(isEditableTarget(document.createElement('textarea'))).toBe(true)
+  })
+
+  it('returns true for text input', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    expect(isEditableTarget(input)).toBe(true)
+  })
+
+  it('returns false for checkbox input', () => {
+    const input = document.createElement('input')
+    input.type = 'checkbox'
+    expect(isEditableTarget(input)).toBe(false)
+  })
+
+  it('returns true for contenteditable element', () => {
+    const div = document.createElement('div')
+    div.contentEditable = 'true'
+    expect(isEditableTarget(div)).toBe(true)
+  })
+
+  it('returns true for select element', () => {
+    expect(isEditableTarget(document.createElement('select'))).toBe(true)
+  })
+
+  it('returns true for element with data-review-keymap="ignore"', () => {
+    const wrapper = document.createElement('div')
+    wrapper.setAttribute('data-review-keymap', 'ignore')
+    const child = document.createElement('span')
+    wrapper.appendChild(child)
+    document.body.appendChild(wrapper)
+    expect(isEditableTarget(child)).toBe(true)
+    document.body.removeChild(wrapper)
+  })
+})
+
+describe('isInteractiveTarget', () => {
+  it('returns false for null', () => {
+    expect(isInteractiveTarget(null)).toBe(false)
+  })
+
+  it('returns true for button', () => {
+    expect(isInteractiveTarget(document.createElement('button'))).toBe(true)
+  })
+
+  it('returns true for anchor with href', () => {
+    const a = document.createElement('a')
+    a.href = '#'
+    document.body.appendChild(a)
+    expect(isInteractiveTarget(a)).toBe(true)
+    document.body.removeChild(a)
+  })
+
+  it('returns false for plain div', () => {
+    expect(isInteractiveTarget(document.createElement('div'))).toBe(false)
+  })
+
+  it('returns true for element with role="button"', () => {
+    const div = document.createElement('div')
+    div.setAttribute('role', 'button')
+    document.body.appendChild(div)
+    expect(isInteractiveTarget(div)).toBe(true)
+    document.body.removeChild(div)
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useReviewKeymap.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewKeymap.spec.ts
@@ -73,6 +73,30 @@ describe('useReviewKeymap', () => {
       expect(handlers.onToggleProvenance).toHaveBeenCalledOnce()
     })
 
+    it('Spacebar (legacy key value) triggers onPreviewDiff', () => {
+      const handlers: ReviewKeymapHandlers = { onPreviewDiff: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown(makeKeyEvent('Spacebar'))
+      expect(handlers.onPreviewDiff).toHaveBeenCalledOnce()
+    })
+
+    it('event.code Space fallback triggers onPreviewDiff', () => {
+      const handlers: ReviewKeymapHandlers = { onPreviewDiff: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      handleKeyDown({
+        key: 'Unidentified',
+        code: 'Space',
+        isComposing: false,
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        target: document.createElement('div'),
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as KeyboardEvent)
+      expect(handlers.onPreviewDiff).toHaveBeenCalledOnce()
+    })
+
     it('unbound keys are ignored', () => {
       const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
       const { handleKeyDown } = useReviewKeymap(handlers)
@@ -128,6 +152,16 @@ describe('useReviewKeymap', () => {
       const event = makeKeyEvent('Enter')
       handleKeyDown(event)
       expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('does not fire when target is an interactive element (button)', () => {
+      const handlers: ReviewKeymapHandlers = { onApply: vi.fn() }
+      const { handleKeyDown } = useReviewKeymap(handlers)
+      const button = document.createElement('button')
+      document.body.appendChild(button)
+      handleKeyDown(makeKeyEvent('Enter', { target: button } as unknown as Partial<KeyboardEvent>))
+      expect(handlers.onApply).not.toHaveBeenCalled()
+      document.body.removeChild(button)
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -12,6 +12,12 @@ const mocks = vi.hoisted(() => ({
   executeProposal: vi.fn(),
   getProposalDiff: vi.fn(),
   dismissProposals: vi.fn(),
+  getProvenance: vi.fn(),
+  getConfidence: vi.fn(),
+  getSideEffects: vi.fn(),
+  getConflicts: vi.fn(),
+  getHistory: vi.fn(),
+  getSimilarPast: vi.fn(),
   getBoards: vi.fn(),
   createRevision: vi.fn(),
   getRevisions: vi.fn(),
@@ -36,6 +42,17 @@ vi.mock('../../../../api/automationApi', () => ({
 
 vi.mock('../../../../api/boardsApi', () => ({
   boardsApi: { getBoards: mocks.getBoards },
+}))
+
+vi.mock('../../../../api/proposalDeepReviewApi', () => ({
+  proposalDeepReviewApi: {
+    getProvenance: mocks.getProvenance,
+    getConfidence: mocks.getConfidence,
+    getSideEffects: mocks.getSideEffects,
+    getConflicts: mocks.getConflicts,
+    getHistory: mocks.getHistory,
+    getSimilarPast: mocks.getSimilarPast,
+  },
 }))
 
 vi.mock('../../../../store/toastStore', () => ({
@@ -125,6 +142,25 @@ describe('PaperReviewView', () => {
     mocks.sessionState.userId = 'u-1'
     mocks.getRevisions.mockResolvedValue([])
     mocks.getLatestRevision.mockResolvedValue(null)
+    mocks.getProvenance.mockResolvedValue([])
+    mocks.getConfidence.mockResolvedValue({
+      overall: 0.84,
+      components: [],
+      note: null,
+      threshold: 0.7,
+      meetsThreshold: true,
+    })
+    mocks.getSideEffects.mockResolvedValue({
+      rows: [],
+      reversibility: {
+        summary: '6 hours',
+        description: 'Undo restores affected cards.',
+        windowMs: 6 * 60 * 60 * 1000,
+      },
+    })
+    mocks.getConflicts.mockResolvedValue([])
+    mocks.getHistory.mockResolvedValue([])
+    mocks.getSimilarPast.mockResolvedValue({ decisions: [], applyRate: 0 })
   })
   afterEach(() => {
     vi.restoreAllMocks()


### PR DESCRIPTION
## Summary

- Adds 44 unit tests covering 3 previously untested composables
- `inkBleedMotion.ts`: phase schedule validation, timing constants, reduced-motion detection
- `useReviewKeymap.ts`: all 6 key bindings, 6 guard conditions (IME, editable targets, modifiers, enabled flag, missing handlers), preventDefault/stopPropagation behavior, `isEditableTarget` and `isInteractiveTarget` helpers
- `useInkBleed.ts`: phase progression, early/late finish semantics, loop state, cancel, singleton guard, runId sequencing

Closes #1081 (partial — covers 3 of 8 composables; remaining can follow)

## Test plan

- [ ] `npx vitest --run src/tests/composables/` passes all 550 tests
- [ ] `npx eslint . --max-warnings=20` reports 0 errors
- [ ] CI green on frontend unit jobs