### PR TITLE
chore: gitignore SQLite migrate-lock sidecar files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@ backend/**/*.db-wal
 taskdeck.db
 taskdeck.db-shm
 taskdeck.db-wal
+**/*.migrate.lock
 api-tests.log
 
 docs/archive/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ backend/.vs/
 *.db
 *.db-shm
 *.db-wal
+*.migrate.lock
 
 # .NET Build Results
 [Dd]ebug/


### PR DESCRIPTION
## Summary
- Adds `*.migrate.lock` to `.gitignore` and `**/*.migrate.lock` to `.dockerignore`.

## Context
`SerializedMigrator` (shipped via #1186, closes the #1164 follow-up) creates a persistent 0-byte advisory-lock sidecar `<db>.migrate.lock` next to the SQLite database on every startup of the API/MCP/CLI, and intentionally never deletes it (only the FileStream is disposed). The existing `*.db` / `*.db-shm` / `*.db-wal` ignore patterns don't match the `.migrate.lock` suffix, so any local run permanently dirties `git status` (one is sitting untracked at `backend/src/Taskdeck.Api/taskdeck.db.migrate.lock` right now) and the file would leak into docker build contexts.

## Verification
- `git check-ignore backend/src/Taskdeck.Api/taskdeck.db.migrate.lock` now matches (verified locally on the branch).
- No code/build impact — ignore-file-only change.

Part of the workspace-hygiene track (#1140).