### PR TITLE
Fix composable cleanup leaks in useReviewProposals, useGlobalSearch, usePaperReviewSelectors

### DIFF
--- a/frontend/taskdeck-web/src/composables/useGlobalSearch.ts
+++ b/frontend/taskdeck-web/src/composables/useGlobalSearch.ts
@@ -27,6 +27,9 @@ export function useGlobalSearch(debounceMs = 250) {
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
   let abortController: AbortController | null = null
+  // Set once the owning scope is disposed; guards the `finally` blocks below so
+  // an abort-triggered continuation doesn't write reactive state after teardown.
+  let isDisposed = false
 
   function reset() {
     query.value = ''
@@ -90,7 +93,7 @@ export function useGlobalSearch(debounceMs = 250) {
       totalCardCount.value = 0
       hasMoreCards.value = false
     } finally {
-      loading.value = false
+      if (!isDisposed) loading.value = false
     }
   }
 
@@ -123,7 +126,7 @@ export function useGlobalSearch(debounceMs = 250) {
       }
       error.value = 'Failed to load more results.'
     } finally {
-      loadingMore.value = false
+      if (!isDisposed) loadingMore.value = false
     }
   }
 
@@ -150,6 +153,7 @@ export function useGlobalSearch(debounceMs = 250) {
   })
 
   onScopeDispose(() => {
+    isDisposed = true
     if (debounceTimer) {
       clearTimeout(debounceTimer)
       debounceTimer = null

--- a/frontend/taskdeck-web/src/composables/useGlobalSearch.ts
+++ b/frontend/taskdeck-web/src/composables/useGlobalSearch.ts
@@ -1,4 +1,4 @@
-import { ref, watch } from 'vue'
+import { onScopeDispose, ref, watch } from 'vue'
 import { searchApi } from '../api/searchApi'
 import type { SearchBoardHit, SearchCardHit } from '../api/searchApi'
 
@@ -147,6 +147,17 @@ export function useGlobalSearch(debounceMs = 250) {
     debounceTimer = setTimeout(() => {
       void executeSearch(newQuery)
     }, debounceMs)
+  })
+
+  onScopeDispose(() => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    if (abortController) {
+      abortController.abort()
+      abortController = null
+    }
   })
 
   return {

--- a/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
+++ b/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
@@ -267,6 +267,11 @@ export function usePaperReviewSelectors(
   })
 
   onScopeDispose(() => {
+    // Invalidate the current generation so any in-flight Promise.allSettled
+    // continuation short-circuits at the `generation !== fetchGeneration`
+    // guard instead of writing reactive state after the scope is gone.
+    // (Promise.allSettled resolves even when its inner requests are aborted.)
+    fetchGeneration++
     if (abortController) {
       abortController.abort()
       abortController = null

--- a/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
+++ b/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
@@ -1,4 +1,4 @@
-import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
+import { computed, onScopeDispose, ref, watch, type ComputedRef, type Ref } from 'vue'
 import type { Proposal as ApiProposal } from '../types/automation'
 import { proposalDeepReviewApi } from '../api/proposalDeepReviewApi'
 import type {
@@ -264,6 +264,13 @@ export function usePaperReviewSelectors(
     const applied = rows.filter((r) => r.verdict === 'applied').length
     const total = rows.length
     return { applied, total, ratio: total === 0 ? 0 : applied / total }
+  })
+
+  onScopeDispose(() => {
+    if (abortController) {
+      abortController.abort()
+      abortController = null
+    }
   })
 
   const loading = computed(() => isLoading.value)

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -36,6 +36,10 @@ export function useReviewProposals() {
   let clockInterval: ReturnType<typeof setInterval> | null = null
 
   function startClock() {
+    // Guard against double-start: a second call would overwrite clockInterval
+    // and permanently leak the first interval (neither stopClock nor
+    // onScopeDispose can clear a handle they no longer hold).
+    if (clockInterval !== null) return
     clockInterval = setInterval(() => {
       nowMs.value = Date.now()
     }, 60_000)

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, onScopeDispose, ref, watch } from 'vue'
 import { isNavigationFailure, NavigationFailureType, useRoute, useRouter } from 'vue-router'
 import { automationApi } from '../api/automationApi'
 import { boardsApi } from '../api/boardsApi'
@@ -47,6 +47,8 @@ export function useReviewProposals() {
       clockInterval = null
     }
   }
+
+  onScopeDispose(stopClock)
 
   const completedStatuses = new Set(['Applied', 'Rejected', 'Failed', 'Expired', 'Dismissed'])
 

--- a/frontend/taskdeck-web/src/tests/composables/useGlobalSearch.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useGlobalSearch.spec.ts
@@ -305,4 +305,38 @@ describe('useGlobalSearch', () => {
 
     expect(mockSearch).not.toHaveBeenCalled()
   })
+
+  it('does not write reactive state in finally when disposed mid-search', async () => {
+    const scope = effectScope()
+    let search!: ReturnType<typeof useGlobalSearch>
+    scope.run(() => {
+      search = useGlobalSearch(200)
+    })
+
+    // Mirror the real API: reject with AbortError once the signal aborts.
+    mockSearch.mockImplementation(
+      (_q: string, signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          )
+        }) as ReturnType<typeof searchApi.search>,
+    )
+
+    search.query.value = 'hello world'
+    await nextTick()
+    vi.advanceTimersByTime(300) // fire debounce -> executeSearch starts
+    await nextTick()
+    expect(search.loading.value).toBe(true)
+    expect(mockSearch).toHaveBeenCalledTimes(1)
+
+    scope.stop() // aborts the in-flight controller -> search rejects AbortError
+    await nextTick()
+    await nextTick()
+
+    // The guarded `finally` must not flip loading back, and no results land.
+    expect(search.loading.value).toBe(true)
+    expect(search.boards.value).toEqual([])
+    expect(search.cards.value).toEqual([])
+  })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useGlobalSearch.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useGlobalSearch.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { nextTick } from 'vue'
+import { effectScope, nextTick } from 'vue'
 import { useGlobalSearch } from '../../composables/useGlobalSearch'
 
 const mockSearchResult = {
@@ -284,5 +284,25 @@ describe('useGlobalSearch', () => {
     // Second call should have offset = 1 (number of cards from first result)
     const secondCall = mockSearch.mock.calls[1]
     expect(secondCall[2]).toEqual(expect.objectContaining({ offset: 1 }))
+  })
+
+  it('clears debounce timer and aborts in-flight request on scope disposal', async () => {
+    const scope = effectScope()
+    let search: ReturnType<typeof useGlobalSearch>
+
+    scope.run(() => {
+      search = useGlobalSearch(200)
+    })
+
+    mockSearch.mockImplementation(() => new Promise(() => {}))
+    search!.query.value = 'test query'
+    await nextTick()
+
+    scope.stop()
+
+    vi.advanceTimersByTime(300)
+    await nextTick()
+
+    expect(mockSearch).not.toHaveBeenCalled()
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, effectScope } from 'vue'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
 import { proposalDeepReviewApi } from '../../api/proposalDeepReviewApi'
 import type { Proposal as ApiProposal } from '../../types/automation'
@@ -242,6 +242,54 @@ describe('usePaperReviewSelectors', () => {
     })
 
     expect(selectors.confidenceBreakdown.value.note).toBeUndefined()
+  })
+
+  it('aborts in-flight requests and discards their result on scope disposal', async () => {
+    let resolveProvenance: (v: never[]) => void
+    const pending = new Promise<never[]>((r) => { resolveProvenance = r })
+    let capturedSignal: AbortSignal | undefined
+    vi.mocked(proposalDeepReviewApi.getProvenance).mockImplementation((_id, opts) => {
+      capturedSignal = opts?.signal
+      return pending
+    })
+    vi.mocked(proposalDeepReviewApi.getConfidence).mockResolvedValue({
+      overall: 0.5,
+      components: [],
+      note: null,
+      threshold: 0.7,
+      meetsThreshold: false,
+    })
+    vi.mocked(proposalDeepReviewApi.getSideEffects).mockResolvedValue({
+      rows: [],
+      reversibility: { summary: '6h', description: 'Safe', windowMs: 21600000 },
+    })
+    vi.mocked(proposalDeepReviewApi.getConflicts).mockResolvedValue([])
+    vi.mocked(proposalDeepReviewApi.getHistory).mockResolvedValue([])
+    vi.mocked(proposalDeepReviewApi.getSimilarPast).mockResolvedValue({ decisions: [], applyRate: 0 })
+
+    const scope = effectScope()
+    let selectors!: ReturnType<typeof usePaperReviewSelectors>
+    scope.run(() => {
+      const proposal = ref<ApiProposal | null>(makeProposal({ id: 'p-1' }))
+      const activeProposal = computed(() => proposal.value)
+      selectors = usePaperReviewSelectors(activeProposal)
+    })
+
+    await nextTick()
+    expect(capturedSignal?.aborted).toBe(false)
+
+    // Tear the scope down while the provenance request is still in flight.
+    scope.stop()
+    expect(capturedSignal?.aborted).toBe(true)
+
+    // Resolve the previously in-flight request after disposal; the generation
+    // guard must prevent any reactive write-back.
+    resolveProvenance!([{ icon: '📄', key: 'late', value: 'v', weight: 'primary' }] as never[])
+    await nextTick()
+    await nextTick()
+
+    expect(selectors.provenance.value.some((r) => r.key === 'late')).toBe(false)
+    expect(selectors.loading.value).toBe(true)
   })
 
   it('maps side effects with appliedAt from proposal', async () => {

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -443,6 +443,24 @@ describe('useReviewProposals', () => {
       vi.advanceTimersByTime(60_000)
       expect(rp.nowMs.value).toBe(afterDispose)
     })
+
+    it('startClock is idempotent so a double call cannot leak an interval', () => {
+      vi.useFakeTimers()
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+      const rp = useReviewProposals()
+
+      rp.startClock()
+      rp.startClock() // second call must be a no-op (guarded)
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+      // A single stopClock fully halts the clock — proving no orphaned interval.
+      rp.stopClock()
+      const afterStop = rp.nowMs.value
+      vi.advanceTimersByTime(120_000)
+      expect(rp.nowMs.value).toBe(afterStop)
+
+      setIntervalSpy.mockRestore()
+    })
   })
 
   describe('matchesActiveBoardFilter', () => {

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -7,6 +7,7 @@ const {
   mockAutomationApi,
   mockBoardsApi,
   mockToast,
+  mockOnScopeDispose,
 } = vi.hoisted(() => {
   return {
     watchers: [] as Array<[unknown, () => void]>,
@@ -20,6 +21,7 @@ const {
       getBoards: vi.fn(() => Promise.resolve([])),
     },
     mockToast: { error: vi.fn(), info: vi.fn() },
+    mockOnScopeDispose: vi.fn(),
   }
 })
 
@@ -28,7 +30,7 @@ vi.mock('vue', () => ({
   computed: (fn: () => unknown) => ({ get value() { return fn() } }),
   watch: (source: unknown, cb: () => void) => { watchers.push([source, cb]) },
   nextTick: vi.fn(() => Promise.resolve()),
-  onScopeDispose: vi.fn(),
+  onScopeDispose: mockOnScopeDispose,
 }))
 
 vi.mock('vue-router', () => ({
@@ -426,6 +428,20 @@ describe('useReviewProposals', () => {
       const afterStop = rp.nowMs.value
       vi.advanceTimersByTime(60_000)
       expect(rp.nowMs.value).toBe(afterStop)
+    })
+
+    it('registers stopClock via onScopeDispose', () => {
+      vi.useFakeTimers()
+      mockOnScopeDispose.mockClear()
+      const rp = useReviewProposals()
+      expect(mockOnScopeDispose).toHaveBeenCalledWith(expect.any(Function))
+
+      rp.startClock()
+      const registered = mockOnScopeDispose.mock.calls[0][0] as () => void
+      registered()
+      const afterDispose = rp.nowMs.value
+      vi.advanceTimersByTime(60_000)
+      expect(rp.nowMs.value).toBe(afterDispose)
     })
   })
 


### PR DESCRIPTION
Resolves #1094. (Re-opened from #1096, which GitHub auto-closed when its stacked base branch `fix/1093` was deleted on merge of #1095. Rebased onto main; carries the same commits + both adversarial reviews.)

## What
Adds `onScopeDispose` cleanup to three composables so timers, intervals, and in-flight AbortControllers are released when the owning scope tears down:
- `useReviewProposals` — 60s clock interval (with idempotent `startClock` guard)
- `useGlobalSearch` — debounce timer + AbortController, with `finally` writes guarded against post-disposal mutation
- `usePaperReviewSelectors` — AbortController, with fetch-generation invalidation on dispose so aborted `Promise.allSettled` continuations don't write reactive state

## Reviews
Two independent adversarial reviews were completed on #1096; all findings (3 HIGH, 3 MEDIUM, 1 LOW) addressed. See the consolidated review + fix-evidence comment below.

## Verification
`vue-tsc -b` clean · eslint clean · 63/63 tests across the 3 specs (3 new disposal tests added).