### PR TITLE
Fix bare root '/' returning 401 under global FallbackPolicy (#1181)

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
@@ -122,17 +122,21 @@ public static class PipelineConfiguration
         app.MapControllers();
         app.MapHub<BoardsHub>("/hubs/boards");
 
-        // Bare root "/" serves the SPA shell. The {*path:nonfile} catch-all in MapFallbackToFile
-        // does not match the empty path, so "/" needs its own endpoint (#1181).
-        app.MapGet("/", async (HttpContext ctx, IWebHostEnvironment env) =>
+        // Bare root "/": in production, UseDefaultFiles + UseStaticFiles (above) rewrites "/" to
+        // "/index.html" and serves it before routing. When wwwroot is absent (dev/test without a
+        // frontend build), that middleware no-ops and the request reaches routing. The {*path:nonfile}
+        // catch-all in MapFallbackToFile does not match the empty path, so this explicit endpoint
+        // prevents "/" from hitting the global RequireAuthenticatedUser FallbackPolicy (#1181).
+        var webRootProvider = app.Environment.WebRootFileProvider;
+        app.MapGet("/", async (HttpContext ctx) =>
         {
-            var file = env.WebRootFileProvider.GetFileInfo("index.html");
+            var file = webRootProvider.GetFileInfo("index.html");
             if (!file.Exists)
             {
                 ctx.Response.StatusCode = 404;
                 return;
             }
-            ctx.Response.ContentType = "text/html";
+            ctx.Response.ContentType = "text/html; charset=utf-8";
             ctx.Response.Headers["Cache-Control"] = "no-cache";
             await ctx.Response.SendFileAsync(file);
         }).AllowAnonymous();

--- a/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
@@ -122,6 +122,21 @@ public static class PipelineConfiguration
         app.MapControllers();
         app.MapHub<BoardsHub>("/hubs/boards");
 
+        // Bare root "/" serves the SPA shell. The {*path:nonfile} catch-all in MapFallbackToFile
+        // does not match the empty path, so "/" needs its own endpoint (#1181).
+        app.MapGet("/", async (HttpContext ctx, IWebHostEnvironment env) =>
+        {
+            var file = env.WebRootFileProvider.GetFileInfo("index.html");
+            if (!file.Exists)
+            {
+                ctx.Response.StatusCode = 404;
+                return;
+            }
+            ctx.Response.ContentType = "text/html";
+            ctx.Response.Headers["Cache-Control"] = "no-cache";
+            await ctx.Response.SendFileAsync(file);
+        }).AllowAnonymous();
+
         // MCP Streamable HTTP endpoint for external AI agent integration.
         // Authenticated via ApiKeyMiddleware (Bearer tdsk_... tokens).
         // Rate limiting applied per API key user identity.

--- a/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
@@ -73,7 +73,8 @@ public class FallbackPolicyTests : IClassFixture<TestWebApplicationFactory>
         using var client = _factory.CreateClient();
 
         // The bare root "/" must serve the SPA shell anonymously (#1181). The {*path:nonfile}
-        // catch-all does not match the empty path, so "/" has its own MapFallbackToFile mapping.
+        // catch-all does not match the empty path, so "/" has its own explicit MapGet endpoint.
+        // Returns 200 if wwwroot/index.html exists (frontend built), 404 otherwise — never 401.
         var response = await client.GetAsync("/");
 
         response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);

--- a/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FallbackPolicyTests.cs
@@ -68,6 +68,18 @@ public class FallbackPolicyTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task BareRoot_NotBlockedByFallbackPolicy_WhenAnonymous()
+    {
+        using var client = _factory.CreateClient();
+
+        // The bare root "/" must serve the SPA shell anonymously (#1181). The {*path:nonfile}
+        // catch-all does not match the empty path, so "/" has its own MapFallbackToFile mapping.
+        var response = await client.GetAsync("/");
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task McpEndpoint_WithoutApiKey_Returns401_FromApiKeyMiddleware()
     {
         using var client = _factory.CreateClient();


### PR DESCRIPTION
## Summary
- **Bug**: `GET /` returned HTTP 401 instead of the SPA shell because the `{*path:nonfile}` catch-all in `MapFallbackToFile` does not match the empty root path, causing it to fall through to the global `RequireAuthenticatedUser` fallback policy (#1176 AC4).
- **Fix**: Added an explicit `MapGet("/")` endpoint with `.AllowAnonymous()` that serves `index.html` from wwwroot (or returns 404 if absent), matching the `no-cache` policy applied to `index.html` by the static files middleware.
- **Test**: Added `BareRoot_NotBlockedByFallbackPolicy_WhenAnonymous` regression test in `FallbackPolicyTests`.

Closes #1181

## Test plan
- [x] `FallbackPolicyTests` — all 6 tests pass (5 existing + 1 new)
- [ ] Verify `GET /` returns 200 with SPA shell on a published self-contained binary
- [ ] Verify `GET /board`, `GET /login` still work (SPA fallback unchanged)
- [ ] Verify `GET /api/boards` still returns 401 without auth (FallbackPolicy intact)