### PR TITLE
Proposal create: return 409 for duplicate idempotency key (fix #1125 500s)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
@@ -350,12 +350,14 @@ public class UnitOfWork : IUnitOfWork
         if (exception.InnerException is null)
             return false;
 
-        return exception.InnerException.Message.Contains(
-            "AutomationProposalOperations.IdempotencyKey",
-            StringComparison.OrdinalIgnoreCase)
-            || exception.InnerException.Message.Contains(
-                "IX_AutomationProposalOperations_IdempotencyKey",
-                StringComparison.OrdinalIgnoreCase);
+        var message = exception.InnerException.Message;
+
+        // Match UNIQUE violations only. The bare column name also appears in NOT NULL
+        // violation messages ("NOT NULL constraint failed: AutomationProposalOperations.IdempotencyKey"),
+        // so require the UNIQUE qualifier (SQLite) or the unique index name (other providers).
+        return (message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase)
+                && message.Contains("AutomationProposalOperations.IdempotencyKey", StringComparison.OrdinalIgnoreCase))
+            || message.Contains("IX_AutomationProposalOperations_IdempotencyKey", StringComparison.OrdinalIgnoreCase);
     }
 
     private bool TryResolveDuplicateDailySnapshotConflicts(DbUpdateException exception)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/UnitOfWork.cs
@@ -151,6 +151,13 @@ public class UnitOfWork : IUnitOfWork
                     "Proposal revision was created by another session. Refresh and retry your edit.",
                     ex);
             }
+            catch (DbUpdateException ex) when (IsOperationIdempotencyKeyUniqueViolation(ex))
+            {
+                throw new DomainException(
+                    ErrorCodes.Conflict,
+                    "An automation operation with this idempotency key already exists.",
+                    ex);
+            }
             catch (DbUpdateException ex) when (!resolvedRecoverableUniqueConflict && TryResolveRecoverableUniqueConflicts(ex))
             {
                 resolvedRecoverableUniqueConflict = true;
@@ -335,6 +342,19 @@ public class UnitOfWork : IUnitOfWork
             StringComparison.OrdinalIgnoreCase)
             || exception.InnerException.Message.Contains(
                 "IX_ProposalRevisions_ProposalId_RevisionNumber",
+                StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsOperationIdempotencyKeyUniqueViolation(DbUpdateException exception)
+    {
+        if (exception.InnerException is null)
+            return false;
+
+        return exception.InnerException.Message.Contains(
+            "AutomationProposalOperations.IdempotencyKey",
+            StringComparison.OrdinalIgnoreCase)
+            || exception.InnerException.Message.Contains(
+                "IX_AutomationProposalOperations_IdempotencyKey",
                 StringComparison.OrdinalIgnoreCase);
     }
 

--- a/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
@@ -191,44 +191,73 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
             $"Proposal creation returned 500 for expiryMinutes={expiryMinutes}");
     }
 
-    // ─────────────────────── Known 500 bugs (skip-annotated) ───────────────────────
-    // These tests document real API bugs discovered by adversarial testing.
-    // When operations contain unexpected actionType values or nested parameter JSON,
-    // the proposal creation endpoint returns 500 instead of 4xx.
+    // ─────────────────────── Operation input robustness ───────────────────────
+    // These previously carried [Fact(Skip)] "known 500 bug" annotations. The real
+    // root cause was a *shared* idempotency key ("key1") colliding with the global
+    // unique index on AutomationProposalOperation.IdempotencyKey across tests on the
+    // shared test DB — a duplicate key now returns 409 instead of 500 (see
+    // DuplicateIdempotencyKey_ShouldReturnConflictNot500). With unique keys, unusual
+    // actionType values and deeply nested parameter JSON are handled without a 500.
 
-    [Fact(Skip = "Known bug: proposal endpoint returns 500 when operations contain XSS in actionType")]
-    public async Task KnownBug_XssInActionType_Causes500()
+    [Fact]
+    public async Task MalformedActionType_ShouldNotReturn500()
     {
         await EnsureAuthenticatedAsync();
 
+        var key = System.Guid.NewGuid().ToString("N");
         var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
                    "\"operations\": [{\"sequence\": 0, \"actionType\": \"<script>alert(1)</script>\", " +
-                   "\"targetType\": \"card\", \"parameters\": \"{}\", \"idempotencyKey\": \"key1\"}]}";
+                   "\"targetType\": \"card\", \"parameters\": \"{}\", \"idempotencyKey\": \"" + key + "\"}]}";
 
         var content = new StringContent(body, Encoding.UTF8, "application/json");
         var response = await _client.PostAsync("/api/automation/proposals", content);
 
-        // BUG: This returns 500 instead of 400/422.
-        // Expected: ((int)response.StatusCode).Should().BeLessThan(500);
-        ((int)response.StatusCode).Should().Be(500,
-            "Documenting known bug: XSS in actionType causes 500");
+        var actual = (int)response.StatusCode;
+        var respBody = await response.Content.ReadAsStringAsync();
+        actual.Should().BeLessThan(500,
+            $"an unusual actionType must not cause a server error. actual={actual} body={respBody}");
     }
 
-    [Fact(Skip = "Known bug: proposal endpoint returns 500 when operations contain deeply nested parameter JSON")]
-    public async Task KnownBug_DeepNestedParameters_Causes500()
+    [Fact]
+    public async Task DeepNestedParameters_ShouldNotReturn500()
     {
         await EnsureAuthenticatedAsync();
 
+        var key = System.Guid.NewGuid().ToString("N");
         var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
                    "\"operations\": [{\"sequence\": 0, \"actionType\": \"create\", \"targetType\": \"card\", " +
-                   "\"parameters\": \"{\\\"nested\\\": {\\\"deep\\\": {\\\"deeper\\\": true}}}\", \"idempotencyKey\": \"key1\"}]}";
+                   "\"parameters\": \"{\\\"nested\\\": {\\\"deep\\\": {\\\"deeper\\\": true}}}\", \"idempotencyKey\": \"" + key + "\"}]}";
 
         var content = new StringContent(body, Encoding.UTF8, "application/json");
         var response = await _client.PostAsync("/api/automation/proposals", content);
 
-        // BUG: This returns 500 instead of 400/422 or 201.
-        // Expected: ((int)response.StatusCode).Should().BeLessThan(500);
-        ((int)response.StatusCode).Should().Be(500,
-            "Documenting known bug: nested parameter JSON causes 500");
+        var actual = (int)response.StatusCode;
+        var respBody = await response.Content.ReadAsStringAsync();
+        actual.Should().BeLessThan(500,
+            $"deeply nested parameter JSON must not cause a server error. actual={actual} body={respBody}");
+    }
+
+    [Fact]
+    public async Task DuplicateIdempotencyKey_ShouldReturnConflictNot500()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var key = System.Guid.NewGuid().ToString("N");
+        string BuildBody() =>
+            "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+            "\"operations\": [{\"sequence\": 0, \"actionType\": \"create\", \"targetType\": \"card\", " +
+            "\"parameters\": \"{}\", \"idempotencyKey\": \"" + key + "\"}]}";
+
+        var first = await _client.PostAsync("/api/automation/proposals",
+            new StringContent(BuildBody(), Encoding.UTF8, "application/json"));
+        ((int)first.StatusCode).Should().BeLessThan(400,
+            "the first create with a fresh idempotency key should succeed");
+
+        var second = await _client.PostAsync("/api/automation/proposals",
+            new StringContent(BuildBody(), Encoding.UTF8, "application/json"));
+        var actual = (int)second.StatusCode;
+        var respBody = await second.Content.ReadAsStringAsync();
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            $"a duplicate operation idempotency key must return 409, not a 500. actual={actual} body={respBody}");
     }
 }


### PR DESCRIPTION
## Summary
Addresses #1125 (the duplicate-idempotency-key 500) and corrects its premise. The two `[Fact(Skip)]` "known 500 bug" tests were **misdiagnosed**.

### What I found (empirically verified)
- The `DeepNestedParameters` case does **not** reproduce — nested parameter JSON is handled fine (`<500`).
- The `MalformedActionType` case **passes when run alone** but **deterministically 500s when run after** another proposal-creating test (3/3). Root cause: both skipped tests reused `idempotencyKey: "key1"`, and `AutomationProposalOperation.IdempotencyKey` has a **global unique index** (`AutomationProposalOperationConfiguration.cs:54-55`). On the shared test DB the second insert hit a `DbUpdateException` (a non-`DomainException`) that escaped `CreateProposalAsync`'s `catch (DomainException)` → unhandled → 500. So it was an **idempotency-key collision surfacing as a 500**, not an XSS/`actionType` validation gap.

### Fix
- **Product** (`UnitOfWork.cs`): translate an `AutomationProposalOperations.IdempotencyKey` unique violation into `DomainException(ErrorCodes.Conflict)` in `SaveChangesAsync`, mirroring the existing `IsProposalRevisionUniqueViolation` handler. The create endpoint now returns **409 Conflict** (via `ResultExtensions` `Conflict → 409`) instead of 500 — which is the correct semantics for a duplicate idempotency key.
- **Tests**: un-skip both tests with **unique** keys (proving unusual `actionType` and deeply nested params don't 500), and add `DuplicateIdempotencyKey_ShouldReturnConflictNot500` asserting the new 409.

### Verification
- `ProposalOperationsAdversarialTests` full class: **38/38 pass** (was 36 + 2 skipped).
- Regression: `~Proposal | ~Capture` in Api.Tests: **300/300 pass**.
- The `UnitOfWork` catch only matches the specific IdempotencyKey unique-violation message, so other DB errors still surface normally (no silent-failure widening).

### Scope note on #1125 (updated 2026-05-31 after pass-2 review)
This PR fixes the **500 root cause** but does **not** implement #1125's acceptance criterion #1 (create-time `actionType`/`targetType` allowlist + bounded `parameters` JSON → 400/422). So this PR is intentionally **not** auto-closing #1125 — **Refs #1125**, which stays open for the create-time defensive-validation hardening, landing in a separate focused PR. Idempotency-key contract follow-ups (per-owner scoping + replay-vs-409 ADR) are tracked in #1149.
