### PR TITLE
Release build: align local scripts with CI flags, drop stale PKG-01 warning

### DIFF
--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -142,9 +142,9 @@ function Publish-Backend {
         -c Release `
         -r $Rid `
         --self-contained true `
-        -p:PublishSingleFile=true `
-        -p:PublishTrimmed=false `
-        -p:IncludeNativeLibrariesForSelfExtract=true `
+        '-p:PublishSingleFile=true' `
+        '-p:PublishTrimmed=false' `
+        '-p:IncludeNativeLibrariesForSelfExtract=true' `
         -o $OutputDir
 
     if ($LASTEXITCODE -ne 0) { Write-Fatal "dotnet publish failed (exit $LASTEXITCODE)." }

--- a/scripts/build-release.ps1
+++ b/scripts/build-release.ps1
@@ -40,10 +40,8 @@ $FrontendDir  = Join-Path $RepoRoot "frontend/taskdeck-web"
 $FrontendDist = Join-Path $FrontendDir "dist"
 
 $ApiProject  = Join-Path $RepoRoot "backend/src/Taskdeck.Api/Taskdeck.Api.csproj"
-# NOTE: PKG-01 (#533) must be merged before UseStaticFiles / wwwroot serving is configured
-# in the .NET API (Program.cs / PipelineConfiguration.cs). Until that PR lands, the published
-# binary will NOT serve the SPA — it will return 404 for the frontend routes. Do not ship
-# a release artifact built from main until PKG-01 is merged.
+# SPA serving is wired (PKG-01/#533 merged): PipelineConfiguration.cs calls UseStaticFiles +
+# MapFallbackToFile("index.html"), so the published binary serves the frontend from wwwroot.
 $Wwwroot     = Join-Path $RepoRoot "backend/src/Taskdeck.Api/wwwroot"
 
 $OutputBase  = Join-Path $RepoRoot "artifacts\publish"
@@ -136,16 +134,17 @@ function Publish-Backend {
         Write-Fatal "API project file not found: $ApiProject"
     }
 
-    # TRIM WARNING: PublishTrimmed=true can silently break reflection-heavy code paths
-    # (EF Core migrations, ASP.NET DI conventions, System.Text.Json, SignalR).
-    # Validate the trimmed artifact with a smoke test before shipping.
+    # Match the validated CI release flags (.github/workflows/release-desktop.yml):
+    # PublishTrimmed=false (trimming silently breaks EF Core migrations, ASP.NET DI
+    # conventions, System.Text.Json, SignalR) and IncludeNativeLibrariesForSelfExtract=true
+    # so the SQLite native lib (e_sqlite3) is extracted for single-file self-contained runs.
     & dotnet publish $ApiProject `
         -c Release `
         -r $Rid `
         --self-contained true `
         -p:PublishSingleFile=true `
-        -p:PublishTrimmed=true `
-        -p:TrimmerRootAssembly=Taskdeck.Api `
+        -p:PublishTrimmed=false `
+        -p:IncludeNativeLibrariesForSelfExtract=true `
         -o $OutputDir
 
     if ($LASTEXITCODE -ne 0) { Write-Fatal "dotnet publish failed (exit $LASTEXITCODE)." }

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -26,10 +26,8 @@ FRONTEND_DIR="$REPO_ROOT/frontend/taskdeck-web"
 FRONTEND_DIST="$FRONTEND_DIR/dist"
 
 API_PROJECT="$REPO_ROOT/backend/src/Taskdeck.Api/Taskdeck.Api.csproj"
-# NOTE: PKG-01 (#533) must be merged before UseStaticFiles / wwwroot serving is configured
-# in the .NET API (Program.cs / PipelineConfiguration.cs). Until that PR lands, the published
-# binary will NOT serve the SPA — it will return 404 for the frontend routes. Do not ship
-# a release artifact built from main until PKG-01 is merged.
+# SPA serving is wired (PKG-01/#533 merged): PipelineConfiguration.cs calls UseStaticFiles +
+# MapFallbackToFile("index.html"), so the published binary serves the frontend from wwwroot.
 WWWROOT="$REPO_ROOT/backend/src/Taskdeck.Api/wwwroot"
 
 OUTPUT_BASE="$REPO_ROOT/artifacts/publish"
@@ -136,16 +134,17 @@ publish_backend() {
         fail "API project file not found: $API_PROJECT"
     fi
 
-    # TRIM WARNING: PublishTrimmed=true can silently break reflection-heavy code paths
-    # (EF Core migrations, ASP.NET DI conventions, System.Text.Json, SignalR).
-    # Validate the trimmed artifact with a smoke test before shipping.
+    # Match the validated CI release flags (.github/workflows/release-desktop.yml):
+    # PublishTrimmed=false (trimming silently breaks EF Core migrations, ASP.NET DI
+    # conventions, System.Text.Json, SignalR) and IncludeNativeLibrariesForSelfExtract=true
+    # so the SQLite native lib (e_sqlite3) is extracted for single-file self-contained runs.
     dotnet publish "$API_PROJECT" \
         -c Release \
         -r "$rid" \
         --self-contained true \
         -p:PublishSingleFile=true \
-        -p:PublishTrimmed=true \
-        -p:TrimmerRootAssembly=Taskdeck.Api \
+        -p:PublishTrimmed=false \
+        -p:IncludeNativeLibrariesForSelfExtract=true \
         -o "$output_dir"
 
     log "Publish complete: $output_dir"


### PR DESCRIPTION
## Summary
First slice of #1123 (v0.1.0 release validation). Makes the local release-build scripts produce the same artifact CI does, and removes a stale instruction that would block shipping.

- **Flag alignment**: `scripts/build-release.{sh,ps1}` used `-p:PublishTrimmed=true` and omitted `IncludeNativeLibrariesForSelfExtract`, diverging from the validated CI workflow (`.github/workflows/release-desktop.yml:124-126` → `PublishTrimmed=false`, `IncludeNativeLibrariesForSelfExtract=true`). Trimming silently breaks EF Core migrations / DI / System.Text.Json / SignalR, and the SQLite native lib (`e_sqlite3`) needs native-lib extraction in single-file self-contained mode — so the local scripts likely produced a **broken exe**. Now matched to CI; dropped the irrelevant `TrimmerRootAssembly`.
- **Stale warning removed**: both scripts carried a `# Do not ship ... until PKG-01 (#533) is merged` block claiming the binary won't serve the SPA. PKG-01 **is** merged — `PipelineConfiguration.cs:80` (`UseStaticFiles`) and `:135` (`MapFallbackToFile("index.html")`) wire SPA serving. A maintainer obeying the stale comment would needlessly block the release. Replaced with an accurate note.

## Verification
- `bash -n scripts/build-release.sh` → OK.
- PowerShell tokenizer parse of `build-release.ps1` → OK.
- No residual `PublishTrimmed=true` / `TrimmerRootAssembly` / "do not ship" refs; new flags present in both scripts.
- CI flags cross-checked against `release-desktop.yml`.

## Remaining in #1123 (follow-ups)
Post-publish launch/smoke test in `release-desktop.yml` (boot exe, poll `/health/ready`, GET `/`), and the actual `v0.1.0` tag + clean-VM smoke. Left for a separate change.

Not merging — for review. Refs #1123.