### PR TITLE
Global authorization FallbackPolicy (require auth by default) + AllowAnonymous audit (#1132 AC4)

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
@@ -124,6 +124,10 @@ public static class PipelineConfiguration
         // Authenticated via ApiKeyMiddleware (Bearer tdsk_... tokens).
         // Rate limiting applied per API key user identity.
         var mcpEndpoint = app.MapMcp();
+        // MCP is authenticated by ApiKeyMiddleware (above): it 401s missing/invalid/revoked keys
+        // before routing and sets an authenticated principal for valid keys, which satisfies the
+        // global FallbackPolicy (#1132 AC4). The MCP SDK endpoint does not honor an
+        // .AllowAnonymous() convention, so the principal — not endpoint metadata — is the opt-in.
         if (rateLimitingSettings.Enabled)
         {
             mcpEndpoint.RequireRateLimiting(RateLimiting.RateLimitingPolicyNames.McpPerApiKey);
@@ -131,8 +135,9 @@ public static class PipelineConfiguration
 
         // SPA fallback: any route not matched by a controller or hub endpoint returns index.html,
         // enabling Vue Router's client-side navigation. API (/api/*) and hub (/hubs/*) routes
-        // are matched above and never reach this fallback.
-        app.MapFallbackToFile("index.html");
+        // are matched above and never reach this fallback. AllowAnonymous so the app shell loads for
+        // unauthenticated users (e.g. to reach the login page) under the global FallbackPolicy (#1132 AC4).
+        app.MapFallbackToFile("index.html").AllowAnonymous();
 
         return app;
     }

--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
@@ -107,6 +108,15 @@ public sealed class ApiKeyMiddleware
 
         // Set the authenticated user ID for HttpUserContextProvider
         context.Items[HttpUserContextProvider.UserIdItemKey] = apiKey.UserId;
+
+        // Establish an authenticated principal so the global authorization FallbackPolicy
+        // (RequireAuthenticatedUser, #1132 AC4) is satisfied for valid-key MCP requests — a valid
+        // API key IS authentication. It carries only the user id (no JWT 'iat', so
+        // TokenValidationMiddleware's JWT-invalidation check is a no-op for it). Set before
+        // UseAuthentication runs; JwtBearer finds no token on /mcp and does not overwrite it.
+        context.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, apiKey.UserId.ToString()) },
+            authenticationType: "ApiKey"));
 
         // Update last-used timestamp before continuing the pipeline.
         // This is non-critical so failures are swallowed.

--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -27,6 +27,12 @@ public sealed class ApiKeyMiddleware
     /// <summary>The path prefix that triggers API key authentication.</summary>
     private const string McpPathPrefix = "/mcp";
 
+    /// <summary>
+    /// Authentication type stamped on the ClaimsIdentity for a valid API key so downstream
+    /// middleware (e.g. TokenValidationMiddleware) can distinguish API-key principals from JWT ones.
+    /// </summary>
+    public const string AuthenticationType = "ApiKey";
+
     public ApiKeyMiddleware(RequestDelegate next, ILogger<ApiKeyMiddleware> logger)
     {
         _next = next;
@@ -112,11 +118,13 @@ public sealed class ApiKeyMiddleware
         // Establish an authenticated principal so the global authorization FallbackPolicy
         // (RequireAuthenticatedUser, #1132 AC4) is satisfied for valid-key MCP requests — a valid
         // API key IS authentication. It carries only the user id (no JWT 'iat', so
-        // TokenValidationMiddleware's JWT-invalidation check is a no-op for it). Set before
-        // UseAuthentication runs; JwtBearer finds no token on /mcp and does not overwrite it.
+        // TokenValidationMiddleware's JWT-invalidation check is a no-op for it, and that middleware
+        // short-circuits on this AuthenticationType). Set before UseAuthentication runs: JwtBearer
+        // reads the "Bearer tdsk_..." header and fails to validate it as a JWT, returning a null
+        // Principal that AuthenticationMiddleware does not assign over context.User, so this survives.
         context.User = new ClaimsPrincipal(new ClaimsIdentity(
             new[] { new Claim(ClaimTypes.NameIdentifier, apiKey.UserId.ToString()) },
-            authenticationType: "ApiKey"));
+            authenticationType: AuthenticationType));
 
         // Update last-used timestamp before continuing the pipeline.
         // This is non-critical so failures are swallowed.

--- a/backend/src/Taskdeck.Api/Middleware/TokenValidationMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/TokenValidationMiddleware.cs
@@ -41,6 +41,15 @@ public sealed class TokenValidationMiddleware
             return;
         }
 
+        // API-key principals (MCP) are validated by ApiKeyMiddleware — freshness + active checks —
+        // and carry no JWT 'iat', so the JWT token-invalidation logic below is a no-op for them.
+        // Short-circuit to avoid a redundant per-request user load on every authenticated MCP call. (#1176 review)
+        if (string.Equals(user.Identity.AuthenticationType, ApiKeyMiddleware.AuthenticationType, StringComparison.Ordinal))
+        {
+            await _next(context);
+            return;
+        }
+
         var userIdClaim = user.FindFirst(ClaimTypes.NameIdentifier)
                           ?? user.FindFirst(JwtRegisteredClaimNames.Sub);
 

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -323,7 +323,15 @@ var circuitBreakerSettings = builder.Services
     .FirstOrDefault();
 builder.Services.AddTaskdeckAuthentication(jwtSettings, gitHubOAuthSettings, oidcSettings, circuitBreakerTracker, circuitBreakerSettings);
 builder.Services.AddAuthorizationBuilder()
-    .AddPolicy("AdminOnly", policy => policy.RequireRole("Owner", "Admin"));
+    .AddPolicy("AdminOnly", policy => policy.RequireRole("Owner", "Admin"))
+    // Defense-in-depth (#1132 AC4): any endpoint without explicit authorization metadata requires
+    // an authenticated user. Anonymous endpoints opt out explicitly — login/register/health/OAuth
+    // controllers carry [AllowAnonymous]; the SPA fallback calls .AllowAnonymous(); and /mcp is
+    // satisfied because ApiKeyMiddleware sets an authenticated principal for valid API keys (and
+    // 401s invalid ones). The standalone --mcp HTTP host has no UseAuthorization and is unaffected.
+    .SetFallbackPolicy(new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build());
 
 // Add OpenTelemetry observability
 builder.Services.AddTaskdeckObservability(observabilitySettings);

--- a/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http;
 using FluentAssertions;
-using Taskdeck.Api.Tests.Support;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -16,6 +18,21 @@ public class FallbackPolicyTests : IClassFixture<TestWebApplicationFactory>
     private readonly TestWebApplicationFactory _factory;
 
     public FallbackPolicyTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task FallbackPolicy_RequiringAuthenticatedUser_IsRegistered()
+    {
+        // Directly proves SetFallbackPolicy(RequireAuthenticatedUser) was applied — this assertion
+        // (unlike the endpoint tests, which exercise explicit [Authorize]/[AllowAnonymous] metadata)
+        // fails if SetFallbackPolicy is removed, since GetFallbackPolicyAsync then returns null.
+        using var scope = _factory.Services.CreateScope();
+        var policyProvider = scope.ServiceProvider.GetRequiredService<IAuthorizationPolicyProvider>();
+
+        var fallback = await policyProvider.GetFallbackPolicyAsync();
+
+        fallback.Should().NotBeNull("the global FallbackPolicy must be configured (#1132 AC4)");
+        fallback!.Requirements.Should().Contain(r => r is DenyAnonymousAuthorizationRequirement);
+    }
 
     [Fact]
     public async Task AnonymousAllowlistedEndpoint_StillReachable_UnderFallbackPolicy()

--- a/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Guards the global authorization FallbackPolicy (#1132 AC4): endpoints without explicit
+/// authorization metadata require an authenticated user, while the SPA shell, the API-key-gated
+/// /mcp endpoint, and the [AllowAnonymous] auth/health endpoints stay reachable.
+/// </summary>
+public class FallbackPolicyTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public FallbackPolicyTests(TestWebApplicationFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task AnonymousAllowlistedEndpoint_StillReachable_UnderFallbackPolicy()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/health/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ProtectedEndpoint_Returns401_WhenAnonymous()
+    {
+        using var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/api/boards");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task SpaFallback_NotBlockedByFallbackPolicy_WhenAnonymous()
+    {
+        using var client = _factory.CreateClient();
+
+        // A non-API/non-hub route hits MapFallbackToFile, which is AllowAnonymous: the fallback
+        // policy must NOT convert this into a 401 (it serves the shell, or 404 if the test host
+        // ships no wwwroot). Without the AllowAnonymous opt-out this would be 401.
+        var response = await client.GetAsync("/some/client/route");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task McpEndpoint_WithoutApiKey_Returns401_FromApiKeyMiddleware()
+    {
+        using var client = _factory.CreateClient();
+
+        // /mcp is AllowAnonymous to the JWT policy but gated by ApiKeyMiddleware, which rejects a
+        // missing key with 401 before routing — proving the fallback opt-out did not bypass MCP auth.
+        using var content = new StringContent(string.Empty);
+        var response = await client.PostAsync("/mcp", content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/docs/decisions/ADR-0036-default-deny-authorization-fallback-policy.md
+++ b/docs/decisions/ADR-0036-default-deny-authorization-fallback-policy.md
@@ -1,0 +1,62 @@
+# ADR-0036: Default-Deny Authorization via a Global FallbackPolicy
+
+- Status: Accepted
+- Date: 2026-06-05
+- Deciders: Repository maintainers
+- Related: #1132 (AC4), ADR-0002 (Claims-First Identity), #1110/#1116 (per-action authz architecture guards)
+
+## Context
+
+Every API controller already declares explicit `[Authorize]` or `[AllowAnonymous]`, enforced by the
+`ApiControllerBoundaryTests` architecture guard. But that guard only covers MVC controllers. A future
+minimal-API endpoint, a `MapX` endpoint, or a controller action that forgot its attribute would be
+**open by default** — there was no global safety net requiring authentication.
+
+#1132 AC4 calls for a global `AuthorizationOptions.FallbackPolicy = RequireAuthenticatedUser`.
+This is a security-posture and cross-cutting-convention change (per `CLAUDE.md`, that warrants an ADR),
+and it interacts non-trivially with the API-key-authenticated MCP endpoint.
+
+## Decision
+
+Set a global `FallbackPolicy = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build()`
+(Program.cs `AddAuthorizationBuilder`). Any endpoint **without** explicit authorization metadata now
+requires an authenticated user — default-deny defense-in-depth beyond the per-controller attributes.
+
+Endpoints that must remain anonymous opt out explicitly:
+
+- **login / register / health / OAuth callback** controllers already carry `[AllowAnonymous]`.
+- **SPA fallback** (`MapFallbackToFile`) → `.AllowAnonymous()` so the app shell loads to reach the login page.
+- **`/mcp`** is authenticated by `ApiKeyMiddleware`, which now sets an **authenticated `ClaimsPrincipal`**
+  (NameIdentifier = userId, `AuthenticationType` = `ApiKey`) for a valid key. A valid API key *is*
+  authentication, so the fallback policy is satisfied; invalid/missing/revoked keys are still 401'd
+  before routing. The MCP SDK endpoint does **not** honor an `.AllowAnonymous()` endpoint convention,
+  so the principal — not endpoint metadata — is the opt-in. This is load-bearing: editing
+  `ApiKeyMiddleware` to drop the principal would break MCP under the fallback policy.
+- The standalone `--mcp` HTTP host has no `UseAuthorization` and is unaffected.
+
+`TokenValidationMiddleware` short-circuits for `AuthenticationType == ApiKey` principals (they carry no
+JWT `iat`, and `ApiKeyMiddleware` already validated freshness/active state) to avoid a redundant
+per-request user load.
+
+## Alternatives Considered
+
+- **Rely only on the per-controller architecture guard.** Rejected: it does not cover non-controller
+  endpoints, leaving a default-open gap for future minimal APIs / mapped endpoints.
+- **`.AllowAnonymous()` on the MCP endpoint instead of a principal.** Rejected: verified that the MCP
+  SDK endpoint ignores the `.AllowAnonymous()` convention (the SPA `MapFallbackToFile` opt-out works,
+  the MCP one did not), so a valid-key request hit the fallback and 401'd. The principal approach also
+  models a valid API key as genuine authentication.
+
+## Consequences
+
+- A future endpoint that forgets explicit authorization metadata is denied by default rather than open.
+- `ApiKeyMiddleware`'s principal is now load-bearing for MCP under the fallback policy (documented here
+  and in code comments); a regression test asserts the fallback policy is registered.
+- A minor extra consideration for any future non-JWT authentication path: it must either set an
+  authenticated principal or `[AllowAnonymous]` to coexist with the fallback policy.
+
+## References
+
+- #1132 — Security gate + config hardening (AC4)
+- ADR-0002 — Claims-First Identity Model
+- ADR-0035 — Required Security-Scan Merge Gate (sibling AC of #1132)

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -37,3 +37,4 @@
 | [0033](ADR-0033-ambient-channel-vscode-over-voice.md) | Ambient Channel Hardening — VS Code Extension over Desktop Voice | Accepted | 2026-05-16 |
 | [0034](ADR-0034-dependency-version-caps.md) | Dependency Version Caps via Dependabot Ignore Rules (EF Core 8.x, FluentAssertions 7.x) | Accepted | 2026-05-29 |
 | [0035](ADR-0035-required-security-scan-merge-gate.md) | Promote Secret / Dependency / SAST Scans into the Required PR Merge Gate | Accepted | 2026-06-05 |
+| [0036](ADR-0036-default-deny-authorization-fallback-policy.md) | Default-Deny Authorization via a Global FallbackPolicy | Accepted | 2026-06-05 |


### PR DESCRIPTION
## Summary
Closes #1132 AC4 — adds a global `AuthorizationOptions.FallbackPolicy = RequireAuthenticatedUser`
so any endpoint that lacks explicit authorization metadata requires an authenticated user
(defense-in-depth beyond the per-controller `[Authorize]` the architecture test already enforces).

### Endpoint audit (the AC's "explicit `[AllowAnonymous]`")
| Endpoint | Handling |
|----------|----------|
| login / register / health / OAuth controllers | already `[AllowAnonymous]` (unchanged) |
| `BoardsHub` (`MapHub`) | already `[Authorize]` → fallback doesn't apply |
| SPA fallback (`MapFallbackToFile`) | **`.AllowAnonymous()`** so the app shell loads to reach the login page |
| `/mcp` (`MapMcp`) | **`ApiKeyMiddleware` now sets an authenticated principal** for valid keys |
| Swagger | dev-only middleware, runs before authorization → unaffected |
| standalone `--mcp` HTTP host | has no `UseAuthorization` → unaffected |

### Why a principal for MCP (not `AllowAnonymous`)
`ApiKeyMiddleware` already 401s missing/invalid/revoked keys before routing but only set
`HttpContext.Items[UserId]`, not an authenticated `HttpContext.User`. The MCP SDK endpoint does
**not** honor an `.AllowAnonymous()` endpoint convention (verified: the SPA `MapFallbackToFile`
`.AllowAnonymous()` works, the MCP one didn't), so a valid-key request hit the fallback → 401.
A valid API key *is* authentication, so the middleware now sets a minimal `ClaimsPrincipal`
(NameIdentifier = userId, authType `ApiKey`). `TokenValidationMiddleware` is a no-op for it (its
JWT-invalidation check only fires when an `iat` claim is present), and it is set before
`UseAuthentication`, which finds no JWT on `/mcp` and does not overwrite it.

## Tests
New `FallbackPolicyTests`: anonymous allowlisted endpoint reachable; protected endpoint 401 when
anonymous; SPA fallback not blocked when anonymous; `/mcp` without a key 401 from ApiKeyMiddleware.

```
Passed!  Failed: 0, Passed: 276  (FallbackPolicy + Mcp + ApiKey + Auth)
```
Earlier broad run (Auth + Cors + Mcp + Health + Boards + Authorization + CrossUser) also green after
the MCP-principal fix. Full Api.Tests suite runs in CI.

## Review
Two independent adversarial reviews will run; all findings (every severity) addressed before merge.
