### PR TITLE
Harden /api/automation/proposals: create-time operation input validation (#1125)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -50,6 +50,13 @@ public class AutomationProposalService : IAutomationProposalService
 
     public async Task<Result<ProposalDto>> CreateProposalAsync(CreateProposalDto dto, CancellationToken cancellationToken = default)
     {
+        // Defensive create-time validation (issue #1125): reject malformed operation input
+        // (markup/binary actionType-targetType, non-JSON or oversized/over-nested parameters)
+        // with 400 before any persistence, so junk never persists and never escapes as a 500.
+        var operationValidation = ProposalOperationInputValidator.Validate(dto.Operations);
+        if (!operationValidation.IsSuccess)
+            return Result.Failure<ProposalDto>(operationValidation.ErrorCode, operationValidation.ErrorMessage);
+
         try
         {
             var proposal = new AutomationProposal(

--- a/backend/src/Taskdeck.Application/Services/ProposalOperationInputValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalOperationInputValidator.cs
@@ -1,0 +1,130 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Create-time defensive validation for automation proposal operations (issue #1125).
+///
+/// Operations on a proposal are not executed at create time — they are persisted for
+/// review-first approval and applied later by <c>OperationHandlerRegistry</c>. This validator
+/// rejects clearly-malformed operation input at the create boundary so junk never persists
+/// and never escapes as an unhandled 500:
+/// <list type="bullet">
+///   <item><description><c>actionType</c>/<c>targetType</c> must be short identifier-like tokens
+///   (letters/digits and '. _ -' separators, starting with a letter). This rejects markup, SQL,
+///   control characters, whitespace, and oversized strings while accepting every verb/target the
+///   apply registry uses (create, update, move, archive, reorder, ...), namespaced forms
+///   (card.create), and any future identifier-like verb — so it never rejects a legitimate
+///   planner / chat / capture / MCP operation.</description></item>
+///   <item><description><c>parameters</c> must be valid JSON, within a bounded size and
+///   nesting depth.</description></item>
+/// </list>
+/// Returns <see cref="ErrorCodes.ValidationError"/> (HTTP 400) on the first violation.
+/// </summary>
+public static class ProposalOperationInputValidator
+{
+    /// <summary>Maximum length of an <c>actionType</c> or <c>targetType</c> token.</summary>
+    public const int MaxTokenLength = 64;
+
+    /// <summary>Maximum UTF-8 byte size of an operation's <c>parameters</c> JSON.</summary>
+    public const int MaxParametersBytes = 64 * 1024;
+
+    /// <summary>Maximum nesting depth of an operation's <c>parameters</c> JSON.</summary>
+    public const int MaxParametersDepth = 32;
+
+    // Identifier-like token: starts with a letter, then letters/digits and the '. _ -'
+    // separators (covers plain verbs like "create" and namespaced ones like "card.create").
+    // Deliberately permissive (not a fixed allowlist) so new legitimate verbs/targets are not
+    // rejected, while markup, SQL, control/binary characters, and whitespace are.
+    private static readonly Regex TokenPattern = new(
+        "^[A-Za-z][A-Za-z0-9_.-]*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static Result Validate(IReadOnlyList<CreateProposalOperationDto>? operations)
+    {
+        if (operations is null || operations.Count == 0)
+            return Result.Success();
+
+        for (var i = 0; i < operations.Count; i++)
+        {
+            var op = operations[i];
+            var prefix = $"Operation {i} (sequence {op.Sequence})";
+
+            if (!IsValidToken(op.ActionType))
+                return Result.Failure(
+                    ErrorCodes.ValidationError,
+                    $"{prefix}: actionType must be a short identifier-like token (letters, digits, and . _ - separators; start with a letter; max {MaxTokenLength} characters).");
+
+            if (!IsValidToken(op.TargetType))
+                return Result.Failure(
+                    ErrorCodes.ValidationError,
+                    $"{prefix}: targetType must be a short identifier-like token (letters, digits, and . _ - separators; start with a letter; max {MaxTokenLength} characters).");
+
+            var parametersError = ValidateParameters(op.Parameters, prefix);
+            if (parametersError is not null)
+                return Result.Failure(ErrorCodes.ValidationError, parametersError);
+        }
+
+        return Result.Success();
+    }
+
+    private static bool IsValidToken(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        var trimmed = value.Trim();
+        return trimmed.Length <= MaxTokenLength && TokenPattern.IsMatch(trimmed);
+    }
+
+    private static string? ValidateParameters(string? rawParameters, string prefix)
+    {
+        if (string.IsNullOrWhiteSpace(rawParameters))
+            return $"{prefix}: parameters cannot be empty.";
+
+        // Bound size before parsing so an abusive payload is rejected cheaply.
+        if (Encoding.UTF8.GetByteCount(rawParameters) > MaxParametersBytes)
+            return $"{prefix}: parameters exceed the maximum size of {MaxParametersBytes} bytes.";
+
+        try
+        {
+            // JsonDocument.Parse rejects input nested deeper than its default max depth (64),
+            // which bounds the recursion in MeasureDepth below.
+            using var document = JsonDocument.Parse(rawParameters);
+            if (MeasureDepth(document.RootElement) > MaxParametersDepth)
+                return $"{prefix}: parameters are nested too deeply (max depth {MaxParametersDepth}).";
+        }
+        catch (JsonException ex)
+        {
+            return $"{prefix}: parameters must be valid JSON ({ex.Message}).";
+        }
+
+        return null;
+    }
+
+    private static int MeasureDepth(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                var maxObject = 0;
+                foreach (var property in element.EnumerateObject())
+                    maxObject = Math.Max(maxObject, MeasureDepth(property.Value));
+                return maxObject + 1;
+
+            case JsonValueKind.Array:
+                var maxArray = 0;
+                foreach (var item in element.EnumerateArray())
+                    maxArray = Math.Max(maxArray, MeasureDepth(item));
+                return maxArray + 1;
+
+            default:
+                return 1;
+        }
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/ProposalOperationInputValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalOperationInputValidator.cs
@@ -41,8 +41,10 @@ public static class ProposalOperationInputValidator
     // separators (covers plain verbs like "create" and namespaced ones like "card.create").
     // Deliberately permissive (not a fixed allowlist) so new legitimate verbs/targets are not
     // rejected, while markup, SQL, control/binary characters, and whitespace are.
+    // Uses \A..\z (absolute string anchors), NOT ^..$: in .NET, $ also matches just before a
+    // trailing newline, so "create\n" would otherwise slip through.
     private static readonly Regex TokenPattern = new(
-        "^[A-Za-z][A-Za-z0-9_.-]*$",
+        @"\A[A-Za-z][A-Za-z0-9_.-]*\z",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     public static Result Validate(IReadOnlyList<CreateProposalOperationDto>? operations)
@@ -53,6 +55,11 @@ public static class ProposalOperationInputValidator
         for (var i = 0; i < operations.Count; i++)
         {
             var op = operations[i];
+            if (op is null)
+                return Result.Failure(
+                    ErrorCodes.ValidationError,
+                    $"Operation {i}: operation cannot be null.");
+
             var prefix = $"Operation {i} (sequence {op.Sequence})";
 
             if (!IsValidToken(op.ActionType))
@@ -78,8 +85,9 @@ public static class ProposalOperationInputValidator
         if (string.IsNullOrWhiteSpace(value))
             return false;
 
-        var trimmed = value.Trim();
-        return trimmed.Length <= MaxTokenLength && TokenPattern.IsMatch(trimmed);
+        // Match the raw value (no Trim): the regex rejects leading/trailing whitespace, so the
+        // value we validate is exactly the value that gets persisted and later matched at apply time.
+        return value.Length <= MaxTokenLength && TokenPattern.IsMatch(value);
     }
 
     private static string? ValidateParameters(string? rawParameters, string prefix)

--- a/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
@@ -73,8 +73,8 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
             "\"operations\": \"not-an-array\"}"
         };
 
-        // NOTE: Deeply nested JSON parameters and XSS in actionType cause 500s.
-        // These are documented as known bugs in separate skip-annotated tests below.
+        // NOTE: deeply nested JSON parameters and markup in actionType are now rejected with
+        // 400 by ProposalOperationInputValidator — see the dedicated *_ShouldReturn400 tests below.
 
         // Null/empty operations
         yield return new object[]
@@ -88,7 +88,7 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
             "\"operations\": []}"
         };
 
-        // NOTE: XSS in actionType causes 500 — documented in a separate skip-annotated test below.
+        // NOTE: markup in actionType is now rejected with 400 — see MalformedActionType_ShouldReturn400 below.
 
         // SQL injection in parameters
         yield return new object[]
@@ -191,16 +191,17 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
             $"Proposal creation returned 500 for expiryMinutes={expiryMinutes}");
     }
 
-    // ─────────────────────── Operation input robustness ───────────────────────
-    // These previously carried [Fact(Skip)] "known 500 bug" annotations. The real
-    // root cause was a *shared* idempotency key ("key1") colliding with the global
-    // unique index on AutomationProposalOperation.IdempotencyKey across tests on the
-    // shared test DB — a duplicate key now returns 409 instead of 500 (see
-    // DuplicateIdempotencyKey_ShouldReturnConflictNot500). With unique keys, unusual
-    // actionType values and deeply nested parameter JSON are handled without a 500.
+    // ─────────────────────── Operation input robustness (#1125) ───────────────────────
+    // These previously carried [Fact(Skip)] "known 500 bug" annotations. Two distinct root
+    // causes were found: (1) a *shared* idempotency key ("key1") colliding with the global
+    // unique index on AutomationProposalOperation.IdempotencyKey produced a 500 — now a 409
+    // (see DuplicateIdempotencyKey_ShouldReturnConflictNot500); (2) malformed operation input
+    // was persisted unvalidated. ProposalOperationInputValidator now rejects markup/binary
+    // actionType/targetType and non-JSON / oversized / over-nested parameters with 400 at the
+    // create boundary, before any persistence.
 
     [Fact]
-    public async Task MalformedActionType_ShouldNotReturn500()
+    public async Task MalformedActionType_ShouldReturn400()
     {
         await EnsureAuthenticatedAsync();
 
@@ -214,8 +215,8 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
 
         var actual = (int)response.StatusCode;
         var respBody = await response.Content.ReadAsStringAsync();
-        actual.Should().BeLessThan(500,
-            $"an unusual actionType must not cause a server error. actual={actual} body={respBody}");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            $"markup in actionType is malformed input and must be rejected with 400, not persisted. actual={actual} body={respBody}");
     }
 
     [Fact]
@@ -259,5 +260,70 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
         var respBody = await second.Content.ReadAsStringAsync();
         second.StatusCode.Should().Be(HttpStatusCode.Conflict,
             $"a duplicate operation idempotency key must return 409, not a 500. actual={actual} body={respBody}");
+    }
+
+    [Fact]
+    public async Task NonJsonParameters_ShouldReturn400()
+    {
+        await EnsureAuthenticatedAsync();
+
+        var key = System.Guid.NewGuid().ToString("N");
+        var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+                   "\"operations\": [{\"sequence\": 0, \"actionType\": \"create\", \"targetType\": \"card\", " +
+                   "\"parameters\": \"not valid json\", \"idempotencyKey\": \"" + key + "\"}]}";
+
+        var response = await _client.PostAsync("/api/automation/proposals",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        var respBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            $"non-JSON operation parameters must be rejected with 400. body={respBody}");
+    }
+
+    [Fact]
+    public async Task TooDeeplyNestedParameters_ShouldReturn400()
+    {
+        await EnsureAuthenticatedAsync();
+
+        // Build JSON nested well beyond ProposalOperationInputValidator.MaxParametersDepth (32).
+        const int depth = 40;
+        var nested = new StringBuilder();
+        for (var i = 0; i < depth; i++) nested.Append("{\\\"a\\\":");
+        nested.Append('1');
+        for (var i = 0; i < depth; i++) nested.Append('}');
+
+        var key = System.Guid.NewGuid().ToString("N");
+        var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+                   "\"operations\": [{\"sequence\": 0, \"actionType\": \"create\", \"targetType\": \"card\", " +
+                   "\"parameters\": \"" + nested + "\", \"idempotencyKey\": \"" + key + "\"}]}";
+
+        var response = await _client.PostAsync("/api/automation/proposals",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        var respBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            $"parameters nested beyond the depth bound must be rejected with 400. body={respBody}");
+    }
+
+    [Fact]
+    public async Task OversizedParameters_ShouldReturn400()
+    {
+        await EnsureAuthenticatedAsync();
+
+        // Valid JSON whose UTF-8 size exceeds ProposalOperationInputValidator.MaxParametersBytes (64 KiB).
+        var hugeValue = new string('x', 70 * 1024);
+        var parameters = "{\\\"note\\\":\\\"" + hugeValue + "\\\"}";
+
+        var key = System.Guid.NewGuid().ToString("N");
+        var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+                   "\"operations\": [{\"sequence\": 0, \"actionType\": \"create\", \"targetType\": \"card\", " +
+                   "\"parameters\": \"" + parameters + "\", \"idempotencyKey\": \"" + key + "\"}]}";
+
+        var response = await _client.PostAsync("/api/automation/proposals",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        var respBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            $"oversized operation parameters must be rejected with 400. body={respBody}");
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalOperationsAdversarialTests.cs
@@ -326,4 +326,23 @@ public class ProposalOperationsAdversarialTests : IClassFixture<TestWebApplicati
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
             $"oversized operation parameters must be rejected with 400. body={respBody}");
     }
+
+    [Fact]
+    public async Task NullOperationElement_ShouldReturn400()
+    {
+        await EnsureAuthenticatedAsync();
+
+        // A null element inside the operations array binds to a List with a null entry; the
+        // validator must reject it with 400 rather than dereferencing it into an unhandled 500.
+        var body = "{\"sourceType\": 0, \"summary\": \"test\", \"riskLevel\": 0, \"correlationId\": \"abc\", " +
+                   "\"operations\": [null]}";
+
+        var response = await _client.PostAsync("/api/automation/proposals",
+            new StringContent(body, Encoding.UTF8, "application/json"));
+
+        var actual = (int)response.StatusCode;
+        var respBody = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            $"a null operation element must be rejected with 400, not cause a 500. actual={actual} body={respBody}");
+    }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalOperationInputValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalOperationInputValidatorTests.cs
@@ -44,7 +44,9 @@ public class ProposalOperationInputValidatorTests
     [InlineData("<script>alert(1)</script>")]
     [InlineData("'; DROP TABLE cards; --")]
     [InlineData("create card")]            // internal whitespace
-    [InlineData("card\tcreate")]           // embedded tab survives Trim()
+    [InlineData("card\tcreate")]           // embedded tab
+    [InlineData(" create ")]               // surrounding whitespace (no longer trimmed away)
+    [InlineData("create\n")]               // trailing newline
     [InlineData("")]                       // empty
     [InlineData("   ")]                    // whitespace only
     [InlineData("1create")]                // must start with a letter
@@ -69,6 +71,43 @@ public class ProposalOperationInputValidatorTests
     {
         var longToken = "a" + new string('b', ProposalOperationInputValidator.MaxTokenLength);
         var result = ProposalOperationInputValidator.Validate(One(actionType: longToken));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_OverlongTargetType_Fails()
+    {
+        var longToken = "a" + new string('b', ProposalOperationInputValidator.MaxTokenLength);
+        var result = ProposalOperationInputValidator.Validate(One(targetType: longToken));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_NullOperationElement_Fails()
+    {
+        var ops = new List<CreateProposalOperationDto> { null! };
+        var result = ProposalOperationInputValidator.Validate(ops);
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_ParametersAtDepthBound_Succeeds()
+    {
+        // MeasureDepth(BuildNested(n)) == n + 1; BuildNested(Max-1) -> depth == Max (allowed).
+        var json = BuildNested(ProposalOperationInputValidator.MaxParametersDepth - 1);
+        var result = ProposalOperationInputValidator.Validate(One(parameters: json));
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_ParametersJustBeyondDepthBound_Fails()
+    {
+        // BuildNested(Max) -> depth == Max + 1 (just over the bound).
+        var json = BuildNested(ProposalOperationInputValidator.MaxParametersDepth);
+        var result = ProposalOperationInputValidator.Validate(One(parameters: json));
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
     }

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalOperationInputValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalOperationInputValidatorTests.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+/// <summary>
+/// Unit tests for create-time proposal operation input validation (#1125).
+/// </summary>
+public class ProposalOperationInputValidatorTests
+{
+    private static List<CreateProposalOperationDto> One(
+        string actionType = "create",
+        string targetType = "card",
+        string parameters = "{}")
+        => new() { new CreateProposalOperationDto(0, actionType, targetType, parameters, "key") };
+
+    [Fact]
+    public void Validate_NullOrEmptyOperations_Succeeds()
+    {
+        ProposalOperationInputValidator.Validate(null).IsSuccess.Should().BeTrue();
+        ProposalOperationInputValidator.Validate(new List<CreateProposalOperationDto>())
+            .IsSuccess.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("create", "card")]
+    [InlineData("card.create", "Card")]    // dotted verb + capitalized target (real fixture style)
+    [InlineData("bulk_move", "card")]
+    [InlineData("create_column", "column")]
+    [InlineData("reorder", "column")]
+    [InlineData("card-move", "card")]
+    public void Validate_WellFormedTokens_Succeeds(string actionType, string targetType)
+    {
+        var result = ProposalOperationInputValidator.Validate(One(actionType, targetType));
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("'; DROP TABLE cards; --")]
+    [InlineData("create card")]            // internal whitespace
+    [InlineData("card\tcreate")]           // embedded tab survives Trim()
+    [InlineData("")]                       // empty
+    [InlineData("   ")]                    // whitespace only
+    [InlineData("1create")]                // must start with a letter
+    [InlineData(".create")]                // must start with a letter
+    public void Validate_MalformedActionType_Fails(string actionType)
+    {
+        var result = ProposalOperationInputValidator.Validate(One(actionType: actionType));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_MalformedTargetType_Fails()
+    {
+        var result = ProposalOperationInputValidator.Validate(One(targetType: "<b>card</b>"));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_OverlongActionType_Fails()
+    {
+        var longToken = "a" + new string('b', ProposalOperationInputValidator.MaxTokenLength);
+        var result = ProposalOperationInputValidator.Validate(One(actionType: longToken));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Theory]
+    [InlineData("not json")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Validate_InvalidOrEmptyParameters_Fails(string parameters)
+    {
+        var result = ProposalOperationInputValidator.Validate(One(parameters: parameters));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_ParametersWithinDepthBound_Succeeds()
+    {
+        var result = ProposalOperationInputValidator.Validate(One(parameters: BuildNested(5)));
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_ParametersBeyondDepthBound_Fails()
+    {
+        var json = BuildNested(ProposalOperationInputValidator.MaxParametersDepth + 10);
+        var result = ProposalOperationInputValidator.Validate(One(parameters: json));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_OversizedParameters_Fails()
+    {
+        var huge = "{\"note\":\"" +
+                   new string('x', ProposalOperationInputValidator.MaxParametersBytes + 1024) + "\"}";
+        var result = ProposalOperationInputValidator.Validate(One(parameters: huge));
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public void Validate_ReportsOffendingOperationIndex()
+    {
+        var ops = new List<CreateProposalOperationDto>
+        {
+            new(0, "create", "card", "{}", "k0"),
+            new(1, "<bad>", "card", "{}", "k1"),
+        };
+
+        var result = ProposalOperationInputValidator.Validate(ops);
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Operation 1");
+    }
+
+    private static string BuildNested(int depth)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < depth; i++) sb.Append("{\"a\":");
+        sb.Append('1');
+        for (var i = 0; i < depth; i++) sb.Append('}');
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining hardening from #1125 — create-time **defensive validation** of automation proposal operations — completing the issue's acceptance criterion #1. (#1146 already fixed the reproduced 500 root cause: a duplicate operation idempotency-key collision now returns 409, and the two `[Fact(Skip)]` tests were un-skipped.)

## What this does

New `ProposalOperationInputValidator` (Application layer), called at the top of `AutomationProposalService.CreateProposalAsync` **before any persistence**. For each operation it rejects malformed input with `ValidationError` → **HTTP 400**:

- **`actionType` / `targetType`** must be a short **identifier-like token** — starts with a letter, then letters/digits and `. _ -` separators, max 64 chars. This rejects markup (`<script>…`), SQL, whitespace, and control/binary characters, while accepting every verb/target the apply registry uses (`create`, `update`, `move`, `archive`, `reorder`, …), namespaced forms (`card.create`), and any future identifier-like verb.
- **`parameters`** must be **valid JSON**, within a bounded **size (≤ 64 KiB)** and **nesting depth (≤ 32)**.

## Why a format check, not a fixed allowlist

`CreateProposalAsync` is the **single shared persistence path for every proposal producer** — the manual `POST /api/automation/proposals` endpoint, MCP `WriteTools`, the LLM planner, chat, capture triage, inbox digest, and all `Propose*` executors. A hard `{card:[create,…], board:[update], …}` membership allowlist here would reject legitimate planner/chat/capture/MCP operations and break the core capture→proposal loop. A permissive **normalization/format** constraint (issue criterion #1 explicitly allows "allowlist *or* normalization") rejects genuinely-malformed input without constraining the legitimate set — the apply-time `OperationHandlerRegistry` remains the authority on which operations are *executable*.

The producer regression suite proved the point: it caught a real fixture using `actionType: "card.create"` (dotted), which an initial letters/digits/underscore-only pattern wrongly rejected. The pattern was loosened to allow `. _ -`; the XSS/SQL cases still reject.

## "Convert unexpected exceptions to a safe 4xx with logging"

Addressed by (a) validation now rejecting malformed input at the boundary so it never becomes an exception, and (b) the existing `UnhandledExceptionMiddleware`, which already converts any unhandled exception to a safe generic 500 (no stack leak) with redacted logging and cancellation-aware handling. No behavior-widening service-level catch was added on the shared internal path.

## Tests

- `ProposalOperationInputValidatorTests` — 12 unit cases (well-formed incl. dotted/namespaced; markup/SQL/whitespace/tab/empty/leading-non-letter/overlong; non-JSON; depth within/beyond bound; oversized; offending-index reporting).
- `ProposalOperationsAdversarialTests` — tightened `MalformedActionType` to assert **400** (was `<500`) and added `NonJsonParameters`, `TooDeeplyNestedParameters`, `OversizedParameters` → **400**.

## Verification (local, Debug)

- `ProposalOperationInputValidatorTests` + `AutomationProposalServiceTests`: **56/56**.
- `ProposalOperationsAdversarialTests`: **41/41**.
- Full producer-path regression (filter: Proposal | Capture | Automation | GoldenPath | Mcp | Chat | Planner | Inbox | Tools across the solution): **Domain 320, Application 607, Api 411, Architecture 7 (+1 pre-existing INV-10 skip), Integration 6 — 0 failures**. CI runs the full suite.

Closes #1125. Idempotency-key contract follow-ups (per-owner scoping + replay-vs-409 ADR) are tracked separately in #1149.

Not merging — for review (2 adversarial passes per merge policy).
