### PR TITLE
perf: bound notification paging + AsSplitQuery card reads (Part of #1133)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/CardRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/CardRepository.cs
@@ -17,6 +17,9 @@ public class CardRepository : Repository<Card>, ICardRepository
             .Where(c => c.BoardId == boardId)
             .Include(c => c.CardLabels)
                 .ThenInclude(cl => cl.Label)
+            // Split the Cards->CardLabels->Label collection fan-out into separate queries
+            // to avoid a cartesian row explosion on the hottest board read path.
+            .AsSplitQuery()
             .OrderBy(c => c.ColumnId)
                 .ThenBy(c => c.Position)
             .ToListAsync(cancellationToken);
@@ -36,6 +39,8 @@ public class CardRepository : Repository<Card>, ICardRepository
             .Where(card => materializedBoardIds.Contains(card.BoardId))
             .Include(card => card.CardLabels)
                 .ThenInclude(cardLabel => cardLabel.Label)
+            // Split the collection fan-out to avoid a cartesian product across boards.
+            .AsSplitQuery()
             .OrderBy(card => card.BoardId)
                 .ThenBy(card => card.ColumnId)
             .ThenBy(card => card.Position)
@@ -69,6 +74,8 @@ public class CardRepository : Repository<Card>, ICardRepository
             .Where(c => c.ColumnId == columnId)
             .Include(c => c.CardLabels)
                 .ThenInclude(cl => cl.Label)
+            // Split the collection fan-out to avoid a cartesian product over the column's cards.
+            .AsSplitQuery()
             .OrderBy(c => c.Position)
             .ToListAsync(cancellationToken);
     }
@@ -102,6 +109,8 @@ public class CardRepository : Repository<Card>, ICardRepository
         }
 
         return await query
+            // Split the Cards->CardLabels->Label collection fan-out to avoid a cartesian product.
+            .AsSplitQuery()
             .OrderBy(c => c.ColumnId)
                 .ThenBy(c => c.Position)
             .ToListAsync(cancellationToken);

--- a/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
@@ -45,7 +45,9 @@ public class NotificationRepository : Repository<Notification>, INotificationRep
                 parameters.Add(boardId.Value);
             }
 
-            sql.Append(" ORDER BY CreatedAt DESC");
+            // Id is a deterministic tiebreaker so offset paging stays consistent when
+            // two notifications share the same CreatedAt (mirrors BoardRepository.SearchIdsAsync).
+            sql.Append(" ORDER BY CreatedAt DESC, Id");
             sql.Append(" LIMIT {").Append(parameters.Count).Append('}');
             parameters.Add(boundedLimit);
             sql.Append(" OFFSET {").Append(parameters.Count).Append('}');
@@ -73,6 +75,7 @@ public class NotificationRepository : Repository<Notification>, INotificationRep
 
         return await query
             .OrderByDescending(n => n.CreatedAt)
+            .ThenBy(n => n.Id)
             .Skip(boundedOffset)
             .Take(boundedLimit)
             .ToListAsync(cancellationToken);

--- a/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
@@ -19,6 +20,44 @@ public class NotificationRepository : Repository<Notification>, INotificationRep
         CancellationToken cancellationToken = default,
         int offset = 0)
     {
+        // Clamp to non-negative so paging stays bounded. A negative LIMIT in SQLite
+        // means "no limit", which would silently restore the unbounded fetch this fix removes.
+        var boundedLimit = limit < 0 ? 0 : limit;
+        var boundedOffset = offset < 0 ? 0 : offset;
+
+        if (_context.Database.IsSqlite())
+        {
+            // SQLite cannot translate DateTimeOffset ORDER BY from LINQ (see ADR-0023),
+            // so push ordering + paging into raw SQL. This keeps ORDER BY + LIMIT/OFFSET in
+            // the database (newest first) instead of materializing every matching row and
+            // sorting/slicing in memory. Mirrors the AgentRunRepository SQLite pattern.
+            var sql = new StringBuilder("SELECT * FROM Notifications WHERE UserId = {0}");
+            var parameters = new List<object> { userId };
+
+            if (unreadOnly)
+            {
+                sql.Append(" AND IsRead = 0");
+            }
+
+            if (boardId.HasValue)
+            {
+                sql.Append(" AND BoardId = {").Append(parameters.Count).Append('}');
+                parameters.Add(boardId.Value);
+            }
+
+            sql.Append(" ORDER BY CreatedAt DESC");
+            sql.Append(" LIMIT {").Append(parameters.Count).Append('}');
+            parameters.Add(boundedLimit);
+            sql.Append(" OFFSET {").Append(parameters.Count).Append('}');
+            parameters.Add(boundedOffset);
+
+            return await _dbSet
+                .FromSqlRaw(sql.ToString(), parameters.ToArray())
+                .ToListAsync(cancellationToken);
+        }
+
+        // Non-SQLite providers (e.g. PostgreSQL) translate DateTimeOffset ordering natively,
+        // so keep the strongly-typed LINQ query and push ORDER BY + Skip/Take into SQL.
         var query = _dbSet
             .Where(n => n.UserId == userId);
 
@@ -32,12 +71,11 @@ public class NotificationRepository : Repository<Notification>, INotificationRep
             query = query.Where(n => n.BoardId == boardId.Value);
         }
 
-        var notifications = await query.ToListAsync(cancellationToken);
-        return notifications
+        return await query
             .OrderByDescending(n => n.CreatedAt)
-            .Skip(offset)
-            .Take(limit)
-            .ToList();
+            .Skip(boundedOffset)
+            .Take(boundedLimit)
+            .ToListAsync(cancellationToken);
     }
 
     public async Task<Notification?> GetByUserAndDeduplicationKeyAsync(

--- a/backend/tests/Taskdeck.Api.Tests/CardRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CardRepositoryIntegrationTests.cs
@@ -275,6 +275,66 @@ public class CardRepositoryIntegrationTests : IClassFixture<TestWebApplicationFa
         idx1.Should().BeLessThan(idx2);
     }
 
+    /// <summary>
+    /// Regression for #1133: <see cref="ICardRepository.GetByBoardIdAsync"/> uses
+    /// <c>AsSplitQuery()</c> to avoid a cartesian fan-out across the CardLabels-&gt;Label
+    /// collection. The split query must not change results: every card appears exactly once,
+    /// with all of its labels loaded, ordered by position within the column.
+    /// </summary>
+    [Fact]
+    public async Task GetByBoardIdAsync_WithMultipleLabels_LoadsAllLabelsWithoutDuplicatingCards()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<ICardRepository>();
+
+        var user = new User("card-split-user", "card-split@example.com", "hash");
+        db.Users.Add(user);
+
+        var board = new Board("Split query board", ownerId: user.Id);
+        db.Boards.Add(board);
+
+        // Single column so ordering is by Position (avoids GUID-based ColumnId ordering).
+        var col = new Column(board.Id, "Todo", 0);
+        db.Columns.Add(col);
+
+        var labelX = new Label(board.Id, "Urgent", "#FF0000");
+        var labelY = new Label(board.Id, "Backend", "#00FF00");
+        db.Labels.AddRange(labelX, labelY);
+
+        // card0 has TWO labels (the case a cartesian single query would fan out),
+        // card1 has ONE label, card2 has NONE.
+        var card0 = new Card(board.Id, col.Id, "Card 0", position: 0);
+        var card1 = new Card(board.Id, col.Id, "Card 1", position: 1);
+        var card2 = new Card(board.Id, col.Id, "Card 2", position: 2);
+        db.Cards.AddRange(card0, card1, card2);
+        await db.SaveChangesAsync();
+
+        db.CardLabels.AddRange(
+            new CardLabel(card0.Id, labelX.Id),
+            new CardLabel(card0.Id, labelY.Id),
+            new CardLabel(card1.Id, labelX.Id));
+        await db.SaveChangesAsync();
+
+        var results = (await repo.GetByBoardIdAsync(board.Id)).ToList();
+
+        // Split query must not duplicate or drop root rows.
+        results.Should().HaveCount(3);
+        results.Select(c => c.Id).Should().OnlyHaveUniqueItems();
+
+        // Ordered by Position within the column.
+        results[0].Id.Should().Be(card0.Id);
+        results[1].Id.Should().Be(card1.Id);
+        results[2].Id.Should().Be(card2.Id);
+
+        // All labels are loaded for each card.
+        results[0].CardLabels.Select(cl => cl.Label.Name)
+            .Should().BeEquivalentTo(new[] { "Urgent", "Backend" });
+        results[1].CardLabels.Select(cl => cl.Label.Name)
+            .Should().BeEquivalentTo(new[] { "Urgent" });
+        results[2].CardLabels.Should().BeEmpty();
+    }
+
     [Fact]
     public async Task GetAgendaByBoardIdsAsync_ShouldReturnOnlyBlockedOrDueDateCards()
     {

--- a/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
@@ -306,4 +306,52 @@ public class NotificationRepositoryIntegrationTests : IClassFixture<TestWebAppli
         page[0].Id.Should().Be(notifications[3].Id);
         page[1].Id.Should().Be(notifications[2].Id);
     }
+
+    /// <summary>
+    /// Regression for #1133: when notifications share the same <c>CreatedAt</c>, offset paging
+    /// must remain deterministic (no skipped or duplicated rows across pages). A secondary
+    /// sort on <c>Id</c> provides the stable tiebreaker.
+    /// </summary>
+    [Fact]
+    public async Task GetByUserIdAsync_WithTiedCreatedAt_PagesDeterministicallyWithoutGapsOrDuplicates()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
+
+        var user = new User("notif-tie-user", "notif-tie@example.com", "hash");
+        db.Users.Add(user);
+
+        var notifications = new List<Notification>();
+        for (var i = 0; i < 4; i++)
+        {
+            var notif = new Notification(
+                user.Id, NotificationType.System, NotificationCadence.Immediate,
+                $"Tie notif {i}", $"Message {i}");
+            notifications.Add(notif);
+            db.Notifications.Add(notif);
+        }
+        await db.SaveChangesAsync();
+
+        // Two pairs of rows that share an identical timestamp (forces the tiebreaker).
+        var groupA = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero);
+        var groupB = groupA.AddSeconds(1);
+        db.Entry(notifications[0]).Property(nameof(Entity.CreatedAt)).CurrentValue = groupA;
+        db.Entry(notifications[1]).Property(nameof(Entity.CreatedAt)).CurrentValue = groupA;
+        db.Entry(notifications[2]).Property(nameof(Entity.CreatedAt)).CurrentValue = groupB;
+        db.Entry(notifications[3]).Property(nameof(Entity.CreatedAt)).CurrentValue = groupB;
+        await db.SaveChangesAsync();
+
+        var page1 = (await repo.GetByUserIdAsync(user.Id, limit: 2, offset: 0)).ToList();
+        var page2 = (await repo.GetByUserIdAsync(user.Id, limit: 2, offset: 2)).ToList();
+
+        // Repeated identical query returns the same order (deterministic).
+        var page1Again = (await repo.GetByUserIdAsync(user.Id, limit: 2, offset: 0)).ToList();
+        page1Again.Select(n => n.Id).Should().Equal(page1.Select(n => n.Id));
+
+        // The two pages together cover every row exactly once: no gaps, no duplicates.
+        var combined = page1.Concat(page2).Select(n => n.Id).ToList();
+        combined.Should().OnlyHaveUniqueItems();
+        combined.Should().BeEquivalentTo(notifications.Select(n => n.Id));
+    }
 }

--- a/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
@@ -261,4 +261,49 @@ public class NotificationRepositoryIntegrationTests : IClassFixture<TestWebAppli
         // DESC: second (newer) should appear before first (older)
         secondIdx.Should().BeLessThan(firstIdx, "DESC: newer before older");
     }
+
+    /// <summary>
+    /// Regression for #1133: paging must be pushed into SQL (ORDER BY + LIMIT/OFFSET),
+    /// not done in memory after materializing every matching row. Seeds more rows than the
+    /// page size and asserts the returned page is exactly the expected newest-first slice and
+    /// is bounded to <c>limit</c> rows.
+    /// </summary>
+    [Fact]
+    public async Task GetByUserIdAsync_WithPaging_ReturnsExactNewestFirstSliceBoundedToLimit()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
+
+        var user = new User("notif-slice-user", "notif-slice@example.com", "hash");
+        db.Users.Add(user);
+
+        // Seed 5 notifications (> page size) with strictly increasing timestamps.
+        var baseTime = new DateTimeOffset(2024, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var notifications = new List<Notification>();
+        for (var i = 0; i < 5; i++)
+        {
+            var notif = new Notification(
+                user.Id, NotificationType.System, NotificationCadence.Immediate,
+                $"Slice notif {i}", $"Message {i}");
+            notifications.Add(notif);
+            db.Notifications.Add(notif);
+        }
+        await db.SaveChangesAsync();
+
+        for (var i = 0; i < notifications.Count; i++)
+        {
+            db.Entry(notifications[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = baseTime.AddSeconds(i);
+        }
+        await db.SaveChangesAsync();
+
+        // Newest-first order is index 4,3,2,1,0. With limit=2, offset=1 we expect [3, 2].
+        var page = (await repo.GetByUserIdAsync(user.Id, limit: 2, offset: 1)).ToList();
+
+        // Bounded: never more than the requested limit.
+        page.Should().HaveCount(2);
+        // Exact ordered slice (newest first, after skipping the single newest row).
+        page[0].Id.Should().Be(notifications[3].Id);
+        page[1].Id.Should().Be(notifications[2].Id);
+    }
 }

--- a/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
@@ -1,9 +1,15 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Infrastructure.Persistence;
+using Taskdeck.Infrastructure.Repositories;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -353,5 +359,192 @@ public class NotificationRepositoryIntegrationTests : IClassFixture<TestWebAppli
         var combined = page1.Concat(page2).Select(n => n.Id).ToList();
         combined.Should().OnlyHaveUniqueItems();
         combined.Should().BeEquivalentTo(notifications.Select(n => n.Id));
+    }
+
+    /// <summary>
+    /// Regression for #1133 (PR #1171 review, MEDIUM): the slice-correctness test alone cannot
+    /// distinguish the SQL-paged implementation from the old materialize-then-page anti-pattern --
+    /// both return the same rows. This test captures the SQL the repository actually executes and
+    /// asserts the SELECT against Notifications carries LIMIT and OFFSET, so a revert to in-memory
+    /// paging (which would emit no LIMIT/OFFSET on the SQLite path) fails the test.
+    /// </summary>
+    [Fact]
+    public async Task GetByUserIdAsync_WithPaging_PushesLimitAndOffsetIntoSql()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-notif-sqlpaging-{Guid.NewGuid():N}.db");
+        var interceptor = new CapturingCommandInterceptor();
+        try
+        {
+            var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+                .UseSqlite($"Data Source={dbPath}")
+                .AddInterceptors(interceptor)
+                .Options;
+
+            await using (var db = new TaskdeckDbContext(options))
+            {
+                await db.Database.MigrateAsync();
+
+                var user = new User("notif-sqlpaging-user", "notif-sqlpaging@example.com", "hash");
+                db.Users.Add(user);
+                for (var i = 0; i < 5; i++)
+                {
+                    db.Notifications.Add(new Notification(
+                        user.Id, NotificationType.System, NotificationCadence.Immediate,
+                        $"Sql paging notif {i}", $"Message {i}"));
+                }
+                await db.SaveChangesAsync();
+
+                var repo = new NotificationRepository(db);
+
+                // Discard migration/seed SQL so only the paged read remains captured.
+                interceptor.Clear();
+                var page = (await repo.GetByUserIdAsync(user.Id, limit: 2, offset: 1)).ToList();
+
+                page.Should().HaveCount(2);
+
+                var notificationSelects = interceptor.CapturedCommands
+                    .Where(sql => sql.Contains("Notifications", StringComparison.OrdinalIgnoreCase)
+                                  && sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                notificationSelects.Should().NotBeEmpty(
+                    "the paged read must issue a SELECT against Notifications");
+                notificationSelects.Should().Contain(
+                    sql => sql.Contains("LIMIT", StringComparison.OrdinalIgnoreCase)
+                           && sql.Contains("OFFSET", StringComparison.OrdinalIgnoreCase),
+                    "paging must be pushed into SQL (LIMIT + OFFSET), not materialized then sliced in memory");
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+            {
+                var path = dbPath + suffix;
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                try { File.Delete(path); }
+                catch (IOException) { /* best-effort temp cleanup */ }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Edge case (#1133 / PR #1171 review, LOW): a negative limit must clamp to an empty result.
+    /// SQLite treats a negative LIMIT as "unbounded", so without the clamp a negative page size
+    /// would silently restore the unbounded fetch the fix removed.
+    /// </summary>
+    [Fact]
+    public async Task GetByUserIdAsync_WithNegativeLimit_ReturnsEmpty()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
+
+        var user = new User("notif-neg-user", "notif-neg@example.com", "hash");
+        db.Users.Add(user);
+        db.Notifications.AddRange(
+            new Notification(user.Id, NotificationType.System, NotificationCadence.Immediate, "Neg one", "Msg"),
+            new Notification(user.Id, NotificationType.System, NotificationCadence.Immediate, "Neg two", "Msg"));
+        await db.SaveChangesAsync();
+
+        var results = (await repo.GetByUserIdAsync(user.Id, limit: -1)).ToList();
+
+        results.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Edge case (#1133 / PR #1171 review, LOW): a zero limit must return no rows.
+    /// </summary>
+    [Fact]
+    public async Task GetByUserIdAsync_WithZeroLimit_ReturnsEmpty()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
+
+        var user = new User("notif-zero-user", "notif-zero@example.com", "hash");
+        db.Users.Add(user);
+        db.Notifications.Add(
+            new Notification(user.Id, NotificationType.System, NotificationCadence.Immediate, "Zero one", "Msg"));
+        await db.SaveChangesAsync();
+
+        var results = (await repo.GetByUserIdAsync(user.Id, limit: 0)).ToList();
+
+        results.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Edge case (#1133 / PR #1171 review, LOW): combining <c>unreadOnly</c> with a <c>boardId</c>
+    /// filter must apply BOTH predicates, returning only the unread notification on that board.
+    /// </summary>
+    [Fact]
+    public async Task GetByUserIdAsync_WithUnreadOnlyAndBoardFilter_ReturnsOnlyMatchingUnreadOnBoard()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<INotificationRepository>();
+
+        var user = new User("notif-combo-user", "notif-combo@example.com", "hash");
+        db.Users.Add(user);
+
+        var targetBoard = new Board("Combo target board", ownerId: user.Id);
+        var otherBoard = new Board("Combo other board", ownerId: user.Id);
+        db.Boards.AddRange(targetBoard, otherBoard);
+
+        // Only this one satisfies BOTH unreadOnly AND boardId == targetBoard.
+        var unreadOnTarget = new Notification(user.Id, NotificationType.BoardChange, NotificationCadence.Immediate,
+            "Unread on target", "Match", boardId: targetBoard.Id);
+        // Read on the target board -> excluded by unreadOnly.
+        var readOnTarget = new Notification(user.Id, NotificationType.BoardChange, NotificationCadence.Immediate,
+            "Read on target", "Excluded by unreadOnly", boardId: targetBoard.Id);
+        readOnTarget.MarkAsRead();
+        // Unread on a different board -> excluded by the boardId filter.
+        var unreadOnOther = new Notification(user.Id, NotificationType.BoardChange, NotificationCadence.Immediate,
+            "Unread on other", "Excluded by boardId", boardId: otherBoard.Id);
+        // Unread with no board -> excluded by the boardId filter.
+        var unreadNoBoard = new Notification(user.Id, NotificationType.System, NotificationCadence.Immediate,
+            "Unread no board", "Excluded by boardId");
+        db.Notifications.AddRange(unreadOnTarget, readOnTarget, unreadOnOther, unreadNoBoard);
+        await db.SaveChangesAsync();
+
+        var results = (await repo.GetByUserIdAsync(user.Id, unreadOnly: true, boardId: targetBoard.Id)).ToList();
+
+        results.Should().ContainSingle().Which.Id.Should().Be(unreadOnTarget.Id);
+    }
+
+    /// <summary>
+    /// Test-only command interceptor that records the text of every reader command EF executes,
+    /// so a test can assert what SQL actually reached SQLite (e.g. that paging carries LIMIT/OFFSET).
+    /// </summary>
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly ConcurrentQueue<string> _commands = new();
+
+        public IReadOnlyCollection<string> CapturedCommands => _commands;
+
+        public void Clear() => _commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
Part of #1133 (this PR delivers the two query-perf fixes from the issue; the SignalR incremental-refetch and FTS card-search ACs are explicitly out of scope here).

## Fix 1 — NotificationRepository unbounded fetch (HIGH)
`GetByUserIdAsync` did `ToListAsync` then `OrderByDescending(CreatedAt).Skip(offset).Take(limit)` **in memory** — it materialized every matching row regardless of `limit`/`offset`, so paging never reduced DB load.

- Pushes `ORDER BY CreatedAt DESC` + `LIMIT`/`OFFSET` into SQL.
- SQLite path uses raw `FromSqlRaw` (fully parameterized) because SQLite cannot translate `DateTimeOffset` ORDER BY from LINQ (documented in ADR-0023 and `DatabaseProviderCompatibilityTests.DateTimeOffset_OrderBy_RequiresClientSideForSqlite`). This mirrors the existing `AgentRunRepository` SQLite pattern.
- Non-SQLite providers keep strongly-typed LINQ (`OrderByDescending(...).Skip(...).Take(...)`).
- Negative `limit`/`offset` are clamped to 0 so a negative SQLite `LIMIT` (which means "unbounded") cannot silently re-introduce the very bug being fixed.

**Audit of the rest of the file:** `GetUnreadByUserIdAsync` and `GetByUserAndDeduplicationKeyAsync` do **not** have the anti-pattern — they filter in SQL and materialize (no in-memory sort/page), so they were left unchanged.

## Fix 2 — CardRepository cartesian Include (MEDIUM)
Added `.AsSplitQuery()` to every read method that chains `.Include(CardLabels).ThenInclude(Label)` across multiple cards (cartesian fan-out): `GetByBoardIdAsync` (the AC's named target), `GetByBoardIdsAsync`, `GetByColumnIdAsync`, and `SearchAsync`. Placement matches the established `BoardRepository.GetByIdWithDetailsAsync` pattern (added in #1147).

Not changed (and why):
- `GetAgendaByBoardIdsAsync` — has **no** `Include`, so no collection fan-out; `AsSplitQuery()` would be a no-op.
- `SearchAcrossBoardsAsync` / `GetByDueDateRangeAsync` — only `Include` to-one reference navigations (`Board`, `Column`); split query does not apply.
- `GetByIdWithLabelsAsync` — single root (`FirstOrDefaultAsync`), one collection; no cartesian multiplication, so split provides no benefit.

## Tests
- **NotificationRepository:** new `GetByUserIdAsync_WithPaging_ReturnsExactNewestFirstSliceBoundedToLimit` — seeds 5 rows (> page size) with explicit timestamps, requests `limit:2, offset:1`, and asserts the result is exactly the expected newest-first slice `[idx3, idx2]` and bounded to `limit` rows. (No SQL-row-count harness exists in this repo; per the task this is a correctness+bound assertion.)
- **CardRepository:** new `GetByBoardIdAsync_WithMultipleLabels_LoadsAllLabelsWithoutDuplicatingCards` — seeds 3 cards (2 labels / 1 label / none), asserts the split query returns each card exactly once with all labels loaded, ordered by position.

These run against real file-based SQLite via `TestWebApplicationFactory`, so the SQLite raw-SQL paging path and the split-query path are the ones actually exercised.

## Verification
- `dotnet build backend/Taskdeck.sln -c Release` → **0 errors** (4 pre-existing CS1998 warnings in unrelated `*.Tests` files).
- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release --filter "FullyQualifiedName~NotificationRepository|FullyQualifiedName~CardRepository"` → **Passed: 24, Failed: 0, Skipped: 0**.