### PR TITLE
chore: ignore EF Core major bumps in dependabot (stop recurring 8/9 split)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,19 @@ updates:
           - minor
           - patch
     # Let major versions come as individual PRs for explicit review
+    ignore:
+      # The project intentionally pins Entity Framework Core to the 8.x line
+      # (see #760/#767). Dependabot repeatedly proposes EF Core 9.x for the main
+      # package while the Sqlite/Design providers stay on 8.x, which desyncs the
+      # providers and reintroduces the ambiguous ExecuteDeleteAsync break
+      # (fixed in #1102 and again in #1106). Block EF Core major bumps until the
+      # project deliberately migrates the whole EF stack together.
+      - dependency-name: "Microsoft.EntityFrameworkCore"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.Sqlite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.Design"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps(nuget)"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,14 +25,17 @@ updates:
         update-types:
           - minor
           - patch
-    # Let major versions come as individual PRs for explicit review
+    # Let other major versions come as individual PRs for explicit review.
     ignore:
-      # The project intentionally pins Entity Framework Core to the 8.x line
-      # (see #760/#767). Dependabot repeatedly proposes EF Core 9.x for the main
-      # package while the Sqlite/Design providers stay on 8.x, which desyncs the
-      # providers and reintroduces the ambiguous ExecuteDeleteAsync break
-      # (fixed in #1102 and again in #1106). Block EF Core major bumps until the
-      # project deliberately migrates the whole EF stack together.
+      # Keep the three RUNTIME EF Core packages mutually consistent on the 8.x
+      # line (see #760/#767). Dependabot repeatedly proposes EF Core 9.x for the
+      # main package while the Sqlite/Design providers stay on 8.x, which desyncs
+      # them and reintroduces the ambiguous ExecuteDeleteAsync break (fixed in
+      # #1102 and again in #1106). Block their major bumps until the project
+      # deliberately migrates the runtime EF stack together.
+      # Note: Microsoft.EntityFrameworkCore.Tools is a design-time-only package
+      # (PrivateAssets) tracked separately on its own line and is intentionally
+      # NOT pinned here; it does not affect the runtime compile.
       - dependency-name: "Microsoft.EntityFrameworkCore"
         update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.EntityFrameworkCore.Sqlite"

--- a/docs/ops/DEPENDENCY_UPDATE_POLICY.md
+++ b/docs/ops/DEPENDENCY_UPDATE_POLICY.md
@@ -122,3 +122,13 @@ For each security advisory or Dependabot security PR:
 
 - Maintainers should review open Dependabot PRs at least weekly (aligned with the Monday generation schedule).
 - Stale Dependabot PRs older than 30 days should be investigated: either the update is blocked (needs an issue) or it was overlooked.
+
+## Pinned / version-capped dependencies
+
+Some dependencies are intentionally held below their latest major via `ignore`
+rules in `.github/dependabot.yml`. These must be removed deliberately (as a
+coordinated migration), not incidentally.
+
+| Package(s) | Cap | Reason | Remove when |
+|---|---|---|---|
+| `Microsoft.EntityFrameworkCore`, `.Sqlite`, `.Design` | major bumps blocked (stay on 8.x) | The project pins the runtime EF Core stack to 8.x (#760/#767). Dependabot otherwise bumps the core package to 9.x while the providers stay on 8.x, desyncing them and reintroducing an ambiguous `ExecuteDeleteAsync` compile break (#1102, #1106). | The runtime EF Core stack is migrated to 9.x+ together, in one PR. |


### PR DESCRIPTION
## Why
Dependabot's `dotnet-minor-patch` group has now twice (#1102, and again #1106) proposed `Microsoft.EntityFrameworkCore` **9.0.16** while leaving `.Sqlite`/`.Design` on **8.0.27**. That version desync reintroduces the ambiguous `ExecuteDeleteAsync` compile break each cycle, requiring a manual pin every time.

The project intentionally stays on the EF Core **8.x** line (per #760/#767). Until a deliberate whole-stack EF migration, dependabot should not propose EF Core majors.

## Change
Adds an `ignore` rule to the NuGet update config for `version-update:semver-major` on `Microsoft.EntityFrameworkCore`, `.Sqlite`, and `.Design`. Minor/patch bumps within 8.x still flow normally.

## Verification
- `dependabot.yml` parses as valid YAML.
- Indentation matches sibling keys (`groups`, `commit-message`) under the `/backend` nuget entry.

Durable follow-up to the per-PR EF pins on #1102 and #1106.