### PR TITLE
Surface swallowed audit-log failures via shared AuditLogWriter (#1134 first slice)

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/ApplicationServiceRegistration.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Taskdeck.Api.Health;
 using Taskdeck.Api.Realtime;
 using Taskdeck.Api.Services;
@@ -21,7 +22,8 @@ public static class ApplicationServiceRegistration
                 sp.GetService<IBoardRealtimeNotifier>(),
                 sp.GetService<IHistoryService>(),
                 sp.GetService<ICacheService>(),
-                sp.GetService<CacheSettings>()));
+                sp.GetService<CacheSettings>(),
+                sp.GetService<ILogger<BoardService>>()));
         services.AddScoped<ColumnService>();
         services.AddScoped<CardService>();
         services.AddScoped<CardCommentService>();

--- a/backend/src/Taskdeck.Application/Services/AuditLogWriter.cs
+++ b/backend/src/Taskdeck.Application/Services/AuditLogWriter.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+using Taskdeck.Domain.Enums;
+
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Shared safe audit-log writer (issue #1134).
+///
+/// Audit/history writes are secondary to the mutation they describe, so a failure must never
+/// crash the mutation — but it must not be swallowed silently either. This replaces the
+/// copy-pasted empty-catch <c>SafeLogAsync</c> that lived in BoardService/CardService/
+/// ColumnService/LabelService: a thrown exception OR a returned failed <c>Result</c> is now
+/// logged at Warning, while the mutation still proceeds.
+/// </summary>
+internal static class AuditLogWriter
+{
+    public static async Task SafeLogAsync(
+        IHistoryService? historyService,
+        ILogger? logger,
+        string entityType,
+        Guid entityId,
+        AuditAction action,
+        Guid? userId = null,
+        string? changes = null)
+    {
+        if (historyService is null)
+            return;
+
+        try
+        {
+            var result = await historyService.LogActionAsync(entityType, entityId, action, userId, changes);
+            if (!result.IsSuccess)
+            {
+                logger?.LogWarning(
+                    "Audit log write failed for {EntityType} {EntityId} action {Action}: {ErrorCode} {ErrorMessage}. Mutation continues.",
+                    entityType, entityId, action, result.ErrorCode, result.ErrorMessage);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(
+                ex,
+                "Audit log write threw for {EntityType} {EntityId} action {Action}. Mutation continues.",
+                entityType, entityId, action);
+        }
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/AuditLogWriter.cs
+++ b/backend/src/Taskdeck.Application/Services/AuditLogWriter.cs
@@ -29,7 +29,15 @@ internal static class AuditLogWriter
         try
         {
             var result = await historyService.LogActionAsync(entityType, entityId, action, userId, changes);
-            if (!result.IsSuccess)
+            if (result is null)
+            {
+                // Defensive: a null Result shouldn't happen in production, but classify it as a
+                // failed write rather than letting the catch below mislabel it as a throw/NRE.
+                logger?.LogWarning(
+                    "Audit log write returned a null result for {EntityType} {EntityId} action {Action}. Mutation continues.",
+                    entityType, entityId, action);
+            }
+            else if (!result.IsSuccess)
             {
                 logger?.LogWarning(
                     "Audit log write failed for {EntityType} {EntityId} action {Action}: {ErrorCode} {ErrorMessage}. Mutation continues.",

--- a/backend/src/Taskdeck.Application/Services/BoardService.cs
+++ b/backend/src/Taskdeck.Application/Services/BoardService.cs
@@ -1,4 +1,5 @@
-﻿using Taskdeck.Application.DTOs;
+﻿using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
@@ -15,6 +16,7 @@ public class BoardService
     private readonly IHistoryService? _historyService;
     private readonly ICacheService? _cacheService;
     private readonly CacheSettings? _cacheSettings;
+    private readonly ILogger<BoardService>? _logger;
 
     public BoardService(IUnitOfWork unitOfWork)
         : this(unitOfWork, authorizationService: null, realtimeNotifier: null, historyService: null)
@@ -27,7 +29,8 @@ public class BoardService
         IBoardRealtimeNotifier? realtimeNotifier = null,
         IHistoryService? historyService = null,
         ICacheService? cacheService = null,
-        CacheSettings? cacheSettings = null)
+        CacheSettings? cacheSettings = null,
+        ILogger<BoardService>? logger = null)
     {
         _unitOfWork = unitOfWork;
         _authorizationService = authorizationService;
@@ -35,14 +38,11 @@ public class BoardService
         _historyService = historyService;
         _cacheService = cacheService;
         _cacheSettings = cacheSettings ?? new CacheSettings();
+        _logger = logger;
     }
 
-    private async Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
-    {
-        if (_historyService == null) return;
-        try { await _historyService.LogActionAsync(entityType, entityId, action, userId, changes); }
-        catch (Exception) { /* Audit is secondary — never crash the mutation */ }
-    }
+    private Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
+        => AuditLogWriter.SafeLogAsync(_historyService, _logger, entityType, entityId, action, userId, changes);
 
     public async Task<Result<BoardDto>> CreateBoardAsync(CreateBoardDto dto, Guid actingUserId, CancellationToken cancellationToken = default)
     {

--- a/backend/src/Taskdeck.Application/Services/CardService.cs
+++ b/backend/src/Taskdeck.Application/Services/CardService.cs
@@ -1,4 +1,5 @@
-﻿using Taskdeck.Application.DTOs;
+﻿using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
@@ -12,25 +13,23 @@ public class CardService
     private readonly IUnitOfWork _unitOfWork;
     private readonly IBoardRealtimeNotifier _realtimeNotifier;
     private readonly IHistoryService? _historyService;
+    private readonly ILogger<CardService>? _logger;
 
     public CardService(IUnitOfWork unitOfWork)
         : this(unitOfWork, realtimeNotifier: null, historyService: null)
     {
     }
 
-    public CardService(IUnitOfWork unitOfWork, IBoardRealtimeNotifier? realtimeNotifier = null, IHistoryService? historyService = null)
+    public CardService(IUnitOfWork unitOfWork, IBoardRealtimeNotifier? realtimeNotifier = null, IHistoryService? historyService = null, ILogger<CardService>? logger = null)
     {
         _unitOfWork = unitOfWork;
         _realtimeNotifier = realtimeNotifier ?? NoOpBoardRealtimeNotifier.Instance;
         _historyService = historyService;
+        _logger = logger;
     }
 
-    private async Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
-    {
-        if (_historyService == null) return;
-        try { await _historyService.LogActionAsync(entityType, entityId, action, userId, changes); }
-        catch (Exception) { /* Audit is secondary — never crash the mutation */ }
-    }
+    private Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
+        => AuditLogWriter.SafeLogAsync(_historyService, _logger, entityType, entityId, action, userId, changes);
 
     public async Task<Result<CardDto>> CreateCardAsync(CreateCardDto dto, CancellationToken cancellationToken = default)
     {

--- a/backend/src/Taskdeck.Application/Services/ColumnService.cs
+++ b/backend/src/Taskdeck.Application/Services/ColumnService.cs
@@ -1,4 +1,5 @@
-﻿using Taskdeck.Application.DTOs;
+﻿using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
@@ -12,25 +13,23 @@ public class ColumnService
     private readonly IUnitOfWork _unitOfWork;
     private readonly IBoardRealtimeNotifier _realtimeNotifier;
     private readonly IHistoryService? _historyService;
+    private readonly ILogger<ColumnService>? _logger;
 
     public ColumnService(IUnitOfWork unitOfWork)
         : this(unitOfWork, realtimeNotifier: null, historyService: null)
     {
     }
 
-    public ColumnService(IUnitOfWork unitOfWork, IBoardRealtimeNotifier? realtimeNotifier = null, IHistoryService? historyService = null)
+    public ColumnService(IUnitOfWork unitOfWork, IBoardRealtimeNotifier? realtimeNotifier = null, IHistoryService? historyService = null, ILogger<ColumnService>? logger = null)
     {
         _unitOfWork = unitOfWork;
         _realtimeNotifier = realtimeNotifier ?? NoOpBoardRealtimeNotifier.Instance;
         _historyService = historyService;
+        _logger = logger;
     }
 
-    private async Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
-    {
-        if (_historyService == null) return;
-        try { await _historyService.LogActionAsync(entityType, entityId, action, userId, changes); }
-        catch (Exception) { /* Audit is secondary — never crash the mutation */ }
-    }
+    private Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
+        => AuditLogWriter.SafeLogAsync(_historyService, _logger, entityType, entityId, action, userId, changes);
 
     public async Task<Result<ColumnDto>> CreateColumnAsync(CreateColumnDto dto, CancellationToken cancellationToken = default)
     {

--- a/backend/src/Taskdeck.Application/Services/LabelService.cs
+++ b/backend/src/Taskdeck.Application/Services/LabelService.cs
@@ -1,4 +1,5 @@
-﻿using Taskdeck.Application.DTOs;
+﻿using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
@@ -12,25 +13,23 @@ public class LabelService
     private readonly IUnitOfWork _unitOfWork;
     private readonly IBoardRealtimeNotifier _realtimeNotifier;
     private readonly IHistoryService? _historyService;
+    private readonly ILogger<LabelService>? _logger;
 
     public LabelService(IUnitOfWork unitOfWork)
         : this(unitOfWork, realtimeNotifier: null, historyService: null)
     {
     }
 
-    public LabelService(IUnitOfWork unitOfWork, IBoardRealtimeNotifier? realtimeNotifier = null, IHistoryService? historyService = null)
+    public LabelService(IUnitOfWork unitOfWork, IBoardRealtimeNotifier? realtimeNotifier = null, IHistoryService? historyService = null, ILogger<LabelService>? logger = null)
     {
         _unitOfWork = unitOfWork;
         _realtimeNotifier = realtimeNotifier ?? NoOpBoardRealtimeNotifier.Instance;
         _historyService = historyService;
+        _logger = logger;
     }
 
-    private async Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
-    {
-        if (_historyService == null) return;
-        try { await _historyService.LogActionAsync(entityType, entityId, action, userId, changes); }
-        catch (Exception) { /* Audit is secondary — never crash the mutation */ }
-    }
+    private Task SafeLogAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
+        => AuditLogWriter.SafeLogAsync(_historyService, _logger, entityType, entityId, action, userId, changes);
 
     public async Task<Result<LabelDto>> CreateLabelAsync(CreateLabelDto dto, CancellationToken cancellationToken = default)
     {

--- a/backend/tests/Taskdeck.Application.Tests/Services/AuditLogWriterTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AuditLogWriterTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+/// <summary>
+/// Tests for the shared safe audit-log writer (#1134): audit failures must surface at Warning
+/// (a thrown exception OR a returned failed Result) without ever crashing the mutation.
+/// </summary>
+public class AuditLogWriterTests
+{
+    [Fact]
+    public async Task SafeLogAsync_WhenLogActionThrows_LogsWarningWithExceptionAndDoesNotThrow()
+    {
+        var logger = new RecordingLogger();
+        var history = new FakeHistoryService(FakeBehavior.Throw);
+
+        await AuditLogWriter.SafeLogAsync(history, logger, "card", Guid.NewGuid(), AuditAction.Created);
+
+        var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.Single(warnings);
+        Assert.NotNull(warnings[0].Exception);
+    }
+
+    [Fact]
+    public async Task SafeLogAsync_WhenLogActionReturnsFailure_LogsWarning()
+    {
+        var logger = new RecordingLogger();
+        var history = new FakeHistoryService(FakeBehavior.Fail);
+
+        await AuditLogWriter.SafeLogAsync(history, logger, "card", Guid.NewGuid(), AuditAction.Updated);
+
+        Assert.Contains(logger.Entries, e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact]
+    public async Task SafeLogAsync_WhenLogActionSucceeds_LogsNothing()
+    {
+        var logger = new RecordingLogger();
+        var history = new FakeHistoryService(FakeBehavior.Succeed);
+
+        await AuditLogWriter.SafeLogAsync(history, logger, "card", Guid.NewGuid(), AuditAction.Created);
+
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public async Task SafeLogAsync_WhenHistoryServiceNull_IsNoOp()
+    {
+        var logger = new RecordingLogger();
+
+        await AuditLogWriter.SafeLogAsync(null, logger, "card", Guid.NewGuid(), AuditAction.Created);
+
+        Assert.Empty(logger.Entries);
+    }
+
+    [Fact]
+    public async Task SafeLogAsync_WhenLoggerNull_StillNeverThrows()
+    {
+        var history = new FakeHistoryService(FakeBehavior.Throw);
+
+        // Older/optional call sites may pass a null logger; failure must still not crash the mutation.
+        var ex = await Record.ExceptionAsync(() =>
+            AuditLogWriter.SafeLogAsync(history, logger: null, "card", Guid.NewGuid(), AuditAction.Created));
+
+        Assert.Null(ex);
+    }
+
+    private enum FakeBehavior { Succeed, Fail, Throw }
+
+    private sealed class FakeHistoryService : IHistoryService
+    {
+        private readonly FakeBehavior _behavior;
+        public FakeHistoryService(FakeBehavior behavior) => _behavior = behavior;
+
+        public Task<Result> LogActionAsync(string entityType, Guid entityId, AuditAction action, Guid? userId = null, string? changes = null)
+            => _behavior switch
+            {
+                FakeBehavior.Throw => throw new InvalidOperationException("audit store unavailable"),
+                FakeBehavior.Fail => Task.FromResult(Result.Failure("AuditError", "could not write audit log")),
+                _ => Task.FromResult(Result.Success()),
+            };
+
+        public Task<Result<IEnumerable<AuditLogDto>>> GetBoardHistoryAsync(Guid boardId, int limit = 100) => throw new NotSupportedException();
+        public Task<Result<IEnumerable<AuditLogDto>>> GetEntityHistoryAsync(string entityType, Guid entityId, int limit = 100) => throw new NotSupportedException();
+        public Task<Result<IEnumerable<AuditLogDto>>> GetUserHistoryAsync(Guid userId, int limit = 100) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public readonly List<(LogLevel Level, Exception? Exception)> Entries = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/AuditLogWriterTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AuditLogWriterTests.cs
@@ -74,7 +74,21 @@ public class AuditLogWriterTests
         Assert.Null(ex);
     }
 
-    private enum FakeBehavior { Succeed, Fail, Throw }
+    [Fact]
+    public async Task SafeLogAsync_WhenLogActionReturnsNullResult_LogsWarningWithoutException()
+    {
+        var logger = new RecordingLogger();
+        var history = new FakeHistoryService(FakeBehavior.ReturnNull);
+
+        await AuditLogWriter.SafeLogAsync(history, logger, "card", Guid.NewGuid(), AuditAction.Created);
+
+        // A null result is classified as a failed write (Warning, no exception), not a throw/NRE.
+        var warnings = logger.Entries.Where(e => e.Level == LogLevel.Warning).ToList();
+        Assert.Single(warnings);
+        Assert.Null(warnings[0].Exception);
+    }
+
+    private enum FakeBehavior { Succeed, Fail, Throw, ReturnNull }
 
     private sealed class FakeHistoryService : IHistoryService
     {
@@ -86,6 +100,7 @@ public class AuditLogWriterTests
             {
                 FakeBehavior.Throw => throw new InvalidOperationException("audit store unavailable"),
                 FakeBehavior.Fail => Task.FromResult(Result.Failure("AuditError", "could not write audit log")),
+                FakeBehavior.ReturnNull => Task.FromResult<Result>(null!),
                 _ => Task.FromResult(Result.Success()),
             };
 


### PR DESCRIPTION
## Summary

First slice of #1134 — **acceptance criterion #1 only** ("one shared audit helper logging at Warning on failure (keep never-crash intent) + a test").

The identical empty-catch `SafeLogAsync` was copy-pasted in `BoardService`, `CardService`, `ColumnService`, and `LabelService`:

```csharp
try { await _historyService.LogActionAsync(...); }
catch (Exception) { /* Audit is secondary — never crash the mutation */ }
```

This swallowed audit-trail loss **silently** — invisible in a product whose thesis is trustworthy review history.

## Change

- New shared `AuditLogWriter.SafeLogAsync(historyService, logger, ...)` (Application layer). It keeps the never-crash intent but logs at **Warning** on failure — and surfaces **both** swallow paths the old code missed: a thrown exception **and** a returned failed `Result` (`LogActionAsync` returns `Task<Result>`, whose failure value was previously ignored).
- Each of the 4 services now delegates its private `SafeLogAsync` to the shared writer (call sites unchanged) and takes an optional `ILogger<T>`. `BoardService`'s DI factory passes the logger through; the others are auto-registered so DI injects it. The MCP host's minimal `BoardService` factory leaves it null (it also has no `IHistoryService`, so logging is a no-op there).

## Tests

`AuditLogWriterTests` — 5 cases: thrown exception → Warning (with exception) + no throw; returned `Result.Failure` → Warning; success → no log; null history → no-op; **null logger → still never throws**.

## Verification (local, Debug)

Solution builds clean. Regression sweep `Audit | History | GoldenPath | Board | Card | Column | Label` across the solution: **Domain 300, Application 839, Api 498, Cli 32, Architecture 1, Integration 12 — 0 failures.**

## Scope

**Refs #1134 (AC #1).** This is the deliberately-narrow first slice. The remaining 6 acceptance criteria stay open in #1134: regex-timeout catch logging/dedupe, migration-folder consolidation, `ParseInstructionAsync`/LLM-provider decomposition, credential blob key-id/versioning + re-auth state, MCP identity fail-closed, and MCP last-used write debounce.

Not merging — for review (2 adversarial passes per merge policy).
