### PR TITLE
BE: Migrate Telemetry + EgressDisclosure controllers onto AuthenticatedControllerBase

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/EgressDisclosureController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/EgressDisclosureController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 
 namespace Taskdeck.Api.Controllers;
@@ -8,11 +9,12 @@ namespace Taskdeck.Api.Controllers;
 [Authorize]
 [Route("api/privacy/egress")]
 [Produces("application/json")]
-public class EgressDisclosureController : ControllerBase
+public class EgressDisclosureController : AuthenticatedControllerBase
 {
     private readonly IEgressRegistry _egressRegistry;
 
-    public EgressDisclosureController(IEgressRegistry egressRegistry)
+    public EgressDisclosureController(IEgressRegistry egressRegistry, IUserContext userContext)
+        : base(userContext)
     {
         _egressRegistry = egressRegistry;
     }

--- a/backend/src/Taskdeck.Api/Controllers/TelemetryController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/TelemetryController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 
 namespace Taskdeck.Api.Controllers;
@@ -11,7 +12,7 @@ namespace Taskdeck.Api.Controllers;
 [ApiController]
 [Route("api/telemetry")]
 [Authorize]
-public class TelemetryController : ControllerBase
+public class TelemetryController : AuthenticatedControllerBase
 {
     private readonly ITelemetryEventService _telemetryEventService;
     private readonly SentrySettings _sentrySettings;
@@ -22,7 +23,9 @@ public class TelemetryController : ControllerBase
         ITelemetryEventService telemetryEventService,
         SentrySettings sentrySettings,
         AnalyticsSettings analyticsSettings,
-        TelemetrySettings telemetrySettings)
+        TelemetrySettings telemetrySettings,
+        IUserContext userContext)
+        : base(userContext)
     {
         _telemetryEventService = telemetryEventService;
         _sentrySettings = sentrySettings;

--- a/backend/tests/Taskdeck.Architecture.Tests/ApiControllerBoundaryTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/ApiControllerBoundaryTests.cs
@@ -15,10 +15,11 @@ public class ApiControllerBoundaryTests
 
     private static readonly HashSet<string> AllowedControllerBaseTypes = new(StringComparer.Ordinal)
     {
+        // AuthController uses per-method [Authorize] (mixed-auth: login/register are anonymous);
+        // HealthController is intentionally anonymous (liveness/readiness probes). Both legitimately
+        // sidestep class-level [Authorize] + the AuthenticatedControllerBase seam.
         "AuthController",
-        "HealthController",
-        "TelemetryController",
-        "EgressDisclosureController"
+        "HealthController"
     };
 
     [Fact]


### PR DESCRIPTION
Resolves #1109.

Two controllers extended plain `ControllerBase` while every other authenticated controller uses the shared `AuthenticatedControllerBase` identity seam. Both are `[Authorize]`d and touch no user-scoped data today, so there's no leak — but they sidestepped the shared `TryGetCurrentUserId`/`IUserContext` helper, risking ad-hoc identity resolution if a future endpoint needs a userId.

## Change
- `TelemetryController` and `EgressDisclosureController` now extend `AuthenticatedControllerBase`, injecting `IUserContext` and passing it to `base(...)`. No behavior change.

## Verification
- `dotnet build backend/src/Taskdeck.Api -c Release` → 0 errors/warnings.
- `TelemetryApiTests`, `TelemetryConfigurationTests`, `EgressDisclosureApiTests` — 32/32 pass (auth behavior unchanged).

Part of the 2026-05-29 identity/authz consistency hardening; #1110 adds Architecture.Tests guards to prevent regressions.