### PR TITLE
Fix N+1 notification deletion in AccountDeletionService (#1172)

### DIFF
--- a/backend/src/Taskdeck.Application/Interfaces/INotificationRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/INotificationRepository.cs
@@ -21,4 +21,11 @@ public interface INotificationRepository : IRepository<Notification>
         Guid userId,
         Guid? boardId = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes all notifications for a user in batched SQL DELETEs to avoid
+    /// unbounded memory and N+1 single-row deletes.
+    /// </summary>
+    /// <returns>Total number of deleted rows.</returns>
+    Task<int> DeleteByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
 }

--- a/backend/src/Taskdeck.Application/Services/AccountDeletionService.cs
+++ b/backend/src/Taskdeck.Application/Services/AccountDeletionService.cs
@@ -100,14 +100,9 @@ public class AccountDeletionService : IAccountDeletionService
             var auditLogs = await _unitOfWork.AuditLogs.GetByUserAsync(userId, limit: 100000, cancellationToken: cancellationToken);
             var auditLogsAnonymized = auditLogs.Count();
 
-            // 2. Delete notifications (personal data)
-            var notifications = await _unitOfWork.Notifications.GetByUserIdAsync(userId, limit: 100000, cancellationToken: cancellationToken);
-            var notificationsDeleted = 0;
-            foreach (var notification in notifications)
-            {
-                await _unitOfWork.Notifications.DeleteAsync(notification, cancellationToken);
-                notificationsDeleted++;
-            }
+            // 2. Delete notifications (personal data) — batched SQL DELETE avoids
+            //    unbounded memory from fetching all rows and N+1 single-row deletes.
+            var notificationsDeleted = await _unitOfWork.Notifications.DeleteByUserIdAsync(userId, cancellationToken);
 
             // 3. Delete capture/inbox items (personal data)
             var captures = await _unitOfWork.LlmQueue.GetByUserAsync(userId, cancellationToken);

--- a/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
@@ -106,4 +106,40 @@ public class NotificationRepository : Repository<Notification>, INotificationRep
 
         return await query.ToListAsync(cancellationToken);
     }
+
+    /// <inheritdoc />
+    public async Task<int> DeleteByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        const int batchSize = 1000;
+        var totalDeleted = 0;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            int deleted;
+            if (_context.Database.IsSqlite())
+            {
+                deleted = await _context.Database.ExecuteSqlRawAsync(
+                    "DELETE FROM Notifications WHERE Id IN (SELECT Id FROM Notifications WHERE UserId = {0} LIMIT {1})",
+                    new object[] { userId, batchSize },
+                    cancellationToken);
+            }
+            else
+            {
+                // SQL Server: use a CTE with TOP for deterministic batch deletion.
+                deleted = await _context.Database.ExecuteSqlRawAsync(
+                    "WITH CTE AS (SELECT TOP({1}) Id FROM Notifications WHERE UserId = {0}) DELETE FROM Notifications WHERE Id IN (SELECT Id FROM CTE)",
+                    new object[] { userId, batchSize },
+                    cancellationToken);
+            }
+
+            totalDeleted += deleted;
+
+            if (deleted < batchSize)
+            {
+                break;
+            }
+        }
+
+        return totalDeleted;
+    }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/NotificationRepository.cs
@@ -108,6 +108,16 @@ public class NotificationRepository : Repository<Notification>, INotificationRep
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Uses raw SQL (ExecuteSqlRawAsync) which bypasses the EF Core change tracker.
+    /// Callers must not query Notification entities into the same DbContext before
+    /// calling this method, or the tracked entities will become stale.
+    /// This is the same pattern used by <see cref="AuditLogRepository.DeleteOldEntriesAsync"/>.
+    ///
+    /// When called inside a transaction (e.g. AccountDeletionService), cancellation
+    /// mid-batch is safe — the enclosing transaction rollback will undo partial deletes
+    /// and the returned count will be discarded by the caller's catch block.
+    /// </remarks>
     public async Task<int> DeleteByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
     {
         const int batchSize = 1000;

--- a/backend/tests/Taskdeck.Application.Tests/Services/AccountDeletionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AccountDeletionServiceTests.cs
@@ -258,13 +258,9 @@ public class AccountDeletionServiceTests
         SetupUserFound();
         SetupEmptyRepositories();
 
-        var notification = new Notification(
-            _userId, NotificationType.System, NotificationCadence.Immediate,
-            "Test", "Test message");
-
         _notificationRepoMock
-            .Setup(r => r.GetByUserIdAsync(_userId, 100000, false, null, default, 0))
-            .ReturnsAsync(new[] { notification });
+            .Setup(r => r.DeleteByUserIdAsync(_userId, default))
+            .ReturnsAsync(3);
 
         var request = new AccountDeletionRequest(_password, "DELETE MY ACCOUNT");
 
@@ -273,8 +269,8 @@ public class AccountDeletionServiceTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.NotificationsDeleted.Should().Be(1);
-        _notificationRepoMock.Verify(r => r.DeleteAsync(notification, default), Times.Once);
+        result.Value.NotificationsDeleted.Should().Be(3);
+        _notificationRepoMock.Verify(r => r.DeleteByUserIdAsync(_userId, default), Times.Once);
     }
 
     [Fact]
@@ -592,8 +588,8 @@ public class AccountDeletionServiceTests
             .Setup(r => r.GetByUserAsync(_userId, It.IsAny<int>(), default))
             .ReturnsAsync(Enumerable.Empty<AuditLog>());
         _notificationRepoMock
-            .Setup(r => r.GetByUserIdAsync(_userId, It.IsAny<int>(), false, null, default, 0))
-            .ReturnsAsync(Enumerable.Empty<Notification>());
+            .Setup(r => r.DeleteByUserIdAsync(_userId, default))
+            .ReturnsAsync(0);
         _llmQueueRepoMock
             .Setup(r => r.GetByUserAsync(_userId, default))
             .ReturnsAsync(Enumerable.Empty<LlmRequest>());


### PR DESCRIPTION
## Summary

- **Add `DeleteByUserIdAsync`** to `INotificationRepository` — a batched bulk-delete method that replaces the unbounded fetch-then-loop-delete pattern
- **Implement batched SQL DELETE** in `NotificationRepository` using a loop with batch size 1000, following the `AuditLogRepository.DeleteOldEntriesAsync` pattern (supports both SQLite LIMIT and SQL Server CTE+TOP)
- **Replace the N+1 delete** in `AccountDeletionService` (lines 103-110) with a single call to the new repository method
- **Update unit tests** to mock and verify the new `DeleteByUserIdAsync` method

Closes #1172

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` — 0 errors, 0 warnings
- [x] All 25 `AccountDeletionServiceTests` pass
- [x] Architecture tests pass (no layer violations)
- [ ] CI green on PR