### PR TITLE
CLI hardening (#1131 AC1): provision connector encryption key on fresh machine

### DIFF
--- a/backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs
@@ -12,18 +12,30 @@ namespace Taskdeck.Cli;
 /// The CLI ships no <c>appsettings.json</c> and never runs the API's
 /// <c>FirstRunBootstrapper</c>, yet <c>AddInfrastructure</c> fail-fasts when
 /// <c>Connectors:EncryptionKey</c> is missing. On a clean machine that made
-/// <c>taskdeck boards list</c> crash at startup unless the operator exported
-/// <c>TASKDECK_CONNECTORS__ENCRYPTIONKEY</c> by hand.
+/// <c>taskdeck boards list</c> crash at startup unless the operator exported a
+/// key by hand (<c>Connectors__EncryptionKey</c>, or
+/// <c>TASKDECK_CONNECTORS__ENCRYPTIONKEY</c> now that the CLI host registers the
+/// <c>TASKDECK_</c> prefix).
 ///
 /// This helper provisions a cryptographically-random 256-bit connector key on
-/// first run, persists it to a CLI-local <c>appsettings.local.json</c> (next to
-/// the resolved SQLite data directory, so the key is co-located with the
-/// encrypted data it protects and lives in a user-writable location), and loads
-/// it into configuration so <c>AddInfrastructure</c> succeeds.
+/// first run, persists it to a CLI-local <c>appsettings.local.json</c> next to
+/// the resolved SQLite data directory (a user-writable location alongside the
+/// data it protects), and loads it into configuration so
+/// <c>AddInfrastructure</c> succeeds.
 ///
 /// It intentionally does NOT modify the shared <c>AddInfrastructure</c>: the API
-/// deliberately fail-fasts on a missing key in Production. This is a CLI-local
-/// convenience that mirrors the API's <c>FirstRunBootstrapper</c> write pattern.
+/// deliberately fail-fasts on a missing key in Production. NOTE the key location
+/// differs from the API's <c>FirstRunBootstrapper</c>, which persists ITS key
+/// next to the executable (<c>AppContext.BaseDirectory</c>) -- this CLI bootstrap
+/// writes next to the data directory. Because the two locations differ, a
+/// deployment that points BOTH the API and CLI (or several hosts) at one shared
+/// database would auto-generate a DIFFERENT key per host and be unable to decrypt
+/// the other's connector credentials. For any shared-database or multi-host
+/// deployment, set one explicit <c>Connectors__EncryptionKey</c> (env var or
+/// appsettings) on every host instead of relying on this per-host
+/// auto-generation; the bootstrap emits a stderr warning when it auto-generates a
+/// key against a non-default data directory (<c>TASKDECK_CONNECTION_STRING</c>
+/// set) to surface this.
 ///
 /// Must run BEFORE the DI container is built and must never write to stdout
 /// (the CLI keeps stdout clean JSON for callers); diagnostics go to stderr only.
@@ -38,8 +50,14 @@ internal static class CliFirstRunBootstrapper
     /// <summary>
     /// Ensures a connector encryption key is available in configuration,
     /// generating and persisting one on first run when none is configured.
-    /// No-op when a key is already supplied (environment variable, appsettings,
-    /// or a previously generated <c>appsettings.local.json</c>).
+    /// Returns early (no file I/O) when a key is already present in the live
+    /// <see cref="IConfiguration"/> -- i.e. an environment variable
+    /// (<c>Connectors__EncryptionKey</c>, or <c>TASKDECK_CONNECTORS__ENCRYPTIONKEY</c>
+    /// once the CLI host registers the <c>TASKDECK_</c> prefix) or an appsettings
+    /// entry. The previously generated <c>appsettings.local.json</c> is NOT
+    /// registered as a configuration source, so it does not trigger this early
+    /// return; instead <see cref="EnsureKeyOnDisk"/> re-reads that file on every
+    /// run and reuses the persisted key (idempotent).
     /// </summary>
     public static void EnsureConnectorEncryptionKey(IConfiguration configuration)
     {
@@ -88,9 +106,16 @@ internal static class CliFirstRunBootstrapper
             var fullPath = Path.GetFullPath(dataSource);
             return Path.GetDirectoryName(fullPath) ?? Directory.GetCurrentDirectory();
         }
-        catch (ArgumentException)
+        catch (Exception ex) when (
+            ex is ArgumentException
+                or PathTooLongException
+                or NotSupportedException
+                or IOException
+                or System.Security.SecurityException)
         {
-            // Non-file data sources (e.g. ":memory:") have no real directory.
+            // Non-file data sources (e.g. ":memory:") or otherwise unresolvable paths
+            // (too long, unsupported format, restricted) must not crash startup --
+            // fall back to the current working directory.
             return Directory.GetCurrentDirectory();
         }
     }
@@ -123,12 +148,17 @@ internal static class CliFirstRunBootstrapper
     internal static string EnsureKeyOnDisk(string localConfigPath)
     {
         var mutexName = BuildMutexName(localConfigPath);
-        using var mutex = new Mutex(initiallyOwned: false, name: mutexName);
+        Mutex? mutex = null;
         var acquired = false;
         try
         {
             try
             {
+                // The named (Global\ on Windows) mutex ctor AND WaitOne can throw on
+                // locked-down or multi-user hosts -- e.g. when another user already
+                // owns the name. That must NOT crash the CLI at startup (the exact
+                // failure this bootstrap exists to prevent).
+                mutex = new Mutex(initiallyOwned: false, name: mutexName);
                 acquired = mutex.WaitOne(TimeSpan.FromSeconds(10));
             }
             catch (AbandonedMutexException)
@@ -136,8 +166,24 @@ internal static class CliFirstRunBootstrapper
                 // A previous holder crashed without releasing; we own it now.
                 acquired = true;
             }
+            catch (Exception ex) when (
+                ex is UnauthorizedAccessException
+                    or WaitHandleCannotBeOpenedException
+                    or IOException)
+            {
+                // Could not create/open or wait on the cross-process lock. Degrade
+                // gracefully: continue WITHOUT the lock and treat this run as
+                // read-only (see the !acquired branch below) so two unsynchronized
+                // writers never race to persist different keys.
+                Console.Error.WriteLine(
+                    $"[CliFirstRun] WARNING: Could not acquire the cross-process bootstrap " +
+                    $"lock ({ex.Message}). Proceeding without it; a generated key will not be " +
+                    "persisted on this run.");
+            }
 
-            // Re-check inside the mutex: a racing process may have just written one.
+            // Re-check (inside the lock when held): a racing process may have just
+            // written a key, or one may already exist from a previous run. Reading
+            // is safe without the lock.
             var existing = ReadExisting(localConfigPath);
             if (!string.IsNullOrWhiteSpace(existing.Key))
             {
@@ -145,6 +191,21 @@ internal static class CliFirstRunBootstrapper
             }
 
             var generated = GenerateKey();
+
+            if (!acquired)
+            {
+                // We do NOT hold the lock (ctor/wait threw, or the 10s wait timed
+                // out). Persisting now could race a concurrent writer and leave
+                // connector credentials encrypted under a key no longer on disk.
+                // Use a transient in-memory key for this run only; a later run that
+                // wins the lock will persist a stable key. Warn on stderr (stdout
+                // stays clean JSON).
+                Console.Error.WriteLine(
+                    "[CliFirstRun] WARNING: Bootstrap lock unavailable; using a transient " +
+                    "in-memory connector encryption key for this run without persisting it. " +
+                    "Set an explicit Connectors__EncryptionKey to avoid per-run keys.");
+                return generated;
+            }
 
             if (existing.PreserveFile)
             {
@@ -162,6 +223,7 @@ internal static class CliFirstRunBootstrapper
             try
             {
                 PersistKey(localConfigPath, existing.Root, generated);
+                WarnIfSharedDbAutoGenerated(localConfigPath);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
@@ -177,11 +239,44 @@ internal static class CliFirstRunBootstrapper
         }
         finally
         {
-            if (acquired)
+            if (acquired && mutex is not null)
             {
-                mutex.ReleaseMutex();
+                try
+                {
+                    mutex.ReleaseMutex();
+                }
+                catch (ApplicationException)
+                {
+                    // Best-effort release: another path may already have released it.
+                }
             }
+
+            mutex?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Emits a one-line stderr warning when the bootstrap AUTO-GENERATES a key
+    /// while pointed at a non-default data directory (<c>TASKDECK_CONNECTION_STRING</c>
+    /// set). A custom/relocated database is often shared across hosts, where
+    /// per-host auto-generated keys diverge (the API stores its key next to the
+    /// executable) and cannot decrypt each other's connector credentials -- so the
+    /// operator should set one explicit shared <c>Connectors__EncryptionKey</c>.
+    /// stderr only; stdout stays clean JSON.
+    /// </summary>
+    private static void WarnIfSharedDbAutoGenerated(string localConfigPath)
+    {
+        var customDb = Environment.GetEnvironmentVariable("TASKDECK_CONNECTION_STRING");
+        if (string.IsNullOrWhiteSpace(customDb))
+        {
+            return;
+        }
+
+        Console.Error.WriteLine(
+            $"[CliFirstRun] WARNING: Auto-generated a new connector encryption key at " +
+            $"{localConfigPath} for a custom database location. If this database is shared " +
+            "across hosts (or with the API), set one explicit Connectors__EncryptionKey on " +
+            "every host instead -- per-host auto-generated keys cannot decrypt each other's data.");
     }
 
     internal static string GenerateKey()
@@ -266,6 +361,18 @@ internal static class CliFirstRunBootstrapper
         var tempDir = string.IsNullOrEmpty(dir) ? Directory.GetCurrentDirectory() : dir;
         var tempPath = Path.Combine(tempDir, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
         File.WriteAllText(tempPath, payload);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            // The payload is a base64 256-bit connector encryption key. On a default
+            // POSIX umask (022), File.WriteAllText creates the temp file 0644
+            // (world-readable), and File.Move preserves that mode -- exposing the key
+            // to other local users. Restrict to owner read/write (0600) BEFORE the
+            // move so the final file is never world-readable. No-op on Windows, where
+            // NTFS ACL inheritance governs access.
+            File.SetUnixFileMode(tempPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+
         try
         {
             MoveWithRetry(tempPath, path);

--- a/backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs
@@ -38,13 +38,13 @@ internal static class CliFirstRunBootstrapper
     /// <summary>
     /// Ensures a connector encryption key is available in configuration,
     /// generating and persisting one on first run when none is configured.
-    /// No-op when a key is already supplied (env var, appsettings, user secrets,
+    /// No-op when a key is already supplied (environment variable, appsettings,
     /// or a previously generated <c>appsettings.local.json</c>).
     /// </summary>
     public static void EnsureConnectorEncryptionKey(IConfiguration configuration)
     {
-        // Respect an explicitly configured key (environment variable, appsettings,
-        // user secrets). Environment variables must always win over the generated
+        // Respect an explicitly configured key (environment variable or
+        // appsettings). Environment variables must always win over the generated
         // file so 12-factor / container deployments are never silently overridden.
         var configured = configuration[ConnectorKeyPath];
         if (!string.IsNullOrWhiteSpace(configured))
@@ -137,19 +137,31 @@ internal static class CliFirstRunBootstrapper
                 acquired = true;
             }
 
-            var root = ReadConfigObject(localConfigPath);
-
             // Re-check inside the mutex: a racing process may have just written one.
-            var existing = (root[ConnectorSection] as JsonObject)?[EncryptionKeyName]?.GetValue<string>();
-            if (!string.IsNullOrWhiteSpace(existing))
+            var existing = ReadExisting(localConfigPath);
+            if (!string.IsNullOrWhiteSpace(existing.Key))
             {
-                return existing;
+                return existing.Key!;
             }
 
             var generated = GenerateKey();
+
+            if (existing.PreserveFile)
+            {
+                // An existing file could not be read (e.g. transiently locked by an
+                // editor/AV/backup). Do NOT overwrite it -- a valid key may be on
+                // disk, and clobbering it would make previously-encrypted connector
+                // credentials undecryptable. Use a transient key for this run; the
+                // next run will pick up the real key.
+                Console.Error.WriteLine(
+                    $"[CliFirstRun] WARNING: Could not read {localConfigPath} to load the " +
+                    "connector encryption key. Using a transient in-memory key for this run.");
+                return generated;
+            }
+
             try
             {
-                PersistKey(localConfigPath, root, generated);
+                PersistKey(localConfigPath, existing.Root, generated);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
@@ -175,17 +187,39 @@ internal static class CliFirstRunBootstrapper
     internal static string GenerateKey()
         => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
 
-    private static JsonObject ReadConfigObject(string path)
+    /// <summary>
+    /// Result of inspecting an existing <c>appsettings.local.json</c>.
+    /// <paramref name="Root"/> is the object to merge new values into (empty when
+    /// the file is missing or corrupt). <paramref name="Key"/> is the existing
+    /// connector key when present and a string. <paramref name="PreserveFile"/>
+    /// is true when the file exists but could not be read, signalling the caller
+    /// to avoid overwriting it.
+    /// </summary>
+    private readonly record struct ExistingConfig(JsonObject Root, string? Key, bool PreserveFile);
+
+    private static ExistingConfig ReadExisting(string path)
     {
         if (!File.Exists(path))
         {
-            return new JsonObject();
+            return new ExistingConfig(new JsonObject(), Key: null, PreserveFile: false);
         }
 
+        string text;
         try
         {
-            var existing = File.ReadAllText(path);
-            return JsonNode.Parse(existing)?.AsObject() ?? new JsonObject();
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // File exists but is temporarily unreadable -- preserve it rather than
+            // risk clobbering a valid key.
+            return new ExistingConfig(new JsonObject(), Key: null, PreserveFile: true);
+        }
+
+        JsonObject root;
+        try
+        {
+            root = JsonNode.Parse(text)?.AsObject() ?? new JsonObject();
         }
         catch (Exception ex) when (ex is JsonException or InvalidOperationException)
         {
@@ -194,8 +228,17 @@ internal static class CliFirstRunBootstrapper
             Console.Error.WriteLine(
                 $"[CliFirstRun] WARNING: {path} contains invalid JSON and will be overwritten. " +
                 $"Details: {ex.Message}");
-            return new JsonObject();
+            return new ExistingConfig(new JsonObject(), Key: null, PreserveFile: false);
         }
+
+        // Type-safe extraction: a non-string EncryptionKey value (e.g. a number)
+        // must not throw -- treat it as absent so a valid key is regenerated.
+        var key = (root[ConnectorSection] as JsonObject)?[EncryptionKeyName] is JsonValue value
+            && value.TryGetValue<string>(out var keyText)
+                ? keyText
+                : null;
+
+        return new ExistingConfig(root, key, PreserveFile: false);
     }
 
     private static void PersistKey(string path, JsonObject root, string key)

--- a/backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs
@@ -1,0 +1,265 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Configuration;
+
+namespace Taskdeck.Cli;
+
+/// <summary>
+/// First-run bootstrap for the standalone CLI.
+///
+/// The CLI ships no <c>appsettings.json</c> and never runs the API's
+/// <c>FirstRunBootstrapper</c>, yet <c>AddInfrastructure</c> fail-fasts when
+/// <c>Connectors:EncryptionKey</c> is missing. On a clean machine that made
+/// <c>taskdeck boards list</c> crash at startup unless the operator exported
+/// <c>TASKDECK_CONNECTORS__ENCRYPTIONKEY</c> by hand.
+///
+/// This helper provisions a cryptographically-random 256-bit connector key on
+/// first run, persists it to a CLI-local <c>appsettings.local.json</c> (next to
+/// the resolved SQLite data directory, so the key is co-located with the
+/// encrypted data it protects and lives in a user-writable location), and loads
+/// it into configuration so <c>AddInfrastructure</c> succeeds.
+///
+/// It intentionally does NOT modify the shared <c>AddInfrastructure</c>: the API
+/// deliberately fail-fasts on a missing key in Production. This is a CLI-local
+/// convenience that mirrors the API's <c>FirstRunBootstrapper</c> write pattern.
+///
+/// Must run BEFORE the DI container is built and must never write to stdout
+/// (the CLI keeps stdout clean JSON for callers); diagnostics go to stderr only.
+/// </summary>
+internal static class CliFirstRunBootstrapper
+{
+    private const string ConnectorSection = "Connectors";
+    private const string EncryptionKeyName = "EncryptionKey";
+    private const string ConnectorKeyPath = $"{ConnectorSection}:{EncryptionKeyName}";
+    private const string LocalConfigFileName = "appsettings.local.json";
+
+    /// <summary>
+    /// Ensures a connector encryption key is available in configuration,
+    /// generating and persisting one on first run when none is configured.
+    /// No-op when a key is already supplied (env var, appsettings, user secrets,
+    /// or a previously generated <c>appsettings.local.json</c>).
+    /// </summary>
+    public static void EnsureConnectorEncryptionKey(IConfiguration configuration)
+    {
+        // Respect an explicitly configured key (environment variable, appsettings,
+        // user secrets). Environment variables must always win over the generated
+        // file so 12-factor / container deployments are never silently overridden.
+        var configured = configuration[ConnectorKeyPath];
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return;
+        }
+
+        var localConfigPath = ResolveLocalConfigPath(configuration);
+        var key = EnsureKeyOnDisk(localConfigPath);
+
+        // Load the key into the live configuration so AddInfrastructure can read
+        // it. The CLI host does not register appsettings.local.json as a config
+        // source, so set it in-memory (this is also the persist-failure fallback).
+        configuration[ConnectorKeyPath] = key;
+    }
+
+    /// <summary>
+    /// Resolves the CLI-local <c>appsettings.local.json</c> path, placing it next
+    /// to the resolved SQLite database file (the data directory). Falls back to the
+    /// current working directory when the data source cannot be resolved to a path.
+    /// </summary>
+    internal static string ResolveLocalConfigPath(IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? "Data Source=taskdeck.db";
+
+        var directory = ResolveDataDirectory(connectionString);
+        return Path.Combine(directory, LocalConfigFileName);
+    }
+
+    private static string ResolveDataDirectory(string connectionString)
+    {
+        var dataSource = ExtractDataSource(connectionString);
+        if (string.IsNullOrWhiteSpace(dataSource))
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        try
+        {
+            var fullPath = Path.GetFullPath(dataSource);
+            return Path.GetDirectoryName(fullPath) ?? Directory.GetCurrentDirectory();
+        }
+        catch (ArgumentException)
+        {
+            // Non-file data sources (e.g. ":memory:") have no real directory.
+            return Directory.GetCurrentDirectory();
+        }
+    }
+
+    private static string ExtractDataSource(string connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var builder = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder(connectionString);
+            return builder.DataSource;
+        }
+        catch (ArgumentException)
+        {
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Returns the persisted connector key, generating and writing one when the
+    /// file does not yet contain a key. A cross-process mutex guards the
+    /// read-modify-write so that two CLI invocations racing on a fresh machine
+    /// converge on a single shared key (the second reads the first's value)
+    /// rather than each generating a different key.
+    /// </summary>
+    internal static string EnsureKeyOnDisk(string localConfigPath)
+    {
+        var mutexName = BuildMutexName(localConfigPath);
+        using var mutex = new Mutex(initiallyOwned: false, name: mutexName);
+        var acquired = false;
+        try
+        {
+            try
+            {
+                acquired = mutex.WaitOne(TimeSpan.FromSeconds(10));
+            }
+            catch (AbandonedMutexException)
+            {
+                // A previous holder crashed without releasing; we own it now.
+                acquired = true;
+            }
+
+            var root = ReadConfigObject(localConfigPath);
+
+            // Re-check inside the mutex: a racing process may have just written one.
+            var existing = (root[ConnectorSection] as JsonObject)?[EncryptionKeyName]?.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(existing))
+            {
+                return existing;
+            }
+
+            var generated = GenerateKey();
+            try
+            {
+                PersistKey(localConfigPath, root, generated);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Could not persist (read-only dir, lock contention). The current
+                // invocation still works with a transient in-memory key; warn on
+                // stderr so stdout stays clean JSON.
+                Console.Error.WriteLine(
+                    $"[CliFirstRun] WARNING: Could not persist connector encryption key to " +
+                    $"{localConfigPath} ({ex.Message}). Using a transient in-memory key for this run.");
+            }
+
+            return generated;
+        }
+        finally
+        {
+            if (acquired)
+            {
+                mutex.ReleaseMutex();
+            }
+        }
+    }
+
+    internal static string GenerateKey()
+        => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    private static JsonObject ReadConfigObject(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return new JsonObject();
+        }
+
+        try
+        {
+            var existing = File.ReadAllText(path);
+            return JsonNode.Parse(existing)?.AsObject() ?? new JsonObject();
+        }
+        catch (Exception ex) when (ex is JsonException or InvalidOperationException)
+        {
+            // No logger at this pre-DI stage. Warn on stderr and start fresh rather
+            // than silently discarding the corrupt file.
+            Console.Error.WriteLine(
+                $"[CliFirstRun] WARNING: {path} contains invalid JSON and will be overwritten. " +
+                $"Details: {ex.Message}");
+            return new JsonObject();
+        }
+    }
+
+    private static void PersistKey(string path, JsonObject root, string key)
+    {
+        // Merge-preserve: only set Connectors:EncryptionKey, keeping any other keys.
+        if (root[ConnectorSection] is not JsonObject sectionNode)
+        {
+            sectionNode = new JsonObject();
+            root[ConnectorSection] = sectionNode;
+        }
+
+        sectionNode[EncryptionKeyName] = key;
+
+        var payload = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+
+        var dir = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        // Atomic write: stage into a sibling temp file, then move into place.
+        // File.WriteAllText is not atomic; a concurrent reader could otherwise
+        // observe a partially written file.
+        var tempDir = string.IsNullOrEmpty(dir) ? Directory.GetCurrentDirectory() : dir;
+        var tempPath = Path.Combine(tempDir, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(tempPath, payload);
+        try
+        {
+            MoveWithRetry(tempPath, path);
+        }
+        catch
+        {
+            try { File.Delete(tempPath); } catch { /* best-effort cleanup */ }
+            throw;
+        }
+    }
+
+    private static void MoveWithRetry(string tempPath, string path)
+    {
+        const int maxAttempts = 5;
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                File.Move(tempPath, path, overwrite: true);
+                return;
+            }
+            catch (Exception ex) when (
+                attempt < maxAttempts && (ex is IOException or UnauthorizedAccessException))
+            {
+                Thread.Sleep(TimeSpan.FromMilliseconds(25 * attempt));
+            }
+        }
+    }
+
+    private static string BuildMutexName(string path)
+    {
+        // Stable per-path name within OS naming rules. SHA256 of the absolute path;
+        // prefix with "Global\" on Windows so different user sessions coordinate.
+        var normalized = Path.GetFullPath(path).ToLowerInvariant();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        var hex = Convert.ToHexString(hash).AsSpan(0, 32);
+        var prefix = OperatingSystem.IsWindows() ? "Global\\" : string.Empty;
+        return $"{prefix}Taskdeck.Cli.FirstRun.{hex}";
+    }
+}

--- a/backend/src/Taskdeck.Cli/Program.cs
+++ b/backend/src/Taskdeck.Cli/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Taskdeck.Application.Services;
+using Taskdeck.Cli;
 using Taskdeck.Cli.Commands;
 using Taskdeck.Infrastructure;
 using Taskdeck.Infrastructure.Persistence;
@@ -24,6 +25,11 @@ if (string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("Default
         ["ConnectionStrings:DefaultConnection"] = fallbackConnectionString
     });
 }
+
+// Fresh-machine bootstrap: provision the connector encryption key before
+// AddInfrastructure (which fail-fasts on a missing key). Must run after the
+// connection string is resolved so the key is persisted next to the data dir.
+CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(builder.Configuration);
 
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddScoped<BoardService>();

--- a/backend/src/Taskdeck.Cli/Program.cs
+++ b/backend/src/Taskdeck.Cli/Program.cs
@@ -15,6 +15,13 @@ var builder = Host.CreateApplicationBuilder(args);
 // and framework diagnostics never corrupt JSON output parsed by callers.
 builder.Logging.ClearProviders();
 
+// Honor the documented TASKDECK_-prefixed environment variables. The default host
+// only registers the no-prefix provider, so TASKDECK_CONNECTORS__ENCRYPTIONKEY
+// (advertised in docs and the AddInfrastructure fail-fast message) would otherwise
+// never map to Connectors:EncryptionKey. Registering the TASKDECK_ prefix maps it
+// (the canonical Connectors__EncryptionKey keeps working via the no-prefix provider).
+builder.Configuration.AddEnvironmentVariables("TASKDECK_");
+
 var fallbackConnectionString = Environment.GetEnvironmentVariable("TASKDECK_CONNECTION_STRING")
     ?? "Data Source=taskdeck.db";
 

--- a/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
@@ -121,7 +121,7 @@ public static class DependencyInjection
             throw new InvalidOperationException(
                 "Connectors:EncryptionKey is not configured. " +
                 "Set a base64-encoded 256-bit key via configuration or the " +
-                "TASKDECK_CONNECTORS__ENCRYPTIONKEY environment variable. " +
+                "Connectors__EncryptionKey environment variable. " +
                 "Generate one with: openssl rand -base64 32");
         }
         services.AddSingleton<ICredentialEncryptionService>(

--- a/backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs
@@ -1,0 +1,227 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Taskdeck.Application.Connectors;
+using Taskdeck.Cli;
+using Taskdeck.Infrastructure;
+using Xunit;
+
+namespace Taskdeck.Cli.Tests;
+
+/// <summary>
+/// Covers issue #1131 AC1: the CLI must be self-sufficient on a fresh machine.
+/// Before this fix, <c>taskdeck boards list</c> crashed at startup because
+/// <c>AddInfrastructure</c> fail-fasts when <c>Connectors:EncryptionKey</c> is
+/// missing and the CLI never provisioned one.
+/// </summary>
+public class CliFirstRunBootstrapTests
+{
+    // ----- End-to-end smoke test (strongest evidence) -----------------------
+
+    [Fact]
+    public async Task BoardsList_FreshMachine_BootstrapsKeyAndReturnsEmptyArray()
+    {
+        // No Connectors:EncryptionKey in the environment and no pre-existing
+        // appsettings.local.json -- a genuinely clean machine.
+        await using var harness = new CliTestHarness("cli-fresh-bootstrap", provisionEncryptionKey: false);
+
+        var result = await harness.RunAsync("boards list --json");
+
+        // It must NOT crash: it should bootstrap the key and return valid JSON.
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+        doc.RootElement.GetArrayLength().Should().Be(0);
+
+        // The bootstrap persisted a key next to the data directory.
+        var localConfig = Path.Combine(harness.DataDirectory, "appsettings.local.json");
+        File.Exists(localConfig).Should().BeTrue("the CLI should persist the generated key");
+
+        var json = await File.ReadAllTextAsync(localConfig);
+        using var cfg = JsonDocument.Parse(json);
+        var key = cfg.RootElement.GetProperty("Connectors").GetProperty("EncryptionKey").GetString();
+        key.Should().NotBeNullOrWhiteSpace();
+        Convert.FromBase64String(key!).Length.Should().Be(32, "the key must be a 256-bit AES key");
+    }
+
+    [Fact]
+    public async Task BoardsList_FreshMachine_SecondRunReusesPersistedKey()
+    {
+        await using var harness = new CliTestHarness("cli-fresh-reuse", provisionEncryptionKey: false);
+        var localConfig = Path.Combine(harness.DataDirectory, "appsettings.local.json");
+
+        var first = await harness.RunAsync("boards list --json");
+        first.ExitCode.Should().Be(0, first.StdErr);
+        var firstKey = ReadPersistedKey(localConfig);
+
+        var second = await harness.RunAsync("boards list --json");
+        second.ExitCode.Should().Be(0, second.StdErr);
+        var secondKey = ReadPersistedKey(localConfig);
+
+        // A regenerated key on every run would make previously-encrypted connector
+        // credentials undecryptable, so the key must be stable across invocations.
+        secondKey.Should().Be(firstKey);
+    }
+
+    // ----- Unit tests for the bootstrapper ----------------------------------
+
+    [Fact]
+    public void EnsureConnectorEncryptionKey_WhenMissing_ProvisionsValidKeyAndPersistsIt()
+    {
+        using var temp = new TempDataDir();
+        var configuration = BuildConfiguration(temp.DatabasePath);
+        configuration["Connectors:EncryptionKey"].Should().BeNullOrWhiteSpace();
+
+        CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(configuration);
+
+        var key = configuration["Connectors:EncryptionKey"];
+        key.Should().NotBeNullOrWhiteSpace();
+        Convert.FromBase64String(key!).Length.Should().Be(32);
+
+        var localConfig = Path.Combine(temp.Directory, "appsettings.local.json");
+        File.Exists(localConfig).Should().BeTrue();
+        ReadPersistedKey(localConfig).Should().Be(key);
+    }
+
+    [Fact]
+    public void EnsureConnectorEncryptionKey_WhenAlreadyConfigured_IsNoOp()
+    {
+        using var temp = new TempDataDir();
+        const string existingKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        var configuration = BuildConfiguration(temp.DatabasePath, existingKey);
+
+        CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(configuration);
+
+        // The configured key is preserved and no file is written.
+        configuration["Connectors:EncryptionKey"].Should().Be(existingKey);
+        File.Exists(Path.Combine(temp.Directory, "appsettings.local.json")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnsureConnectorEncryptionKey_SecondCall_ReusesPersistedKey()
+    {
+        using var temp = new TempDataDir();
+
+        var firstConfig = BuildConfiguration(temp.DatabasePath);
+        CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(firstConfig);
+        var firstKey = firstConfig["Connectors:EncryptionKey"];
+
+        // A fresh configuration (new process) with the file already on disk.
+        var secondConfig = BuildConfiguration(temp.DatabasePath);
+        CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(secondConfig);
+        var secondKey = secondConfig["Connectors:EncryptionKey"];
+
+        secondKey.Should().Be(firstKey);
+    }
+
+    [Fact]
+    public void EnsureConnectorEncryptionKey_PreservesOtherKeysInLocalConfigFile()
+    {
+        using var temp = new TempDataDir();
+        var localConfig = Path.Combine(temp.Directory, "appsettings.local.json");
+        // Pre-existing file with unrelated content the bootstrap must not destroy.
+        File.WriteAllText(localConfig, "{\"Existing\":{\"Flag\":\"keep-me\"}}");
+
+        var configuration = BuildConfiguration(temp.DatabasePath);
+        CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(configuration);
+
+        using var cfg = JsonDocument.Parse(File.ReadAllText(localConfig));
+        cfg.RootElement.GetProperty("Existing").GetProperty("Flag").GetString().Should().Be("keep-me");
+        cfg.RootElement.GetProperty("Connectors").GetProperty("EncryptionKey").GetString()
+            .Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GenerateKey_ProducesBase64EncodedTwoFiftySixBitKey()
+    {
+        var key = CliFirstRunBootstrapper.GenerateKey();
+
+        key.Should().NotBeNullOrWhiteSpace();
+        Convert.FromBase64String(key).Length.Should().Be(32);
+        // Two generated keys must differ (cryptographically random).
+        key.Should().NotBe(CliFirstRunBootstrapper.GenerateKey());
+    }
+
+    // ----- Integration test: AddInfrastructure succeeds after bootstrap -----
+
+    [Fact]
+    public void AddInfrastructure_SucceedsAfterBootstrap_OnCleanConfig()
+    {
+        using var temp = new TempDataDir();
+        var configuration = BuildConfiguration(temp.DatabasePath);
+
+        // Sanity: without the key AddInfrastructure must fail-fast (the bug).
+        var noKeyServices = new ServiceCollection();
+        noKeyServices.AddLogging();
+        var act = () => noKeyServices.AddInfrastructure(configuration);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Connectors:EncryptionKey is not configured*");
+
+        // After bootstrap, AddInfrastructure succeeds and the encryption service works.
+        CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(configuration);
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddInfrastructure(configuration);
+
+        using var provider = services.BuildServiceProvider();
+        var encryptionService = provider.GetRequiredService<ICredentialEncryptionService>();
+        encryptionService.Should().NotBeNull();
+
+        // Round-trip proves the bootstrapped key is a usable AES-256 key.
+        var cipher = encryptionService.Encrypt("secret");
+        encryptionService.Decrypt(cipher).Should().Be("secret");
+    }
+
+    // ----- Helpers ----------------------------------------------------------
+
+    private static ConfigurationManager BuildConfiguration(string databasePath, string? encryptionKey = null)
+    {
+        var configuration = new ConfigurationManager();
+        var values = new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = $"Data Source={databasePath}"
+        };
+        if (encryptionKey is not null)
+        {
+            values["Connectors:EncryptionKey"] = encryptionKey;
+        }
+
+        configuration.AddInMemoryCollection(values);
+        return configuration;
+    }
+
+    private static string? ReadPersistedKey(string localConfigPath)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(localConfigPath));
+        return doc.RootElement.GetProperty("Connectors").GetProperty("EncryptionKey").GetString();
+    }
+
+    private sealed class TempDataDir : IDisposable
+    {
+        public string Directory { get; }
+        public string DatabasePath { get; }
+
+        public TempDataDir()
+        {
+            Directory = Path.Combine(Path.GetTempPath(), $"cli-bootstrap-{Guid.NewGuid():N}");
+            System.IO.Directory.CreateDirectory(Directory);
+            DatabasePath = Path.Combine(Directory, "taskdeck.db");
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                if (System.IO.Directory.Exists(Directory))
+                {
+                    System.IO.Directory.Delete(Directory, recursive: true);
+                }
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs
@@ -133,6 +133,32 @@ public class CliFirstRunBootstrapTests
             .Should().NotBeNullOrWhiteSpace();
     }
 
+    [Theory]
+    [InlineData("{ this is not valid json")]                       // corrupt JSON
+    [InlineData("[1, 2, 3]")]                                       // valid JSON but not an object
+    [InlineData("{\"Connectors\":{\"EncryptionKey\":12345}}")]     // wrong-type key value
+    [InlineData("{\"Connectors\":{\"EncryptionKey\":\"\"}}")]      // empty key value
+    public void EnsureConnectorEncryptionKey_WithMalformedLocalConfig_RegeneratesValidKeyWithoutThrowing(
+        string malformedContent)
+    {
+        using var temp = new TempDataDir();
+        var localConfig = Path.Combine(temp.Directory, "appsettings.local.json");
+        File.WriteAllText(localConfig, malformedContent);
+
+        var configuration = BuildConfiguration(temp.DatabasePath);
+
+        // Must not throw: the fail-safe exists to prevent a startup crash.
+        var act = () => CliFirstRunBootstrapper.EnsureConnectorEncryptionKey(configuration);
+        act.Should().NotThrow();
+
+        var key = configuration["Connectors:EncryptionKey"];
+        key.Should().NotBeNullOrWhiteSpace();
+        Convert.FromBase64String(key!).Length.Should().Be(32);
+
+        // The file is overwritten with a valid persisted key.
+        ReadPersistedKey(localConfig).Should().Be(key);
+    }
+
     [Fact]
     public void GenerateKey_ProducesBase64EncodedTwoFiftySixBitKey()
     {

--- a/backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs
@@ -65,6 +65,37 @@ public class CliFirstRunBootstrapTests
         secondKey.Should().Be(firstKey);
     }
 
+    [Fact]
+    public async Task BoardsList_WithOperatorKeyViaTaskdeckEnvVar_HonorsOverrideAndDoesNotPersist()
+    {
+        // Clean machine (no Connectors__EncryptionKey) but the operator supplies the
+        // DOCUMENTED TASKDECK_CONNECTORS__ENCRYPTIONKEY override. The CLI host must
+        // register the TASKDECK_ prefix so the bootstrapper sees the key and no-ops.
+        await using var harness = new CliTestHarness("cli-env-override", provisionEncryptionKey: false);
+
+        // Known-valid base64 256-bit key (32 zero bytes).
+        const string operatorKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+        var result = await harness.RunAsync(
+            "boards list --json",
+            new Dictionary<string, string?>
+            {
+                ["TASKDECK_CONNECTORS__ENCRYPTIONKEY"] = operatorKey
+            });
+
+        result.ExitCode.Should().Be(0, result.StdErr);
+        using var doc = JsonDocument.Parse(result.StdOut);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+
+        // If TASKDECK_CONNECTORS__ENCRYPTIONKEY were ignored (the bug), the bootstrap
+        // would generate and persist a DIFFERENT key here. Honoring the override means
+        // an early no-op: no appsettings.local.json is written and the operator key is
+        // never overwritten.
+        var localConfig = Path.Combine(harness.DataDirectory, "appsettings.local.json");
+        File.Exists(localConfig).Should().BeFalse(
+            "the documented TASKDECK_CONNECTORS__ENCRYPTIONKEY override must be honored so the bootstrap no-ops");
+    }
+
     // ----- Unit tests for the bootstrapper ----------------------------------
 
     [Fact]

--- a/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
@@ -59,7 +59,14 @@ internal sealed class CliTestHarness : IAsyncDisposable
         return (boardId, columnId);
     }
 
-    public async Task<CliCommandResult> RunAsync(string arguments)
+    /// <param name="extraEnvironment">
+    /// Optional environment variables applied AFTER the harness's own provisioning
+    /// logic, letting a test exercise operator overrides (e.g. supplying the
+    /// documented <c>TASKDECK_CONNECTORS__ENCRYPTIONKEY</c> on a clean machine).
+    /// </param>
+    public async Task<CliCommandResult> RunAsync(
+        string arguments,
+        IReadOnlyDictionary<string, string?>? extraEnvironment = null)
     {
         var cliDllPath = ResolveCliDllPath();
         var startInfo = new ProcessStartInfo
@@ -86,6 +93,22 @@ internal sealed class CliTestHarness : IAsyncDisposable
             // the CLI's first-run bootstrap is exercised.
             startInfo.Environment.Remove("Connectors__EncryptionKey");
             startInfo.Environment.Remove("TASKDECK_CONNECTORS__ENCRYPTIONKEY");
+        }
+
+        // Test-supplied overrides win over the provisioning defaults above.
+        if (extraEnvironment is not null)
+        {
+            foreach (var (name, value) in extraEnvironment)
+            {
+                if (value is null)
+                {
+                    startInfo.Environment.Remove(name);
+                }
+                else
+                {
+                    startInfo.Environment[name] = value;
+                }
+            }
         }
 
         using var process = new Process { StartInfo = startInfo };

--- a/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
+++ b/backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs
@@ -12,14 +12,35 @@ internal sealed class CliTestHarness : IAsyncDisposable
 {
     private static readonly TimeSpan ProcessTimeout = TimeSpan.FromSeconds(30);
 
+    private readonly string _dataDirectory;
     private readonly string _databasePath;
     private readonly string _connectionString;
+    private readonly bool _provisionEncryptionKey;
 
-    public CliTestHarness(string dbPrefix = "taskdeck-cli-tests")
+    /// <param name="provisionEncryptionKey">
+    /// When true (default) the harness injects a test connector encryption key via
+    /// the environment, matching a configured machine. When false the harness
+    /// simulates a CLEAN machine: no key is supplied, so the CLI must bootstrap
+    /// one itself.
+    /// </param>
+    public CliTestHarness(string dbPrefix = "taskdeck-cli-tests", bool provisionEncryptionKey = true)
     {
-        _databasePath = Path.Combine(Path.GetTempPath(), $"{dbPrefix}-{Guid.NewGuid():N}.db");
+        // Each harness gets its own data directory so the SQLite file -- and any
+        // appsettings.local.json written by the CLI's first-run bootstrap -- are
+        // isolated from other tests and cleaned up on dispose.
+        _dataDirectory = Path.Combine(Path.GetTempPath(), $"{dbPrefix}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dataDirectory);
+        _databasePath = Path.Combine(_dataDirectory, "taskdeck.db");
         _connectionString = $"Data Source={_databasePath}";
+        _provisionEncryptionKey = provisionEncryptionKey;
     }
+
+    /// <summary>
+    /// Directory that holds this harness's SQLite database. On a fresh-machine run
+    /// (<c>provisionEncryptionKey: false</c>) the CLI's first-run bootstrap writes
+    /// <c>appsettings.local.json</c> here.
+    /// </summary>
+    public string DataDirectory => _dataDirectory;
 
     public async Task<(Guid BoardId, Guid ColumnId)> CreateBoardAndColumnAsync(
         string boardName = "TestBoard",
@@ -54,8 +75,18 @@ internal sealed class CliTestHarness : IAsyncDisposable
 
         startInfo.Environment["TASKDECK_CONNECTION_STRING"] = _connectionString;
         startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
-        // Test-only 256-bit encryption key for connector credentials.
-        startInfo.Environment["Connectors__EncryptionKey"] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        if (_provisionEncryptionKey)
+        {
+            // Test-only 256-bit encryption key for connector credentials.
+            startInfo.Environment["Connectors__EncryptionKey"] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        }
+        else
+        {
+            // Clean machine: ensure no key leaks in from the parent environment so
+            // the CLI's first-run bootstrap is exercised.
+            startInfo.Environment.Remove("Connectors__EncryptionKey");
+            startInfo.Environment.Remove("TASKDECK_CONNECTORS__ENCRYPTIONKEY");
+        }
 
         using var process = new Process { StartInfo = startInfo };
         using var cts = new CancellationTokenSource(ProcessTimeout);
@@ -81,14 +112,15 @@ internal sealed class CliTestHarness : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
-        foreach (var path in new[] { _databasePath, $"{_databasePath}-wal", $"{_databasePath}-shm", $"{_databasePath}-journal" })
+        try
         {
-            try
+            if (Directory.Exists(_dataDirectory))
             {
-                if (File.Exists(path)) File.Delete(path);
+                Directory.Delete(_dataDirectory, recursive: true);
             }
-            catch (IOException) { }
         }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
 
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
## Summary
Part of #1131 (AC1 only). On a clean machine, `taskdeck boards list` crashed at startup: `Cli/Program.cs` calls `AddInfrastructure`, which fail-fasts with `InvalidOperationException` when `Connectors:EncryptionKey` is empty. The CLI ships no `appsettings.json` and never provisioned the key, so it was unusable unless the operator exported `TASKDECK_CONNECTORS__ENCRYPTIONKEY` by hand.

This makes the CLI self-sufficient on first run by provisioning the connector encryption key **before** `AddInfrastructure`.

> AC2 (claims-first authorization routing for board/card/column mutations) is intentionally **deferred** and not in this PR.

## Approach: provision (not lazy)
New CLI-local helper `Taskdeck.Cli/CliFirstRunBootstrapper.cs`, invoked from `Program.cs` after the connection string is resolved and before `AddInfrastructure`:

1. If `Connectors:EncryptionKey` is already present (env var, appsettings, user secrets) it is a **no-op** — explicit/operator config always wins.
2. Otherwise it reads/generates a key and persists it to a CLI-local `appsettings.local.json`, then loads it into configuration so `AddInfrastructure` succeeds.

Chose **provision** over lazy `ICredentialEncryptionService` registration because the key must be **stable across runs** — a regenerated key each invocation would make previously-encrypted connector credentials undecryptable. Persisting mirrors the API's `FirstRunBootstrapper` write pattern. The shared `AddInfrastructure` is **not** modified (the API intentionally fail-fasts on a missing key in Production).

### Key persistence location
Next to the **resolved SQLite data directory** (parsed from the connection string), not next to the executable. This is user-writable (the install dir may be read-only), co-locates the key with the encrypted data it protects, and is the same dir as `taskdeck.db`. Falls back to the current working directory if the data source can't be resolved to a path.

### Safety
- 256-bit key via `RandomNumberGenerator.GetBytes(32)` -> base64.
- Only provisions when missing; never overwrites a configured key.
- Merge-preserves any other keys already in `appsettings.local.json` (JSON read-modify-write).
- Atomic write (temp file + `File.Move(overwrite)` with retry) so a partial/corrupt file is never observed.
- Cross-process named mutex with re-check inside the lock, so two CLI invocations racing on a fresh machine converge on **one** shared key instead of each generating a different one.
- Never writes to stdout (CLI keeps stdout clean JSON); diagnostics go to stderr only, and only on the persist-failure fallback.

## Tests
Both end-to-end and focused tests (the harness change made the end-to-end path practical):
- **End-to-end CLI smoke tests** (`CliTestHarness` extended with `provisionEncryptionKey: false` + per-instance isolated data dir): run `boards list --json` against a clean env (no key, no pre-existing `appsettings.local.json`) and assert exit 0, empty JSON array, and that `appsettings.local.json` now contains a valid base64 256-bit key. A second test asserts the key is **stable across two runs**.
- **Unit tests** of `CliFirstRunBootstrapper`: provisions when missing; no-op when configured; reuses the persisted key on a second (fresh-process) call; preserves unrelated keys in the file; `GenerateKey` yields a unique base64 256-bit value.
- **Integration test**: `AddInfrastructure` throws on a clean config (reproduces the bug), then succeeds after the bootstrap, and the resolved `ICredentialEncryptionService` does a real encrypt/decrypt round-trip.

## Verification
- `dotnet build backend/Taskdeck.sln -c Release` -> **0 errors** (11 warnings, all pre-existing in unrelated `Api.Tests`/`Application.Tests`).
- `dotnet test backend/tests/Taskdeck.Cli.Tests/...` -> **90 passed, 0 failed** (8 new). New class alone: **8 passed**.

## Files changed
- `backend/src/Taskdeck.Cli/CliFirstRunBootstrapper.cs` (new)
- `backend/src/Taskdeck.Cli/Program.cs` (wire-in before `AddInfrastructure`)
- `backend/tests/Taskdeck.Cli.Tests/CliTestHarness.cs` (fresh-machine mode + isolated data dir)
- `backend/tests/Taskdeck.Cli.Tests/CliFirstRunBootstrapTests.cs` (new)
