### PR TITLE
PAPER-05: Add E2E test for Paper board card drag + audit-log assertion

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -12,6 +12,12 @@ const mocks = vi.hoisted(() => ({
   executeProposal: vi.fn(),
   getProposalDiff: vi.fn(),
   dismissProposals: vi.fn(),
+  getProvenance: vi.fn(),
+  getConfidence: vi.fn(),
+  getSideEffects: vi.fn(),
+  getConflicts: vi.fn(),
+  getHistory: vi.fn(),
+  getSimilarPast: vi.fn(),
   getBoards: vi.fn(),
   createRevision: vi.fn(),
   getRevisions: vi.fn(),
@@ -36,6 +42,17 @@ vi.mock('../../../../api/automationApi', () => ({
 
 vi.mock('../../../../api/boardsApi', () => ({
   boardsApi: { getBoards: mocks.getBoards },
+}))
+
+vi.mock('../../../../api/proposalDeepReviewApi', () => ({
+  proposalDeepReviewApi: {
+    getProvenance: mocks.getProvenance,
+    getConfidence: mocks.getConfidence,
+    getSideEffects: mocks.getSideEffects,
+    getConflicts: mocks.getConflicts,
+    getHistory: mocks.getHistory,
+    getSimilarPast: mocks.getSimilarPast,
+  },
 }))
 
 vi.mock('../../../../store/toastStore', () => ({
@@ -125,6 +142,25 @@ describe('PaperReviewView', () => {
     mocks.sessionState.userId = 'u-1'
     mocks.getRevisions.mockResolvedValue([])
     mocks.getLatestRevision.mockResolvedValue(null)
+    mocks.getProvenance.mockResolvedValue([])
+    mocks.getConfidence.mockResolvedValue({
+      overall: 0.84,
+      components: [],
+      note: null,
+      threshold: 0.7,
+      meetsThreshold: true,
+    })
+    mocks.getSideEffects.mockResolvedValue({
+      rows: [],
+      reversibility: {
+        summary: '6 hours',
+        description: 'Undo restores affected cards.',
+        windowMs: 6 * 60 * 60 * 1000,
+      },
+    })
+    mocks.getConflicts.mockResolvedValue([])
+    mocks.getHistory.mockResolvedValue([])
+    mocks.getSimilarPast.mockResolvedValue({ decisions: [], applyRate: 0 })
   })
   afterEach(() => {
     vi.restoreAllMocks()

--- a/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
@@ -138,13 +138,37 @@ test.describe('Paper board card drag', () => {
     await page.goto(`/workspace/boards/${boardId}`)
     await expect(page.locator('[data-testid="paper-board-lanes"]')).toBeVisible()
 
-    const card = page.locator('[data-card-id]').first()
-    await page.keyboard.press('Tab')
-    await card.focus()
+    const card = page
+      .locator('[data-card-id]')
+      .filter({ hasText: `Focus Card ${seed}` })
+      .first()
+    for (let i = 0; i < 40; i += 1) {
+      if (await card.evaluate((el) => document.activeElement === el)) break
+      await page.keyboard.press('Tab')
+    }
     await expect(card).toBeFocused()
 
-    const outline = await card.evaluate((el) => window.getComputedStyle(el).outline)
-    expect(outline).toContain('2px')
-    expect(outline).toContain('solid')
+    const focusStyle = await card.evaluate((el) => {
+      const style = window.getComputedStyle(el)
+      const paperRoot = el.closest('.paper') ?? document.documentElement
+      const ember = window.getComputedStyle(paperRoot).getPropertyValue('--ember').trim()
+      const probe = document.createElement('span')
+      probe.style.color = ember
+      document.body.appendChild(probe)
+      const expectedEmber = window.getComputedStyle(probe).color
+      probe.remove()
+
+      return {
+        outlineWidth: style.outlineWidth,
+        outlineStyle: style.outlineStyle,
+        outlineOffset: style.outlineOffset,
+        outlineColor: style.outlineColor,
+        expectedEmber,
+      }
+    })
+    expect(focusStyle.outlineWidth).toBe('2px')
+    expect(focusStyle.outlineStyle).toBe('solid')
+    expect(focusStyle.outlineOffset).toBe('1px')
+    expect(focusStyle.outlineColor).toBe(focusStyle.expectedEmber)
   })
 })

--- a/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test, type Page } from '@playwright/test'
+import { API_BASE_URL, registerAndAttachSession, type AuthResult } from './support/authSession'
+import { assertOk } from './support/httpAsserts'
+import type { APIRequestContext } from '@playwright/test'
+
+async function enablePaperMode(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('td.paper.mode', 'paper')
+  })
+}
+
+async function createBoardWith2Columns(
+  request: APIRequestContext,
+  auth: AuthResult,
+  seed: string,
+) {
+  const response = await request.post(
+    `${API_BASE_URL}/import/boards?userId=${encodeURIComponent(auth.user.id)}`,
+    {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: {
+        name: `Paper Drag ${seed}`,
+        description: 'E2E paper drag test board',
+        columns: [
+          { name: 'Backlog', position: 0, wipLimit: null },
+          { name: 'Done', position: 1, wipLimit: null },
+        ],
+        cards: [],
+        labels: [],
+      },
+    },
+  )
+  await assertOk(response, 'Import board for paper drag test')
+  const result = await response.json()
+  return result.boardId as string
+}
+
+async function addCardViaApi(
+  request: APIRequestContext,
+  auth: AuthResult,
+  boardId: string,
+  columnId: string,
+  title: string,
+) {
+  const response = await request.post(
+    `${API_BASE_URL}/boards/${boardId}/cards`,
+    {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      data: { title, description: '', columnId, position: 0 },
+    },
+  )
+  await assertOk(response, `Create card '${title}'`)
+  const card = await response.json()
+  return card.id as string
+}
+
+async function getColumns(
+  request: APIRequestContext,
+  auth: AuthResult,
+  boardId: string,
+) {
+  const response = await request.get(
+    `${API_BASE_URL}/boards/${boardId}/columns`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+  await assertOk(response, 'Get columns')
+  return await response.json() as Array<{ id: string; name: string; position: number }>
+}
+
+async function getAuditLog(
+  request: APIRequestContext,
+  auth: AuthResult,
+  boardId: string,
+) {
+  const response = await request.get(
+    `${API_BASE_URL}/audit/boards/${boardId}?limit=10`,
+    { headers: { Authorization: `Bearer ${auth.token}` } },
+  )
+  await assertOk(response, 'Get audit log')
+  return await response.json() as Array<{ action: string; entityType: string; [key: string]: unknown }>
+}
+
+test.describe('Paper board card drag', () => {
+  test('dragging a card across columns in Paper mode persists and creates audit entry', async ({ page, request }) => {
+    await enablePaperMode(page)
+    const auth = await registerAndAttachSession(page, request, 'paper-drag')
+    const seed = `${Date.now()}`
+    const boardId = await createBoardWith2Columns(request, auth, seed)
+
+    const columns = await getColumns(request, auth, boardId)
+    const backlogCol = columns.find((c) => c.name === 'Backlog')!
+    const doneCol = columns.find((c) => c.name === 'Done')!
+
+    await addCardViaApi(request, auth, boardId, backlogCol.id, `Drag Target ${seed}`)
+
+    await page.goto(`/workspace/boards/${boardId}`)
+    await expect(page.locator('[data-testid="paper-board-lanes"]')).toBeVisible()
+
+    const cardTitle = `Drag Target ${seed}`
+    const card = page.locator('[data-card-id]').filter({ hasText: cardTitle }).first()
+    await expect(card).toBeVisible()
+
+    const cardHandle = card.locator('[data-action="drag-card-handle"]')
+    const targetLane = page
+      .locator('[data-column-dnd-id]')
+      .filter({ has: page.getByRole('heading', { name: 'Done', exact: true }) })
+      .first()
+
+    await cardHandle.dragTo(targetLane)
+
+    await expect(
+      targetLane.locator('[data-card-id]').filter({ hasText: cardTitle }).first(),
+    ).toBeVisible()
+
+    const sourceLane = page
+      .locator('[data-column-dnd-id]')
+      .filter({ has: page.getByRole('heading', { name: 'Backlog', exact: true }) })
+      .first()
+    await expect(
+      sourceLane.locator('[data-card-id]').filter({ hasText: cardTitle }),
+    ).toHaveCount(0)
+
+    const audit = await getAuditLog(request, auth, boardId)
+    const moveEntry = audit.find(
+      (e) => e.action === 'Moved' && e.entityType === 'Card',
+    )
+    expect(moveEntry).toBeDefined()
+  })
+
+  test('paper card focus ring is visible on keyboard focus', async ({ page, request }) => {
+    await enablePaperMode(page)
+    const auth = await registerAndAttachSession(page, request, 'paper-focus')
+    const seed = `${Date.now()}`
+    const boardId = await createBoardWith2Columns(request, auth, seed)
+
+    const columns = await getColumns(request, auth, boardId)
+    await addCardViaApi(request, auth, boardId, columns[0].id, `Focus Card ${seed}`)
+
+    await page.goto(`/workspace/boards/${boardId}`)
+    await expect(page.locator('[data-testid="paper-board-lanes"]')).toBeVisible()
+
+    const card = page.locator('[data-card-id]').first()
+    await card.focus()
+
+    const outline = await card.evaluate((el) => window.getComputedStyle(el).outline)
+    expect(outline).toContain('2px')
+    expect(outline).toContain('solid')
+  })
+})

--- a/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
@@ -77,7 +77,7 @@ async function getAuditLog(
     { headers: { Authorization: `Bearer ${auth.token}` } },
   )
   await assertOk(response, 'Get audit log')
-  return await response.json() as Array<{ action: string; entityType: string; [key: string]: unknown }>
+  return await response.json() as Array<{ action: number; entityType: string; [key: string]: unknown }>
 }
 
 test.describe('Paper board card drag', () => {
@@ -89,7 +89,6 @@ test.describe('Paper board card drag', () => {
 
     const columns = await getColumns(request, auth, boardId)
     const backlogCol = columns.find((c) => c.name === 'Backlog')!
-    const doneCol = columns.find((c) => c.name === 'Done')!
 
     await addCardViaApi(request, auth, boardId, backlogCol.id, `Drag Target ${seed}`)
 
@@ -122,7 +121,7 @@ test.describe('Paper board card drag', () => {
 
     const audit = await getAuditLog(request, auth, boardId)
     const moveEntry = audit.find(
-      (e) => e.action === 'Moved' && e.entityType === 'Card',
+      (e) => e.action === 5 && e.entityType === 'card',
     )
     expect(moveEntry).toBeDefined()
   })
@@ -140,7 +139,8 @@ test.describe('Paper board card drag', () => {
     await expect(page.locator('[data-testid="paper-board-lanes"]')).toBeVisible()
 
     const card = page.locator('[data-card-id]').first()
-    await card.focus()
+    await page.keyboard.press('Tab')
+    await expect(card).toBeFocused()
 
     const outline = await card.evaluate((el) => window.getComputedStyle(el).outline)
     expect(outline).toContain('2px')

--- a/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/paper-board-drag.spec.ts
@@ -140,6 +140,7 @@ test.describe('Paper board card drag', () => {
 
     const card = page.locator('[data-card-id]').first()
     await page.keyboard.press('Tab')
+    await card.focus()
     await expect(card).toBeFocused()
 
     const outline = await card.evaluate((el) => window.getComputedStyle(el).outline)


### PR DESCRIPTION
## Summary

- Adds the missing Playwright E2E test required by #1001 (PAPER-05) acceptance criteria
- Tests card drag across columns in Paper mode with audit-log verification
- Tests keyboard focus ring visibility (2px ember, 1px gap)
- The board/column/card components and unit tests were already shipped in prior PRs

## Test plan

- [ ] E2E: `paper-board-drag.spec.ts` passes against running backend (drag + audit assertion)
- [ ] E2E: Focus ring test validates outline CSS on keyboard focus
- [ ] CI: Existing unit tests remain green (no production code changes)

Closes #1001