### PR TITLE
Fix ProposalGeneratorV1 queue path bypassing operation input validation (#1152)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/ProposalGeneratorV1.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalGeneratorV1.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
@@ -59,6 +60,26 @@ public class ProposalGeneratorV1 : IProposalGenerator
                     break;
 
                 var proposal = CreateProposalFromIntent(intent, envelope, boardId);
+
+                // Defensive create-time validation (issue #1152): match the API path
+                // (AutomationProposalService.CreateProposalAsync) by running the same
+                // ProposalOperationInputValidator before persisting, so malformed operation
+                // input from the queue path never reaches the database.
+                var operationDtos = proposal.Operations
+                    .Select(op => new CreateProposalOperationDto(
+                        op.Sequence, op.ActionType, op.TargetType,
+                        op.Parameters, op.IdempotencyKey, op.TargetId, op.ExpectedVersion))
+                    .ToList();
+                var operationValidation = ProposalOperationInputValidator.Validate(operationDtos);
+                if (!operationValidation.IsSuccess)
+                {
+                    _logger.LogWarning(
+                        "Operation input validation failed for envelope {EnvelopeId}, intent {IntentId}: {Error}",
+                        envelope.Id, intent.Id, operationValidation.ErrorMessage);
+                    return Result.Failure<ProposalGenerationResult>(
+                        operationValidation.ErrorCode, operationValidation.ErrorMessage);
+                }
+
                 await _unitOfWork.AutomationProposals.AddAsync(proposal, cancellationToken);
                 batch.AddProposalId(proposal.Id);
 

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalGeneratorV1Tests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalGeneratorV1Tests.cs
@@ -342,6 +342,81 @@ public class ProposalGeneratorV1Tests
         return envelope;
     }
 
+    [Theory]
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("drop-table;--")]
+    [InlineData("action with spaces")]
+    public async Task GenerateAsync_MalformedActionType_ReturnsValidationFailure(string badActionType)
+    {
+        var envelope = CreateEnvelopeWithActionType(badActionType);
+        var boardId = Guid.NewGuid();
+
+        var result = await _sut.GenerateAsync(envelope, boardId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("actionType");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_MalformedActionType_DoesNotPersist()
+    {
+        var envelope = CreateEnvelopeWithActionType("<script>alert(1)</script>");
+        var boardId = Guid.NewGuid();
+
+        await _sut.GenerateAsync(envelope, boardId);
+
+        _proposalRepo.Verify(
+            r => r.AddAsync(It.IsAny<AutomationProposal>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _unitOfWork.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_MalformedActionType_LogsWarning()
+    {
+        var envelope = CreateEnvelopeWithActionType("<script>");
+        var boardId = Guid.NewGuid();
+
+        await _sut.GenerateAsync(envelope, boardId);
+
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Operation input validation failed")),
+                null,
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ValidActionType_PassesValidation()
+    {
+        // Ensure legitimate identifier-like action types still work
+        var envelope = CreateEnvelopeWithActionType("create-card");
+        var boardId = Guid.NewGuid();
+
+        var result = await _sut.GenerateAsync(envelope, boardId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Proposals.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_NamespacedActionType_PassesValidation()
+    {
+        var envelope = CreateEnvelopeWithActionType("card.create");
+        var boardId = Guid.NewGuid();
+
+        var result = await _sut.GenerateAsync(envelope, boardId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Proposals.Should().HaveCount(1);
+    }
+
     private IntentEnvelopeV1 CreateEnvelopeWithActionType(string actionType)
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
## Summary

- **ProposalGeneratorV1.GenerateAsync()** now calls `ProposalOperationInputValidator.Validate()` after building operations but before persisting via `AddAsync`, matching the validation the API path (`AutomationProposalService.CreateProposalAsync` line 56) already enforces.
- On validation failure, returns a `Result.Failure` with `ErrorCodes.ValidationError` and logs a warning with envelope/intent context.
- Adds 7 new tests covering malformed actionType rejection (markup, SQL-like, spaces), non-persistence on failure, warning log emission, and continued acceptance of valid identifier-like and namespaced action types.

## Test plan

- [x] `dotnet build backend/Taskdeck.sln -c Release` -- zero errors
- [x] `dotnet test --filter ProposalGeneratorV1Tests` -- 25/25 passed (18 existing + 7 new)
- [ ] CI green on PR

Closes #1152