### PR TITLE
Add aria-labels to filter clear buttons in FilterPanel

### DIFF
--- a/frontend/taskdeck-web/src/components/board/FilterPanel.vue
+++ b/frontend/taskdeck-web/src/components/board/FilterPanel.vue
@@ -189,15 +189,15 @@ const hasActiveFilters = computed(() => {
         <span class="text-sm text-on-surface-variant">Active filters:</span>
         <span v-if="localFilters.searchText" class="inline-flex items-center gap-1 px-2 py-1 bg-primary/20 text-primary text-xs rounded">
           Search: "{{ localFilters.searchText }}"
-          <button @click="localFilters.searchText = ''; updateFilters()" class="hover:text-primary/70">&times;</button>
+          <button @click="localFilters.searchText = ''; updateFilters()" class="hover:text-primary/70" aria-label="Clear search filter">&times;</button>
         </span>
         <span v-if="localFilters.dueDateFilter !== 'all'" class="inline-flex items-center gap-1 px-2 py-1 bg-primary/20 text-primary text-xs rounded">
           {{ localFilters.dueDateFilter }}
-          <button @click="localFilters.dueDateFilter = 'all'; updateFilters()" class="hover:text-primary/70">&times;</button>
+          <button @click="localFilters.dueDateFilter = 'all'; updateFilters()" class="hover:text-primary/70" aria-label="Clear due date filter">&times;</button>
         </span>
         <span v-if="localFilters.showBlockedOnly" class="inline-flex items-center gap-1 px-2 py-1 bg-primary/20 text-primary text-xs rounded">
           Blocked only
-          <button @click="localFilters.showBlockedOnly = false; updateFilters()" class="hover:text-primary/70">&times;</button>
+          <button @click="localFilters.showBlockedOnly = false; updateFilters()" class="hover:text-primary/70" aria-label="Clear blocked filter">&times;</button>
         </span>
         <span
           v-for="labelId in localFilters.labelIds"
@@ -205,7 +205,7 @@ const hasActiveFilters = computed(() => {
           class="inline-flex items-center gap-1 px-2 py-1 bg-primary/20 text-primary text-xs rounded"
         >
           {{ labels.find(l => l.id === labelId)?.name }}
-          <button @click="toggleLabel(labelId)" class="hover:text-primary/70">&times;</button>
+          <button @click="toggleLabel(labelId)" class="hover:text-primary/70" :aria-label="`Clear ${labels.find(l => l.id === labelId)?.name ?? 'label'} filter`">&times;</button>
         </span>
       </div>
     </div>

--- a/frontend/taskdeck-web/src/components/board/FilterPanel.vue
+++ b/frontend/taskdeck-web/src/components/board/FilterPanel.vue
@@ -57,6 +57,15 @@ const isLabelSelected = (labelId: string) => {
   return localFilters.value.labelIds.includes(labelId)
 }
 
+// Resolve active label IDs to display names once so the chip text and its
+// aria-label don't each run a separate `labels.find` per active filter.
+const activeLabelChips = computed(() =>
+  localFilters.value.labelIds.map((labelId) => ({
+    id: labelId,
+    name: props.labels.find((l) => l.id === labelId)?.name ?? 'label',
+  })),
+)
+
 const clearAllFilters = () => {
   localFilters.value = {
     searchText: '',
@@ -200,12 +209,12 @@ const hasActiveFilters = computed(() => {
           <button @click="localFilters.showBlockedOnly = false; updateFilters()" class="hover:text-primary/70" aria-label="Clear blocked filter">&times;</button>
         </span>
         <span
-          v-for="labelId in localFilters.labelIds"
-          :key="labelId"
+          v-for="chip in activeLabelChips"
+          :key="chip.id"
           class="inline-flex items-center gap-1 px-2 py-1 bg-primary/20 text-primary text-xs rounded"
         >
-          {{ labels.find(l => l.id === labelId)?.name }}
-          <button @click="toggleLabel(labelId)" class="hover:text-primary/70" :aria-label="`Clear ${labels.find(l => l.id === labelId)?.name ?? 'label'} filter`">&times;</button>
+          {{ chip.name }}
+          <button @click="toggleLabel(chip.id)" class="hover:text-primary/70" :aria-label="`Clear ${chip.name} filter`">&times;</button>
         </span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Add `aria-label` attributes to the four × (clear) buttons in the active filters section of `FilterPanel.vue`
- Search, due date, blocked, and label filter clear buttons now announce their purpose to screen readers
- Label filter buttons use dynamic labels including the label name

Closes #1097.

## Test plan

- [ ] `vue-tsc -b` typecheck: clean
- [ ] `vitest --run`: 3601 tests pass
- [ ] Verify filter clear buttons are accessible via screen reader (VoiceOver/NVDA)
- [ ] Verify no visual regression in filter panel