### PR TITLE
Add post-publish smoke test to release-desktop workflow (#1123 AC2)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -142,6 +142,154 @@ jobs:
           fi
           echo "Frontend assets verified ($(find publish/${{ matrix.rid }}/wwwroot -type f | wc -l) files)"
 
+      # -----------------------------------------------------------------------
+      # Post-publish smoke test (#1123 AC2)
+      #
+      # Proves the just-published self-contained executable actually boots and
+      # serves the product before we archive and ship it:
+      #   1. GET /health/ready returns success  -> EF migrations applied, DB
+      #      reachable, workers heartbeating (PipelineConfiguration runs the
+      #      SerializedMigrator at startup; HealthController.ReadyCheck gates on
+      #      DB + queue + workers).
+      #   2. GET /                returns the SPA index.html -> same-origin
+      #      wwwroot serving works (UseDefaultFiles + UseStaticFiles).
+      # The process is always killed (trap ... EXIT) so it never leaks, and any
+      # failure (no boot, never ready, / not HTML) fails the release job.
+      #
+      # Runner-native RIDs only: the GitHub macos-latest runner is arm64, so the
+      # osx-x64 binary is cross-arch and may not launch there. It is SKIPPED via
+      # the `if:` gate below; osx-arm64 is the macOS RID exercised instead.
+      # win-x64 (windows-latest) and linux-x64 (ubuntu-latest) are native.
+      #
+      # shell: bash so one script covers Windows + Linux + macOS (bash ships on
+      # the Windows runner). curl + openssl are available on all three runners.
+      #
+      # Secrets: a downloaded desktop exe runs with ASPNETCORE_ENVIRONMENT unset,
+      # which defaults to Production. First-run auto-generates the JWT secret, but
+      # in Production the connector encryption key is NOT auto-generated and
+      # FirstRunBootstrapper.ValidateProductionSecrets hard-fails without it. We
+      # therefore pass throwaway Jwt__SecretKey and Connectors__EncryptionKey env
+      # vars (generated with openssl; the connector key must base64-decode to
+      # exactly 32 bytes per AesCredentialEncryptionService). Supplying the JWT
+      # secret also stops first-run from writing appsettings.local.json into the
+      # publish dir, and the DB is pointed at a temp dir, so nothing pollutes the
+      # archive built in the next step.
+      - name: Smoke test published executable
+        if: matrix.rid != 'osx-x64'  # cross-arch on the arm64 macOS runner — not launchable there
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PORT=5099
+          URL="http://127.0.0.1:${PORT}"
+          PUBLISH_DIR="publish/${{ matrix.rid }}"
+
+          # The published assembly name is Taskdeck.Api (no AssemblyName override);
+          # the apphost gets a .exe suffix on Windows only.
+          if [ "${RUNNER_OS}" = "Windows" ]; then
+            EXE="${PUBLISH_DIR}/Taskdeck.Api.exe"
+          else
+            EXE="${PUBLISH_DIR}/Taskdeck.Api"
+          fi
+
+          if [ ! -f "$EXE" ]; then
+            echo "::error::Published executable not found at $EXE"
+            ls -la "$PUBLISH_DIR" || true
+            exit 1
+          fi
+          chmod +x "$EXE" 2>/dev/null || true
+
+          # Isolated temp data dir so no SQLite file lands in the publish output.
+          SMOKE_DATA_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t taskdeck-smoke)"
+          # .NET needs a native path for the connection string on Windows; the
+          # MSYS path from mktemp (/tmp/...) is meaningless to the Win32 process.
+          if [ "${RUNNER_OS}" = "Windows" ]; then
+            DB_DIR="$(cygpath -w "${SMOKE_DATA_DIR}")"
+          else
+            DB_DIR="${SMOKE_DATA_DIR}"
+          fi
+
+          # Throwaway secrets (never reused, discarded with the temp dir).
+          SMOKE_JWT_SECRET="$(openssl rand -base64 48 | tr -d '\n')"
+          SMOKE_CONNECTOR_KEY="$(openssl rand -base64 32 | tr -d '\n')"
+
+          APP_PID=""
+          LOG="${SMOKE_DATA_DIR}/app.log"
+          cleanup() {
+            if [ -n "${APP_PID}" ]; then
+              kill "${APP_PID}" 2>/dev/null || true
+            fi
+            if [ "${RUNNER_OS}" = "Windows" ]; then
+              # MSYS->Win32 PID mapping can miss; make sure the apphost is gone.
+              taskkill //F //IM Taskdeck.Api.exe 2>/dev/null || true
+            fi
+            rm -rf "${SMOKE_DATA_DIR}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          EXE_NAME="$(basename "$EXE")"
+          echo "Launching ${EXE_NAME} (cwd=${PUBLISH_DIR}) on ${URL} (data dir: ${SMOKE_DATA_DIR})"
+          # Run with the publish dir as the working directory so ASP.NET Core resolves the
+          # content root there and serves wwwroot/index.html + appsettings.json — exactly as
+          # an end user runs the extracted exe (the content root defaults to the CWD, not the
+          # exe folder). The DB + log use absolute temp paths, so the publish dir (archived in
+          # the next step) stays clean. `exec` replaces the subshell with the apphost so $! is
+          # the real process PID for a clean kill.
+          (
+            cd "$PUBLISH_DIR"
+            ASPNETCORE_URLS="${URL}" \
+            ConnectionStrings__DefaultConnection="Data Source=${DB_DIR}/taskdeck-smoke.db" \
+            Jwt__SecretKey="${SMOKE_JWT_SECRET}" \
+            Connectors__EncryptionKey="${SMOKE_CONNECTOR_KEY}" \
+            FirstRun__AutoOpenBrowser="false" \
+            exec "./${EXE_NAME}"
+          ) > "$LOG" 2>&1 &
+          APP_PID=$!
+          echo "Started PID ${APP_PID}"
+
+          # Poll /health/ready (DB migrated + reachable, workers heartbeating).
+          # -f makes curl non-zero on any non-2xx (e.g. a 503 NotReady), so the
+          # loop only breaks once the app reports fully Ready. Bounded to ~60s.
+          READY=0
+          for i in $(seq 1 60); do
+            if curl -fsS -o /dev/null --max-time 5 "${URL}/health/ready"; then
+              READY=1
+              echo "health/ready returned success after ~${i}s"
+              break
+            fi
+            # Fast-fail if the process already died (skip on Windows where the
+            # MSYS->Win32 PID mapping makes kill -0 unreliable; fall through to
+            # the timeout instead of a false negative).
+            if [ "${RUNNER_OS}" != "Windows" ] && ! kill -0 "${APP_PID}" 2>/dev/null; then
+              echo "::error::Taskdeck process exited before /health/ready became ready"
+              echo "--- app log (tail) ---"; tail -n 60 "$LOG" || true
+              exit 1
+            fi
+            sleep 1
+          done
+
+          if [ "${READY}" -ne 1 ]; then
+            echo "::error::/health/ready did not return success within 60s"
+            echo "--- app log (tail) ---"; tail -n 60 "$LOG" || true
+            exit 1
+          fi
+
+          # GET / must serve the SPA shell (same-origin index.html from wwwroot, HTTP 200).
+          ROOT_BODY="${SMOKE_DATA_DIR}/root.html"
+          ROOT_CODE="$(curl -s -o "$ROOT_BODY" -w '%{http_code}' --max-time 10 "${URL}/" || echo 000)"
+          if [ "$ROOT_CODE" = "200" ] && grep -qiE '<div id="app"|<!doctype html' "$ROOT_BODY"; then
+            echo "GET / served the SPA index.html (HTTP 200) — smoke test passed for ${{ matrix.rid }}"
+          else
+            echo "::error::GET / did not serve the SPA index.html (HTTP ${ROOT_CODE})"
+            # Diagnostics: separate "the SPA is not served at all" from "only the bare root / fails"
+            # (e.g. the root path 401ing under the global auth fallback policy) so the failure is actionable.
+            echo "  diag: GET /index.html      -> $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${URL}/index.html")"
+            echo "  diag: GET /board (SPA nav) -> $(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "${URL}/board")"
+            echo "--- first 500 chars of GET / body ---"; head -c 500 "$ROOT_BODY" 2>/dev/null || true; echo
+            echo "--- app log (tail) ---"; tail -n 60 "$LOG" || true
+            exit 1
+          fi
+
       - name: Determine version tag
         id: version
         shell: bash


### PR DESCRIPTION
## What
Implements **#1123 AC2** only: a **post-publish smoke step** in `release-desktop.yml`'s `build-backend` matrix job, inserted **after "Verify frontend assets present"** and **before** the version/archive steps. It launches the just-published self-contained exe, polls `/health/ready`, asserts `GET /` serves the SPA `index.html`, and **fails the release job** on any error. The process is always killed via a `trap ... EXIT`.

Part of #1123. AC1 shipped in #1145; **AC3 (clean-VM) and AC4 (tag push) remain and need maintainer action.**

## How the exe is launched
- `shell: bash` (one script for Windows + Linux + macOS; bash/curl/openssl are on all three runners).
- Exe name resolved per OS: `Taskdeck.Api.exe` on Windows, `Taskdeck.Api` elsewhere.
- Launched with **cwd = the publish dir** so ASP.NET Core resolves the content root there and serves `wwwroot/index.html` + `appsettings.json` (content root defaults to the CWD, not the exe folder).
- Env: `ASPNETCORE_URLS=http://127.0.0.1:5099`; `ConnectionStrings__DefaultConnection` -> a SQLite file in a `mktemp -d` temp dir (native path via `cygpath` on Windows); `FirstRun__AutoOpenBrowser=false`.
- **Secrets first-run needs:** the exe defaults to `ASPNETCORE_ENVIRONMENT=Production`. First-run auto-generates the **JWT secret**, but in Production the **connector encryption key is NOT auto-generated** and `ValidateProductionSecrets` hard-fails without it. So the step passes throwaway `Jwt__SecretKey` and `Connectors__EncryptionKey` (`openssl rand -base64 48` / `-base64 32`; the connector key must base64-decode to exactly 32 bytes per `AesCredentialEncryptionService`). Supplying the JWT secret also stops first-run from writing `appsettings.local.json` into the publish dir, and the DB lives in a temp dir, so **nothing pollutes the archive** built next.

## Assertions
- `GET /health/ready` must return success (bounded ~60s; `curl -f` so a 503 NotReady keeps polling). This gates on EF migrations applied + DB reachable + workers heartbeating.
- `GET /` must return **HTTP 200** with a SPA marker (`<div id="app"` or `<!doctype html`). On failure it prints actionable diagnostics (`/index.html` and `/board` status codes + body + app-log tail).

## Runner-native RID gating (why osx-x64 is skipped)
The matrix builds win-x64 (windows-latest), linux-x64 (ubuntu-latest), osx-x64 + osx-arm64 (both macos-latest). **macos-latest runners are arm64**, so the **osx-x64** binary is cross-arch and may not launch. The step is gated with `if: matrix.rid != 'osx-x64'` (commented inline). win-x64, linux-x64, and **osx-arm64** are exercised; osx-x64 is intentionally skipped.

## Cleanup
`trap cleanup EXIT` kills the launched PID (and `taskkill //F //IM Taskdeck.Api.exe` on Windows for the MSYS->Win32 PID-mapping gap) and removes the temp dir, so the process never leaks and runs in a finally manner regardless of success/failure.

## Verification
- `python -c "import yaml; yaml.safe_load(...)"` -> **YAML OK**.
- **Locally smoke-tested** the script against a real `dotnet publish` win-x64 self-contained single-file exe (the runner-native RID on this box): exe boots in Production with the throwaway secrets, `/health/ready` -> 200 in ~1s, publish dir stays clean (no new files), PID cleanup works.

## :warning: Finding surfaced by this smoke (tracked as #1181)
Local testing revealed the packaged binary returns **`GET /` -> 401** (bare root not served), while `/index.html`, `/board`, `/login` all return 200. Root cause: the `MapFallbackToFile("index.html")` catch-all (`{*path:nonfile}`) doesn't match the empty root path, so `/` hits the global `RequireAuthenticatedUser` fallback policy. Environment-independent (Prod + Dev). This is a real first-run UX bug (`/` is the auto-opened/logged URL) in the SPA-serving/first-run domain (AC3-adjacent), **out of AC2 scope** — filed as **#1181** with a recommended fix.

**Decision point for review:** the smoke asserts `GET /` strictly per the AC2 spec, so a release run stays red until #1181 is fixed (the gate doing its job — a first release whose root URL 401s shouldn't ship). If you'd rather unblock shipping immediately and track `/` separately, I can relax the assertion to "SPA shell served" (assert `/index.html` + a client route, warn-and-track on bare `/`).

Could **not** verify: macOS/Linux runtime behavior (no local runners) — gated/traced by logic only. Residual risks: port 5099 conflict (low), first-run startup time vs. the 60s budget (observed ~1s locally), and the #1181 root-path 401.