### PR TITLE
Fix unhandled promise rejections in frontend composables

### DIFF
--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -156,7 +156,7 @@ export function useCaptureQueueSync() {
   }
 
   onMounted(() => {
-    refreshCount().catch(() => {})
+    refreshCount().catch((err) => logWarn('Capture queue count refresh failed on mount:', err))
     registerServiceWorkerMessageReplay()
 
     onlineHandler = () => {

--- a/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
+++ b/frontend/taskdeck-web/src/composables/useCaptureQueueSync.ts
@@ -149,26 +149,26 @@ export function useCaptureQueueSync() {
     if (!('serviceWorker' in navigator)) return
     serviceWorkerMessageHandler = (event: MessageEvent<unknown>) => {
       if (isCaptureSyncMessage(event)) {
-        void replayQueue()
+        replayQueue().catch(() => {})
       }
     }
     navigator.serviceWorker.addEventListener('message', serviceWorkerMessageHandler)
   }
 
   onMounted(() => {
-    void refreshCount()
+    refreshCount().catch(() => {})
     registerServiceWorkerMessageReplay()
 
     onlineHandler = () => {
       if (isOnline.value) {
-        void replayQueue()
+        replayQueue().catch(() => {})
         requestServiceWorkerQueueReplay()
       }
     }
     window.addEventListener('online', onlineHandler)
 
     if (isOnline.value) {
-      void replayQueue()
+      replayQueue().catch(() => {})
     }
   })
 

--- a/frontend/taskdeck-web/src/composables/useCardModal.ts
+++ b/frontend/taskdeck-web/src/composables/useCardModal.ts
@@ -3,6 +3,7 @@ import { useBoardStore } from '../store/boardStore'
 import { useSessionStore } from '../store/sessionStore'
 import type { Card, CardCaptureProvenance, Label } from '../types/board'
 import type { CardComment } from '../types/comments'
+import { useToastStore } from '../store/toastStore'
 import { logError } from '../utils/errorReporting'
 
 export interface UseCardModalOptions {
@@ -16,6 +17,7 @@ export interface UseCardModalOptions {
 export function useCardModal(options: UseCardModalOptions) {
   const boardStore = useBoardStore()
   const sessionStore = useSessionStore()
+  const toastStore = useToastStore()
 
   // Form state
   const title = ref('')
@@ -156,6 +158,7 @@ export function useCardModal(options: UseCardModalOptions) {
       options.onClose()
     } catch (error) {
       logError('Failed to update card:', error)
+      toastStore.show('Failed to save card changes. Please try again.', 'error')
     }
   }
 

--- a/frontend/taskdeck-web/src/composables/useCardModal.ts
+++ b/frontend/taskdeck-web/src/composables/useCardModal.ts
@@ -17,7 +17,7 @@ export interface UseCardModalOptions {
 export function useCardModal(options: UseCardModalOptions) {
   const boardStore = useBoardStore()
   const sessionStore = useSessionStore()
-  const toastStore = useToastStore()
+  const toast = useToastStore()
 
   // Form state
   const title = ref('')
@@ -87,7 +87,7 @@ export function useCardModal(options: UseCardModalOptions) {
       loadedCaptureProvenanceCardId.value = null
 
       if (options.getIsOpen()) {
-        void loadCaptureProvenance()
+        loadCaptureProvenance().catch(() => {})
       }
     }
   }, { immediate: true })
@@ -158,7 +158,7 @@ export function useCardModal(options: UseCardModalOptions) {
       options.onClose()
     } catch (error) {
       logError('Failed to update card:', error)
-      toastStore.show('Failed to save card changes. Please try again.', 'error')
+      toast.error('Failed to save card changes. Please try again.')
     }
   }
 
@@ -181,6 +181,7 @@ export function useCardModal(options: UseCardModalOptions) {
       options.onClose()
     } catch (error) {
       logError('Failed to delete card:', error)
+      toast.error('Failed to delete card. Please try again.')
     } finally {
       isDeleting.value = false
     }
@@ -222,6 +223,7 @@ export function useCardModal(options: UseCardModalOptions) {
       }
     } catch (error) {
       logError('Failed to add comment:', error)
+      toast.error('Failed to add comment. Please try again.')
     }
   }
 
@@ -250,6 +252,7 @@ export function useCardModal(options: UseCardModalOptions) {
       handleCancelEditComment()
     } catch (error) {
       logError('Failed to update comment:', error)
+      toast.error('Failed to update comment. Please try again.')
     }
   }
 
@@ -266,6 +269,7 @@ export function useCardModal(options: UseCardModalOptions) {
       await boardStore.deleteCardComment(card.value.boardId, card.value.id, comment.id)
     } catch (error) {
       logError('Failed to delete comment:', error)
+      toast.error('Failed to delete comment. Please try again.')
     }
   }
 

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -1,5 +1,5 @@
 import { computed, nextTick, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { isNavigationFailure, NavigationFailureType, useRoute, useRouter } from 'vue-router'
 import { automationApi } from '../api/automationApi'
 import { boardsApi } from '../api/boardsApi'
 import type { ReviewSummaryCard } from '../components/review/ReviewSummaryCards.vue'
@@ -13,6 +13,7 @@ import { normalizeBoardIdQueryParam } from '../utils/navigation'
 import type { Proposal as ApiProposal } from '../types/automation'
 import type { Board } from '../types/board'
 import { getErrorDisplay } from './useErrorMapper'
+import { logError } from '../utils/errorReporting'
 import { usePerformanceMark } from './usePerformanceMark'
 
 export function useReviewProposals() {
@@ -182,6 +183,16 @@ export function useReviewProposals() {
     return candidate?.response?.status === 404
   }
 
+  async function safeReplace(to: Parameters<typeof router.replace>[0]) {
+    try {
+      await router.replace(to)
+    } catch (err) {
+      if (!isNavigationFailure(err, NavigationFailureType.duplicated | NavigationFailureType.cancelled | NavigationFailureType.aborted)) {
+        logError('Unexpected navigation failure:', err)
+      }
+    }
+  }
+
   async function openProposalFromHash() {
     if (proposalsLoading.value) return
     const proposalId = getProposalIdFromHash(route.hash)
@@ -190,7 +201,7 @@ export function useReviewProposals() {
     const currentProposal = proposals.value.find((p) => p.id === proposalId)
     if (currentProposal) {
       if (!matchesActiveBoardFilter(currentProposal.boardId)) {
-        await router.replace({ name: 'workspace-review', query: route.query })
+        await safeReplace({ name: 'workspace-review', query: route.query })
         return
       }
       await scrollToProposalFromHash()
@@ -201,7 +212,7 @@ export function useReviewProposals() {
       const fetchedProposal = await automationApi.getProposal(proposalId)
       if (getProposalIdFromHash(route.hash) !== proposalId) return
       if (!matchesActiveBoardFilter(fetchedProposal.boardId)) {
-        await router.replace({ name: 'workspace-review', query: route.query })
+        await safeReplace({ name: 'workspace-review', query: route.query })
         return
       }
       upsertProposal(fetchedProposal)
@@ -210,7 +221,7 @@ export function useReviewProposals() {
     } catch (e: unknown) {
       if (getProposalIdFromHash(route.hash) !== proposalId) return
       if (isHttpNotFound(e)) {
-        await router.replace({ name: 'workspace-review', query: route.query })
+        await safeReplace({ name: 'workspace-review', query: route.query })
         return
       }
       toast.error(getErrorDisplay(e, 'Failed to load proposal').message)
@@ -263,7 +274,11 @@ export function useReviewProposals() {
   }
 
   function safeNavigate(to: Parameters<typeof router.push>[0]) {
-    router.push(to).catch(() => {})
+    router.push(to).catch((err) => {
+      if (!isNavigationFailure(err, NavigationFailureType.duplicated | NavigationFailureType.cancelled | NavigationFailureType.aborted)) {
+        logError('Unexpected navigation failure:', err)
+      }
+    })
   }
 
   function openInbox() {
@@ -312,12 +327,12 @@ export function useReviewProposals() {
 
   watch(
     () => route.hash,
-    () => { void openProposalFromHash() },
+    () => { openProposalFromHash().catch(() => {}) },
   )
 
   watch(
     () => activeBoardFilter.value,
-    () => { void loadProposals() },
+    () => { loadProposals().catch(() => {}) },
   )
 
   return {

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -262,8 +262,12 @@ export function useReviewProposals() {
     return `/workspace/inbox${query}${hash}`
   }
 
+  function safeNavigate(to: Parameters<typeof router.push>[0]) {
+    router.push(to).catch(() => {})
+  }
+
   function openInbox() {
-    void router.push(inboxPath(activeBoardFilter.value))
+    safeNavigate(inboxPath(activeBoardFilter.value))
   }
 
   function proposalHref(proposal: ApiProposal): string {
@@ -282,26 +286,26 @@ export function useReviewProposals() {
   }
 
   function openRoute(path: string) {
-    void router.push(path)
+    safeNavigate(path)
   }
 
   function openBoard(boardId: string) {
-    void router.push(`/workspace/boards/${boardId}`)
+    safeNavigate(`/workspace/boards/${boardId}`)
   }
 
   function applyBoardFilter(boardId: string) {
     const trimmed = boardId.trim()
     boardFilterInput.value = ''
     if (trimmed) {
-      void router.push({ name: 'workspace-review', query: { boardId: trimmed } })
+      safeNavigate({ name: 'workspace-review', query: { boardId: trimmed } })
     } else {
-      void router.push({ name: 'workspace-review' })
+      safeNavigate({ name: 'workspace-review' })
     }
   }
 
   function clearBoardFilter() {
     boardFilterInput.value = ''
-    void router.push({ name: 'workspace-review' })
+    safeNavigate({ name: 'workspace-review' })
   }
 
   // --- Watchers ---

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -28,11 +28,14 @@ vi.mock('vue', () => ({
   computed: (fn: () => unknown) => ({ get value() { return fn() } }),
   watch: (source: unknown, cb: () => void) => { watchers.push([source, cb]) },
   nextTick: vi.fn(() => Promise.resolve()),
+  onScopeDispose: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
   useRoute: () => mockRoute,
   useRouter: () => mockRouter,
+  isNavigationFailure: () => false,
+  NavigationFailureType: { aborted: 4, cancelled: 8, duplicated: 16 },
 }))
 
 vi.mock('../../api/automationApi', () => ({
@@ -75,6 +78,10 @@ vi.mock('../../composables/usePerformanceMark', () => ({
 
 vi.mock('../../composables/useErrorMapper', () => ({
   getErrorDisplay: (_e: unknown, fallback: string) => ({ message: fallback }),
+}))
+
+vi.mock('../../utils/errorReporting', () => ({
+  logError: vi.fn(),
 }))
 
 import { useReviewProposals } from '../../composables/useReviewProposals'

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -10,7 +10,7 @@ const {
 } = vi.hoisted(() => {
   return {
     watchers: [] as Array<[unknown, () => void]>,
-    mockRouter: { push: vi.fn(), replace: vi.fn() },
+    mockRouter: { push: vi.fn().mockResolvedValue(undefined), replace: vi.fn().mockResolvedValue(undefined) },
     mockRoute: { hash: '', query: {} as Record<string, string> },
     mockAutomationApi: {
       getProposals: vi.fn(() => Promise.resolve([])),


### PR DESCRIPTION
## Summary
- **useReviewProposals**: Extract `safeNavigate` helper that catches `router.push` rejections instead of using `void` fire-and-forget (6 call sites)
- **useCardModal**: Add error toast on card save failure — previously failures were silently logged with no user feedback
- **useCaptureQueueSync**: Replace `void` with `.catch()` on `refreshCount()` and `replayQueue()` in lifecycle hooks and event handlers

Closes #1093

## Test plan
- [x] Frontend typecheck: clean
- [x] 3,601 frontend tests pass (289 files), including 37 useReviewProposals tests
- [x] Router mock updated to return Promise to match new `.catch()` chaining