### PR TITLE
Harden FirstRunBootstrapper key-file write: 0600 perms + guarded Mutex ctor

### DIFF
--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -349,18 +349,37 @@ public static class FirstRunBootstrapper
         // one finishes, producing the `'}' is invalid after a single JSON
         // value` parse error seen in CI.
         var mutexName = BuildMutexName(path);
-        using var mutex = new System.Threading.Mutex(initiallyOwned: false, name: mutexName);
+        Mutex? mutex = null;
         var acquired = false;
         try
         {
             try
             {
+                // The named (Global\ on Windows) mutex ctor AND WaitOne can throw on
+                // locked-down or multi-user hosts -- e.g. when another user already
+                // owns the name. That must NOT crash API startup.
+                mutex = new System.Threading.Mutex(initiallyOwned: false, name: mutexName);
                 acquired = mutex.WaitOne(TimeSpan.FromSeconds(10));
             }
             catch (AbandonedMutexException)
             {
                 // A previous holder crashed without releasing; we still own it now.
                 acquired = true;
+            }
+            catch (Exception ex) when (
+                ex is UnauthorizedAccessException
+                    or WaitHandleCannotBeOpenedException
+                    or IOException)
+            {
+                // Could not create/open or wait on the cross-process lock. Degrade
+                // gracefully: skip the persistent write entirely so two unsynchronized
+                // writers never race to persist different keys. The caller's catch
+                // block will fall back to an in-memory value.
+                Console.Error.WriteLine(
+                    $"[FirstRun] WARNING: Could not acquire the cross-process bootstrap " +
+                    $"lock ({ex.Message}). Skipping persistent write.");
+                throw new IOException(
+                    "Cross-process bootstrap lock unavailable; skipping persistent write.", ex);
             }
 
             JsonObject root;
@@ -405,6 +424,18 @@ public static class FirstRunBootstrapper
             Directory.CreateDirectory(dir);
             var tempPath = Path.Combine(dir, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
             File.WriteAllText(tempPath, payload);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                // The payload may contain a base64 encryption key. On a default POSIX
+                // umask (022), File.WriteAllText creates the temp file 0644
+                // (world-readable), and File.Move preserves that mode -- exposing the
+                // key to other local users. Restrict to owner read/write (0600) BEFORE
+                // the move so the final file is never world-readable. No-op on Windows,
+                // where NTFS ACL inheritance governs access.
+                File.SetUnixFileMode(tempPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+
             try
             {
                 ReplaceFileWithRetry(tempPath, path);
@@ -420,8 +451,9 @@ public static class FirstRunBootstrapper
         {
             if (acquired)
             {
-                mutex.ReleaseMutex();
+                mutex?.ReleaseMutex();
             }
+            mutex?.Dispose();
         }
     }
 
@@ -445,7 +477,7 @@ public static class FirstRunBootstrapper
         }
     }
 
-    private static string BuildMutexName(string path)
+    internal static string BuildMutexName(string path)
     {
         // Named mutex must be stable per-path and fit OS name rules.
         // Use SHA256 of the absolute path; prefix with "Global\" on Windows

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -438,17 +438,19 @@ public static class FirstRunBootstrapper
             var dir = Path.GetDirectoryName(path)!;
             Directory.CreateDirectory(dir);
             var tempPath = Path.Combine(dir, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
-            File.WriteAllText(tempPath, payload);
 
             if (!OperatingSystem.IsWindows())
             {
-                // The payload may contain a base64 encryption key. On a default POSIX
-                // umask (022), File.WriteAllText creates the temp file 0644
-                // (world-readable), and File.Move preserves that mode -- exposing the
-                // key to other local users. Restrict to owner read/write (0600) BEFORE
-                // the move so the final file is never world-readable. No-op on Windows,
-                // where NTFS ACL inheritance governs access.
+                // Create the file empty and restrict to 0600 BEFORE writing the payload,
+                // eliminating the TOCTOU window where secrets would be world-readable
+                // under the default umask (022).
+                File.Create(tempPath).Dispose();
                 File.SetUnixFileMode(tempPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+                File.WriteAllText(tempPath, payload);
+            }
+            else
+            {
+                File.WriteAllText(tempPath, payload);
             }
 
             try
@@ -466,7 +468,8 @@ public static class FirstRunBootstrapper
         {
             if (acquired)
             {
-                mutex?.ReleaseMutex();
+                try { mutex?.ReleaseMutex(); }
+                catch (ApplicationException) { }
             }
             mutex?.Dispose();
         }

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -294,7 +294,22 @@ public static class FirstRunBootstrapper
 
         // Write into the local config file so the value is picked up by
         // AddInfrastructure later in the startup pipeline.
-        PersistValue("ConnectionStrings", "DefaultConnection", resolvedConnectionString);
+        try
+        {
+            PersistValue("ConnectionStrings", "DefaultConnection", resolvedConnectionString);
+        }
+        catch (IOException ex)
+        {
+            // The cross-process bootstrap lock may be unavailable on locked-down
+            // hosts. Fall back to setting the value in-memory so the current
+            // startup still succeeds with a relative DB path.
+            configuration["ConnectionStrings:DefaultConnection"] = resolvedConnectionString;
+            logger.LogWarning(
+                "First-run: Could not persist DB path to {ConfigFile} ({Error}). " +
+                "A transient in-memory connection string has been set instead.",
+                LocalConfigPath, ex.Message);
+            return;
+        }
 
         if (configuration is IConfigurationRoot root)
         {

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Xunit;
@@ -115,5 +116,79 @@ public class FirstRunBootstrapperTests
         Assert.True(envIndex > fileIndex,
             $"EnvironmentVariablesConfigurationSource (index {envIndex}) should come AFTER " +
             $"the local config file source (index {fileIndex}) so env vars take precedence.");
+    }
+
+    // ---- BuildMutexName ---------------------------------------------------------
+
+    [Fact]
+    public void BuildMutexName_ReturnsDeterministicNameForSamePath()
+    {
+        var name1 = FirstRunBootstrapper.BuildMutexName("/tmp/test.json");
+        var name2 = FirstRunBootstrapper.BuildMutexName("/tmp/test.json");
+        Assert.Equal(name1, name2);
+    }
+
+    [Fact]
+    public void BuildMutexName_ReturnsDifferentNamesForDifferentPaths()
+    {
+        var name1 = FirstRunBootstrapper.BuildMutexName("/tmp/a.json");
+        var name2 = FirstRunBootstrapper.BuildMutexName("/tmp/b.json");
+        Assert.NotEqual(name1, name2);
+    }
+
+    [Fact]
+    public void BuildMutexName_ContainsTaskdeckPrefix()
+    {
+        var name = FirstRunBootstrapper.BuildMutexName("/tmp/test.json");
+        Assert.Contains("Taskdeck.FirstRun.", name);
+    }
+
+    // ---- PersistValue structural hardening (mutex guard + Unix perms) -----------
+    // PersistValue is private, so these tests verify the hardening structurally
+    // via reflection-based assertions on the source code patterns.
+
+    [Fact]
+    public void PersistValue_MutexConstructorIsGuarded_StructuralCheck()
+    {
+        // Verify that the PersistValue method source contains the guarded
+        // exception types matching the CLI's CliFirstRunBootstrapper pattern.
+        // This is a structural assertion: if someone removes the guard, the
+        // test fails.
+        var source = File.ReadAllText(
+            FindSourceFile("FirstRunBootstrapper.cs"));
+
+        Assert.Contains("UnauthorizedAccessException", source);
+        Assert.Contains("WaitHandleCannotBeOpenedException", source);
+        // Verify the mutex is constructed inside the try block (nullable pattern).
+        Assert.Contains("Mutex? mutex = null", source);
+    }
+
+    [Fact]
+    public void PersistValue_SetsUnixFileMode_StructuralCheck()
+    {
+        // Verify that the temp file gets 0600 permissions on Unix before being
+        // moved into place, matching the CLI's CliFirstRunBootstrapper pattern.
+        var source = File.ReadAllText(
+            FindSourceFile("FirstRunBootstrapper.cs"));
+
+        Assert.Contains("SetUnixFileMode", source);
+        Assert.Contains("UnixFileMode.UserRead | UnixFileMode.UserWrite", source);
+        Assert.Contains("!OperatingSystem.IsWindows()", source);
+    }
+
+    private static string FindSourceFile(string fileName)
+    {
+        // Walk up from the test output directory to find the repo source.
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir, "backend", "src", "Taskdeck.Api", "FirstRun", fileName);
+            if (File.Exists(candidate))
+                return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate {fileName} by walking up from {AppContext.BaseDirectory}");
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Xunit;


### PR DESCRIPTION
## Summary

Closes #1178

- **Guarded Mutex constructor**: The `new Mutex()` call and `WaitOne` in `PersistValue` are now wrapped in a try/catch for `UnauthorizedAccessException`, `WaitHandleCannotBeOpenedException`, and `IOException` -- matching the CLI's `CliFirstRunBootstrapper` pattern. On locked-down enterprise hosts, the API degrades gracefully to in-memory-only values instead of crashing at startup.
- **Unix file permissions (0600)**: After `File.WriteAllText` and before the atomic `File.Move`, the temp file mode is set to `UserRead | UserWrite` on non-Windows systems so the key file is never world-readable on POSIX.
- **`BuildMutexName` promoted to `internal`** for direct test access.
- **5 new tests**: `BuildMutexName` determinism/uniqueness/prefix, plus structural checks that the mutex guard and Unix permissions patterns are present in the source.

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` -- 0 errors, 0 new warnings
- [x] `dotnet test` with `FullyQualifiedName~FirstRunBootstrapperTests` -- 16/16 pass (11 existing + 5 new)
- [ ] CI green on this PR