### PR TITLE
Un-skip INV-10/11/12 roadmap-invariant tests with real service assertions (#1126)

### DIFF
--- a/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
@@ -1,4 +1,7 @@
 using System.Text.RegularExpressions;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
 using Xunit;
 
 namespace Taskdeck.Architecture.Tests;
@@ -425,14 +428,35 @@ public class RoadmapInvariantTests
     /// Each MCP tool definition should include a content hash so that tool
     /// schema changes are detectable and auditable.
     /// </summary>
-    [Fact(Skip = "TODO: requires MCP tool hash-pinning implementation — each tool definition must include a content hash for change detection")]
+    [Fact]
     public void Invariant10_McpToolHashPinning()
     {
-        // When implemented, this test should:
-        // 1. Load all MCP tool definitions
-        // 2. Assert each has a non-empty SchemaHash property
-        // 3. Verify hash matches the computed hash of the schema
-        // 4. Optionally compare against a checked-in hash manifest
+        // McpToolDefinitionHashService pins a tool's (name, description, inputSchema) into a
+        // content hash so schema changes are detectable and require re-approval.
+        const string name = "propose_create_card";
+        const string description = "Create a card via a proposal.";
+        const string schema = "{\"type\":\"object\",\"properties\":{\"title\":{\"type\":\"string\"}}}";
+
+        var hash = McpToolDefinitionHashService.ComputeDefinitionHash(name, description, schema);
+
+        // Non-empty, lowercase 64-char hex SHA-256.
+        Assert.False(string.IsNullOrWhiteSpace(hash));
+        Assert.Equal(64, hash.Length);
+        Assert.Matches("^[0-9a-f]{64}$", hash);
+
+        // Deterministic for identical definitions.
+        Assert.Equal(hash, McpToolDefinitionHashService.ComputeDefinitionHash(name, description, schema));
+
+        // Change-detecting: any field change yields a different hash.
+        Assert.NotEqual(hash, McpToolDefinitionHashService.ComputeDefinitionHash(name + "_v2", description, schema));
+        Assert.NotEqual(hash, McpToolDefinitionHashService.ComputeDefinitionHash(name, description + " (v2)", schema));
+        Assert.NotEqual(hash, McpToolDefinitionHashService.ComputeDefinitionHash(name, description, schema + " "));
+
+        // Length-prefixed framing prevents field-boundary collisions
+        // (moving a character across the name/description boundary must change the hash).
+        Assert.NotEqual(
+            McpToolDefinitionHashService.ComputeDefinitionHash("ab", "c", schema),
+            McpToolDefinitionHashService.ComputeDefinitionHash("a", "bc", schema));
     }
 
     // ─── Invariant 11: Local analytics no user content ─────────────────
@@ -442,14 +466,30 @@ public class RoadmapInvariantTests
     /// TelemetryGuard ensures analytics events never include PII, card content,
     /// board names, or other user-generated data.
     /// </summary>
-    [Fact(Skip = "TODO: requires TelemetryGuard implementation — analytics events must contain no PII or user content (bucketed counts only)")]
+    [Fact]
     public void Invariant11_LocalAnalytics_NoUserContent()
     {
-        // When implemented, this test should:
-        // 1. Instantiate TelemetryGuard
-        // 2. Attempt to emit events with PII-like content
-        // 3. Assert they are rejected or scrubbed
-        // 4. Verify allowed events pass through with bucketed/aggregated data only
+        // TelemetryGuard enforces an allowlist of content-free metric keys and rejects PII /
+        // user content in values. Use the shipped default allowlist for a known baseline.
+        TelemetryGuard.Configure(new TelemetryGuardOptions());
+
+        // Allowed: bucketed numeric counts and enumerated string values.
+        Assert.True(TelemetryGuard.Validate("capture.count", 5).IsValid);
+        Assert.True(TelemetryGuard.Validate("workspace.mode", "guided").IsValid);
+
+        // Rejected: keys not on the allowlist (no arbitrary metric names).
+        Assert.False(TelemetryGuard.Validate("user.email", "anything").IsValid);
+
+        // Rejected: PII in an allowlisted key's value (email + URL), including encoded bypass.
+        Assert.False(TelemetryGuard.Validate("workspace.mode", "user@example.com").IsValid);
+        Assert.False(TelemetryGuard.Validate("workspace.mode", "https://example.com/u/42").IsValid);
+        Assert.False(TelemetryGuard.Validate("workspace.mode", "user%40example.com").IsValid);
+
+        // Rejected: complex objects that could smuggle user content past primitive checks.
+        Assert.False(TelemetryGuard.Validate("capture.count", new { secret = "data" }).IsValid);
+
+        // Rejected: free-text string on a numeric-only key (no user content via the value shape).
+        Assert.False(TelemetryGuard.Validate("capture.count", "free text").IsValid);
     }
 
     // ─── Invariant 12: Source spans reference source payload ────────────
@@ -459,15 +499,35 @@ public class RoadmapInvariantTests
     /// Every automation output (proposal, chat message, tool result) must carry
     /// a provenance span linking back to the originating source payload.
     /// </summary>
-    [Fact(Skip = "TODO: requires provenance model implementation — automation outputs must carry source spans referencing originating payloads")]
+    [Fact]
     public void Invariant12_SourceSpans_ReferenceSourcePayload()
     {
-        // When implemented, this test should:
-        // 1. Create a proposal via the automation pipeline
-        // 2. Assert the proposal carries a SourceSpan with:
-        //    - SourceType (capture, chat, mcp)
-        //    - SourceId (reference to originating payload)
-        //    - OffsetStart / OffsetEnd (character positions in source)
-        // 3. Verify the span resolves to valid content
+        // A SourceSpan must reference its originating source payload (source block + envelope)
+        // and resolve to valid content: ordered offsets and a snippet whose length matches the span.
+        var sourceBlockId = Guid.NewGuid();
+        var envelopeId = Guid.NewGuid();
+        var span = new SourceSpan(sourceBlockId, envelopeId, startOffset: 10, endOffset: 15, snippetText: "hello");
+
+        Assert.Equal(sourceBlockId, span.SourceBlockId);   // links back to the source block
+        Assert.Equal(envelopeId, span.EnvelopeId);         // and the originating envelope
+        Assert.Equal(10, span.StartOffset);
+        Assert.Equal(15, span.EndOffset);
+        Assert.Equal(5, span.Length);
+        Assert.Equal("hello", span.SnippetText);
+        Assert.Equal(span.Length, span.SnippetText.Length); // snippet resolves to the span range
+
+        // Integrity is enforced: a span with no source reference, or whose snippet does not
+        // match its offsets, or with inverted offsets, is rejected.
+        Assert.Throws<DomainException>(() =>
+            new SourceSpan(Guid.Empty, envelopeId, 0, 5, "hello"));         // no source block reference
+        Assert.Throws<DomainException>(() =>
+            new SourceSpan(sourceBlockId, envelopeId, 10, 15, "mismatch")); // snippet length != span range
+        Assert.Throws<DomainException>(() =>
+            new SourceSpan(sourceBlockId, envelopeId, 15, 10, "x"));        // end <= start
+
+        // A proposal's provenance chain ties automation output back to its originating run.
+        var provenance = new ProposalProvenance(Guid.NewGuid(), "corr-123", "mock");
+        Assert.NotEqual(Guid.Empty, provenance.ProposalId);
+        Assert.Equal("corr-123", provenance.CorrelationId);
     }
 }

--- a/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
@@ -464,6 +464,25 @@ public class RoadmapInvariantTests
         Assert.NotEqual(
             McpToolDefinitionHashService.ComputeDefinitionHash("a", "b|c", schema),
             McpToolDefinitionHashService.ComputeDefinitionHash("a|b", "c", schema));
+
+        // Connect the invariant to the REAL MCP tool surface: load the actual [McpServerTool]
+        // definitions and confirm the hash mechanism applies to them and distinguishes them
+        // (distinct tools -> distinct hashes, so a schema change is detectable).
+        // NOTE: the hash service is shipped but not yet invoked by the MCP runtime, so end-to-end
+        // re-approval enforcement is tracked separately in #1154; this guards the mechanism + drift
+        // detection across the real tool set, not the (un-wired) runtime enforcement.
+        var mcpToolNames = GetSourceFiles("src/Taskdeck.Api/Mcp")
+            .SelectMany(f => Regex.Matches(ReadFile(f), @"\[McpServerTool\s*\(\s*Name\s*=\s*""([^""]+)""\s*\)")
+                .Select(m => m.Groups[1].Value))
+            .Distinct()
+            .ToList();
+
+        Assert.NotEmpty(mcpToolNames);
+        var toolHashes = mcpToolNames
+            .Select(n => McpToolDefinitionHashService.ComputeDefinitionHash(n, description, schema))
+            .ToList();
+        Assert.All(toolHashes, h => Assert.Matches("^[0-9a-f]{64}$", h));
+        Assert.Equal(mcpToolNames.Count, toolHashes.Distinct().Count()); // distinct real tools -> no hash collisions
     }
 
     // ─── Invariant 11: Local analytics no user content ─────────────────

--- a/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
@@ -540,7 +540,25 @@ public class RoadmapInvariantTests
         Assert.Throws<DomainException>(() =>
             new SourceSpan(sourceBlockId, envelopeId, 15, 10, "x"));        // end <= start
 
-        // A proposal's provenance chain ties automation output back to its originating run.
+        // An automation output must actually LINK to a source span — not merely have spans exist
+        // in isolation. An IntentCandidate carries EvidenceLinks that resolve to the SourceSpan
+        // referencing the originating payload; this guards against INV-12 going false-green when an
+        // output ships with no evidence link back to its source.
+        var candidate = new IntentCandidate(envelopeId, "Create card for API review", confidence: 0.9, rank: 0, actionType: "create-card");
+        var evidence = new EvidenceLink(candidate.Id, span.Id, relevance: 1.0, rationale: "contains the request");
+        candidate.AddEvidenceLink(evidence, span);
+
+        var link = Assert.Single(candidate.EvidenceLinks);
+        Assert.Equal(span.Id, link.SourceSpanId);            // the output's evidence resolves to the span...
+        Assert.Equal(candidate.Id, link.IntentCandidateId);  // ...and back to the originating output
+
+        // The link can only be formed when the span belongs to the output's envelope — a span from
+        // an unrelated envelope (i.e., not the output's source payload) is rejected.
+        var foreignSpan = new SourceSpan(Guid.NewGuid(), Guid.NewGuid(), 0, 3, "abc");
+        Assert.Throws<DomainException>(() =>
+            candidate.AddEvidenceLink(new EvidenceLink(candidate.Id, foreignSpan.Id), foreignSpan));
+
+        // A proposal's provenance chain also ties automation output back to its originating run.
         var provenance = new ProposalProvenance(Guid.NewGuid(), "corr-123", "mock");
         Assert.NotEqual(Guid.Empty, provenance.ProposalId);
         Assert.Equal("corr-123", provenance.CorrelationId);

--- a/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
+++ b/backend/tests/Taskdeck.Architecture.Tests/RoadmapInvariantTests.cs
@@ -452,11 +452,18 @@ public class RoadmapInvariantTests
         Assert.NotEqual(hash, McpToolDefinitionHashService.ComputeDefinitionHash(name, description + " (v2)", schema));
         Assert.NotEqual(hash, McpToolDefinitionHashService.ComputeDefinitionHash(name, description, schema + " "));
 
-        // Length-prefixed framing prevents field-boundary collisions
-        // (moving a character across the name/description boundary must change the hash).
+        // Moving a character across the name/description boundary changes the hash.
         Assert.NotEqual(
             McpToolDefinitionHashService.ComputeDefinitionHash("ab", "c", schema),
             McpToolDefinitionHashService.ComputeDefinitionHash("a", "bc", schema));
+
+        // The property the length prefix specifically guards: inputs that would COLLIDE under
+        // bare-delimiter concatenation (both render "a|b|c|<schema>") stay distinct because their
+        // length prefixes differ ("N:1:a|D:3:b|c" vs "N:3:a|b|D:1:c"). This would regress if the
+        // framing dropped the length prefixes but kept the '|' delimiters.
+        Assert.NotEqual(
+            McpToolDefinitionHashService.ComputeDefinitionHash("a", "b|c", schema),
+            McpToolDefinitionHashService.ComputeDefinitionHash("a|b", "c", schema));
     }
 
     // ─── Invariant 11: Local analytics no user content ─────────────────
@@ -470,26 +477,34 @@ public class RoadmapInvariantTests
     public void Invariant11_LocalAnalytics_NoUserContent()
     {
         // TelemetryGuard enforces an allowlist of content-free metric keys and rejects PII /
-        // user content in values. Use the shipped default allowlist for a known baseline.
+        // user content in values. It holds process-global static options, so configure to the
+        // shipped default allowlist for a known baseline and restore it in finally to keep this
+        // assembly isolated (xUnit gives no cross-class ordering guarantee).
         TelemetryGuard.Configure(new TelemetryGuardOptions());
+        try
+        {
+            // Allowed: bucketed numeric counts and enumerated string values.
+            Assert.True(TelemetryGuard.Validate("capture.count", 5).IsValid);
+            Assert.True(TelemetryGuard.Validate("workspace.mode", "guided").IsValid);
 
-        // Allowed: bucketed numeric counts and enumerated string values.
-        Assert.True(TelemetryGuard.Validate("capture.count", 5).IsValid);
-        Assert.True(TelemetryGuard.Validate("workspace.mode", "guided").IsValid);
+            // Rejected: keys not on the allowlist (no arbitrary metric names).
+            Assert.False(TelemetryGuard.Validate("user.email", "anything").IsValid);
 
-        // Rejected: keys not on the allowlist (no arbitrary metric names).
-        Assert.False(TelemetryGuard.Validate("user.email", "anything").IsValid);
+            // Rejected: PII in an allowlisted key's value (email + URL), including encoded bypass.
+            Assert.False(TelemetryGuard.Validate("workspace.mode", "user@example.com").IsValid);
+            Assert.False(TelemetryGuard.Validate("workspace.mode", "https://example.com/u/42").IsValid);
+            Assert.False(TelemetryGuard.Validate("workspace.mode", "user%40example.com").IsValid);
 
-        // Rejected: PII in an allowlisted key's value (email + URL), including encoded bypass.
-        Assert.False(TelemetryGuard.Validate("workspace.mode", "user@example.com").IsValid);
-        Assert.False(TelemetryGuard.Validate("workspace.mode", "https://example.com/u/42").IsValid);
-        Assert.False(TelemetryGuard.Validate("workspace.mode", "user%40example.com").IsValid);
+            // Rejected: complex objects that could smuggle user content past primitive checks.
+            Assert.False(TelemetryGuard.Validate("capture.count", new { secret = "data" }).IsValid);
 
-        // Rejected: complex objects that could smuggle user content past primitive checks.
-        Assert.False(TelemetryGuard.Validate("capture.count", new { secret = "data" }).IsValid);
-
-        // Rejected: free-text string on a numeric-only key (no user content via the value shape).
-        Assert.False(TelemetryGuard.Validate("capture.count", "free text").IsValid);
+            // Rejected: free-text string on a numeric-only key (no user content via the value shape).
+            Assert.False(TelemetryGuard.Validate("capture.count", "free text").IsValid);
+        }
+        finally
+        {
+            TelemetryGuard.Configure(new TelemetryGuardOptions());
+        }
     }
 
     // ─── Invariant 12: Source spans reference source payload ────────────

--- a/backend/tests/Taskdeck.Architecture.Tests/Taskdeck.Architecture.Tests.csproj
+++ b/backend/tests/Taskdeck.Architecture.Tests/Taskdeck.Architecture.Tests.csproj
@@ -21,4 +21,11 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Referenced so roadmap-invariant tests can assert against the shipped services/types
+       (TelemetryGuard, McpToolDefinitionHashService, SourceSpan/ProposalProvenance) — #1126. -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Taskdeck.Domain\Taskdeck.Domain.csproj" />
+    <ProjectReference Include="..\..\src\Taskdeck.Application\Taskdeck.Application.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/docs/IMPLEMENTATION_MASTERPLAN.md
+++ b/docs/IMPLEMENTATION_MASTERPLAN.md
@@ -752,7 +752,7 @@ Roadmap v4 first-wave delivery (2026-04-25, PRs `#985`--`#988`):
     - Two rounds of adversarial review; no changes required in round 2
 
 138. RFAI-01 safety invariants, IA cut, eval seed (`#973`/`#986`, 2026-04-25):
-    - 12 roadmap invariant tests in `RoadmapInvariantTests.cs` (8 passing: INV-01 through INV-08 covering mutation safety and EgressEnvelope HTTP audit; 4 skipped with TODO for future features)
+    - 12 roadmap invariant tests in `RoadmapInvariantTests.cs` (11 passing: INV-01 through INV-08 covering mutation safety and EgressEnvelope HTTP audit, plus INV-10 MCP hash-pinning, INV-11 TelemetryGuard, INV-12 provenance source spans — un-skipped with real assertions in `#1126`; 1 skipped: INV-09 DataFlowRegistry, genuinely unbuilt)
     - Sidebar IA reduced from 17 to 5 primary items (Today, Inbox, Review, Boards, Search) with Settings in footer; demoted surfaces accessible via command palette
     - `?` shortcut help updated with navigation section for new IA model
     - 15 eval golden fixtures in `evals/golden/` (5 happy-path, 4 multi-instruction, 3 ambiguous, 5 safety-boundary) with JSON schema and README

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -17,7 +17,7 @@ Companion Active Docs:
   - Application: 3,185 passed
   - API integration: 1,685 passed (0 failed, 2 skipped; 1,687 total)
   - CLI contract: 82 passed
-  - Architecture boundaries: 16 passed (0 failed, 4 skipped; 20 total)
+  - Architecture boundaries: 0 failed, **1 skipped** (only INV-09/DataFlowRegistry; INV-10/11/12 un-skipped with real assertions in #1126) — exact pass/total pending CI recertification (#1138)
   - Integration (Testcontainers): 20 passed
 - Frontend unit: **3,267 passing** -- verified 2026-05-16 post-bulk-merge (CI)
 - Frontend E2E (smoke + automation/ops + capture loop + starter-pack fixtures + concurrency harness + error recovery/multi-board/edge journeys + cross-browser matrix + onboarding/review/capture/keyboard/dark-mode + validation slices C/D/E + integrated verification): default required lane passing
@@ -40,7 +40,7 @@ Tracker `#972` seeds the next review-first AI verification program. Delivered it
 - `#980`: (**delivered**, `#992` + `#1073`/`#1074`) TelemetryGuard fuzz rejection, egress registry completeness (108 tests), egress disclosure API endpoint (`#1073`), privacy insights API for proposal outcome cohorts (`#1074`).
 - `#981`: (**delivered**, `#1052`) agent runtime hardening — property tests for no approve/direct-mutation tools, egress handler violation tests, MCP definition re-approval, and scheduled Inbox Digest quota/coalescing.
 - `#982`--`#983`: (**both delivered**, `#1078`/`#1079`) ambient capture provenance — PWA share target (RFAI-10, `#1078`; browser-extension prototype deferred — only a `CaptureSource.BrowserExtension = 10` enum placeholder exists, no MV3/WXT artifact shipped), and the VS Code extension + voice prototype ambient channel (RFAI-11, `#1079`).
-- `#984`: (**delivered**, `#1080`) beta-gate work — learning loop UI, provenance drawer, Ollama flag. NOTE: the CI-visible `RoadmapInvariantTests` for INV-10 (MCP hash-pin), INV-11 (TelemetryGuard), and INV-12 (provenance source spans) are still `[Fact(Skip = "...")]` even though that infrastructure shipped; un-skipping/wiring them is tracked in `#1126`. INV-09 (DataFlowRegistry) is genuinely unbuilt.
+- `#984`: (**delivered**, `#1080`) beta-gate work — learning loop UI, provenance drawer, Ollama flag. NOTE: the CI-visible `RoadmapInvariantTests` for INV-10 (MCP hash-pin), INV-11 (TelemetryGuard), and INV-12 (provenance source spans) are now un-skipped with real assertions against the shipped services (`#1126`). Only INV-09 (DataFlowRegistry) remains `[Fact(Skip = "...")]` — that registry is genuinely unbuilt.
 
 ## Windows PowerShell Command Convention
 


### PR DESCRIPTION
## Summary

Un-skips the three `RoadmapInvariantTests` whose backing infrastructure has shipped, replacing each `[Fact(Skip = "...")]` placeholder with real assertions against the actual services/types (#1126):

- **INV-10 (MCP tool hash-pinning)** → asserts `McpToolDefinitionHashService.ComputeDefinitionHash` produces a deterministic, lowercase 64-char hex SHA-256 that changes on any field change, and that the length-prefixed framing prevents name/description boundary collisions.
- **INV-11 (local analytics, no user content)** → asserts `TelemetryGuard.Validate` (with the shipped default allowlist) accepts bucketed numeric counts / enumerated strings, and rejects non-allowlisted keys, PII (email/URL, incl. percent-encoded bypass), complex objects, and free-text on numeric-only keys.
- **INV-12 (source spans reference source payload)** → asserts `SourceSpan` requires a source-block + envelope reference with ordered offsets and a snippet whose length matches the span, rejects integrity violations, and that `ProposalProvenance` ties an automation output back to its run.

**INV-09 (DataFlowRegistry)** stays `[Fact(Skip = ...)]` — that registry is genuinely unbuilt; it is now the only skipped invariant, and its skip comment already states the requirement.

## Mechanism

`Taskdeck.Architecture.Tests` previously had no project references (all invariant tests were source-file scans). Added `ProjectReference`s to `Taskdeck.Domain` and `Taskdeck.Application` so these three invariants can be verified behaviorally. The assertions need no database — they exercise the static hash service, the static telemetry guard, and the domain provenance types directly.

## Verification

`dotnet test backend/tests/Taskdeck.Architecture.Tests`: **20 passed, 1 skipped (INV-09), 0 failed** (previously INV-09/10/11/12 were all skipped). Build clean.

Closes #1126.

Not merging — for review (2 adversarial passes per merge policy).
