### PR TITLE
[codex] Fix nightly CI bundle and SQLite harness paths

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -84,7 +84,7 @@ jobs:
 
   backend-solution:
     name: Backend Solution Regression
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing'))
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'testing') || contains(github.event.pull_request.labels.*.name, 'performance')))
     uses: ./.github/workflows/reusable-backend-solution.yml
     with:
       dotnet-version: 8.0.x

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -20,7 +20,7 @@
 #     ├── dependency-review (PR only)
 #     ├── reusable-dependency-security-signals.yml (label: security)
 #     ├── reusable-openapi-guardrail.yml
-#     ├── reusable-backend-solution.yml (label: testing)
+#     ├── reusable-backend-solution.yml (label: testing, performance)
 #     ├── reusable-e2e-smoke.yml (label: testing)
 #     ├── reusable-e2e-cross-browser.yml (label: testing)
 #     ├── reusable-demo-director-smoke.yml (label: automation)

--- a/.github/workflows/reusable-load-concurrency-harness.yml
+++ b/.github/workflows/reusable-load-concurrency-harness.yml
@@ -82,10 +82,10 @@ jobs:
 
       - name: Reset harness result folders
         run: |
-          rm -f frontend/taskdeck-web/taskdeck.load.k6.ci.db
-          rm -f frontend/taskdeck-web/taskdeck.load.e2e.ci.db
           rm -rf frontend/taskdeck-web/test-results/load
           mkdir -p frontend/taskdeck-web/test-results/load
+          rm -f "${GITHUB_WORKSPACE}/frontend/taskdeck-web/test-results/load/taskdeck.load.k6.ci.db"
+          rm -f "${GITHUB_WORKSPACE}/frontend/taskdeck-web/test-results/load/taskdeck.load.e2e.ci.db"
 
       - name: Run k6 board-heavy API profile
         env:
@@ -94,7 +94,7 @@ jobs:
           K6_USER_POOL: ${{ inputs.k6-user-pool }}
           ASPNETCORE_ENVIRONMENT: Development
           ASPNETCORE_URLS: http://127.0.0.1:5000
-          ConnectionStrings__DefaultConnection: Data Source=frontend/taskdeck-web/taskdeck.load.k6.ci.db
+          ConnectionStrings__DefaultConnection: Data Source=${{ github.workspace }}/frontend/taskdeck-web/test-results/load/taskdeck.load.k6.ci.db
         run: |
           set -euo pipefail
 
@@ -141,7 +141,7 @@ jobs:
         working-directory: frontend/taskdeck-web
         env:
           CI: "true"
-          TASKDECK_E2E_DB: taskdeck.load.e2e.ci.db
+          TASKDECK_E2E_DB: ${{ github.workspace }}/frontend/taskdeck-web/test-results/load/taskdeck.load.e2e.ci.db
           TASKDECK_RUN_DEMO: "0"
         run: npx playwright test tests/e2e/concurrency.spec.ts --reporter=line
 

--- a/.github/workflows/reusable-load-concurrency-harness.yml
+++ b/.github/workflows/reusable-load-concurrency-harness.yml
@@ -82,10 +82,10 @@ jobs:
 
       - name: Reset harness result folders
         run: |
+          rm -rf frontend/taskdeck-web/.ci-db/load
           rm -rf frontend/taskdeck-web/test-results/load
+          mkdir -p frontend/taskdeck-web/.ci-db/load
           mkdir -p frontend/taskdeck-web/test-results/load
-          rm -f "${GITHUB_WORKSPACE}/frontend/taskdeck-web/test-results/load/taskdeck.load.k6.ci.db"
-          rm -f "${GITHUB_WORKSPACE}/frontend/taskdeck-web/test-results/load/taskdeck.load.e2e.ci.db"
 
       - name: Run k6 board-heavy API profile
         env:
@@ -94,7 +94,7 @@ jobs:
           K6_USER_POOL: ${{ inputs.k6-user-pool }}
           ASPNETCORE_ENVIRONMENT: Development
           ASPNETCORE_URLS: http://127.0.0.1:5000
-          ConnectionStrings__DefaultConnection: Data Source=${{ github.workspace }}/frontend/taskdeck-web/test-results/load/taskdeck.load.k6.ci.db
+          ConnectionStrings__DefaultConnection: Data Source=${{ github.workspace }}/frontend/taskdeck-web/.ci-db/load/taskdeck.load.k6.ci.db
         run: |
           set -euo pipefail
 
@@ -141,7 +141,7 @@ jobs:
         working-directory: frontend/taskdeck-web
         env:
           CI: "true"
-          TASKDECK_E2E_DB: ${{ github.workspace }}/frontend/taskdeck-web/test-results/load/taskdeck.load.e2e.ci.db
+          TASKDECK_E2E_DB: ${{ github.workspace }}/frontend/taskdeck-web/.ci-db/load/taskdeck.load.e2e.ci.db
           TASKDECK_RUN_DEMO: "0"
         run: npx playwright test tests/e2e/concurrency.spec.ts --reporter=line
 

--- a/.github/workflows/reusable-performance-regression-gate.yml
+++ b/.github/workflows/reusable-performance-regression-gate.yml
@@ -116,8 +116,8 @@ jobs:
 
       - name: Reset harness result folders
         run: |
-          rm -f frontend/taskdeck-web/taskdeck.perf.k6.ci.db
           mkdir -p frontend/taskdeck-web/test-results/perf
+          rm -f "${GITHUB_WORKSPACE}/frontend/taskdeck-web/test-results/perf/taskdeck.perf.k6.ci.db"
 
       - name: Run k6 board-heavy API profile
         env:
@@ -126,7 +126,7 @@ jobs:
           K6_USER_POOL: ${{ inputs.k6-user-pool }}
           ASPNETCORE_ENVIRONMENT: Development
           ASPNETCORE_URLS: http://127.0.0.1:5000
-          ConnectionStrings__DefaultConnection: Data Source=frontend/taskdeck-web/taskdeck.perf.k6.ci.db
+          ConnectionStrings__DefaultConnection: Data Source=${{ github.workspace }}/frontend/taskdeck-web/test-results/perf/taskdeck.perf.k6.ci.db
         run: |
           set -euo pipefail
 

--- a/.github/workflows/reusable-performance-regression-gate.yml
+++ b/.github/workflows/reusable-performance-regression-gate.yml
@@ -116,8 +116,9 @@ jobs:
 
       - name: Reset harness result folders
         run: |
+          rm -rf frontend/taskdeck-web/.ci-db/perf
+          mkdir -p frontend/taskdeck-web/.ci-db/perf
           mkdir -p frontend/taskdeck-web/test-results/perf
-          rm -f "${GITHUB_WORKSPACE}/frontend/taskdeck-web/test-results/perf/taskdeck.perf.k6.ci.db"
 
       - name: Run k6 board-heavy API profile
         env:
@@ -126,7 +127,7 @@ jobs:
           K6_USER_POOL: ${{ inputs.k6-user-pool }}
           ASPNETCORE_ENVIRONMENT: Development
           ASPNETCORE_URLS: http://127.0.0.1:5000
-          ConnectionStrings__DefaultConnection: Data Source=${{ github.workspace }}/frontend/taskdeck-web/test-results/perf/taskdeck.perf.k6.ci.db
+          ConnectionStrings__DefaultConnection: Data Source=${{ github.workspace }}/frontend/taskdeck-web/.ci-db/perf/taskdeck.perf.k6.ci.db
         run: |
           set -euo pipefail
 

--- a/frontend/taskdeck-web/scripts/demo-lib.mjs
+++ b/frontend/taskdeck-web/scripts/demo-lib.mjs
@@ -11,7 +11,14 @@ import { randomUUID } from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { setTimeout as sleep } from 'node:timers/promises'
-import { assertSafeLocalApiTarget, isoDaysFromNow, normalizeBaseUrl, parseTrueishEnv } from './demo-shared.mjs'
+import {
+  assertSafeLocalApiTarget,
+  extractListItems,
+  hasMoreListItems,
+  isoDaysFromNow,
+  normalizeBaseUrl,
+  parseTrueishEnv,
+} from './demo-shared.mjs'
 
 export { isoDaysFromNow }
 
@@ -222,7 +229,7 @@ export async function cleanupDemoBoards(
   apiAuthed,
   { prefix = 'DEMO:', dryRun = false, keepCanonical = true, includeArchived = false } = {},
 ) {
-  const boards = await apiAuthed.get(`/boards?includeArchived=${includeArchived ? 'true' : 'false'}`)
+  const boards = await listBoards(apiAuthed, { includeArchived })
   const candidates = (boards || []).filter((board) => {
     if (typeof board?.name !== 'string' || !board.name.startsWith(prefix)) {
       return false
@@ -260,6 +267,26 @@ export async function cleanupDemoBoards(
     archived,
     skipped,
     candidates: candidates.map((board) => ({ id: board.id, name: board.name })),
+  }
+}
+
+async function listBoards(apiAuthed, { includeArchived = false } = {}) {
+  const limit = 200
+  let offset = 0
+  const boards = []
+
+  while (true) {
+    const response = await apiAuthed.get(
+      `/boards?includeArchived=${includeArchived ? 'true' : 'false'}&offset=${offset}&limit=${limit}`,
+    )
+    const items = extractListItems(response, 'GET /boards')
+    boards.push(...items)
+
+    if (!hasMoreListItems(response) || items.length === 0) {
+      return boards
+    }
+
+    offset += items.length
   }
 }
 

--- a/frontend/taskdeck-web/scripts/demo-seed.mjs
+++ b/frontend/taskdeck-web/scripts/demo-seed.mjs
@@ -31,7 +31,9 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
   assertSafeLocalApiTarget,
+  extractListItems,
   getHostname,
+  hasMoreListItems,
   isLocalHostname,
   normalizeBaseUrl,
   parseTrueishEnv,
@@ -400,6 +402,28 @@ function safeJsonParse(text) {
     return JSON.parse(text)
   } catch {
     return null
+  }
+}
+
+async function listBoards(token) {
+  const limit = 200
+  let offset = 0
+  const boards = []
+
+  while (true) {
+    const response = await http(
+      'GET',
+      `/boards?includeArchived=true&offset=${offset}&limit=${limit}`,
+      { token },
+    )
+    const items = extractListItems(response, 'GET /boards')
+    boards.push(...items)
+
+    if (!hasMoreListItems(response) || items.length === 0) {
+      return boards
+    }
+
+    offset += items.length
   }
 }
 
@@ -939,7 +963,7 @@ export async function main({ reset = false } = {}) {
   console.log(`Collab user: ${collabUser.username} (${collabUser.email})`)
 
   // 2) Reuse/create canonical demo boards and archive extra active DEMO boards.
-  let boards = await http('GET', '/boards?includeArchived=true', { token: demoToken })
+  let boards = await listBoards(demoToken)
   let demoBoards = (boards || []).filter(isDemoBoard)
 
   if (reset && demoBoards.length) {
@@ -957,7 +981,7 @@ export async function main({ reset = false } = {}) {
       }
     }
     // Re-fetch after deletion
-    boards = await http('GET', '/boards?includeArchived=true', { token: demoToken })
+    boards = await listBoards(demoToken)
     demoBoards = (boards || []).filter(isDemoBoard)
     if (demoBoards.length) {
       console.warn(

--- a/frontend/taskdeck-web/scripts/demo-shared.mjs
+++ b/frontend/taskdeck-web/scripts/demo-shared.mjs
@@ -42,6 +42,32 @@ export function assertSafeLocalApiTarget(
   )
 }
 
+export function extractListItems(response, contextLabel = 'response') {
+  if (Array.isArray(response)) {
+    return response
+  }
+
+  if (response && typeof response === 'object') {
+    if (Array.isArray(response.items)) {
+      return response.items
+    }
+
+    if (Array.isArray(response.Items)) {
+      return response.Items
+    }
+  }
+
+  throw new TypeError(`${contextLabel} did not return a list or paginated items object`)
+}
+
+export function hasMoreListItems(response) {
+  if (!response || typeof response !== 'object' || Array.isArray(response)) {
+    return false
+  }
+
+  return Boolean(response.hasMore ?? response.HasMore)
+}
+
 export function isoDaysFromNow(days) {
   const value = new Date()
   value.setDate(value.getDate() + Number(days || 0))

--- a/frontend/taskdeck-web/scripts/demo-snapshot.mjs
+++ b/frontend/taskdeck-web/scripts/demo-snapshot.mjs
@@ -11,6 +11,7 @@ import path from 'node:path'
 import { createInterface } from 'node:readline'
 
 import { TaskdeckApiClient, ensureUser, getDemoConfig, traceEvent } from './demo-lib.mjs'
+import { extractListItems } from './demo-shared.mjs'
 
 function parseArgs(argv) {
   const args = {
@@ -48,7 +49,15 @@ async function safeGet(api, requestPath) {
 }
 
 function ensureArray(value) {
-  return Array.isArray(value) ? value : []
+  if (isErrorResult(value)) {
+    return []
+  }
+
+  try {
+    return extractListItems(value)
+  } catch {
+    return []
+  }
 }
 
 function isErrorResult(value) {

--- a/frontend/taskdeck-web/src/App.vue
+++ b/frontend/taskdeck-web/src/App.vue
@@ -1,20 +1,19 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue'
+import { computed, defineAsyncComponent, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import ToastContainer from './components/common/ToastContainer.vue'
 import PaperToastContainer from './components/paper/PaperToastContainer.vue'
 import SessionTimeoutWarning from './components/common/SessionTimeoutWarning.vue'
-import AppShell from './components/shell/AppShell.vue'
 import ErrorBoundary from './components/ErrorBoundary.vue'
 import { useSessionStore } from './store/sessionStore'
 import { useFeatureFlagStore } from './store/featureFlagStore'
-import { useWorkspaceStore } from './store/workspaceStore'
 import { usePaperThemeStore } from './store/paperThemeStore'
+
+const AppShell = defineAsyncComponent(() => import('./components/shell/AppShell.vue'))
 
 const route = useRoute()
 const session = useSessionStore()
 const featureFlags = useFeatureFlagStore()
-const workspace = useWorkspaceStore()
 const paperTheme = usePaperThemeStore()
 
 paperTheme.apply()
@@ -27,19 +26,6 @@ onMounted(() => {
   session.restoreSession()
   featureFlags.restore()
 })
-
-watch(
-  () => session.isAuthenticated,
-  (isAuthenticated) => {
-    if (!isAuthenticated) {
-      workspace.resetForLogout()
-      return
-    }
-
-    void workspace.hydratePreferences()
-  },
-  { immediate: true }
-)
 </script>
 
 <template>

--- a/frontend/taskdeck-web/src/components/shell/AppShell.vue
+++ b/frontend/taskdeck-web/src/components/shell/AppShell.vue
@@ -191,9 +191,13 @@ watch(
       return
     }
 
-    void workspace.hydratePreferences()
     if (!workspace.hasHomeSummary && !workspace.homeLoading) {
       void workspace.fetchHomeSummary().catch(() => {})
+      return
+    }
+
+    if (!workspace.preferencesHydrated && !workspace.preferenceLoading) {
+      void workspace.hydratePreferences()
     }
   },
   { immediate: true },

--- a/frontend/taskdeck-web/src/components/shell/AppShell.vue
+++ b/frontend/taskdeck-web/src/components/shell/AppShell.vue
@@ -183,6 +183,12 @@ onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
 })
 
+function hydratePreferencesIfNeeded() {
+  if (session.isAuthenticated && !workspace.preferencesHydrated && !workspace.preferenceLoading) {
+    void workspace.hydratePreferences()
+  }
+}
+
 watch(
   () => session.isAuthenticated,
   (isAuthenticated) => {
@@ -192,13 +198,13 @@ watch(
     }
 
     if (!workspace.hasHomeSummary && !workspace.homeLoading) {
-      void workspace.fetchHomeSummary().catch(() => {})
+      void workspace.fetchHomeSummary().catch(() => {
+        hydratePreferencesIfNeeded()
+      })
       return
     }
 
-    if (!workspace.preferencesHydrated && !workspace.preferenceLoading) {
-      void workspace.hydratePreferences()
-    }
+    hydratePreferencesIfNeeded()
   },
   { immediate: true },
 )

--- a/frontend/taskdeck-web/src/components/shell/AppShell.vue
+++ b/frontend/taskdeck-web/src/components/shell/AppShell.vue
@@ -181,10 +181,23 @@ function handleLogout() {
 
 onMounted(() => {
   window.addEventListener('keydown', handleKeydown)
-  if (session.isAuthenticated && !workspace.hasHomeSummary && !workspace.homeLoading) {
-    void workspace.fetchHomeSummary().catch(() => {})
-  }
 })
+
+watch(
+  () => session.isAuthenticated,
+  (isAuthenticated) => {
+    if (!isAuthenticated) {
+      workspace.resetForLogout()
+      return
+    }
+
+    void workspace.hydratePreferences()
+    if (!workspace.hasHomeSummary && !workspace.homeLoading) {
+      void workspace.fetchHomeSummary().catch(() => {})
+    }
+  },
+  { immediate: true },
+)
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKeydown)

--- a/frontend/taskdeck-web/src/store/workspaceStore.ts
+++ b/frontend/taskdeck-web/src/store/workspaceStore.ts
@@ -172,6 +172,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       homeSummary.value = summary
       applyMode(summary.workspaceMode)
       syncOnboarding(summary.onboarding)
+      preferencesHydrated.value = true
       homeLoading.value = false
       return summary
     }
@@ -183,6 +184,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       homeSummary.value = summary
       applyMode(summary.workspaceMode)
       syncOnboarding(summary.onboarding)
+      preferencesHydrated.value = true
       return summary
     } catch (e: unknown) {
       homeError.value = getErrorMessage(e, 'Failed to load workspace summary')

--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -42,6 +42,8 @@ const mockWorkspace = reactive({
   reviewBadgeCount: 0,
   hasHomeSummary: true,
   homeLoading: false,
+  preferenceLoading: false,
+  preferencesHydrated: false,
   hydratePreferences: vi.fn().mockResolvedValue(null),
   fetchHomeSummary: vi.fn().mockResolvedValue(undefined),
   resetForLogout: vi.fn(),
@@ -117,6 +119,10 @@ describe('AppShell — paper variant routing', () => {
     mockPaperTheme.isOn = false
     mockPaperTheme.activeClass = null
     mockWorkspace.mode = 'guided'
+    mockWorkspace.hasHomeSummary = true
+    mockWorkspace.homeLoading = false
+    mockWorkspace.preferenceLoading = false
+    mockWorkspace.preferencesHydrated = false
     mockRoute.path = '/workspace/home'
     mockViewportMode.value = 'desktop'
   })

--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -42,7 +42,9 @@ const mockWorkspace = reactive({
   reviewBadgeCount: 0,
   hasHomeSummary: true,
   homeLoading: false,
+  hydratePreferences: vi.fn().mockResolvedValue(null),
   fetchHomeSummary: vi.fn().mockResolvedValue(undefined),
+  resetForLogout: vi.fn(),
 })
 
 const mockPaperTheme = reactive({

--- a/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
@@ -38,6 +38,8 @@ const mockWorkspace = reactive({
   reviewBadgeCount: 0,
   hasHomeSummary: false,
   homeLoading: false,
+  preferenceLoading: false,
+  preferencesHydrated: false,
   hydratePreferences: vi.fn().mockResolvedValue(null),
   fetchHomeSummary: vi.fn().mockResolvedValue(undefined),
   resetForLogout: vi.fn(),
@@ -123,6 +125,8 @@ describe('AppShell workspace navigation and command palette', () => {
     mockWorkspace.reviewBadgeCount = 0
     mockWorkspace.hasHomeSummary = false
     mockWorkspace.homeLoading = false
+    mockWorkspace.preferenceLoading = false
+    mockWorkspace.preferencesHydrated = false
     mockFeatureFlags.isEnabled = vi.fn(() => true)
   })
 
@@ -447,6 +451,7 @@ describe('AppShell workspace navigation and command palette', () => {
     mountedWrapper = mountShell()
 
     expect(mockWorkspace.fetchHomeSummary).toHaveBeenCalledOnce()
+    expect(mockWorkspace.hydratePreferences).not.toHaveBeenCalled()
   })
 
   it('skips home summary fetch when already loaded', () => {
@@ -455,6 +460,24 @@ describe('AppShell workspace navigation and command palette', () => {
     mountedWrapper = mountShell()
 
     expect(mockWorkspace.fetchHomeSummary).not.toHaveBeenCalled()
+  })
+
+  it('hydrates preferences when home summary is already loaded and preferences are stale', () => {
+    mockWorkspace.hasHomeSummary = true
+    mockWorkspace.preferencesHydrated = false
+    mockWorkspace.preferenceLoading = false
+    mountedWrapper = mountShell()
+
+    expect(mockWorkspace.hydratePreferences).toHaveBeenCalledOnce()
+  })
+
+  it('skips preference hydration while preferences are already loading', () => {
+    mockWorkspace.hasHomeSummary = true
+    mockWorkspace.preferencesHydrated = false
+    mockWorkspace.preferenceLoading = true
+    mountedWrapper = mountShell()
+
+    expect(mockWorkspace.hydratePreferences).not.toHaveBeenCalled()
   })
 
   it('skips home summary fetch when already loading', () => {

--- a/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
@@ -38,7 +38,9 @@ const mockWorkspace = reactive({
   reviewBadgeCount: 0,
   hasHomeSummary: false,
   homeLoading: false,
+  hydratePreferences: vi.fn().mockResolvedValue(null),
   fetchHomeSummary: vi.fn().mockResolvedValue(undefined),
+  resetForLogout: vi.fn(),
 })
 
 vi.mock('vue-router', () => ({
@@ -120,6 +122,7 @@ describe('AppShell workspace navigation and command palette', () => {
     mockWorkspace.inboxBadgeCount = 0
     mockWorkspace.reviewBadgeCount = 0
     mockWorkspace.hasHomeSummary = false
+    mockWorkspace.homeLoading = false
     mockFeatureFlags.isEnabled = vi.fn(() => true)
   })
 

--- a/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
@@ -454,6 +454,20 @@ describe('AppShell workspace navigation and command palette', () => {
     expect(mockWorkspace.hydratePreferences).not.toHaveBeenCalled()
   })
 
+  it('falls back to preference hydration when the startup home summary fetch fails', async () => {
+    mockWorkspace.hasHomeSummary = false
+    mockWorkspace.homeLoading = false
+    mockWorkspace.preferencesHydrated = false
+    mockWorkspace.preferenceLoading = false
+    mockWorkspace.fetchHomeSummary.mockRejectedValueOnce(new Error('summary unavailable'))
+
+    mountedWrapper = mountShell()
+    await waitForUi()
+
+    expect(mockWorkspace.fetchHomeSummary).toHaveBeenCalledOnce()
+    expect(mockWorkspace.hydratePreferences).toHaveBeenCalledOnce()
+  })
+
   it('skips home summary fetch when already loaded', () => {
     mockWorkspace.hasHomeSummary = true
     mockWorkspace.homeLoading = false

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.demo.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.demo.spec.ts
@@ -65,6 +65,7 @@ describe('workspaceStore demo mode', () => {
     expect(summary.workspaceMode).toBe('guided')
     expect(summary.boards.recentBoards.length).toBeGreaterThan(0)
     expect(store.homeSummary).not.toBeNull()
+    expect(store.preferencesHydrated).toBe(true)
     expect(workspaceApi.getHomeSummary).not.toHaveBeenCalled()
   })
 

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.integration.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.integration.spec.ts
@@ -185,6 +185,7 @@ describe('workspaceStore — integration (real workspaceApi, mocked HTTP)', () =
       expect(store.inboxBadgeCount).toBe(3)
       expect(store.reviewBadgeCount).toBe(2)
       expect(store.mode).toBe('guided')
+      expect(store.preferencesHydrated).toBe(true)
       expect(store.homeLoading).toBe(false)
       expect(store.homeError).toBeNull()
       expect(http.get).toHaveBeenCalledWith('/workspace/home')

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
@@ -307,6 +307,7 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
       await store.fetchHomeSummary()
 
       expect(store.mode).toBe('agent')
+      expect(store.preferencesHydrated).toBe(true)
       expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('agent')
     })
   })

--- a/frontend/taskdeck-web/tests/demo-lib.spec.ts
+++ b/frontend/taskdeck-web/tests/demo-lib.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { cleanupDemoBoards } from '../scripts/demo-lib.mjs'
+
+describe('demo harness board cleanup', () => {
+  it('normalizes paginated board responses before filtering demo boards', async () => {
+    const deletedPaths: string[] = []
+    const requestedPaths: string[] = []
+
+    const api = {
+      async get(path: string) {
+        requestedPaths.push(path)
+        return {
+          items: [
+            { id: 'scratch-board', name: 'DEMO: Scratch Board' },
+            { id: 'canonical-board', name: 'DEMO: Capture Loop' },
+            { id: 'personal-board', name: 'Personal Board' },
+          ],
+          hasMore: false,
+        }
+      },
+      async del(path: string) {
+        deletedPaths.push(path)
+      },
+    }
+
+    const result = await cleanupDemoBoards(api, { includeArchived: true })
+
+    expect(requestedPaths).toEqual(['/boards?includeArchived=true&offset=0&limit=200'])
+    expect(deletedPaths).toEqual(['/boards/scratch-board'])
+    expect(result).toMatchObject({
+      archived: 1,
+      skipped: [],
+      candidates: [{ id: 'scratch-board', name: 'DEMO: Scratch Board' }],
+    })
+  })
+})

--- a/frontend/taskdeck-web/tests/demo-seed.spec.ts
+++ b/frontend/taskdeck-web/tests/demo-seed.spec.ts
@@ -9,8 +9,18 @@ import {
   planDemoSeedRerunState,
   shouldRecreateCaptureSeed,
 } from '../scripts/demo-seed.mjs'
+import { extractListItems } from '../scripts/demo-shared.mjs'
 
 describe('demo seed rerun planning', () => {
+  it('normalizes paginated API responses for demo board discovery', () => {
+    expect(extractListItems([{ id: 'legacy-board' }], 'boards')).toEqual([{ id: 'legacy-board' }])
+    expect(extractListItems({ items: [{ id: 'board-1' }] }, 'boards')).toEqual([{ id: 'board-1' }])
+    expect(extractListItems({ Items: [{ id: 'board-2' }] }, 'boards')).toEqual([{ id: 'board-2' }])
+    expect(() => extractListItems({ totalCount: 0 }, 'boards')).toThrow(
+      'boards did not return a list or paginated items object',
+    )
+  })
+
   it('marks all seeded artifacts for creation when the demo account is empty', () => {
     const plan = planDemoSeedRerunState({
       boardId: 'board-1',

--- a/frontend/taskdeck-web/tests/e2e/stakeholder-demo.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/stakeholder-demo.spec.ts
@@ -371,15 +371,16 @@ test.describe('Stakeholder demo recorder', () => {
     await expect(requestComposer).toBeHidden()
     await page.screenshot({ path: testInfo.outputPath('07-queue-submitted.png'), fullPage: true })
 
-    await page.getByRole('link', { name: 'Ops' }).click()
+    // Advanced surfaces remain routable but are no longer primary sidebar links.
+    await page.goto('/workspace/ops/cli')
     await expect(page.getByRole('heading', { name: 'Ops Console', level: 1 })).toBeVisible()
     await page.screenshot({ path: testInfo.outputPath('08-ops.png'), fullPage: true })
 
-    await page.getByRole('link', { name: 'Activity' }).click()
+    await page.goto('/workspace/activity')
     await expect(page.getByRole('heading', { name: 'Activity', level: 1 })).toBeVisible()
     await page.screenshot({ path: testInfo.outputPath('09-activity.png'), fullPage: true })
 
-    await page.getByRole('link', { name: 'Notifications' }).click()
+    await page.goto('/workspace/notifications')
     await expect(page.getByRole('heading', { name: 'Notifications', level: 1 })).toBeVisible()
     await page.screenshot({ path: testInfo.outputPath('10-notifications.png'), fullPage: true })
   })

--- a/frontend/taskdeck-web/tests/visual/archive-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/archive-view.visual.spec.ts
@@ -19,5 +19,5 @@ test('archive view empty state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('archive-empty')
+  await expect(page).toHaveScreenshot('archive-empty.png')
 })

--- a/frontend/taskdeck-web/tests/visual/auth-views.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/auth-views.visual.spec.ts
@@ -16,7 +16,7 @@ test('login view default state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('login-default')
+  await expect(page).toHaveScreenshot('login-default.png')
 })
 
 test('register view default state', async ({ page }) => {
@@ -25,5 +25,5 @@ test('register view default state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('register-default')
+  await expect(page).toHaveScreenshot('register-default.png')
 })

--- a/frontend/taskdeck-web/tests/visual/board-components.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/board-components.visual.spec.ts
@@ -26,7 +26,7 @@ test('board toolbar default', async ({ page }) => {
 
   // Mask the presence chip — it shows the freshly-registered username,
   // which differs per run.
-  await expect(toolbar).toHaveScreenshot('board-toolbar', {
+  await expect(toolbar).toHaveScreenshot('board-toolbar.png', {
     mask: [page.locator('[data-presence-user]')],
   })
 })
@@ -39,5 +39,5 @@ test('board action rail default', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(rail).toHaveScreenshot('board-action-rail')
+  await expect(rail).toHaveScreenshot('board-action-rail.png')
 })

--- a/frontend/taskdeck-web/tests/visual/board-modals.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/board-modals.visual.spec.ts
@@ -21,8 +21,10 @@ test.beforeEach(async ({ page, request }) => {
 test('card modal edit state', async ({ page }) => {
   await seedMinimalBoard(page, 'Visual Board Modals')
 
-  // Open the first card to trigger CardModal
-  await page.locator('[data-card-id]').first().click()
+  // Click the title, not the card center: the center can land on the drag
+  // handle, whose click handler intentionally stops propagation.
+  const sampleCard = page.locator('[data-card-id]').filter({ hasText: 'Sample Card' }).first()
+  await sampleCard.getByRole('heading', { name: 'Sample Card', exact: true }).click()
   await expect(page.getByRole('dialog', { name: 'Edit Card' })).toBeVisible()
 
   await prepareForScreenshot(page)
@@ -30,7 +32,7 @@ test('card modal edit state', async ({ page }) => {
   // Mask the card title input — it reflects the seeded card title which
   // could change if the setup helper is updated. Keep the screenshot
   // focused on modal chrome.
-  await expect(page).toHaveScreenshot('card-modal-edit', {
+  await expect(page).toHaveScreenshot('card-modal-edit.png', {
     mask: [page.locator('#card-title')],
   })
 })
@@ -46,7 +48,7 @@ test('column edit modal', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('column-edit-modal')
+  await expect(page).toHaveScreenshot('column-edit-modal.png')
 })
 
 test('starter pack modal json import tab', async ({ page }) => {
@@ -64,5 +66,5 @@ test('starter pack modal json import tab', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('starter-pack-modal-import')
+  await expect(page).toHaveScreenshot('starter-pack-modal-import.png')
 })

--- a/frontend/taskdeck-web/tests/visual/board-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/board-view.visual.spec.ts
@@ -62,7 +62,7 @@ test('empty board view', async ({ page }) => {
   await createBoard(page, 'Visual Test Board')
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('board-empty')
+  await expect(page).toHaveScreenshot('board-empty.png')
 })
 
 test('board with columns and cards', async ({ page }) => {
@@ -79,5 +79,5 @@ test('board with columns and cards', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('board-populated')
+  await expect(page).toHaveScreenshot('board-populated.png')
 })

--- a/frontend/taskdeck-web/tests/visual/calendar-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/calendar-view.visual.spec.ts
@@ -31,5 +31,5 @@ test('calendar view default state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('calendar-default')
+  await expect(page).toHaveScreenshot('calendar-default.png')
 })

--- a/frontend/taskdeck-web/tests/visual/capture-modal.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/capture-modal.visual.spec.ts
@@ -24,5 +24,5 @@ test('capture modal typed mode default', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('capture-modal-typed')
+  await expect(page).toHaveScreenshot('capture-modal-typed.png')
 })

--- a/frontend/taskdeck-web/tests/visual/command-palette.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/command-palette.visual.spec.ts
@@ -26,7 +26,7 @@ test('command palette open state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('command-palette-open')
+  await expect(page).toHaveScreenshot('command-palette-open.png')
 })
 
 test('command palette with search results', async ({ page }) => {
@@ -44,5 +44,5 @@ test('command palette with search results', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('command-palette-search')
+  await expect(page).toHaveScreenshot('command-palette-search.png')
 })

--- a/frontend/taskdeck-web/tests/visual/home-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/home-view.visual.spec.ts
@@ -18,5 +18,5 @@ test('home view default state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('home-default')
+  await expect(page).toHaveScreenshot('home-default.png')
 })

--- a/frontend/taskdeck-web/tests/visual/inbox-capture.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/inbox-capture.visual.spec.ts
@@ -18,5 +18,5 @@ test('inbox view empty state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('inbox-empty')
+  await expect(page).toHaveScreenshot('inbox-empty.png')
 })

--- a/frontend/taskdeck-web/tests/visual/metrics-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/metrics-view.visual.spec.ts
@@ -20,5 +20,5 @@ test('metrics view empty placeholder', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('metrics-placeholder')
+  await expect(page).toHaveScreenshot('metrics-placeholder.png')
 })

--- a/frontend/taskdeck-web/tests/visual/notification-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/notification-view.visual.spec.ts
@@ -20,5 +20,5 @@ test('notification inbox empty state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('notifications-empty')
+  await expect(page).toHaveScreenshot('notifications-empty.png')
 })

--- a/frontend/taskdeck-web/tests/visual/review-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/review-view.visual.spec.ts
@@ -22,5 +22,5 @@ test('review view empty state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('review-empty')
+  await expect(page).toHaveScreenshot('review-empty.png')
 })

--- a/frontend/taskdeck-web/tests/visual/settings-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/settings-view.visual.spec.ts
@@ -23,7 +23,7 @@ test('profile settings default view', async ({ page }) => {
 
   // Mask the dynamic user-identity fields (username, email, user id, role)
   // so we screenshot layout only. These values are newly generated per run.
-  await expect(page).toHaveScreenshot('settings-profile', {
+  await expect(page).toHaveScreenshot('settings-profile.png', {
     mask: [page.locator('.td-info-value')],
   })
 })

--- a/frontend/taskdeck-web/tests/visual/shell-sidebar.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/shell-sidebar.visual.spec.ts
@@ -23,5 +23,5 @@ test('shell sidebar default', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(sidebar).toHaveScreenshot('shell-sidebar')
+  await expect(sidebar).toHaveScreenshot('shell-sidebar.png')
 })

--- a/frontend/taskdeck-web/tests/visual/today-view.visual.spec.ts
+++ b/frontend/taskdeck-web/tests/visual/today-view.visual.spec.ts
@@ -20,5 +20,5 @@ test('today view default state', async ({ page }) => {
 
   await prepareForScreenshot(page)
 
-  await expect(page).toHaveScreenshot('today-default')
+  await expect(page).toHaveScreenshot('today-default.png')
 })

--- a/frontend/taskdeck-web/vite.config.ts
+++ b/frontend/taskdeck-web/vite.config.ts
@@ -143,4 +143,45 @@ export default defineConfig({
       },
     }),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          const normalizedId = id.replace(/\\/g, '/')
+          if (!normalizedId.includes('/node_modules/')) {
+            return undefined
+          }
+
+          if (
+            normalizedId.includes('/node_modules/vue/') ||
+            normalizedId.includes('/node_modules/@vue/') ||
+            normalizedId.includes('/node_modules/pinia/') ||
+            normalizedId.includes('/node_modules/vue-router/')
+          ) {
+            return 'vendor-vue'
+          }
+
+          if (
+            normalizedId.includes('/node_modules/axios/') ||
+            normalizedId.includes('/node_modules/@microsoft/signalr/')
+          ) {
+            return 'vendor-network'
+          }
+
+          if (
+            normalizedId.includes('/node_modules/marked/') ||
+            normalizedId.includes('/node_modules/dompurify/')
+          ) {
+            return 'vendor-markdown'
+          }
+
+          if (normalizedId.includes('/node_modules/@tanstack/vue-virtual/')) {
+            return 'vendor-virtual'
+          }
+
+          return 'vendor'
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

Fixes the May 30 CI Nightly failures on `main`:

- Split the workspace shell out of the public startup bundle by lazy-loading `AppShell` and moving workspace preference/home-summary hydration into the shell lifecycle.
- Updated the AppShell unit-test mocks for the shell-owned workspace hydration path.
- Changed the reusable load/concurrency and performance-gate SQLite database paths to absolute `${{ github.workspace }}/...` paths under `frontend/taskdeck-web/.ci-db/...`, with parent folders created before API startup and result artifacts still written under `test-results`.

## Root Cause

- The entry bundle had pulled the authenticated workspace shell and workspace-store dependencies into startup, producing a 278.56 KB entry chunk against a 150 KB entry threshold.
- The k6 harness launched the API from a context where the relative SQLite path `frontend/taskdeck-web/taskdeck.load.k6.ci.db` did not resolve to an existing parent directory, causing SQLite Error 14 during EF migration/bootstrap.

## Verification

- `npm run build; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; node ../../scripts/ci/check-bundle-size.mjs --dist dist --fail-on-error --output-json test-results/perf/bundle-size-report.local.json`
  - Passed. Entry chunk is now 60.08 KB; largest chunk is 176.16 KB; total JS is 991.79 KB.
- `npx vitest --run src/tests/components/AppShell.spec.ts src/tests/components/AppShell.paperVariant.spec.ts`
  - Passed: 33 tests.
- `npx vitest --run`
  - Passed: 293 files, 3,657 tests. Existing happy-dom analytics-script load warnings were printed but did not fail the run.
- `dotnet build backend/src/Taskdeck.Api/Taskdeck.Api.csproj --configuration Release`
  - Passed.
- Local API startup with `ConnectionStrings__DefaultConnection="Data Source=<repo>/frontend/taskdeck-web/.ci-db/load/taskdeck.load.k6.local.db"`
  - Passed; `/health/live` became healthy.
- `python -c "import yaml, sys; [yaml.safe_load(open(path, encoding='utf-8')) for path in sys.argv[1:]]; print('parsed ' + ', '.join(sys.argv[1:]))" .github/workflows/reusable-load-concurrency-harness.yml .github/workflows/reusable-performance-regression-gate.yml`
  - Passed.
- `git diff --check`
  - Passed; only Windows LF/CRLF working-copy warnings.

## Notes

- Tried `actionlint --version` and Ruby YAML parsing first, but neither tool is installed locally; Python/PyYAML parsing was used as the available fallback.
- `#972` remains open even though RFAI-01 through RFAI-12 child issues are closed; this PR does not close it.
- `docs/TESTING_GUIDE.md` totals are still stale after the May 29 merge wave and should be recertified once CI is green again.