### PR TITLE
Fix flaky WIP-limit smoke test (await the rejection before asserting the toast)

### DIFF
--- a/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
@@ -103,20 +103,28 @@ async function addCard(
   const addCardInput = column.getByPlaceholder('Enter card title...')
   await expect(addCardInput).toBeVisible()
   await addCardInput.fill(cardTitle)
-  // Wait for the create POST to settle in BOTH cases: a success (2xx) when the
-  // card is expected, or the rejection (non-2xx, e.g. 409 WIP-limit) when it is
-  // not. Awaiting the rejection is what lets callers assert the transient
-  // rejection toast without racing the still-in-flight request (the toast can
-  // auto-dismiss before a non-awaited request even returns).
-  const createCardResponse = page.waitForResponse((response) =>
-    response.request().method() === 'POST'
-    && /\/api\/boards\/[a-f0-9-]+\/cards$/i.test(response.url())
-    && (expectVisible ? response.ok() : !response.ok()))
+  // Wait for the create POST to settle (any status) before asserting anything.
+  // Awaiting the response is what lets callers assert the transient rejection
+  // toast without racing the still-in-flight request (the toast can auto-dismiss
+  // before a non-awaited request even returns). Bound the wait so an unexpected
+  // outcome fails fast rather than hanging to the test timeout.
+  const createCardResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST'
+      && /\/api\/boards\/[a-f0-9-]+\/cards$/i.test(response.url()),
+    { timeout: 15_000 },
+  )
   await column.getByRole('button', { name: 'Add', exact: true }).click()
-  await createCardResponse
+  const created = await createCardResponse
 
   if (expectVisible) {
+    expect(created.ok(), 'card create should succeed').toBeTruthy()
     await expect(cardByTitle(page, cardTitle)).toBeVisible()
+  } else {
+    // A card added beyond the WIP limit must be rejected (WipLimitExceeded -> 400).
+    // Asserting this turns a WIP-enforcement regression (a 2xx here) into an
+    // explicit failure instead of a downstream toast/count timeout.
+    expect(created.ok(), 'card add beyond the WIP limit should be rejected').toBeFalsy()
   }
 }
 

--- a/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
@@ -103,16 +103,17 @@ async function addCard(
   const addCardInput = column.getByPlaceholder('Enter card title...')
   await expect(addCardInput).toBeVisible()
   await addCardInput.fill(cardTitle)
-  const createCardResponse = expectVisible
-    ? page.waitForResponse((response) =>
-      response.request().method() === 'POST'
-      && /\/api\/boards\/[a-f0-9-]+\/cards$/i.test(response.url())
-      && response.ok())
-    : null
+  // Wait for the create POST to settle in BOTH cases: a success (2xx) when the
+  // card is expected, or the rejection (non-2xx, e.g. 409 WIP-limit) when it is
+  // not. Awaiting the rejection is what lets callers assert the transient
+  // rejection toast without racing the still-in-flight request (the toast can
+  // auto-dismiss before a non-awaited request even returns).
+  const createCardResponse = page.waitForResponse((response) =>
+    response.request().method() === 'POST'
+    && /\/api\/boards\/[a-f0-9-]+\/cards$/i.test(response.url())
+    && (expectVisible ? response.ok() : !response.ok()))
   await column.getByRole('button', { name: 'Add', exact: true }).click()
-  if (createCardResponse) {
-    await createCardResponse
-  }
+  await createCardResponse
 
   if (expectVisible) {
     await expect(cardByTitle(page, cardTitle)).toBeVisible()
@@ -325,8 +326,11 @@ test('column WIP limit should reject additional cards', async ({ page }) => {
   await expect(page.locator('[data-card-id]').filter({ hasText: firstCard }).first()).toBeVisible()
 
   await addCard(page, columnName, secondCard, { expectVisible: false })
-  await expect(page.locator('[data-card-id]').filter({ hasText: secondCard })).toHaveCount(0)
+  // Assert the (transient) rejection toast first — addCard has now awaited the
+  // rejecting response, so the toast is freshly rendered here; checking it
+  // before the card-count assertion avoids racing its auto-dismiss.
   await expect(page.locator('text=has reached its WIP limit').first()).toBeVisible()
+  await expect(page.locator('[data-card-id]').filter({ hasText: secondCard })).toHaveCount(0)
 })
 
 test('card drag and drop should move card between columns and persist after refresh', async ({ page }) => {


### PR DESCRIPTION
## What & why
`column WIP limit should reject additional cards` (`frontend/taskdeck-web/tests/e2e/smoke.spec.ts:290`) is intermittently flaky — it failed on PR #1158's CI (151 passed / 1 failed) on a change (a gitleaks workflow comment) that cannot possibly affect it.

**Root cause:** the test's `addCard(secondCard, { expectVisible: false })` helper did **not** await the create `POST` (it only set up a `waitForResponse` for the success case). So when the test then asserted the transient `text=has reached its WIP limit` toast, it was racing the still-in-flight 409 — under worker CPU contention the toast could auto-dismiss, or not yet render, before the 8s `toBeVisible` window, and the assertion failed with "element(s) not found".

## Fix
- `addCard` now awaits the create response in **both** branches: a 2xx when the card is expected, or the non-2xx rejection (e.g. 409 WIP-limit) when it is not. Awaiting the rejection is what lets a caller assert the rejection toast deterministically.
- The WIP test asserts the (transient) toast **immediately after** that awaited response — before its auto-dismiss — then asserts the card count is 0.
- Only the WIP test uses `expectVisible: false`; the success-path matcher is unchanged, so all other `addCard` callers are unaffected.

## Verification
- ESLint on the spec: clean. Only one `expectVisible: false` caller (the WIP test).
- E2E can't be exercised meaningfully on this dev box (needs the full app + many runs to characterise flakiness); the change is strictly more correct (it adds a wait that previously didn't exist) and is validated by the E2E Smoke CI job. Reasoning is laid out above for adversarial review.

Relates to #1128 (harden the test loop for agents).