### PR TITLE
Perf: AsSplitQuery on board/card collection reads (#1133 first slice)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/BoardRepository.cs
@@ -179,6 +179,9 @@ public class BoardRepository : Repository<Board>, IBoardRepository
                     .ThenInclude(card => card.CardLabels)
                         .ThenInclude(cardLabel => cardLabel.Label)
             .Include(b => b.Labels)
+            // Split the 4-level Columns->Cards->CardLabels->Label fan-out into separate
+            // queries to avoid a cartesian row explosion on the hottest board read path.
+            .AsSplitQuery()
             .FirstOrDefaultAsync(b => b.Id == id, cancellationToken);
     }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/CardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/CardRepository.cs
@@ -19,9 +19,6 @@ public class CardRepository : Repository<Card>, ICardRepository
                 .ThenInclude(cl => cl.Label)
             .OrderBy(c => c.ColumnId)
                 .ThenBy(c => c.Position)
-            // Split the cards->labels fan-out so a board with many labelled cards does
-            // not multiply rows; the root OrderBy is preserved under split queries.
-            .AsSplitQuery()
             .ToListAsync(cancellationToken);
     }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/CardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/CardRepository.cs
@@ -19,6 +19,9 @@ public class CardRepository : Repository<Card>, ICardRepository
                 .ThenInclude(cl => cl.Label)
             .OrderBy(c => c.ColumnId)
                 .ThenBy(c => c.Position)
+            // Split the cards->labels fan-out so a board with many labelled cards does
+            // not multiply rows; the root OrderBy is preserved under split queries.
+            .AsSplitQuery()
             .ToListAsync(cancellationToken);
     }
 


### PR DESCRIPTION
## Summary
First slice of #1133. Adds `.AsSplitQuery()` to the two collection-include reads the audit flagged as cartesian-explosion risks on the hottest paths.

- `BoardRepository.GetByIdWithDetailsAsync`: 4-level `Columns→Cards→CardLabels→Label` Include had no split → a single cartesian query EF must materialize/dedupe on every board load and SignalR-triggered refetch.
- `CardRepository.GetByBoardIdAsync`: `Cards→CardLabels→Label` fan-out; root `OrderBy(ColumnId).ThenBy(Position)` is preserved under split queries.

`AsSplitQuery()` is behavior-preserving (same entities loaded; only the number of SQL round-trips changes) and also clears EF's multiple-collection-include cartesian warning.

## Verification
- `~Board | ~Card` in Api.Tests: **415/415 pass**, 0 failures (covers board GET, metrics, golden path, card CRUD).
- Build clean.

## Remaining in #1133 (follow-ups)
Bounded notification paging (in-memory Skip/Take → SQL), incremental SignalR board patch instead of full 3-call refetch, FTS-backed card search. Left for separate changes.

Not merging — for review. Refs #1133.