### PR TITLE
Core-loop correctness: real #678 expiry test, Approved+expired dismiss, quiet provenance 404 (#1124)

### DIFF
--- a/OUTSTANDING_TASKS.md
+++ b/OUTSTANDING_TASKS.md
@@ -39,7 +39,7 @@ Last reviewed: 2026-05-31
 - [ ] **#1132** — Make the required PR gate enforce security: gitleaks/SAST/dependency scan + CORS fail-closed + single ≥32 JWT floor + global `FallbackPolicy` + bundle-size in the required lane.
 - [ ] **#1130** — SQLite local concurrency: enable WAL + `busy_timeout`, fix per-process `Migrate()` race (UI + MCP + CLI share one DB → `SQLITE_BUSY`).
 - [ ] **#1131** — CLI hardening: fresh-machine bootstrap (it crashes without `Connectors:EncryptionKey`) + route CLI mutations through board-access authorization.
-- [ ] **#1124** — Core-loop polish: fix the false-green expiry regression test + the #678 frontend dismiss gap (Approved+expired) + the #680 provenance-404 console noise.
+- [ ] **#1124** — Core-loop polish: fix the false-green expiry regression test + the #678 frontend dismiss gap (Approved+expired) + the #680 provenance-404 console noise. *PR #1162 addresses all three (expiry test → 409, `isProposalDismissable` + Legacy dismiss, provenance opt-out). Paper view has no dismiss affordance for any status — split to **#1161** — so AC2's Paper portion remains open under #1161.*
 - [ ] **#1138** (rest) — Split the 1300+ line `STATUS.md` into a lean current-reality head + `docs/archive/status-history/`; add a rotation rule; recertify TESTING_GUIDE totals from a green CI run; add a markdown link-checker to nightly.
 - [ ] **#1136** — Write an ADR deciding the Paper vs Legacy UI question; remove dead paper composables.
 - [ ] **#1137** — Refocus strategy/roadmap on shipping to first users; freeze new feature/re-skin tracks until v0.1.0 ships.

--- a/backend/tests/Taskdeck.Api.Tests/LiveBrowserRegressionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LiveBrowserRegressionApiTests.cs
@@ -111,38 +111,42 @@ public class LiveBrowserRegressionApiTests : IClassFixture<TestWebApplicationFac
     // =================================================================
 
     /// <summary>
-    /// Confirms bug #678: the approve endpoint does NOT currently reject expired proposals.
-    /// The domain entity Approve() checks DateTime.UtcNow > ExpiresAt, but the service layer
-    /// may serve the approval from a cached EF entity or the ExpiresAt check may not be
-    /// reached before status transition. This test documents the bug — once #678 is fixed,
-    /// flip the assertion to expect rejection.
+    /// Bug #678: an expired proposal must not be approvable. <see cref="AutomationProposal.Approve"/>
+    /// throws <c>DomainException(InvalidOperation, "Cannot approve expired proposal")</c> once
+    /// <c>DateTime.UtcNow &gt; ExpiresAt</c>, which the API surfaces as 409 Conflict.
     /// </summary>
+    /// <remarks>
+    /// The earlier version of this test expired the row with raw SQL keyed on the GUID rendered
+    /// as a lowercase string, which did not match EF's stored representation — so zero rows were
+    /// updated, the proposal stayed live, and the test was a false-green no-op asserting 200 OK.
+    /// We now expire it through the EF context (LINQ id match + writing ExpiresAt via the change
+    /// tracker), which is storage-format agnostic and genuinely exercises the expiry guard.
+    /// </remarks>
     [Fact]
-    public async Task ApproveProposal_WhenExpired_CurrentlySucceeds_Bug678()
+    public async Task ApproveProposal_WhenExpired_ReturnsConflict()
     {
-        // Arrange: create a proposal, then directly expire it in the DB
+        // Arrange: create a proposal, then genuinely expire it through EF.
         var userId = await AuthenticateAsync("expired-approve");
         var boardId = await CreateOwnedBoardAsync(userId);
         var proposal = await CreateTestProposal(userId, boardId);
 
-        // Force expiry by setting ExpiresAt to the past via raw SQL
         using (var scope = _factory.Services.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
-            db.Database.ExecuteSqlRaw(
-                "UPDATE AutomationProposals SET ExpiresAt = '2020-01-01T00:00:00Z' WHERE Id = {0}",
-                proposal.Id.ToString());
+            var entity = await db.Set<AutomationProposal>().FirstAsync(p => p.Id == proposal.Id);
+            // ExpiresAt has a private setter; write it through the change tracker so the
+            // persisted row is genuinely expired regardless of Guid/DateTime storage format.
+            db.Entry(entity).Property(nameof(AutomationProposal.ExpiresAt)).CurrentValue =
+                DateTime.UtcNow.AddMinutes(-5);
+            await db.SaveChangesAsync();
         }
 
-        // Act: attempt to approve the expired proposal
+        // Act: attempt to approve the now-expired proposal.
         var approveResponse = await _client.PostAsync(
             $"/api/automation/proposals/{proposal.Id}/approve", null);
 
-        // BUG #678: This SHOULD return 400/409 but currently returns 200.
-        // When #678 is fixed, change this assertion to:
-        //   approveResponse.StatusCode.Should().BeOneOf(HttpStatusCode.Conflict, HttpStatusCode.BadRequest);
-        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK,
-            "bug #678: expired proposals are currently approvable — this test documents the bug");
+        // Assert: expired -> Approve() throws InvalidOperation -> 409 Conflict.
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [Fact]

--- a/frontend/taskdeck-web/src/api/cardsApi.ts
+++ b/frontend/taskdeck-web/src/api/cardsApi.ts
@@ -33,7 +33,13 @@ export const cardsApi = {
 
   async getCardProvenance(boardId: string, cardId: string): Promise<CardCaptureProvenance | null> {
     try {
-      const { data } = await http.get<CardCaptureProvenance>(`/boards/${boardId}/cards/${cardId}/provenance`)
+      // A 404 here is an expected part of the contract — manual cards have no
+      // capture provenance. Mark it expected so the http interceptor does not
+      // log it as an API error (issue #680 console/Sentry noise).
+      const { data } = await http.get<CardCaptureProvenance>(
+        `/boards/${boardId}/cards/${cardId}/provenance`,
+        { expectedStatuses: [404] } as Record<string, unknown>,
+      )
       return data
     } catch (e: unknown) {
       const candidate = e as { response?: { status?: number; data?: { message?: string } } } | null

--- a/frontend/taskdeck-web/src/api/cardsApi.ts
+++ b/frontend/taskdeck-web/src/api/cardsApi.ts
@@ -38,7 +38,7 @@ export const cardsApi = {
       // log it as an API error (issue #680 console/Sentry noise).
       const { data } = await http.get<CardCaptureProvenance>(
         `/boards/${boardId}/cards/${cardId}/provenance`,
-        { expectedStatuses: [404] } as Record<string, unknown>,
+        { expectedStatuses: [404] },
       )
       return data
     } catch (e: unknown) {

--- a/frontend/taskdeck-web/src/api/http.ts
+++ b/frontend/taskdeck-web/src/api/http.ts
@@ -52,16 +52,26 @@ http.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response) {
-      // Log only safe, non-sensitive details -- never the full error object,
-      // which includes error.config.headers (Authorization: Bearer ...).
-      const safeDetails = {
-        status: error.response?.status,
-        statusText: error.response?.statusText,
-        data: error.response?.data,
-        url: error.config?.url,
-        method: error.config?.method,
+      // Callers can set `expectedStatuses` on the request config to mark certain
+      // error statuses as an expected part of that endpoint's contract (e.g. a 404
+      // from the optional card-provenance lookup for manual cards). Those are not
+      // logged as errors, which keeps the console and Sentry free of benign noise.
+      const expectedStatuses = (error.config as Record<string, unknown> | undefined)?.expectedStatuses
+      const isExpectedStatus =
+        Array.isArray(expectedStatuses) && expectedStatuses.includes(error.response.status)
+
+      if (!isExpectedStatus) {
+        // Log only safe, non-sensitive details -- never the full error object,
+        // which includes error.config.headers (Authorization: Bearer ...).
+        const safeDetails = {
+          status: error.response?.status,
+          statusText: error.response?.statusText,
+          data: error.response?.data,
+          url: error.config?.url,
+          method: error.config?.method,
+        }
+        logError('API Error:', safeDetails)
       }
-      logError('API Error:', safeDetails)
 
       // Handle 401 - clear session and redirect to login (skip in demo mode).
       // Callers can set `skipAuth401` on the request config to suppress this

--- a/frontend/taskdeck-web/src/api/http.ts
+++ b/frontend/taskdeck-web/src/api/http.ts
@@ -12,6 +12,20 @@ import {
   type RetryableRequestConfig,
 } from './httpRetry'
 
+// Augment axios so custom Taskdeck request options are type-checked at call
+// sites (a misspelled key becomes a compile error instead of silently no-op).
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    /**
+     * Error statuses that are an expected part of this endpoint's contract
+     * (e.g. a 404 from the optional card-provenance lookup for manual cards).
+     * The response interceptor will not log these as API errors. See
+     * `cardsApi.getCardProvenance`.
+     */
+    expectedStatuses?: number[]
+  }
+}
+
 const REQUEST_ID_HEADER = 'X-Request-Id'
 
 function ensureRequestIdHeader(config: InternalAxiosRequestConfig): void {
@@ -56,7 +70,7 @@ http.interceptors.response.use(
       // error statuses as an expected part of that endpoint's contract (e.g. a 404
       // from the optional card-provenance lookup for manual cards). Those are not
       // logged as errors, which keeps the console and Sentry free of benign noise.
-      const expectedStatuses = (error.config as Record<string, unknown> | undefined)?.expectedStatuses
+      const expectedStatuses = (error.config as InternalAxiosRequestConfig | undefined)?.expectedStatuses
       const isExpectedStatus =
         Array.isArray(expectedStatuses) && expectedStatuses.includes(error.response.status)
 

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -138,13 +138,16 @@ export function useReviewProposals() {
 
   function isProposalDismissable(proposal: ApiProposal): boolean {
     const status = normalizeProposalStatus(proposal.status)
-    if (status === 'Applied' || status === 'Rejected' || status === 'Failed' || status === 'Expired') {
-      return true
-    }
-    // Mirror backend AutomationProposal.CanBeDismissed: an Approved proposal that
-    // expired before it was executed can no longer be applied, so it stays
-    // dismissable (otherwise it lingers in Review with no way to clear it). #1124
-    return status === 'Approved' && isProposalExpired(proposal)
+    return (
+      status === 'Applied' ||
+      status === 'Rejected' ||
+      status === 'Failed' ||
+      status === 'Expired' ||
+      // Mirror backend AutomationProposal.CanBeDismissed: an Approved proposal that
+      // expired before it was executed can no longer be applied, so it stays
+      // dismissable (otherwise it lingers in Review with no way to clear it). #1124
+      (status === 'Approved' && isProposalExpired(proposal))
+    )
   }
 
   const dismissableProposalIds = computed(() =>

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -138,7 +138,13 @@ export function useReviewProposals() {
 
   function isProposalDismissable(proposal: ApiProposal): boolean {
     const status = normalizeProposalStatus(proposal.status)
-    return status === 'Applied' || status === 'Rejected' || status === 'Failed' || status === 'Expired'
+    if (status === 'Applied' || status === 'Rejected' || status === 'Failed' || status === 'Expired') {
+      return true
+    }
+    // Mirror backend AutomationProposal.CanBeDismissed: an Approved proposal that
+    // expired before it was executed can no longer be applied, so it stays
+    // dismissable (otherwise it lingers in Review with no way to clear it). #1124
+    return status === 'Approved' && isProposalExpired(proposal)
   }
 
   const dismissableProposalIds = computed(() =>

--- a/frontend/taskdeck-web/src/tests/api/cardsApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/cardsApi.spec.ts
@@ -132,7 +132,12 @@ describe('cardsApi', () => {
 
       const result = await cardsApi.getCardProvenance('board-1', 'card-1')
 
-      expect(http.get).toHaveBeenCalledWith('/boards/board-1/cards/card-1/provenance')
+      // A 404 here is an expected absence (manual cards have no provenance), so
+      // the request opts the http interceptor out of logging it as an API error.
+      expect(http.get).toHaveBeenCalledWith(
+        '/boards/board-1/cards/card-1/provenance',
+        { expectedStatuses: [404] },
+      )
       expect(result).toEqual(provenance)
     })
 

--- a/frontend/taskdeck-web/src/tests/api/http.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/http.spec.ts
@@ -49,6 +49,15 @@ const navigationMock = vi.hoisted(() => ({
 }))
 vi.mock('../../utils/navigation', () => navigationMock)
 
+// Spy on the error-reporting sink so we can assert what the response
+// interceptor does (and does not) log. Harmless for the other suites, which
+// don't assert on it — it just suppresses real console output.
+const errorReportingMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}))
+vi.mock('../../utils/errorReporting', () => errorReportingMock)
+
 // ─── Module imports (after mocks) ───────────────────────────────────────────
 
 import http from '../../api/http'
@@ -274,6 +283,59 @@ describe('http interceptors (#725)', () => {
       await expect(http.get('/test')).rejects.toThrow()
 
       expect(clearSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Response interceptor: expectedStatuses opt-out (#680) ─────────────
+  // Endpoints whose error status is part of their contract (e.g. the optional
+  // card-provenance 404 for manual cards) can pass `expectedStatuses` so the
+  // interceptor does not log them as API errors.
+  describe('response interceptor — expectedStatuses opt-out (#680)', () => {
+    beforeEach(() => {
+      vi.spyOn(tokenStorage, 'getToken').mockReturnValue(null)
+      errorReportingMock.logError.mockClear()
+    })
+
+    const apiErrorLogCount = () =>
+      errorReportingMock.logError.mock.calls.filter((args) => args[0] === 'API Error:').length
+
+    it('does not log an API error for a status listed in expectedStatuses', async () => {
+      mock.onGet('/provenance').reply(404, { message: 'Capture provenance not found' })
+
+      await expect(
+        http.get('/provenance', { expectedStatuses: [404] } as Record<string, unknown>),
+      ).rejects.toMatchObject({ response: { status: 404 } })
+
+      expect(apiErrorLogCount()).toBe(0)
+    })
+
+    it('still rejects so the caller can handle the expected status', async () => {
+      mock.onGet('/provenance').reply(404, { message: 'Capture provenance not found' })
+
+      await expect(
+        http.get('/provenance', { expectedStatuses: [404] } as Record<string, unknown>),
+      ).rejects.toMatchObject({ response: { status: 404 } })
+    })
+
+    it('logs an API error for a status NOT in expectedStatuses', async () => {
+      mock.onGet('/provenance').reply(500, { message: 'boom' })
+
+      await expect(
+        http.get('/provenance', {
+          expectedStatuses: [404],
+          skipRetry: true,
+        } as Record<string, unknown>),
+      ).rejects.toMatchObject({ response: { status: 500 } })
+
+      expect(apiErrorLogCount()).toBeGreaterThan(0)
+    })
+
+    it('logs an API error for an error response when no expectedStatuses is set', async () => {
+      mock.onGet('/normal').reply(404, { message: 'Not Found' })
+
+      await expect(http.get('/normal')).rejects.toMatchObject({ response: { status: 404 } })
+
+      expect(apiErrorLogCount()).toBeGreaterThan(0)
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -231,6 +231,21 @@ describe('useReviewProposals', () => {
       ] as any
       expect(rp.dismissableProposalIds.value).toEqual(['1', '3', '4', '5'])
     })
+
+    it('includes an Approved proposal that has expired but not a live one (#1124)', () => {
+      const rp = useReviewProposals()
+      rp.nowMs.value = new Date('2026-06-04T00:00:00Z').getTime()
+      rp.proposals.value = [
+        // Approved + already past expiresAt -> can no longer be applied, so dismissable
+        // (mirrors backend AutomationProposal.CanBeDismissed).
+        makeProposal({ id: 'a-expired', status: 'Approved', expiresAt: '2026-05-01T00:00:00Z' }),
+        // Approved + still valid -> NOT dismissable, it can still be executed.
+        makeProposal({ id: 'a-live', status: 'Approved', expiresAt: '2099-01-01T00:00:00Z' }),
+        // Pending + live -> NOT dismissable.
+        makeProposal({ id: 'p-live', status: 'PendingReview', expiresAt: '2099-01-01T00:00:00Z' }),
+      ] as any
+      expect(rp.dismissableProposalIds.value).toEqual(['a-expired'])
+    })
   })
 
   describe('loadProposals', () => {


### PR DESCRIPTION
## What & why

Core-loop correctness fixes from #1124 — the review-first capture→proposal→apply loop is the product thesis, and these three defects each eroded trust in it.

### (a) Genuinely expire the #678 regression test → assert 409 (`test(api)`)
`ApproveProposal_WhenExpired_CurrentlySucceeds_Bug678` expired the row with raw SQL keyed on the GUID rendered as a lowercase string, which did not match EF's stored representation — **0 rows updated**, the proposal stayed live, and the test asserted **200 OK**: a false-green no-op that tested nothing. The live guard was always intact (`AutomationProposal.Approve()` throws `InvalidOperation` on expiry → 409). Now expired through the EF change tracker (LINQ id match + `Entry().Property(ExpiresAt)`), which is storage-format agnostic, and asserts **409 Conflict**. Renamed to `ApproveProposal_WhenExpired_ReturnsConflict`.

### (b) Treat Approved+expired proposals as dismissable (`fix(web)`, #678)
`isProposalDismissable` returned true only for Applied/Rejected/Failed/Expired, diverging from backend `AutomationProposal.CanBeDismissed` which also allows an **Approved proposal that expired before execution**. Those were excluded from the bulk "Clear completed" count and lingered in Review. Aligned the composable with the backend + added a fixture.

This surfaces the dismiss control in the **Legacy/default** review view (its per-card Dismiss is gated on `isExpired`, and the bulk count now includes these). The **Paper** review view has **no dismiss affordance for any status** — a broader pre-existing gap discovered here, tracked separately in **#1161** to keep this diff scoped.

### (c) Silence the benign card-provenance 404 (`fix(web)`, #680)
The http response interceptor `logError`'d every error response, so opening any manual card (no capture provenance) emitted a 404 "API Error:" to console + Sentry even though `getCardProvenance` handles it as empty state. Added a per-request `expectedStatuses` opt-out: listed statuses are treated as part of the endpoint's contract and not logged. `getCardProvenance` passes `{ expectedStatuses: [404] }`.

## Verification
- `ApproveProposal_WhenExpired_ReturnsConflict`: passes (genuine expiry → 409).
- `http.spec.ts` + `cardsApi.spec.ts`: 50 pass (incl. new opt-out tests: silent for expected status, still rejects, logs for unexpected / no opt-out).
- `useReviewProposals.spec.ts`: 40 pass (incl. new Approved+expired fixture).
- Frontend `vue-tsc` typecheck: clean. ESLint on touched files: clean.

## Scope notes
- Relates to **#1124** (addresses parts a + c fully, b for the Legacy/default view). The Paper dismiss affordance is tracked in **#1161**.
- Addresses the underlying #678 (expiry/dismiss) and #680 (provenance noise) defects.

Each PR gets 2 independent adversarial reviews before merge (per repo policy); all findings of every severity will be fixed.
