### PR TITLE
Docs truth: STATUS/TESTING_GUIDE accuracy + broken links

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Taskdeck Status (Source of Truth)
 
-Last Updated: 2026-05-29
+Last Updated: 2026-05-31
 
 Continuous-cycle wave (2026-05-29, 19 PRs merged, zero open PRs): cleared the entire open-PR backlog with two adversarial reviews per PR and all findings (all severities, including bot comments) addressed.
 - **RFAI roadmap complete**: RFAI-11 (`#983`/`#1079`, ambient channel — VS Code extension + voice prototype; final Codex finding fixed: git repo matched by document-path containment) and RFAI-12 (`#984`/`#1080`, learning loop UI, Ollama provider, ProvenanceDrawer, cohort dashboard) delivered. All 12 RFAI issues now shipped.
@@ -1004,6 +1004,8 @@ Reconciliation record:
 - `docs/analysis/2026-02-23_outreach-crm-synthesis.md`
 
 ## Test Status (Executed)
+
+> **Authoritative test totals live in `docs/TESTING_GUIDE.md`** ("Current Verified Totals"). The per-section figures in this block are a historical snapshot (last recertified 2026-04-25) that has since drifted out of sync with TESTING_GUIDE; treat TESTING_GUIDE as the single source of truth and recertify there from a green CI/nightly run. (Tracked for cleanup in #1138.)
 
 Verification Date: 2026-04-25 (recertified after PRs #960–#969 audit-remediation wave)
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -39,7 +39,7 @@ Tracker `#972` seeds the next review-first AI verification program. Delivered it
 - `#978`--`#979`: (**both delivered**, `#990`/`#1050`) vector-search fallback tests, embedding backfill safety (61 tests). RFAI-07 hybrid retrieval, duplicate calibration, and memory-assisted generation delivered in `#1050`.
 - `#980`: (**delivered**, `#992` + `#1073`/`#1074`) TelemetryGuard fuzz rejection, egress registry completeness (108 tests), egress disclosure API endpoint (`#1073`), privacy insights API for proposal outcome cohorts (`#1074`).
 - `#981`: (**delivered**, `#1052`) agent runtime hardening — property tests for no approve/direct-mutation tools, egress handler violation tests, MCP definition re-approval, and scheduled Inbox Digest quota/coalescing.
-- `#982`--`#983`: (**both delivered**, `#1078`/`#1079`) ambient capture provenance — PWA share target (RFAI-10, `#1078`), browser extension prototype, and the VS Code extension + voice prototype ambient channel (RFAI-11, `#1079`).
+- `#982`--`#983`: (**both delivered**, `#1078`/`#1079`) ambient capture provenance — PWA share target (RFAI-10, `#1078`; browser-extension prototype deferred — only a `CaptureSource.BrowserExtension = 10` enum placeholder exists, no MV3/WXT artifact shipped), and the VS Code extension + voice prototype ambient channel (RFAI-11, `#1079`).
 - `#984`: (**delivered**, `#1080`) beta-gate work — learning loop UI, provenance drawer, Ollama flag. NOTE: the CI-visible `RoadmapInvariantTests` for INV-10 (MCP hash-pin), INV-11 (TelemetryGuard), and INV-12 (provenance source spans) are still `[Fact(Skip = "...")]` even though that infrastructure shipped; un-skipping/wiring them is tracked in `#1126`. INV-09 (DataFlowRegistry) is genuinely unbuilt.
 
 ## Windows PowerShell Command Convention

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -38,9 +38,9 @@ Tracker `#972` seeds the next review-first AI verification program. Delivered it
 - `#975`--`#977`: (**delivered**, `#993`/`#994`/`#991` + `#1071`/`#1058`/`#1062`) golden proposal dataset checks, schema validity, extractive quote/span verification, inferred evidence-link resolution, field confidence scoring, and edit-before-approve paths. Full delivery: `IProposalGenerator`/`FieldVerifier`/`ProposalGeneratorV1` (`#1071`), revision endpoints + edit-before-approve flow (`#1058`), Paper Review deep-dive wired to backend APIs (`#1062`). Combined: provenance 139 + revision 70 + confidence 136 + generator/verifier/review wiring tests.
 - `#978`--`#979`: (**both delivered**, `#990`/`#1050`) vector-search fallback tests, embedding backfill safety (61 tests). RFAI-07 hybrid retrieval, duplicate calibration, and memory-assisted generation delivered in `#1050`.
 - `#980`: (**delivered**, `#992` + `#1073`/`#1074`) TelemetryGuard fuzz rejection, egress registry completeness (108 tests), egress disclosure API endpoint (`#1073`), privacy insights API for proposal outcome cohorts (`#1074`).
-- `#981`: agent runtime property tests proving no approve/direct-mutation tools, egress handler violation tests, MCP definition re-approval tests, and scheduled Inbox Digest quota/coalescing checks.
-- `#982`--`#983`: ambient capture provenance checks for PWA share target, browser extension prototype, and the selected voice or IDE channel.
-- `#984`: beta-gate recertification requiring all roadmap invariants, provenance verification targets, edit-before-approve, egress disclosure, optional Ollama safety, and current test totals.
+- `#981`: (**delivered**, `#1052`) agent runtime hardening — property tests for no approve/direct-mutation tools, egress handler violation tests, MCP definition re-approval, and scheduled Inbox Digest quota/coalescing.
+- `#982`--`#983`: (**both delivered**, `#1078`/`#1079`) ambient capture provenance — PWA share target (RFAI-10, `#1078`), browser extension prototype, and the VS Code extension + voice prototype ambient channel (RFAI-11, `#1079`).
+- `#984`: (**delivered**, `#1080`) beta-gate work — learning loop UI, provenance drawer, Ollama flag. NOTE: the CI-visible `RoadmapInvariantTests` for INV-10 (MCP hash-pin), INV-11 (TelemetryGuard), and INV-12 (provenance source spans) are still `[Fact(Skip)]` even though that infrastructure shipped; un-skipping/wiring them is tracked in `#1126`. INV-09 (DataFlowRegistry) is genuinely unbuilt.
 
 ## Windows PowerShell Command Convention
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -40,7 +40,7 @@ Tracker `#972` seeds the next review-first AI verification program. Delivered it
 - `#980`: (**delivered**, `#992` + `#1073`/`#1074`) TelemetryGuard fuzz rejection, egress registry completeness (108 tests), egress disclosure API endpoint (`#1073`), privacy insights API for proposal outcome cohorts (`#1074`).
 - `#981`: (**delivered**, `#1052`) agent runtime hardening — property tests for no approve/direct-mutation tools, egress handler violation tests, MCP definition re-approval, and scheduled Inbox Digest quota/coalescing.
 - `#982`--`#983`: (**both delivered**, `#1078`/`#1079`) ambient capture provenance — PWA share target (RFAI-10, `#1078`), browser extension prototype, and the VS Code extension + voice prototype ambient channel (RFAI-11, `#1079`).
-- `#984`: (**delivered**, `#1080`) beta-gate work — learning loop UI, provenance drawer, Ollama flag. NOTE: the CI-visible `RoadmapInvariantTests` for INV-10 (MCP hash-pin), INV-11 (TelemetryGuard), and INV-12 (provenance source spans) are still `[Fact(Skip)]` even though that infrastructure shipped; un-skipping/wiring them is tracked in `#1126`. INV-09 (DataFlowRegistry) is genuinely unbuilt.
+- `#984`: (**delivered**, `#1080`) beta-gate work — learning loop UI, provenance drawer, Ollama flag. NOTE: the CI-visible `RoadmapInvariantTests` for INV-10 (MCP hash-pin), INV-11 (TelemetryGuard), and INV-12 (provenance source spans) are still `[Fact(Skip = "...")]` even though that infrastructure shipped; un-skipping/wiring them is tracked in `#1126`. INV-09 (DataFlowRegistry) is genuinely unbuilt.
 
 ## Windows PowerShell Command Convention
 

--- a/docs/platform/SIGNALR_SCALEOUT_RUNBOOK.md
+++ b/docs/platform/SIGNALR_SCALEOUT_RUNBOOK.md
@@ -6,7 +6,7 @@ This guide covers deploying Taskdeck with multiple API instances using the Redis
 
 By default, Taskdeck runs with in-memory SignalR transport. This works for single-instance deployments and local development. When scaling to multiple instances behind a load balancer, enable the Redis backplane so that realtime events (board mutations, presence updates, tool status) propagate across all instances.
 
-**Architecture decision**: ADR-0023 documents the rationale for choosing Redis backplane over alternatives.
+**Architecture decision**: ADR-0025 documents the rationale for choosing Redis backplane over alternatives.
 
 ## Prerequisites
 
@@ -189,7 +189,7 @@ The Redis backplane uses a channel prefix of `taskdeck` to namespace its pub/sub
 
 ## Related Documentation
 
-- [ADR-0023: SignalR Scale-Out -- Redis Backplane](../decisions/ADR-0023-signalr-scaleout-redis-backplane.md)
+- [ADR-0025: SignalR Scale-Out -- Redis Backplane](../decisions/ADR-0025-signalr-scaleout-redis-backplane.md)
 - [ADR-0012: SignalR Realtime with Polling Fallback](../decisions/ADR-0012-signalr-realtime-with-polling-fallback.md)
 - [ASP.NET Core SignalR Redis backplane](https://learn.microsoft.com/en-us/aspnet/core/signalr/redis-backplane)
 - [StackExchange.Redis Configuration](https://stackexchange.github.io/StackExchange.Redis/Configuration.html)

--- a/docs/tooling/GEMINI_CLI_GUIDE.md
+++ b/docs/tooling/GEMINI_CLI_GUIDE.md
@@ -9,12 +9,12 @@ Gemini's standout feature for complex engineering work is **Plan Mode**.
 - Nontrivial work should **always start in `/plan`**.
 - Let Gemini read the context, ask clarifying questions, and map dependencies and risks first.
 - Only switch to edit mode once the plan is solid, relying on checkpointing before broad refactors. 
-- *Note: Our [`settings.json`](../../../.gemini/settings.json) enforces `defaultApprovalMode: "plan"` by default.*
+- *Note: Our [`settings.json`](../../.gemini/settings.json) enforces `defaultApprovalMode: "plan"` by default.*
 
 ## 2. The Context Fallacy: Keep GEMINI.md Thin
 `GEMINI.md` is always part of the active context hierarchy. Putting heavy procedures into this file makes it noisy and burns context window space.
 Instead, we maintain a strict split:
-- **[`AGENTS.md`](../../../AGENTS.md) and [`GEMINI.md`](../../../GEMINI.md)**: Reserved for repo conventions, guardrails, branch strategy, testing policies, and definitions of done. (We've configured settings to read both).
+- **[`AGENTS.md`](../../AGENTS.md) and [`GEMINI.md`](../../GEMINI.md)**: Reserved for repo conventions, guardrails, branch strategy, testing policies, and definitions of done. (We've configured settings to read both).
 - **Commands (`.gemini/commands/`)**: Shortcuts for high-frequency workflows (e.g., `/review-pr`, `/write-tests-for`). Use commands for "same prompt shape, different input".
 - **Skills (`.gemini/skills/`)**: Deep, on-demand procedures (e.g., PR reviews, migration planners). These are only loaded when explicitly needed.
 
@@ -42,6 +42,6 @@ Our baseline relies on:
 - **Folder Trust (`folderTrust`)**: Enabled.
 - **Checkpointing**: Enabled.
 - **Plan Mode**: Default.
-- **Policies ([`.gemini/policies/`](../../../.gemini/policies/))**: Restrictive blocking/allowing of tools and modes based on repository needs.
+- **Policies ([`.gemini/policies/`](../../.gemini/policies/))**: Restrictive blocking/allowing of tools and modes based on repository needs.
 
 By adhering to this structure, Gemini CLI provides high-leverage assistance without "turning into configuration soup."


### PR DESCRIPTION
## Summary
Docs-only honesty fixes from the 2026-05-31 repo audit (#1138 first slice). No invented test totals — counts recertification is deferred to a green CI run (still tracked in #1138).

- **STATUS.md**: the read-first doc hardcoded 2026-04-25 test counts (backend 5,060 / frontend 2,805) that contradicted `TESTING_GUIDE.md` (6,614 / 3,267). Added an authoritative-source note pointing to TESTING_GUIDE as the single source of truth and bumped `Last Updated`. (The full STATUS.md split into a lean current-reality head + archive is the larger task in #1138.)
- **TESTING_GUIDE.md**: the "Roadmap v4 Verification Spine" still described #981 / #982-983 / #984 as *planned* although they shipped (#1052 / #1078 / #1079 / #1080). Marked delivered — and added an honest caveat that the CI-visible `RoadmapInvariantTests` for INV-10/11/12 remain `[Fact(Skip)]` despite the infra shipping (un-skip tracked in #1126; INV-09 DataFlowRegistry genuinely unbuilt).
- **SIGNALR_SCALEOUT_RUNBOOK.md**: ADR reference fixed `ADR-0023 → ADR-0025` (0023 is the SQLite→Postgres ADR; the Redis backplane decision is 0025).
- **GEMINI_CLI_GUIDE.md**: `../../../ → ../../` for `.gemini/settings.json`, `AGENTS.md`, `GEMINI.md`, `.gemini/policies/` (the guide is two levels below root; the old links overshot it).

## Verification
- `node scripts/check-docs-governance.mjs` → passed.
- `node scripts/check-golden-principles.mjs` → passed.
- All four corrected link targets verified to exist on disk.

Not merging — leaving for review per the repo merge policy.

Refs #1138, #1126.