### PR TITLE
Fix useAutomationChat missing onUnmounted cleanup (#1192)

### DIFF
--- a/frontend/taskdeck-web/src/composables/useAutomationChat.ts
+++ b/frontend/taskdeck-web/src/composables/useAutomationChat.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onScopeDispose, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { chatApi } from '../api/chatApi'
 import { boardsApi } from '../api/boardsApi'
@@ -27,6 +27,11 @@ export function useAutomationChat() {
   let boardOptionsRequest: Promise<boolean> | null = null
   const chatHealth = ref<ChatProviderHealth | null>(null)
   const chatHealthLoadError = ref<string | null>(null)
+
+  // Set once the owning scope is disposed; guards async continuations so
+  // neither a resolved request nor an error racing teardown writes reactive
+  // state after the scope is gone.
+  let isDisposed = false
 
   const newSessionTitle = ref('')
   const newSessionBoardId = ref('')
@@ -166,21 +171,27 @@ export function useAutomationChat() {
   async function loadSessions() {
     try {
       loadingSessions.value = true
-      sessions.value = await chatApi.getMySessions()
+      const result = await chatApi.getMySessions()
+      if (isDisposed) return
+      sessions.value = result
       if (!selectedSession.value && sessions.value.length > 0) {
         await loadSession(sessions.value[0]!.id)
       }
     } catch (e: unknown) {
+      if (isDisposed) return
       toast.error(getErrorDisplay(e, 'Failed to load chat sessions').message)
     } finally {
-      loadingSessions.value = false
+      if (!isDisposed) loadingSessions.value = false
     }
   }
 
   async function loadSession(sessionId: string) {
     try {
-      selectedSession.value = await chatApi.getSession(sessionId)
+      const result = await chatApi.getSession(sessionId)
+      if (isDisposed) return
+      selectedSession.value = result
     } catch (e: unknown) {
+      if (isDisposed) return
       toast.error(getErrorDisplay(e, 'Failed to load chat session').message)
     }
   }
@@ -189,12 +200,15 @@ export function useAutomationChat() {
     try {
       loadingHealth.value = true
       chatHealthLoadError.value = null
-      chatHealth.value = await chatApi.getHealth(options)
+      const result = await chatApi.getHealth(options)
+      if (isDisposed) return
+      chatHealth.value = result
     } catch (e: unknown) {
+      if (isDisposed) return
       chatHealthLoadError.value = getErrorDisplay(e, 'Failed to load LLM status').message
       toast.error(chatHealthLoadError.value)
     } finally {
-      loadingHealth.value = false
+      if (!isDisposed) loadingHealth.value = false
     }
   }
 
@@ -223,15 +237,18 @@ export function useAutomationChat() {
         title: newSessionTitle.value.trim(),
         boardId: normalizedBoardId,
       })
+      if (isDisposed) return
       newSessionTitle.value = ''
       newSessionBoardId.value = ''
       selectedNewSessionBoardId.value = null
       await loadSessions()
+      if (isDisposed) return
       await loadSession(created.id)
     } catch (e: unknown) {
+      if (isDisposed) return
       toast.error(getErrorDisplay(e, 'Failed to create session').message)
     } finally {
-      creatingSession.value = false
+      if (!isDisposed) creatingSession.value = false
     }
   }
 
@@ -243,17 +260,20 @@ export function useAutomationChat() {
 
     try {
       sendingMessage.value = true
-      await chatApi.sendMessage(selectedSession.value.id, {
+      const sessionId = selectedSession.value.id
+      await chatApi.sendMessage(sessionId, {
         content,
         requestProposal: requestProposal.value,
       })
+      if (isDisposed) return
       messageContent.value = ''
       requestProposal.value = false
-      await loadSession(selectedSession.value.id)
+      await loadSession(sessionId)
     } catch (e: unknown) {
+      if (isDisposed) return
       toast.error(getErrorDisplay(e, 'Failed to send message').message)
     } finally {
-      sendingMessage.value = false
+      if (!isDisposed) sendingMessage.value = false
     }
   }
 
@@ -277,13 +297,16 @@ export function useAutomationChat() {
     request = (async () => {
       try {
         loadingBoards.value = true
-        availableBoards.value = await boardsApi.getBoards()
+        const result = await boardsApi.getBoards()
+        if (isDisposed) return false
+        availableBoards.value = result
         return true
       } catch (e: unknown) {
+        if (isDisposed) return false
         toast.error(getErrorDisplay(e, 'Failed to load boards').message)
         return false
       } finally {
-        loadingBoards.value = false
+        if (!isDisposed) loadingBoards.value = false
         if (boardOptionsRequest === request) {
           boardOptionsRequest = null
         }
@@ -336,12 +359,17 @@ export function useAutomationChat() {
     })
   })
 
-  watch(
+  const stopWatch = watch(
     () => [queryBoardId.value, availableBoards.value.length],
     () => {
       applyRouteBoardContext()
     },
   )
+
+  onScopeDispose(() => {
+    isDisposed = true
+    stopWatch()
+  })
 
   return {
     // State

--- a/frontend/taskdeck-web/src/composables/useAutomationChat.ts
+++ b/frontend/taskdeck-web/src/composables/useAutomationChat.ts
@@ -355,6 +355,10 @@ export function useAutomationChat() {
     void loadSessions()
     void loadProviderHealth()
     void loadBoardOptions().then(() => {
+      // Guard the continuation: loadBoardOptions can resolve after the owning
+      // scope is disposed (e.g. navigation mid-flight), and applyRouteBoardContext
+      // writes reactive state. Skip it once disposed to avoid a post-teardown write.
+      if (isDisposed) return
       applyRouteBoardContext()
     })
   })

--- a/frontend/taskdeck-web/src/composables/useAutomationChat.ts
+++ b/frontend/taskdeck-web/src/composables/useAutomationChat.ts
@@ -225,6 +225,8 @@ export function useAutomationChat() {
       }
     }
 
+    if (isDisposed) return
+
     const normalizedBoardId = normalizeSelectedBoardId(newSessionBoardId.value)
     if (newSessionBoardId.value.trim() && !normalizedBoardId) {
       toast.error('Choose a board from the list or leave board context blank.')

--- a/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
@@ -442,5 +442,43 @@ describe('useAutomationChat', () => {
       // write it to newSessionBoardId after the scope is gone.
       expect(chat.newSessionBoardId.value).toBe('')
     })
+
+    it('does not create a session after disposal lands while loading board options', async () => {
+      // Defer getBoards so disposal can land in the microtask gap between the
+      // boards resolving (loadBoardOptions returns true) and handleCreateSession
+      // resuming after its `await loadBoardOptions()`.
+      let resolveBoards!: (value: unknown[]) => void
+      const boardsPromise = new Promise<unknown[]>((resolve) => { resolveBoards = resolve })
+      boardsApiMocks.getBoards.mockReturnValue(boardsPromise)
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      chat.newSessionTitle.value = 'Test Session'
+      chat.newSessionBoardId.value = 'Project Alpha'
+
+      // Kick off creation without awaiting; it suspends on `await loadBoardOptions()`.
+      const pending = chat.handleCreateSession()
+
+      // Dispose AFTER boards resolve but BEFORE handleCreateSession resumes.
+      // loadBoardOptions's own internal continuation is registered first, so it
+      // resolves to true, then this fires, then handleCreateSession resumes --
+      // exactly the post-load, post-dispose race the guard covers.
+      void boardsPromise.then(() => {
+        for (const fn of scopeDisposeFns) fn()
+      })
+
+      resolveBoards([{ id: 'b1', name: 'Project Alpha', description: null, isArchived: false }])
+
+      // Drain microtasks so the deferred dispose and the resumed continuation run.
+      await new Promise((resolve) => setTimeout(resolve))
+      await pending
+
+      // Post-dispose the function must bail before creating the session or
+      // emitting any toast, and must not leave creatingSession stuck true.
+      expect(chatApiMocks.createSession).not.toHaveBeenCalled()
+      expect(toastMocks.error).not.toHaveBeenCalled()
+      expect(chat.creatingSession.value).toBe(false)
+    })
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
@@ -411,5 +411,36 @@ describe('useAutomationChat', () => {
 
       expect(chat.chatHealth.value).toBeNull()
     })
+
+    it('does not apply route board context after disposal on the mount continuation', async () => {
+      // Route points at a board that the deferred getBoards response contains.
+      routeMocks.query = { boardId: 'b1' }
+
+      let resolveBoards!: (value: unknown[]) => void
+      const boardsPromise = new Promise<unknown[]>((resolve) => { resolveBoards = resolve })
+      boardsApiMocks.getBoards.mockReturnValue(boardsPromise)
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      // Register a disposal hook on the same getBoards promise. Because the
+      // composable's internal `await boardsApi.getBoards()` reaction is registered
+      // first (during the synchronous onMounted), this runs AFTER availableBoards
+      // is populated but BEFORE the onMounted `.then(applyRouteBoardContext)`
+      // continuation -- exactly the post-load, post-dispose race the guard covers.
+      void boardsPromise.then(() => {
+        for (const fn of scopeDisposeFns) fn()
+      })
+
+      resolveBoards([{ id: 'b1', name: 'Project Alpha', description: null, isArchived: false }])
+
+      // Drain all microtasks so the deferred continuation runs.
+      await new Promise((resolve) => setTimeout(resolve))
+
+      // The continuation must be a no-op after disposal. Without the isDisposed
+      // guard, applyRouteBoardContext would resolve 'b1' to 'Project Alpha' and
+      // write it to newSessionBoardId after the scope is gone.
+      expect(chat.newSessionBoardId.value).toBe('')
+    })
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useAutomationChat.spec.ts
@@ -41,12 +41,15 @@ vi.mock('../../api/boardsApi', () => ({
   boardsApi: boardsApiMocks,
 }))
 
+const scopeDisposeFns: Array<() => void> = []
+
 vi.mock('vue', async (importOriginal) => {
   const actual = await importOriginal<typeof import('vue')>()
   return {
     ...actual,
     onMounted: (fn: () => void) => fn(),
-    watch: vi.fn(),
+    watch: vi.fn().mockReturnValue(vi.fn()),
+    onScopeDispose: (fn: () => void) => { scopeDisposeFns.push(fn) },
   }
 })
 
@@ -58,6 +61,7 @@ async function loadComposable() {
 describe('useAutomationChat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    scopeDisposeFns.length = 0
     routeMocks.query = {}
     chatApiMocks.getMySessions.mockResolvedValue([])
     chatApiMocks.getSession.mockResolvedValue(undefined)
@@ -356,6 +360,56 @@ describe('useAutomationChat', () => {
         expect(chat.chatHealthLoadError.value).not.toBeNull()
         expect(toastMocks.error).toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('scope disposal', () => {
+    it('registers an onScopeDispose callback', async () => {
+      const { useAutomationChat } = await loadComposable()
+      useAutomationChat()
+
+      expect(scopeDisposeFns.length).toBeGreaterThan(0)
+    })
+
+    it('does not write reactive state after disposal on loadSessions', async () => {
+      let resolveGetSessions!: (value: unknown[]) => void
+      chatApiMocks.getMySessions.mockReturnValue(
+        new Promise((resolve) => { resolveGetSessions = resolve }),
+      )
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      // Trigger disposal before the pending request resolves
+      for (const fn of scopeDisposeFns) fn()
+
+      // Now resolve the in-flight request
+      resolveGetSessions([{ id: 's1', title: 'Late', boardId: null, recentMessages: [] }])
+      await vi.waitFor(() => {
+        expect(chatApiMocks.getMySessions).toHaveBeenCalled()
+      })
+
+      // The sessions ref should NOT have been updated after disposal
+      expect(chat.sessions.value).toEqual([])
+    })
+
+    it('does not write reactive state after disposal on loadProviderHealth', async () => {
+      let resolveHealth!: (value: unknown) => void
+      chatApiMocks.getHealth.mockReturnValue(
+        new Promise((resolve) => { resolveHealth = resolve }),
+      )
+
+      const { useAutomationChat } = await loadComposable()
+      const chat = useAutomationChat()
+
+      for (const fn of scopeDisposeFns) fn()
+
+      resolveHealth({ status: 'healthy', provider: 'mock' })
+      await vi.waitFor(() => {
+        expect(chatApiMocks.getHealth).toHaveBeenCalled()
+      })
+
+      expect(chat.chatHealth.value).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Store the watch stop handle** (`const stopWatch = watch(...)`) and call it during disposal
- **Add `isDisposed` flag** (plain `let`, matching `useGlobalSearch` pattern) to guard all async continuations after every `await` in `loadSessions`, `loadSession`, `loadProviderHealth`, `handleCreateSession`, `sendMessageToSession`, and `loadBoardOptions`
- **Register `onScopeDispose`** callback that sets `isDisposed = true` and calls `stopWatch()`
- **Add 3 new tests** verifying the disposal callback is registered and that reactive state is not written after scope disposal

Closes #1192

## Test plan

- [x] `npm run typecheck` passes
- [x] All 20 `useAutomationChat.spec.ts` tests pass (17 existing + 3 new disposal tests)
- [x] Full vitest suite passes (294 files, 3674 tests)
- [ ] CI green