### PR TITLE
BE: Architecture guard for per-action authorization + explicit AllowAnonymous

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/AuthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthController.cs
@@ -61,6 +61,7 @@ public class AuthController : AuthenticatedControllerBase
     /// <response code="401">Invalid credentials.</response>
     /// <response code="429">Rate limit exceeded.</response>
     [HttpPost("login")]
+    [AllowAnonymous]
     [SuppressModelStateValidation]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     [ProducesResponseType(typeof(AuthResultDto), StatusCodes.Status200OK)]
@@ -90,6 +91,7 @@ public class AuthController : AuthenticatedControllerBase
     /// <response code="400">Validation error (e.g., duplicate username/email).</response>
     /// <response code="429">Rate limit exceeded.</response>
     [HttpPost("register")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     [ProducesResponseType(typeof(AuthResultDto), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
@@ -177,6 +179,7 @@ public class AuthController : AuthenticatedControllerBase
     /// derives the intent from authentication state to prevent user-controlled bypass.
     /// </summary>
     [HttpGet("github/login")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public IActionResult GitHubLogin([FromQuery] string? returnUrl = null)
     {
@@ -211,6 +214,7 @@ public class AuthController : AuthenticatedControllerBase
     /// Handles the GitHub OAuth callback, creates/links the user, and redirects with a JWT token.
     /// </summary>
     [HttpGet("github/callback")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public async Task<IActionResult> GitHubCallback([FromQuery] string? returnUrl = null)
     {
@@ -343,6 +347,7 @@ public class AuthController : AuthenticatedControllerBase
     /// JWT is re-issued fresh at exchange time -- never stored in the database.
     /// </summary>
     [HttpPost("github/exchange")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public async Task<IActionResult> ExchangeCode([FromBody] ExchangeCodeRequest request)
     {
@@ -504,6 +509,7 @@ public class AuthController : AuthenticatedControllerBase
     /// Returns available authentication providers on this instance.
     /// </summary>
     [HttpGet("providers")]
+    [AllowAnonymous]
     public IActionResult GetProviders()
     {
         var oidcProviders = _oidcSettings.ConfiguredProviders
@@ -521,6 +527,7 @@ public class AuthController : AuthenticatedControllerBase
     /// Initiates OIDC login flow for a named provider. Only available when the provider is configured.
     /// </summary>
     [HttpGet("oidc/{providerName}/login")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public IActionResult OidcLogin(string providerName, [FromQuery] string? returnUrl = null)
     {
@@ -547,6 +554,7 @@ public class AuthController : AuthenticatedControllerBase
     /// Handles the OIDC callback, creates/links the user, and redirects with a short-lived code.
     /// </summary>
     [HttpGet("oidc/{providerName}/callback")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public async Task<IActionResult> OidcCallback(string providerName, [FromQuery] string? returnUrl = null)
     {
@@ -628,6 +636,7 @@ public class AuthController : AuthenticatedControllerBase
     /// Reuses the same database-backed code store as GitHub OAuth.
     /// </summary>
     [HttpPost("oidc/exchange")]
+    [AllowAnonymous]
     [EnableRateLimiting(RateLimitingPolicyNames.AuthPerIp)]
     public async Task<IActionResult> OidcExchangeCode([FromBody] ExchangeCodeRequest request)
     {

--- a/backend/src/Taskdeck.Api/Controllers/AuthenticatedControllerBase.cs
+++ b/backend/src/Taskdeck.Api/Controllers/AuthenticatedControllerBase.cs
@@ -12,6 +12,19 @@ namespace Taskdeck.Api.Controllers;
 /// Base controller for endpoints that require an authenticated user context.
 /// Provides a shared helper to extract and validate the current user's ID from JWT claims.
 /// </summary>
+/// <remarks>
+/// Authorization conventions (enforced by Taskdeck.Architecture.Tests.ApiControllerBoundaryTests):
+/// <list type="bullet">
+/// <item>Every user-facing controller derives from this base and declares a class-level
+/// <c>[Authorize]</c>; identity is resolved only from JWT claims via <see cref="TryGetCurrentUserId"/>,
+/// never from request input.</item>
+/// <item>Controllers without a class-level <c>[Authorize]</c> (only AuthController and HealthController)
+/// must mark every action explicitly with <c>[Authorize]</c> or <c>[AllowAnonymous]</c>.</item>
+/// <item>Board-scoped authorization is performed in the controller via
+/// <see cref="EnsureBoardPermissionAsync"/> as the preferred convention; services that re-check a
+/// board/user grant internally do so as defense in depth, not as a substitute.</item>
+/// </list>
+/// </remarks>
 public abstract class AuthenticatedControllerBase : ControllerBase
 {
     protected readonly IUserContext UserContext;

--- a/backend/src/Taskdeck.Api/Controllers/HealthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/HealthController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Taskdeck.Api.Health;
 using Taskdeck.Api.Telemetry;
@@ -38,12 +39,14 @@ public class HealthController : ControllerBase
     }
 
     [HttpGet("live")]
+    [AllowAnonymous]
     public IActionResult LiveCheck()
     {
         return Ok(new { status = "Healthy", timestamp = DateTimeOffset.UtcNow });
     }
 
     [HttpGet("ready")]
+    [AllowAnonymous]
     public async Task<IActionResult> ReadyCheck(CancellationToken ct = default)
     {
         var checks = new Dictionary<string, object>();

--- a/backend/tests/Taskdeck.Architecture.Tests/ApiControllerBoundaryTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/ApiControllerBoundaryTests.cs
@@ -79,6 +79,85 @@ public class ApiControllerBoundaryTests
             $"Controllers inheriting AuthenticatedControllerBase must declare [Authorize]:{Environment.NewLine}{string.Join(Environment.NewLine, violations)}");
     }
 
+    [Fact]
+    public void Actions_InControllersWithoutClassAuthorize_MustDeclareExplicitAuthorization()
+    {
+        // For controllers that do NOT carry a class-level [Authorize] (the mixed-auth
+        // AuthController and the anonymous HealthController), every HTTP action must
+        // state its intent explicitly via [Authorize] or [AllowAnonymous]. This stops a
+        // newly-added action from being silently anonymous by omission.
+        var violations = new List<string>();
+
+        foreach (var controllerFile in GetControllerFiles())
+        {
+            var content = File.ReadAllText(controllerFile);
+            var declaration = FindControllerDeclaration(controllerFile, content);
+
+            // Controllers with a class-level [Authorize] cover all their actions by default.
+            if (declaration.HasClassAuthorizeAttribute)
+            {
+                continue;
+            }
+
+            foreach (var action in GetActionsMissingExplicitAuthorization(content))
+            {
+                violations.Add(
+                    $"{ArchitectureTestPaths.ToBackendRelativePath(controllerFile)}: action '{action}' is missing [Authorize] or [AllowAnonymous] (its controller has no class-level [Authorize]).");
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            $"Actions in controllers without class-level [Authorize] must declare explicit authorization:{Environment.NewLine}{string.Join(Environment.NewLine, violations)}");
+    }
+
+    private static IEnumerable<string> GetActionsMissingExplicitAuthorization(string content)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var methodMatch = ActionMethodRegex.Match(lines[i]);
+            if (!methodMatch.Success)
+            {
+                continue;
+            }
+
+            // Collect the contiguous attribute lines immediately preceding the method.
+            var attributeLines = new List<string>();
+            var j = i - 1;
+            while (j >= 0 && lines[j].TrimStart().StartsWith("[", StringComparison.Ordinal))
+            {
+                attributeLines.Add(lines[j]);
+                j--;
+            }
+
+            var block = string.Join("\n", attributeLines);
+            if (!HttpVerbAttributeRegex.IsMatch(block))
+            {
+                // Not an HTTP action method (e.g. a constructor or helper).
+                continue;
+            }
+
+            if (!ExplicitAuthorizationRegex.IsMatch(block))
+            {
+                yield return methodMatch.Groups["method"].Value;
+            }
+        }
+    }
+
+    private static readonly Regex ActionMethodRegex = new(
+        @"^\s*public\s+(?:async\s+)?[\w<>\[\],\.\?\s]+?\s+(?<method>[A-Za-z_]\w*)\s*\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex HttpVerbAttributeRegex = new(
+        @"\[Http(Get|Post|Put|Delete|Patch|Head|Options)\b",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ExplicitAuthorizationRegex = new(
+        @"\[(Authorize|AllowAnonymous)\b",
+        RegexOptions.Compiled);
+
     private static IEnumerable<string> GetControllerFiles()
     {
         var controllersDirectory = ArchitectureTestPaths.GetBackendPath("src/Taskdeck.Api/Controllers");

--- a/backend/tests/Taskdeck.Architecture.Tests/ApiControllerBoundaryTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/ApiControllerBoundaryTests.cs
@@ -123,13 +123,29 @@ public class ApiControllerBoundaryTests
                 continue;
             }
 
-            // Collect the contiguous attribute lines immediately preceding the method.
+            // Collect the attribute lines immediately preceding the method. Blank
+            // lines are tolerated (skipped) so an IDE-inserted gap between an
+            // attribute and the signature cannot truncate the block and let an
+            // action slip past the guard — mirroring HasAuthorizeAttributeOnClass.
             var attributeLines = new List<string>();
             var j = i - 1;
-            while (j >= 0 && lines[j].TrimStart().StartsWith("[", StringComparison.Ordinal))
+            while (j >= 0)
             {
-                attributeLines.Add(lines[j]);
-                j--;
+                var trimmed = lines[j].TrimStart();
+                if (trimmed.StartsWith("[", StringComparison.Ordinal))
+                {
+                    attributeLines.Add(lines[j]);
+                    j--;
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    j--;
+                    continue;
+                }
+
+                break;
             }
 
             var block = string.Join("\n", attributeLines);
@@ -151,11 +167,13 @@ public class ApiControllerBoundaryTests
         RegexOptions.Compiled);
 
     private static readonly Regex HttpVerbAttributeRegex = new(
-        @"\[Http(Get|Post|Put|Delete|Patch|Head|Options)\b",
+        @"\[Http(Get|Post|Put|Delete|Patch|Head|Options)(?:Attribute)?\b",
         RegexOptions.Compiled);
 
+    // Accepts both the short and long attribute forms (e.g. [Authorize] and
+    // [AuthorizeAttribute]), matching AuthorizeAttributeTokenRegex's behavior.
     private static readonly Regex ExplicitAuthorizationRegex = new(
-        @"\[(Authorize|AllowAnonymous)\b",
+        @"\[(Authorize|AllowAnonymous)(?:Attribute)?\b",
         RegexOptions.Compiled);
 
     private static IEnumerable<string> GetControllerFiles()


### PR DESCRIPTION
Resolves #1110.

Closes the residual gap from the 2026-05-29 identity/authz audit: controllers **without** a class-level `[Authorize]` (the mixed-auth `AuthController` and anonymous `HealthController`) relied on per-method attributes, but several actions were anonymous **by omission** — so a future action could be silently unauthenticated.

## Changes
- **Explicit intent:** added `[AllowAnonymous]` to the 9 intentionally-anonymous `AuthController` actions (login, register, github/login·callback·exchange, providers, oidc/login·callback·exchange) and to both `HealthController` probes. No behavior change — these were already anonymous by default.
- **Guard test** (`ApiControllerBoundaryTests.Actions_InControllersWithoutClassAuthorize_MustDeclareExplicitAuthorization`): for any controller lacking class-level `[Authorize]`, every HTTP action must declare `[Authorize]` or `[AllowAnonymous]`. Controllers with class-level `[Authorize]` are covered by default and skipped.
- **Convention doc:** added a `<remarks>` block to `AuthenticatedControllerBase` recording the three authorization conventions (claims-first identity, explicit per-action auth for non-`[Authorize]` controllers, controller-level `EnsureBoardPermissionAsync` for board scoping).

## Verification
- `dotnet build backend/src/Taskdeck.Api -c Release` → 0 errors/warnings.
- Architecture tests: 3/3 pass. **Negative-tested** the guard: removing one `[AllowAnonymous]` makes it fail naming the offending action, confirming it's not vacuous.
- `AuthController`/`HealthController` API tests: 201/201 pass.

Follow-up to #1109 (PR #1111). Part of the identity/authz hardening series.