### PR TITLE
chore: ignore FluentAssertions major bumps in dependabot (stay on free 7.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,11 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.EntityFrameworkCore.Design"
         update-types: ["version-update:semver-major"]
+      # FluentAssertions 8.x+ requires a paid commercial license (Xceed); the
+      # project intentionally stays on the free 7.x line (maintainer decision on
+      # #1088). Block major bumps so v8 isn't re-proposed every cycle.
+      - dependency-name: "FluentAssertions"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps(nuget)"
 

--- a/docs/ops/DEPENDENCY_UPDATE_POLICY.md
+++ b/docs/ops/DEPENDENCY_UPDATE_POLICY.md
@@ -132,3 +132,4 @@ coordinated migration), not incidentally.
 | Package(s) | Cap | Reason | Remove when |
 |---|---|---|---|
 | `Microsoft.EntityFrameworkCore`, `.Sqlite`, `.Design` | major bumps blocked (stay on 8.x) | The project pins the runtime EF Core stack to 8.x (#760/#767). Dependabot otherwise bumps the core package to 9.x while the providers stay on 8.x, desyncing them and reintroducing an ambiguous `ExecuteDeleteAsync` compile break (#1102, #1106). | The runtime EF Core stack is migrated to 9.x+ together, in one PR. |
+| `FluentAssertions` | major bumps blocked (stay on 7.x) | FluentAssertions 8.x+ requires a paid commercial license (Xceed); 7.x is the last free line. Maintainer decision on #1088. | The project purchases the Xceed license, or migrates to a free assertion library. |


### PR DESCRIPTION
## Why
After #1088 moved the project to FluentAssertions **7.2.2** (the last free line), dependabot immediately opened #1117 proposing **8.10.0** — the version that requires a **paid Xceed commercial license**. Per the maintainer decision on #1088, the project stays on 7.x.

## Change
Adds a dependabot `ignore` rule for `version-update:semver-major` on `FluentAssertions` (alongside the existing EF Core major caps), and records it in the `Pinned / version-capped dependencies` table in `docs/ops/DEPENDENCY_UPDATE_POLICY.md`. Minor/patch 7.x bumps still flow.

## Verification
- `dependabot.yml` parses as valid YAML.
- Closes the loop on #1117 (closed) so v8 isn't re-proposed each cycle.

Same durable-fix pattern as #1112 (EF Core).