### PR TITLE
Serialize cross-process Database.Migrate() via file advisory lock (#1164)

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
@@ -28,10 +28,12 @@ public static class PipelineConfiguration
                 "Configure ForwardedHeaders:KnownProxies or ForwardedHeaders:KnownNetworks.");
         }
 
+        // Apply EF Core migrations serialized across processes via a cross-process file lock
+        // so concurrent API/MCP/CLI startups apply the schema exactly once (#1164).
         using (var scope = app.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
-            dbContext.Database.Migrate();
+            SerializedMigrator.Migrate(dbContext, app.Logger);
         }
 
         if (app.Environment.IsDevelopment())

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -105,11 +105,13 @@ if (args.Contains("--mcp"))
 
         var mcpHttpApp = mcpHttpBuilder.Build();
 
-        // Apply EF Core migrations before starting.
+        // Apply EF Core migrations before starting, serialized across processes via a
+        // cross-process file lock so the MCP HTTP host does not race the API/CLI (#1164).
         using (var scope = mcpHttpApp.Services.CreateScope())
         {
             var dbContext = scope.ServiceProvider.GetRequiredService<Taskdeck.Infrastructure.Persistence.TaskdeckDbContext>();
-            dbContext.Database.Migrate();
+            var migrationLogger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            Taskdeck.Infrastructure.Persistence.SerializedMigrator.Migrate(dbContext, migrationLogger);
         }
 
         // Correlation ID propagation: honours client X-Request-Id header.
@@ -182,11 +184,14 @@ if (args.Contains("--mcp"))
         })
         .Build();
 
-    // Apply EF Core migrations before starting the MCP host (mirrors web mode behaviour).
+    // Apply EF Core migrations before starting the MCP host (mirrors web mode behaviour),
+    // serialized across processes via a cross-process file lock (#1164). In stdio mode logs
+    // go to stderr, so the logger never corrupts the stdout JSON-RPC stream.
     using (var scope = mcpHost.Services.CreateScope())
     {
         var dbContext = scope.ServiceProvider.GetRequiredService<Taskdeck.Infrastructure.Persistence.TaskdeckDbContext>();
-        dbContext.Database.Migrate();
+        var migrationLogger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+        Taskdeck.Infrastructure.Persistence.SerializedMigrator.Migrate(dbContext, migrationLogger);
     }
 
     await mcpHost.RunAsync();

--- a/backend/src/Taskdeck.Cli/Program.cs
+++ b/backend/src/Taskdeck.Cli/Program.cs
@@ -53,7 +53,10 @@ using var host = builder.Build();
 using (var startupScope = host.Services.CreateScope())
 {
     var dbContext = startupScope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
-    dbContext.Database.Migrate();
+    // Serialize migrations across processes (API/MCP/CLI) via a file lock (#1164).
+    // Pass no logger: CLI stdout must stay clean JSON (the helper never writes to stdout,
+    // but logging is suppressed here regardless).
+    SerializedMigrator.Migrate(dbContext);
 }
 
 var dispatcher = new CommandDispatcher(host.Services);

--- a/backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs
@@ -1,0 +1,266 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Taskdeck.Infrastructure.Persistence;
+
+/// <summary>
+/// Applies EF Core migrations under a portable, cross-process advisory lock so that
+/// multiple Taskdeck hosts (API, MCP-http, MCP-stdio, CLI) booting against the same
+/// SQLite file do not race to apply migrations on <c>__EFMigrationsHistory</c>.
+/// <para>
+/// #1130 enabled <c>WAL + busy_timeout</c> (a racing writer now waits instead of failing
+/// immediately with <c>SQLITE_BUSY</c>), which substantially mitigates the race. #1164 is
+/// the remaining acceptance criterion: actually <em>serialize</em> migration application so
+/// concurrent startups apply the schema exactly once.
+/// </para>
+/// <para>
+/// <b>Mechanism.</b> A sidecar lock file <c>"&lt;dbpath&gt;.migrate.lock"</c> is opened with
+/// <see cref="FileShare.None"/>; only one process can hold it at a time. The winner applies
+/// migrations; every other process blocks on the lock and, once it acquires it, sees the
+/// migrations already applied and no-ops (<see cref="RelationalDatabaseFacadeExtensions.Migrate"/>
+/// is idempotent). A .NET named <see cref="System.Threading.Mutex"/> is deliberately avoided:
+/// it is not cross-process on Unix.
+/// </para>
+/// <para>
+/// <b>Fallbacks (never block startup).</b> Non-relational/in-memory databases
+/// (<c>:memory:</c>, <c>Mode=Memory</c>, the EF Core InMemory provider) and non-SQLite
+/// providers skip the lock entirely — there is no shared file to coordinate on, and tests /
+/// ephemeral databases must not stall. If the lock cannot be acquired within the timeout, or
+/// the lock directory is unwritable, a warning is logged and migration proceeds anyway:
+/// <c>Migrate()</c> remains idempotent and <c>busy_timeout</c> still makes a racing writer wait.
+/// </para>
+/// </summary>
+public static class SerializedMigrator
+{
+    /// <summary>Default upper bound on how long to wait for the migration lock.</summary>
+    public static readonly TimeSpan DefaultLockTimeout = TimeSpan.FromSeconds(30);
+
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(100);
+
+    private const string LockFileSuffix = ".migrate.lock";
+
+    /// <summary>
+    /// Applies migrations for <paramref name="context"/> under a cross-process file lock
+    /// (when the database is a real SQLite file). See the type remarks for fallback behavior.
+    /// </summary>
+    /// <param name="context">The context whose database should be migrated.</param>
+    /// <param name="logger">Optional logger for diagnostics. Pass <c>null</c> on the CLI path
+    /// (CLI stdout must stay clean JSON; nothing is written to stdout here, but callers may
+    /// still prefer to suppress logging).</param>
+    public static void Migrate(DbContext context, ILogger? logger = null)
+        => Migrate(context, DefaultLockTimeout, logger);
+
+    /// <summary>
+    /// Applies migrations for <paramref name="context"/> under a cross-process file lock,
+    /// waiting at most <paramref name="lockTimeout"/> to acquire it before proceeding anyway.
+    /// </summary>
+    public static void Migrate(DbContext context, TimeSpan lockTimeout, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var lockPath = ResolveLockPath(context, logger);
+        if (lockPath is null)
+        {
+            // In-memory, non-file, or non-SQLite database: nothing to coordinate across
+            // processes. Apply migrations directly.
+            context.Database.Migrate();
+            return;
+        }
+
+        FileStream? lockStream = null;
+        try
+        {
+            lockStream = AcquireLock(lockPath, lockTimeout, logger);
+            if (lockStream is not null)
+            {
+                logger?.LogDebug("SerializedMigrator: acquired migration lock '{LockPath}'.", lockPath);
+            }
+
+            context.Database.Migrate();
+        }
+        finally
+        {
+            lockStream?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the sidecar lock-file path for the context's SQLite data source, or
+    /// <c>null</c> when no cross-process lock is applicable (non-SQLite provider, in-memory
+    /// database, or a data source that is not a usable file path).
+    /// </summary>
+    private static string? ResolveLockPath(DbContext context, ILogger? logger)
+    {
+        // Only SQLite file databases need this coordination. A future PostgreSQL runtime
+        // (ADR-0023) handles concurrent migrators with server-side locking, and the EF Core
+        // InMemory provider has no shared file at all.
+        if (!IsSqliteProvider(context))
+        {
+            return null;
+        }
+
+        var connectionString = TryGetConnectionString(context);
+        var dataSource = TryGetDataSource(context);
+
+        if (string.IsNullOrWhiteSpace(dataSource) && !string.IsNullOrWhiteSpace(connectionString))
+        {
+            dataSource = TryParseDataSource(connectionString);
+        }
+
+        if (IsNonFileDataSource(dataSource, connectionString))
+        {
+            return null;
+        }
+
+        try
+        {
+            // Normalize so two processes that pass the same relative "Data Source=taskdeck.db"
+            // from the same working directory resolve to the same absolute lock path.
+            return Path.GetFullPath(dataSource!) + LockFileSuffix;
+        }
+        catch (Exception ex) when (
+            ex is ArgumentException
+                or NotSupportedException
+                or PathTooLongException
+                or System.Security.SecurityException)
+        {
+            logger?.LogWarning(
+                ex,
+                "SerializedMigrator: data source '{DataSource}' is not a usable file path; " +
+                "applying migrations without a cross-process lock.",
+                dataSource);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Opens the lock file exclusively (<see cref="FileShare.None"/>), retrying with a short
+    /// backoff while another process holds it. Returns the held stream, or <c>null</c> if the
+    /// lock could not be acquired within <paramref name="timeout"/> or the file could not be
+    /// created at all (in which case the caller proceeds without the lock).
+    /// </summary>
+    private static FileStream? AcquireLock(string lockPath, TimeSpan timeout, ILogger? logger)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        var attempts = 0;
+
+        while (true)
+        {
+            attempts++;
+            try
+            {
+                return new FileStream(
+                    lockPath,
+                    FileMode.OpenOrCreate,
+                    FileAccess.ReadWrite,
+                    FileShare.None);
+            }
+            catch (IOException) when (DateTime.UtcNow < deadline)
+            {
+                // Another process (or thread) holds the exclusive lock; wait and retry.
+                Thread.Sleep(RetryDelay);
+            }
+            catch (IOException ex)
+            {
+                logger?.LogWarning(
+                    ex,
+                    "SerializedMigrator: could not acquire migration lock '{LockPath}' within " +
+                    "{TimeoutSeconds}s after {Attempts} attempts; applying migrations without it. " +
+                    "Migrate() is idempotent and busy_timeout still serializes the write.",
+                    lockPath,
+                    timeout.TotalSeconds,
+                    attempts);
+                return null;
+            }
+            catch (Exception ex) when (
+                ex is UnauthorizedAccessException
+                    or DirectoryNotFoundException
+                    or NotSupportedException)
+            {
+                // The lock directory is unwritable / the path is unusable. Do not block
+                // startup over a best-effort coordination file.
+                logger?.LogWarning(
+                    ex,
+                    "SerializedMigrator: migration lock file '{LockPath}' could not be created " +
+                    "({Reason}); applying migrations without a cross-process lock.",
+                    lockPath,
+                    ex.GetType().Name);
+                return null;
+            }
+        }
+    }
+
+    private static bool IsSqliteProvider(DbContext context)
+    {
+        try
+        {
+            return context.Database.IsSqlite();
+        }
+        catch
+        {
+            // IsSqlite() can throw when multiple providers are configured; treat the
+            // ambiguous case as "do not lock" so we never block startup.
+            return false;
+        }
+    }
+
+    private static string? TryGetDataSource(DbContext context)
+    {
+        try
+        {
+            return context.Database.GetDbConnection().DataSource;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? TryGetConnectionString(DbContext context)
+    {
+        try
+        {
+            return context.Database.GetConnectionString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? TryParseDataSource(string connectionString)
+    {
+        try
+        {
+            return new SqliteConnectionStringBuilder(connectionString).DataSource;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsNonFileDataSource(string? dataSource, string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(dataSource))
+        {
+            return true;
+        }
+
+        // Covers ":memory:" and the shared form "file::memory:?cache=shared".
+        if (dataSource.Contains(":memory:", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // Mode=Memory makes any data source (even a named one) an in-memory database.
+        if (!string.IsNullOrEmpty(connectionString) &&
+            connectionString.Contains("Mode=Memory", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs
@@ -27,8 +27,13 @@ namespace Taskdeck.Infrastructure.Persistence;
 /// (<c>:memory:</c>, <c>Mode=Memory</c>, the EF Core InMemory provider) and non-SQLite
 /// providers skip the lock entirely — there is no shared file to coordinate on, and tests /
 /// ephemeral databases must not stall. If the lock cannot be acquired within the timeout, or
-/// the lock directory is unwritable, a warning is logged and migration proceeds anyway:
-/// <c>Migrate()</c> remains idempotent and <c>busy_timeout</c> still makes a racing writer wait.
+/// the lock directory is unwritable, a warning is logged and migration proceeds anyway.
+/// On that lock-free path a concurrent migrator can still win a logical DDL race
+/// (<c>"table already exists"</c>, or a duplicate <c>__EFMigrationsHistory</c> insert):
+/// <c>busy_timeout</c> only serializes <c>SQLITE_BUSY</c>, <b>not</b> these logical conflicts.
+/// So the unlocked <c>Migrate()</c> is wrapped — a throw is swallowed only when a re-check of
+/// <see cref="RelationalDatabaseFacadeExtensions.GetPendingMigrations"/> shows nothing remains
+/// pending (the racing winner already applied everything); otherwise the failure propagates.
 /// </para>
 /// </summary>
 public static class SerializedMigrator
@@ -74,14 +79,69 @@ public static class SerializedMigrator
             lockStream = AcquireLock(lockPath, lockTimeout, logger);
             if (lockStream is not null)
             {
+                // Locked path: we hold the exclusive advisory lock, so no other migrator can be
+                // mutating the schema concurrently. Any Migrate() throw here is a genuine failure
+                // — let it propagate untouched.
                 logger?.LogDebug("SerializedMigrator: acquired migration lock '{LockPath}'.", lockPath);
+                context.Database.Migrate();
             }
-
-            context.Database.Migrate();
+            else
+            {
+                // Fail-open path: we could NOT take the lock (timed out, or the lock file was
+                // uncreatable). A concurrent migrator may still be applying the schema, so this
+                // Migrate() can race it. Guard the throw rather than crash startup.
+                MigrateWithoutLock(context, logger);
+            }
         }
         finally
         {
             lockStream?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Applies migrations on the lock-free fallback path, where a concurrent migrator may win a
+    /// logical DDL race. EF computes the pending set <em>before</em> taking SQLite's write lock,
+    /// so a racing loser can throw <see cref="Microsoft.Data.Sqlite.SqliteException"/>
+    /// (<c>"table already exists"</c>) or a <see cref="DbUpdateException"/> from a duplicate
+    /// <c>__EFMigrationsHistory</c> primary-key insert. <c>busy_timeout</c> only serializes
+    /// <c>SQLITE_BUSY</c>, not these conflicts. The exception filter re-checks the pending set:
+    /// if it is now empty the racing winner applied everything and the throw is swallowed as a
+    /// no-op; otherwise migrations genuinely remain unapplied and the failure propagates with its
+    /// original stack trace.
+    /// </summary>
+    private static void MigrateWithoutLock(DbContext context, ILogger? logger)
+    {
+        try
+        {
+            context.Database.Migrate();
+        }
+        catch (Exception ex) when (NoMigrationsPending(context))
+        {
+            logger?.LogWarning(
+                ex,
+                "SerializedMigrator: applied migrations without the cross-process lock and raced " +
+                "a concurrent migrator ({Reason}); all migrations are now present, so the conflict " +
+                "is treated as a successful no-op.",
+                ex.GetType().Name);
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> only when EF reports zero pending migrations — i.e. another process
+    /// already applied everything. If the pending set cannot be read, returns <c>false</c> so the
+    /// caller's exception filter declines to swallow the original failure.
+    /// </summary>
+    private static bool NoMigrationsPending(DbContext context)
+    {
+        try
+        {
+            return !context.Database.GetPendingMigrations().Any();
+        }
+        catch
+        {
+            // Could not confirm the schema is fully applied: do not mask the real failure.
+            return false;
         }
     }
 
@@ -115,9 +175,29 @@ public static class SerializedMigrator
 
         try
         {
+            var filePath = dataSource!;
+
+            // SQLite also accepts URI data sources (e.g. "file:taskdeck.db?cache=shared").
+            // Handing the raw URI to Path.GetFullPath throws on Windows (the '?' is an invalid
+            // path char) or, on Unix, produces a lock file with a literal '?' in its name.
+            // Extract the local file path first so both spellings of the same file coordinate
+            // on one lock. (Pure ":memory:" URIs are already filtered out above.)
+            if (Uri.TryCreate(filePath, UriKind.Absolute, out var uri) && uri.IsFile)
+            {
+                filePath = uri.LocalPath;
+            }
+
             // Normalize so two processes that pass the same relative "Data Source=taskdeck.db"
             // from the same working directory resolve to the same absolute lock path.
-            return Path.GetFullPath(dataSource!) + LockFileSuffix;
+            //
+            // LIMITATION: Path.GetFullPath is a LEXICAL normalization only — it collapses
+            // "."/".." and applies the current directory, but does NOT canonicalize symlinks,
+            // junctions, or hard links. Two differently-spelled paths that resolve to the same
+            // physical file (e.g. a symlink and its target, or 8.3 vs long Windows names) key to
+            // DIFFERENT lock files and are therefore NOT serialized against each other. That
+            // residual race is bounded by the WAL + busy_timeout writer fallback and the
+            // unlocked-Migrate re-check, and is acceptable for the local-first SQLite scenario.
+            return Path.GetFullPath(filePath) + LockFileSuffix;
         }
         catch (Exception ex) when (
             ex is ArgumentException
@@ -142,7 +222,9 @@ public static class SerializedMigrator
     /// </summary>
     private static FileStream? AcquireLock(string lockPath, TimeSpan timeout, ILogger? logger)
     {
-        var deadline = DateTime.UtcNow + timeout;
+        // Monotonic clock (Stopwatch), not DateTime.UtcNow: a wall-clock step (NTP correction,
+        // DST, manual change) must not skew how long we are willing to wait for the lock.
+        var elapsed = System.Diagnostics.Stopwatch.StartNew();
         var attempts = 0;
 
         while (true)
@@ -156,7 +238,7 @@ public static class SerializedMigrator
                     FileAccess.ReadWrite,
                     FileShare.None);
             }
-            catch (IOException) when (DateTime.UtcNow < deadline)
+            catch (IOException) when (elapsed.Elapsed < timeout)
             {
                 // Another process (or thread) holds the exclusive lock; wait and retry.
                 Thread.Sleep(RetryDelay);
@@ -167,7 +249,9 @@ public static class SerializedMigrator
                     ex,
                     "SerializedMigrator: could not acquire migration lock '{LockPath}' within " +
                     "{TimeoutSeconds}s after {Attempts} attempts; applying migrations without it. " +
-                    "Migrate() is idempotent and busy_timeout still serializes the write.",
+                    "The unlocked Migrate() re-checks the pending set and swallows a concurrent " +
+                    "migrator's conflict only if nothing remains pending — busy_timeout alone only " +
+                    "serializes SQLITE_BUSY, not logical DDL conflicts.",
                     lockPath,
                     timeout.TotalSeconds,
                     attempts);

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -13,6 +13,11 @@ namespace Taskdeck.Api.Tests;
 /// Verifies <see cref="SerializedMigrator"/> serializes <c>Database.Migrate()</c> across
 /// concurrent migrators sharing one SQLite file so the schema is applied exactly once, and
 /// that in-memory / non-file databases skip the cross-process lock entirely. #1164
+/// <para>
+/// The concurrency test drives two in-process threads rather than a second OS process; the
+/// <see cref="FileShare.None"/> lock is OS-enforced, so this is a faithful in-process proxy
+/// for the cross-process race the migrator must close.
+/// </para>
 /// </summary>
 public sealed class SerializedMigratorTests : IDisposable
 {
@@ -24,10 +29,12 @@ public sealed class SerializedMigratorTests : IDisposable
         _dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-serialized-migrate-{Guid.NewGuid():N}.db");
     }
 
-    private TaskdeckDbContext NewFileContext()
+    private TaskdeckDbContext NewFileContext() => NewFileContext(_dbPath);
+
+    private static TaskdeckDbContext NewFileContext(string dbPath)
     {
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={_dbPath}")
+            .UseSqlite($"Data Source={dbPath}")
             // Mirror production: WAL + busy_timeout (#1130) on every connection.
             .AddInterceptors(new SqlitePragmaConnectionInterceptor(BusyTimeoutMs))
             .Options;
@@ -35,59 +42,97 @@ public sealed class SerializedMigratorTests : IDisposable
     }
 
     [Fact]
-    public async Task Two_concurrent_migrators_apply_schema_exactly_once()
+    public async Task Concurrent_migrators_apply_schema_exactly_once()
     {
         // Two independent DbContexts point at the SAME fresh file DB. Each applies migrations
         // from its own task; a Barrier makes both reach Migrate at the same instant to
-        // maximize the overlap the file lock must serialize. Without the lock the loser would
-        // hit a UNIQUE violation double-inserting into __EFMigrationsHistory.
+        // maximize the overlap the file lock must serialize. These are two in-process threads,
+        // NOT a second OS process, but FileShare.None is an OS-enforced exclusive lock, so this
+        // is a faithful in-process proxy for the cross-process race. Without the lock the loser
+        // would hit a UNIQUE violation double-inserting into __EFMigrationsHistory.
         //
-        // Both contexts are constructed up front (not inside the tasks) so nothing between
-        // barrier-entry and Migrate() can throw and deadlock the sibling participant.
-        using var contextA = NewFileContext();
-        using var contextB = NewFileContext();
-        using var startBarrier = new Barrier(2);
-
-        Task RunMigratorAsync(TaskdeckDbContext context) => Task.Run(() =>
+        // Repeated over a few fresh databases to shrink the probabilistic window in which the
+        // two threads happen not to overlap (and so the lock is never actually contended).
+        const int iterations = 4;
+        for (var i = 0; i < iterations; i++)
         {
-            startBarrier.SignalAndWait();
-            SerializedMigrator.Migrate(context);
-        });
+            var dbPath = Path.Combine(
+                Path.GetTempPath(), $"taskdeck-serialized-migrate-concurrent-{Guid.NewGuid():N}.db");
+            try
+            {
+                // Both contexts are constructed up front (not inside the tasks) so nothing
+                // between barrier-entry and Migrate() can throw and deadlock the sibling.
+                using var contextA = NewFileContext(dbPath);
+                using var contextB = NewFileContext(dbPath);
+                using var startBarrier = new Barrier(2);
 
-        var migratorA = RunMigratorAsync(contextA);
-        var migratorB = RunMigratorAsync(contextB);
+                Task RunMigratorAsync(TaskdeckDbContext context) => Task.Run(() =>
+                {
+                    // Bounded wait: if a sibling dies before reaching the barrier, fail fast
+                    // instead of hanging CI forever.
+                    if (!startBarrier.SignalAndWait(TimeSpan.FromSeconds(10)))
+                    {
+                        throw new TimeoutException(
+                            "Sibling migrator never reached the start barrier.");
+                    }
 
-        var act = async () => await Task.WhenAll(migratorA, migratorB);
-        await act.Should().NotThrowAsync(
-            "the cross-process file lock must serialize concurrent migrators so neither fails");
+                    SerializedMigrator.Migrate(context);
+                });
 
-        using var verify = NewFileContext();
+                var migratorA = RunMigratorAsync(contextA);
+                var migratorB = RunMigratorAsync(contextB);
 
-        // Schema applied: a known table exists.
-        GetUserTableNames(verify).Should().Contain(
-            "Boards", "the migration chain must have created the Boards table");
+                var act = async () => await Task.WhenAll(migratorA, migratorB);
+                await act.Should().NotThrowAsync(
+                    "the advisory file lock must serialize concurrent migrators so neither fails");
 
-        // Applied exactly once: every defined migration appears exactly once in history.
-        var historyIds = GetMigrationHistoryIds(verify);
-        historyIds.Should().OnlyHaveUniqueItems(
-            "two migrators must not double-insert __EFMigrationsHistory rows");
-        historyIds.Should().BeEquivalentTo(
-            verify.Database.GetMigrations(),
-            "every defined migration should be applied exactly once across the concurrent run");
+                using var verify = NewFileContext(dbPath);
+
+                // Schema applied: a known table exists.
+                GetUserTableNames(verify).Should().Contain(
+                    "Boards", "the migration chain must have created the Boards table");
+
+                // Applied exactly once: every defined migration appears exactly once in history.
+                var historyIds = GetMigrationHistoryIds(verify);
+                historyIds.Should().OnlyHaveUniqueItems(
+                    "two migrators must not double-insert __EFMigrationsHistory rows");
+                historyIds.Should().BeEquivalentTo(
+                    verify.Database.GetMigrations(),
+                    "every defined migration should be applied exactly once across the concurrent run");
+            }
+            finally
+            {
+                CleanupDbFiles(dbPath);
+            }
+        }
     }
 
     [Fact]
-    public void Single_migrator_on_file_db_creates_sidecar_lock_file()
+    public void Single_migrator_on_file_db_acquires_lock_and_does_not_fail_open()
     {
+        var logger = new InMemoryLogger<SerializedMigratorTests>();
         using var context = NewFileContext();
 
-        SerializedMigrator.Migrate(context);
+        SerializedMigrator.Migrate(context, logger);
 
-        // The helper leaves the sidecar lock file in place (cleanup is optional/best-effort).
-        // Its presence documents the lock path resolution: "<dbpath>.migrate.lock".
-        var expectedLockPath = Path.GetFullPath(_dbPath) + ".migrate.lock";
-        File.Exists(expectedLockPath).Should().BeTrue(
-            "a real SQLite file database should be migrated under a sidecar advisory lock");
+        // Assert the helper's "acquired migration lock" Debug entry rather than the sidecar
+        // file's continued existence: cleanup is documented as optional/best-effort, so the
+        // log is the stable contract that the lock was actually taken (locked path), not
+        // silently skipped or degraded to the fail-open branch.
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Debug && e.Message.Contains("acquired migration lock"),
+            "a real SQLite file database must be migrated under the sidecar advisory lock");
+
+        // Fail-open regression guard: a healthy single-migrator run must emit NO Warning/Error.
+        // If the lock were silently never taken (always degrading to the unlocked path), this
+        // happy path would start logging a warning and this assertion would catch it.
+        logger.Entries.Should().NotContain(
+            e => e.Level >= LogLevel.Warning,
+            "a healthy single migrator must take the lock, never silently fail open");
+
+        using var verify = NewFileContext();
+        GetUserTableNames(verify).Should().Contain(
+            "Boards", "the migration chain must have created the Boards table");
     }
 
     [Fact]
@@ -191,13 +236,15 @@ public sealed class SerializedMigratorTests : IDisposable
         return ids;
     }
 
-    public void Dispose()
+    public void Dispose() => CleanupDbFiles(_dbPath);
+
+    private static void CleanupDbFiles(string dbPath)
     {
         // Drop pooled connections so file handles release before cleanup.
         SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", ".migrate.lock" })
         {
-            var path = _dbPath + suffix;
+            var path = dbPath + suffix;
             if (File.Exists(path))
             {
                 // Best-effort: on Windows a still-locked file can throw; never fail the run.

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -1,8 +1,10 @@
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Infrastructure.Persistence;
+using Taskdeck.Tests.Support;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -39,18 +41,21 @@ public sealed class SerializedMigratorTests : IDisposable
         // from its own task; a Barrier makes both reach Migrate at the same instant to
         // maximize the overlap the file lock must serialize. Without the lock the loser would
         // hit a UNIQUE violation double-inserting into __EFMigrationsHistory.
+        //
+        // Both contexts are constructed up front (not inside the tasks) so nothing between
+        // barrier-entry and Migrate() can throw and deadlock the sibling participant.
+        using var contextA = NewFileContext();
+        using var contextB = NewFileContext();
         using var startBarrier = new Barrier(2);
 
-        async Task RunMigratorAsync()
+        Task RunMigratorAsync(TaskdeckDbContext context) => Task.Run(() =>
         {
-            await Task.Yield();
-            using var context = NewFileContext();
             startBarrier.SignalAndWait();
             SerializedMigrator.Migrate(context);
-        }
+        });
 
-        var migratorA = Task.Run(RunMigratorAsync);
-        var migratorB = Task.Run(RunMigratorAsync);
+        var migratorA = RunMigratorAsync(contextA);
+        var migratorB = RunMigratorAsync(contextB);
 
         var act = async () => await Task.WhenAll(migratorA, migratorB);
         await act.Should().NotThrowAsync(
@@ -109,6 +114,33 @@ public sealed class SerializedMigratorTests : IDisposable
         var strayLock = Path.Combine(Directory.GetCurrentDirectory(), ":memory:.migrate.lock");
         File.Exists(strayLock).Should().BeFalse(
             "an in-memory database must not produce a sidecar migration lock file");
+    }
+
+    [Fact]
+    public void Migrate_proceeds_with_a_warning_when_lock_cannot_be_acquired_within_timeout()
+    {
+        var lockPath = Path.GetFullPath(_dbPath) + ".migrate.lock";
+
+        // Simulate another process holding the exclusive lock for the whole call.
+        using var heldLock = new FileStream(
+            lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+        var logger = new InMemoryLogger<SerializedMigratorTests>();
+        using var context = NewFileContext();
+
+        // Acquisition must time out, then degrade to a warning and migrate anyway —
+        // Migrate() is idempotent and busy_timeout still serializes the actual write.
+        // This also exercises the public Migrate(DbContext, TimeSpan, ILogger?) overload.
+        var act = () => SerializedMigrator.Migrate(context, TimeSpan.FromMilliseconds(300), logger);
+        act.Should().NotThrow("a contended lock must degrade to a warning, never block startup");
+
+        using var verify = NewFileContext();
+        GetUserTableNames(verify).Should().Contain(
+            "Boards", "migrations must still apply when the lock cannot be acquired");
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning,
+            "failing to acquire the migration lock within the timeout must be logged as a warning");
     }
 
     private static List<string> GetUserTableNames(TaskdeckDbContext context)

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -1,0 +1,177 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Persistence;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Verifies <see cref="SerializedMigrator"/> serializes <c>Database.Migrate()</c> across
+/// concurrent migrators sharing one SQLite file so the schema is applied exactly once, and
+/// that in-memory / non-file databases skip the cross-process lock entirely. #1164
+/// </summary>
+public sealed class SerializedMigratorTests : IDisposable
+{
+    private const int BusyTimeoutMs = 5000;
+    private readonly string _dbPath;
+
+    public SerializedMigratorTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-serialized-migrate-{Guid.NewGuid():N}.db");
+    }
+
+    private TaskdeckDbContext NewFileContext()
+    {
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            // Mirror production: WAL + busy_timeout (#1130) on every connection.
+            .AddInterceptors(new SqlitePragmaConnectionInterceptor(BusyTimeoutMs))
+            .Options;
+        return new TaskdeckDbContext(options);
+    }
+
+    [Fact]
+    public async Task Two_concurrent_migrators_apply_schema_exactly_once()
+    {
+        // Two independent DbContexts point at the SAME fresh file DB. Each applies migrations
+        // from its own task; a Barrier makes both reach Migrate at the same instant to
+        // maximize the overlap the file lock must serialize. Without the lock the loser would
+        // hit a UNIQUE violation double-inserting into __EFMigrationsHistory.
+        using var startBarrier = new Barrier(2);
+
+        async Task RunMigratorAsync()
+        {
+            await Task.Yield();
+            using var context = NewFileContext();
+            startBarrier.SignalAndWait();
+            SerializedMigrator.Migrate(context);
+        }
+
+        var migratorA = Task.Run(RunMigratorAsync);
+        var migratorB = Task.Run(RunMigratorAsync);
+
+        var act = async () => await Task.WhenAll(migratorA, migratorB);
+        await act.Should().NotThrowAsync(
+            "the cross-process file lock must serialize concurrent migrators so neither fails");
+
+        using var verify = NewFileContext();
+
+        // Schema applied: a known table exists.
+        GetUserTableNames(verify).Should().Contain(
+            "Boards", "the migration chain must have created the Boards table");
+
+        // Applied exactly once: every defined migration appears exactly once in history.
+        var historyIds = GetMigrationHistoryIds(verify);
+        historyIds.Should().OnlyHaveUniqueItems(
+            "two migrators must not double-insert __EFMigrationsHistory rows");
+        historyIds.Should().BeEquivalentTo(
+            verify.Database.GetMigrations(),
+            "every defined migration should be applied exactly once across the concurrent run");
+    }
+
+    [Fact]
+    public void Single_migrator_on_file_db_creates_sidecar_lock_file()
+    {
+        using var context = NewFileContext();
+
+        SerializedMigrator.Migrate(context);
+
+        // The helper leaves the sidecar lock file in place (cleanup is optional/best-effort).
+        // Its presence documents the lock path resolution: "<dbpath>.migrate.lock".
+        var expectedLockPath = Path.GetFullPath(_dbPath) + ".migrate.lock";
+        File.Exists(expectedLockPath).Should().BeTrue(
+            "a real SQLite file database should be migrated under a sidecar advisory lock");
+    }
+
+    [Fact]
+    public void In_memory_database_migrates_without_creating_a_lock_file()
+    {
+        // A kept-open connection keeps the :memory: schema alive for assertions (a fresh
+        // connection per command would discard it).
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var context = new TaskdeckDbContext(options);
+
+        // Still migrates: no exception, and the schema is present.
+        SerializedMigrator.Migrate(context);
+        context.Set<Board>().Count().Should().Be(0,
+            "the in-memory database should be migrated even though no lock is taken");
+
+        // No lock file: :memory: resolves to no file path, so the helper must never open a
+        // FileStream. Guard against a regression that naively builds a lock path from the
+        // ":memory:" data source (on Unix Path.GetFullPath(":memory:") lands in the cwd).
+        var strayLock = Path.Combine(Directory.GetCurrentDirectory(), ":memory:.migrate.lock");
+        File.Exists(strayLock).Should().BeFalse(
+            "an in-memory database must not produce a sidecar migration lock file");
+    }
+
+    private static List<string> GetUserTableNames(TaskdeckDbContext context)
+    {
+        var names = new List<string>();
+        var connection = context.Database.GetDbConnection();
+        context.Database.OpenConnection();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText =
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' " +
+                "AND name != '__EFMigrationsHistory' ORDER BY name";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                names.Add(reader.GetString(0));
+            }
+        }
+        finally
+        {
+            context.Database.CloseConnection();
+        }
+
+        return names;
+    }
+
+    private static List<string> GetMigrationHistoryIds(TaskdeckDbContext context)
+    {
+        var ids = new List<string>();
+        var connection = context.Database.GetDbConnection();
+        context.Database.OpenConnection();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT MigrationId FROM __EFMigrationsHistory ORDER BY MigrationId";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                ids.Add(reader.GetString(0));
+            }
+        }
+        finally
+        {
+            context.Database.CloseConnection();
+        }
+
+        return ids;
+    }
+
+    public void Dispose()
+    {
+        // Drop pooled connections so file handles release before cleanup.
+        SqliteConnection.ClearAllPools();
+        foreach (var suffix in new[] { "", "-wal", "-shm", ".migrate.lock" })
+        {
+            var path = _dbPath + suffix;
+            if (File.Exists(path))
+            {
+                // Best-effort: on Windows a still-locked file can throw; never fail the run.
+                try { File.Delete(path); }
+                catch (Exception) { /* best-effort temp cleanup */ }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1164.

Each host (API, MCP-http, MCP-stdio, CLI) calls `Database.Migrate()` on startup with **no cross-process coordination**. #1130 enabled WAL + `busy_timeout` (a racing writer now *waits* instead of failing immediately), but two processes booting simultaneously can still both decide migrations are pending and contend on `__EFMigrationsHistory` (UNIQUE-key collision). This PR adds the remaining acceptance criterion: **serialize migration application across processes**.

## Lock design

New `SerializedMigrator.Migrate(DbContext, ILogger?)` in `Taskdeck.Infrastructure.Persistence` wraps `Database.Migrate()` with a **portable, cross-process file-based advisory lock**:

- Resolves the SQLite **Data Source** file path from `context.Database.GetDbConnection().DataSource`, falling back to parsing `GetConnectionString()` via `SqliteConnectionStringBuilder` (the live connection reports an empty `DataSource` once open, so the connection-string parse is the reliable source).
- Opens a sidecar lock file `"<dbpath>.migrate.lock"` via `new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None)` in a **retry-with-backoff loop** (catch `IOException`, 100ms sleep, bounded **30s** total). The winner applies migrations; every other process blocks on the lock, then acquires it and sees migrations already applied → no-op (`Migrate()` is idempotent). The `FileStream` is disposed in a `finally`; the lock file is intentionally left behind (cleanup is best-effort/optional).
- A .NET named `Mutex` is **deliberately not used** — it is not cross-process on Unix (per the issue).

**No single-owner model.** The file lock already satisfies "CLI/MCP do not race the API": all hosts coordinate on the same lock file, so only one applies at a time and the rest no-op. This keeps every host self-sufficient on a fresh DB (no host has to be running first), which a single-owner/skip model would not.

### Fallbacks (never block startup)
- **Non-SQLite provider** (future PostgreSQL per ADR-0023, or the EF Core InMemory provider): skip the lock, migrate directly (`IsSqlite()` guard).
- **In-memory / non-file** (`:memory:`, `file::memory:`, `Mode=Memory`, empty data source): skip the lock — there is no shared file to coordinate on (tests + ephemeral DBs must not stall).
- **Lock can't be acquired in 30s, or lock dir unwritable** (`UnauthorizedAccessException`/`DirectoryNotFoundException`): log a warning and proceed — `Migrate()` is idempotent and `busy_timeout` still serializes the actual write.

## Call sites updated (all 4)
- `backend/src/Taskdeck.Cli/Program.cs` — CLI (no logger: CLI stdout must stay clean JSON)
- `backend/src/Taskdeck.Api/Program.cs` — MCP-http mode and MCP-stdio mode (stdio logs to stderr, so the logger never corrupts the JSON-RPC stream)
- `backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs` — main API web host

## Tests
`backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs` (mirrors the #1130 `SqlitePragmaInterceptorTests` / `MigrationBootstrapTests` real-file-SQLite style):
- `Two_concurrent_migrators_apply_schema_exactly_once` — two DbContexts on the SAME fresh file DB, each calling the helper from a `Task.Run`, released together by a `Barrier`; asserts both complete without exception, the `Boards` table exists, and `__EFMigrationsHistory` contains each migration exactly once (no duplicate-key error).
- `Single_migrator_on_file_db_creates_sidecar_lock_file` — documents the `<dbpath>.migrate.lock` path resolution.
- `In_memory_database_migrates_without_creating_a_lock_file` — `:memory:` migrates with no sidecar lock file.

## Verification
- `dotnet build backend/Taskdeck.sln -c Release` → **0 errors**.
- `dotnet test … --filter "SerializedMigrator|MigrationBootstrap|SqlitePragmaInterceptor"` → **13 passed, 0 failed** (3 new).
- CLI smoke: `boards list` against a temp DB → exit 0, migrations applied via `SerializedMigrator`.

## Residual risks
- **Windows vs POSIX file-lock semantics**: `FileShare.None` is enforced by the OS on Windows and by `flock()` (advisory) + an in-process table on .NET/Unix; both serialize same-process threads and cross-process opens, which is what the concurrency test and production need.
- **Lock-file cleanup**: the sidecar `.migrate.lock` is intentionally left on disk (harmless; reused on next boot). A stale lock cannot wedge startup because the holder always releases via `finally`, and acquisition is bounded at 30s with a proceed-anyway fallback.
- **Unwritable lock dir**: degrades gracefully to the pre-#1164 behavior (WAL + busy_timeout), logged as a warning.