### PR TITLE
docs: conclude 2026-05-29 session — MASTERPLAN, RFAI status, failure ledger, ADRs

### DIFF
--- a/docs/IMPLEMENTATION_MASTERPLAN.md
+++ b/docs/IMPLEMENTATION_MASTERPLAN.md
@@ -41,7 +41,7 @@ Update this file at the end of each meaningful delivery cycle or when new work i
 
 Delivered in the latest cycle:
 
-Continuous-cycle wave (2026-05-29, 18 PRs merged, backlog cleared to zero open PRs; 2 independent adversarial reviews per PR, all findings of every severity addressed including bot comments):
+Continuous-cycle wave (2026-05-29, 19 PRs merged, backlog cleared to zero open PRs; 2 independent adversarial reviews per PR, all findings of every severity addressed including bot comments):
 - **RFAI roadmap complete (12 of 12)**: RFAI-11 (`#983`/`#1079`) ambient channel — VS Code extension + voice prototype (ADR-0033 ratified); RFAI-12 (`#984`/`#1080`) learning loop UI, Ollama provider, ProvenanceDrawer, cohort dashboard. Both heavily pre-reviewed; all Codex inline findings audited (one open item fixed on each: 1079 git-repo path-containment, 1080 already-clean).
 - **Composable hardening**: unhandled promise rejections (`#1093`/`#1095`), `onScopeDispose` cleanup + leak fixes (`#1094`/`#1104` — Review 2/2 added startClock double-start guard, fetch-generation invalidation on dispose, isDisposed finally guards, +3 tests), FilterPanel aria-labels + single-resolve label chips (`#1097`/`#1098`).
 - **Identity/authz hardening**: an audit confirmed all 42 API controllers are claims-first with zero bypass risk. `TelemetryController`/`EgressDisclosureController` migrated onto `AuthenticatedControllerBase` (`#1109`/`#1111`); a new `ApiControllerBoundaryTests` guard enforces per-action `[Authorize]`/`[AllowAnonymous]` on non-class-authorized controllers, with explicit attributes added to AuthController/HealthController (`#1110`/`#1116`).

--- a/docs/IMPLEMENTATION_MASTERPLAN.md
+++ b/docs/IMPLEMENTATION_MASTERPLAN.md
@@ -1,6 +1,6 @@
 # Taskdeck Implementation Masterplan
 
-Last Updated: 2026-05-16
+Last Updated: 2026-05-29
 <br>
 Planning Horizon: Next 8 to 12 weeks
 Companion Active Docs:
@@ -40,6 +40,14 @@ Update this file at the end of each meaningful delivery cycle or when new work i
 ## Current Cycle Outcome (Completed)
 
 Delivered in the latest cycle:
+
+Continuous-cycle wave (2026-05-29, 18 PRs merged, backlog cleared to zero open PRs; 2 independent adversarial reviews per PR, all findings of every severity addressed including bot comments):
+- **RFAI roadmap complete (12 of 12)**: RFAI-11 (`#983`/`#1079`) ambient channel — VS Code extension + voice prototype (ADR-0033 ratified); RFAI-12 (`#984`/`#1080`) learning loop UI, Ollama provider, ProvenanceDrawer, cohort dashboard. Both heavily pre-reviewed; all Codex inline findings audited (one open item fixed on each: 1079 git-repo path-containment, 1080 already-clean).
+- **Composable hardening**: unhandled promise rejections (`#1093`/`#1095`), `onScopeDispose` cleanup + leak fixes (`#1094`/`#1104` — Review 2/2 added startClock double-start guard, fetch-generation invalidation on dispose, isDisposed finally guards, +3 tests), FilterPanel aria-labels + single-resolve label chips (`#1097`/`#1098`).
+- **Identity/authz hardening**: an audit confirmed all 42 API controllers are claims-first with zero bypass risk. `TelemetryController`/`EgressDisclosureController` migrated onto `AuthenticatedControllerBase` (`#1109`/`#1111`); a new `ApiControllerBoundaryTests` guard enforces per-action `[Authorize]`/`[AllowAnonymous]` on non-class-authorized controllers, with explicit attributes added to AuthController/HealthController (`#1110`/`#1116`).
+- **Dependency wave**: nuget/npm minor-patch groups, YamlDotNet 18, dotnet group (`#1101`/`#1103`/`#1102`/`#1105`/`#1115`) — **fixed a recurring EF Core 8/9 split** (dependabot bumped the core package to 9.x while Sqlite/Design stayed 8.x → ambiguous `ExecuteDeleteAsync`). FluentAssertions moved to the free **7.x** line (`#1088`) rather than paid v8. Durable dependabot `ignore` rules added for EF Core and FluentAssertions majors (`#1112`/`#1118`, ADR-0034) so neither churn recurs; documented in `docs/ops/DEPENDENCY_UPDATE_POLICY.md`.
+- **A11y + housekeeping**: stable v-for keys (`#1107`/`#1108`), decorative-SVG `aria-hidden` sweep with 5 icon-only-button accessible-name regressions caught by review and fixed (`#1099`/`#1120`), STATUS.md contradiction fix + cleanup (`#1092`/`#1119`), 112 stale stashes cleared.
+- Closed (not merged): `#1100`→recreated `#1105`, `#1113` (unwanted EF 9.x major), `#1106` (superseded), `#1117` (FluentAssertions v8 paid-license — declined).
 
 Bulk merge wave (2026-05-16, PRs `#1055`--`#1074`, 15 PRs merged to main):
 - **Security fixes** (3 PRs, `#1055`/`#1067`/`#1068`): redirect handler hardening (buffer content, filter sensitive headers), SEC-31/SEC-32 (hardcoded key removal + RBAC on abuse endpoints), SEC-33 (health endpoint info disclosure suppression)

--- a/docs/ISSUE_EXECUTION_GUIDE.md
+++ b/docs/ISSUE_EXECUTION_GUIDE.md
@@ -443,9 +443,11 @@ Dependency order:
 7. ~~`#979`~~ RFAI-07 hybrid retrieval, duplicate calibration, and memory-assisted generation (**delivered** PR `#1050`)
 8. ~~`#980`~~ RFAI-08 eval harness expansion, privacy analytics, and egress disclosure (**delivered** PRs `#992` + `#1073` + `#1074`)
 9. ~~`#981`~~ RFAI-09 agent runtime hardening, MCP integrity, and scheduled Inbox Digest (**delivered** PR `#1052`)
-10. `#982` RFAI-10 PWA share-target quick capture and browser extension prototype (`Priority III`; depends on `#974`, `#980`)
-11. `#983` RFAI-11 ambient channel hardening decision and prototype (`Priority IV`; depends on `#982`; reuses `#219` for voice if selected)
-12. `#984` RFAI-12 learning loop UI, provenance drawer, Ollama flag, and beta gate (`Priority II`; depends on `#977`, `#980`, `#981`, `#983`)
+10. ~~`#982`~~ RFAI-10 PWA share-target quick capture and browser extension prototype (**delivered** PR `#1078`)
+11. ~~`#983`~~ RFAI-11 ambient channel hardening decision and prototype (**delivered** PR `#1079`; ADR-0033 ratified — VS Code extension over desktop voice)
+12. ~~`#984`~~ RFAI-12 learning loop UI, provenance drawer, Ollama flag, and beta gate (**delivered** PR `#1080`)
+
+**RFAI roadmap complete (2026-05-29): all 12 of 12 issues (`#973`–`#984`) delivered.**
 
 Execution note:
 - The proposal gate applies to automation-originated writes, not manual board UI writes.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,7 +2,7 @@
 
 Last Updated: 2026-05-29
 
-Continuous-cycle wave (2026-05-29, 17 PRs merged, zero open PRs): cleared the entire open-PR backlog with two adversarial reviews per PR and all findings (all severities, including bot comments) addressed.
+Continuous-cycle wave (2026-05-29, 19 PRs merged, zero open PRs): cleared the entire open-PR backlog with two adversarial reviews per PR and all findings (all severities, including bot comments) addressed.
 - **RFAI roadmap complete**: RFAI-11 (`#983`/`#1079`, ambient channel — VS Code extension + voice prototype; final Codex finding fixed: git repo matched by document-path containment) and RFAI-12 (`#984`/`#1080`, learning loop UI, Ollama provider, ProvenanceDrawer, cohort dashboard) delivered. All 12 RFAI issues now shipped.
 - **Composable hardening**: unhandled promise rejections (`#1093`/`#1095`), cleanup/memory-leak fixes with `onScopeDispose` (`#1094`/`#1104`), FilterPanel aria-labels (`#1097`/`#1098`).
 - **Identity/authz hardening**: an audit confirmed all 42 API controllers are claims-first with zero bypass risk; migrated `TelemetryController`/`EgressDisclosureController` onto `AuthenticatedControllerBase` (`#1109`/`#1111`) and added architecture guards enforcing per-action `[Authorize]`/`[AllowAnonymous]` (`#1110`/`#1116`).

--- a/docs/agentic/FAILURE_LEDGER.md
+++ b/docs/agentic/FAILURE_LEDGER.md
@@ -8,6 +8,10 @@ Machine-appended raw entries live in `docs/agentic/failure_ledger.jsonl`.
 | Date | Class | Surface | Failure | Workaround | Future fix | Status |
 | --- | --- | --- | --- | --- | --- | --- |
 | 2026-05-11 | seed | agentic-pack | Ledger created | n/a | Start recording recurring failures and promote confirmed lessons | open |
+| 2026-05-29 | blocker | dependabot/nuget | `dotnet-minor-patch` group repeatedly bumps `Microsoft.EntityFrameworkCore` to 9.x while `.Sqlite`/`.Design` stay 8.x → `error CS0121: ambiguous ExecuteDeleteAsync` (hit on #1102, recurred on #1106) | Pin core back to 8.0.27 in `Taskdeck.Infrastructure.csproj` per PR | **Resolved** — dependabot `ignore` rule for EF Core majors added (#1112, ADR-0034); project pins EF runtime stack to 8.x (#760/#767) | resolved |
+| 2026-05-29 | blocker | dependabot/nuget | After moving FluentAssertions to free 7.x (#1088), dependabot immediately re-proposed paid v8 (#1117) | Close the v8 PR | **Resolved** — dependabot `ignore` rule for FluentAssertions majors added (#1118, ADR-0034) | resolved |
+| 2026-05-29 | invalid_signal | ci/e2e-smoke | `E2E Smoke` intermittently fails on `multi-board.spec.ts:197` (`restoredBoard toBeVisible` 10s timeout) with a transient DB-connection error in the web-server log; unrelated to the PR diff | Investigate the failing assertion vs the diff; if unrelated, `gh run rerun <id> --failed` | Consider raising the restore-visibility timeout or stabilizing the archive→restore seed in the smoke suite | open |
+| 2026-05-29 | non_blocking_risk | git/worktree | Merging a stacked PR with `gh pr merge --delete-branch` deletes the base branch and **auto-CLOSES** the dependent PR (closed #1096 when #1095's branch was deleted) | Reopen impossible (base gone) → rebase the dependent onto `main`, retarget base, open a fresh PR (recovered as #1104) | Before deleting a base branch, retarget/rebase dependents to `main` first | resolved |
 
 ## Classification
 

--- a/docs/decisions/ADR-0033-ambient-channel-vscode-over-voice.md
+++ b/docs/decisions/ADR-0033-ambient-channel-vscode-over-voice.md
@@ -1,7 +1,7 @@
 # ADR-0033: Ambient Channel Hardening — VS Code Extension over Desktop Voice
 
-- **Status**: Proposed
-- **Date**: 2026-05-16
+- **Status**: Accepted
+- **Date**: 2026-05-16 (ratified 2026-05-29)
 - **Deciders**: Repository maintainers
 
 ## Context

--- a/docs/decisions/ADR-0034-dependency-version-caps.md
+++ b/docs/decisions/ADR-0034-dependency-version-caps.md
@@ -1,0 +1,76 @@
+# ADR-0034: Dependency Version Caps via Dependabot Ignore Rules (EF Core 8.x, FluentAssertions 7.x)
+
+**Status:** Accepted
+
+**Date:** 2026-05-29
+
+**Deciders:** Repository maintainers
+
+## Context
+
+Dependabot's grouped NuGet updates repeatedly proposed major-version bumps that the
+project does not want, creating recurring, self-reinflating churn:
+
+1. **Entity Framework Core.** The runtime EF stack is intentionally pinned to the **8.x**
+   line (see #760/#767). Dependabot's `dotnet-minor-patch` group kept bumping
+   `Microsoft.EntityFrameworkCore` to **9.x** while leaving the `.Sqlite` and `.Design`
+   providers on 8.x. That version split desynchronizes the providers and reintroduces an
+   ambiguous-overload compile error:
+   `CS0121: ambiguous between EntityFrameworkQueryableExtensions.ExecuteDeleteAsync and
+   RelationalQueryableExtensions.ExecuteDeleteAsync`. It was fixed once in #1102 and
+   recurred within the same day on #1106 — each time requiring a manual per-PR pin.
+
+2. **FluentAssertions.** Version **8.x+ requires a paid commercial license** (Xceed);
+   **7.x is the last free line**. After the project moved to FluentAssertions 7.2.2
+   (#1088, maintainer decision), dependabot immediately re-proposed 8.10.0 (#1117).
+
+Per-PR pins/closes do not stop recurrence: dependabot re-proposes the same majors every
+cycle. A durable, declarative cap is needed.
+
+## Decision
+
+Cap these dependencies below their next major via `ignore` rules in
+`.github/dependabot.yml`, scoped to `version-update:semver-major` only (minor/patch
+updates continue to flow):
+
+- `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.Sqlite`,
+  `Microsoft.EntityFrameworkCore.Design` — stay on 8.x until the runtime EF stack is
+  migrated together in one deliberate PR. `Microsoft.EntityFrameworkCore.Tools` is a
+  design-time-only package (`PrivateAssets`) tracked separately on its 10.x line and is
+  intentionally **not** capped (it does not affect the runtime compile).
+- `FluentAssertions` — stay on the free 7.x line until the project either purchases the
+  Xceed license or migrates to a free assertion library.
+
+Each cap is recorded in the "Pinned / version-capped dependencies" table in
+`docs/ops/DEPENDENCY_UPDATE_POLICY.md` with its reason and removal condition, so the cap
+is discoverable and removed deliberately rather than incidentally.
+
+## Alternatives
+
+- **Per-PR pins/closes (status quo).** Rejected: dependabot re-proposes every cycle;
+  unbounded manual toil and a standing risk of an accidental merge.
+- **Central Package Management (`Directory.Packages.props`).** A larger refactor; would
+  centralize versions but does not by itself stop dependabot proposing a major. Out of
+  scope for this decision; the `ignore` rule is the minimal durable fix.
+- **Adopt the bumps.** Rejected: EF 9.x is a deliberate non-goal right now; FluentAssertions
+  8.x carries a paid-license cost the project chose not to take on.
+
+## Consequences
+
+- Dependabot stops re-proposing EF Core 9.x and FluentAssertions 8.x; the recurring
+  `ExecuteDeleteAsync` break and paid-license PRs no longer recur.
+- Security/bugfix updates within 8.x (EF) and 7.x (FluentAssertions) still flow normally.
+- The caps must be removed **deliberately and atomically** when the project chooses to
+  migrate — the EF runtime packages must move to 9.x+ together, and FluentAssertions only
+  after a license/library decision. The removal conditions are tracked in the dependency
+  policy doc.
+- Caps are intentionally narrow (named packages, major-only) to avoid masking other
+  legitimate updates.
+
+## References
+
+- `.github/dependabot.yml` (the `ignore` rules)
+- `docs/ops/DEPENDENCY_UPDATE_POLICY.md` (Pinned / version-capped dependencies table)
+- PRs: #1102, #1106 (EF pins), #1112 (EF ignore rule), #1088 (FluentAssertions 7.x), #1118 (FluentAssertions ignore rule); #1117 (closed v8 bump)
+- Prior EF pin rationale: #760/#767
+- `docs/agentic/FAILURE_LEDGER.md` (2026-05-29 entries)

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -34,4 +34,5 @@
 | [0030](ADR-0030-storybook-baseline-vite-8-compatibility.md) | Storybook Baseline with Vite 8 Compatibility | Accepted | 2026-04-09 |
 | [0031](ADR-0031-sast-scanning-semgrep.md) | SAST Scanning with Semgrep | Accepted | 2026-04-22 |
 | [0032](ADR-0032-polly-circuit-breaker-external-apis.md) | Polly Circuit Breaker for External API Calls | Accepted | 2026-04-22 |
-| [0033](ADR-0033-ambient-channel-vscode-over-voice.md) | Ambient Channel Hardening — VS Code Extension over Desktop Voice | Proposed | 2026-05-16 |
+| [0033](ADR-0033-ambient-channel-vscode-over-voice.md) | Ambient Channel Hardening — VS Code Extension over Desktop Voice | Accepted | 2026-05-16 |
+| [0034](ADR-0034-dependency-version-caps.md) | Dependency Version Caps via Dependabot Ignore Rules (EF Core 8.x, FluentAssertions 7.x) | Accepted | 2026-05-29 |


### PR DESCRIPTION
Concludes the 2026-05-29 continuous-cycle session by recording it in the canonical docs (STATUS.md was already updated in #1119).

## Changes
- **`docs/IMPLEMENTATION_MASTERPLAN.md`** — new "Current Cycle Outcome" entry for the 18-PR wave (RFAI complete, composable/identity-authz hardening, dependency wave + ignore rules, a11y/housekeeping); `Last Updated` → 2026-05-29.
- **`docs/ISSUE_EXECUTION_GUIDE.md`** — RFAI-10/11/12 marked **delivered**; RFAI roadmap noted complete (12/12, #973–#984).
- **`docs/agentic/FAILURE_LEDGER.md`** — logged the recurring failures + workarounds: EF Core 8/9 dependabot split (resolved via ignore rule), FluentAssertions v8 re-proposal (resolved), E2E Smoke board-restore flake (investigate-then-rerun), and the stacked-PR `--delete-branch` auto-close gotcha (retarget/rebase first).
- **`docs/decisions/`** — ADR-0033 ratified **Accepted** (RFAI-11 #1079 shipped the VS Code extension); new **ADR-0034** documents the dependency version-cap policy (EF Core 8.x + FluentAssertions 7.x via dependabot ignore rules, incl. the v8 licensing rationale); INDEX updated.

## Verification
- `node scripts/check-docs-governance.mjs` → passed.
- ADR files (34) match INDEX rows (34); ADR-0034 present.

Docs-only; no code change.