### PR TITLE
FE: Use stable v-for keys instead of array index in static lists

### DIFF
--- a/frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue
+++ b/frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue
@@ -108,13 +108,13 @@ const categories: ShortcutCategory[] = [
               </h3>
               <div class="space-y-2 ml-3">
                 <div
-                  v-for="(shortcut, index) in category.shortcuts"
-                  :key="index"
+                  v-for="shortcut in category.shortcuts"
+                  :key="`${category.title}-${shortcut.description}`"
                   class="flex items-center justify-between py-2 px-3 rounded hover:bg-gray-50 transition-colors"
                 >
                   <span class="text-gray-700">{{ shortcut.description }}</span>
                   <div class="flex items-center gap-1">
-                    <template v-for="(key, keyIndex) in shortcut.keys" :key="keyIndex">
+                    <template v-for="(key, keyIndex) in shortcut.keys" :key="`${shortcut.description}-${keyIndex}-${key}`">
                       <kbd
                         class="px-2 py-1 text-sm font-semibold text-gray-800 bg-gray-100 border border-gray-300 rounded shadow-sm min-w-[2rem] text-center"
                       >

--- a/frontend/taskdeck-web/src/components/chat/ChatParseHintCard.vue
+++ b/frontend/taskdeck-web/src/components/chat/ChatParseHintCard.vue
@@ -48,8 +48,8 @@ const emit = defineEmits<{
       aria-label="Supported instruction patterns"
     >
       <li
-        v-for="(pattern, index) in hint.hint.supportedPatterns"
-        :key="index"
+        v-for="pattern in hint.hint.supportedPatterns"
+        :key="pattern"
       >
         <code>{{ pattern }}</code>
       </li>

--- a/frontend/taskdeck-web/src/tests/utils/chat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/utils/chat.spec.ts
@@ -50,6 +50,21 @@ describe('extractParseHint', () => {
     expect(extractParseHint(content)).toBeNull()
   })
 
+  it('de-duplicates repeated supportedPatterns so list keys stay unique', () => {
+    const payload = {
+      supportedPatterns: ['create card "title"', 'archive card {id}', 'create card "title"'],
+      exampleInstruction: 'create card "test"',
+      closestPattern: 'create card "title"',
+      detectedIntent: null,
+    }
+    const content = `Text[PARSE_HINT]${JSON.stringify(payload)}`
+
+    const result = extractParseHint(content)
+
+    expect(result).not.toBeNull()
+    expect(result!.hint.supportedPatterns).toEqual(['create card "title"', 'archive card {id}'])
+  })
+
   it('trims trailing whitespace from text before hint', () => {
     const payload = {
       supportedPatterns: ['create card "title"'],

--- a/frontend/taskdeck-web/src/utils/chat.ts
+++ b/frontend/taskdeck-web/src/utils/chat.ts
@@ -34,6 +34,9 @@ export function extractParseHint(content: string): ParsedHintMessage | null {
     if (!hint.supportedPatterns || !Array.isArray(hint.supportedPatterns)) {
       return null
     }
+    // De-duplicate so the rendered list (keyed on the pattern string) can never
+    // emit duplicate Vue keys regardless of what an LLM-produced payload contains.
+    hint.supportedPatterns = [...new Set(hint.supportedPatterns)]
     return { textBeforeHint, hint }
   } catch {
     return null


### PR DESCRIPTION
Resolves #1107.

Replaces `:key="index"` array-index keys with stable, content-derived keys in two components:
- `ChatParseHintCard.vue` — keys on `pattern` string (dropped unused `index`).
- `KeyboardShortcutsHelp.vue` — shortcut rows keyed on `${category.title}-${shortcut.description}`; nested key chips keyed on `${shortcut.description}-${keyIndex}-${key}` (kept `keyIndex` — still used for the 'or' separator).

## Verification
- `vue-tsc -b` clean
- `KeyboardShortcutsHelp.spec.ts` + `useKeyboardShortcuts.spec.ts` — 20/20 pass

Small hardening slice seeded from a 2026-05-29 codebase analysis pass.