### PR TITLE
docs: name both required compose secrets in quickstart (#1139 AC1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,14 @@ From the repo root:
 
 ```bash
 cp deploy/.env.example deploy/.env
-# Edit deploy/.env and set BOTH required secrets before starting:
-#   TASKDECK_JWT_SECRET                (generate with: openssl rand -base64 48)
-#   TASKDECK_CONNECTORS_ENCRYPTION_KEY (generate with: openssl rand -base64 32)
+```
+
+Edit `deploy/.env` and set BOTH required secrets before starting:
+
+- `TASKDECK_JWT_SECRET` (generate with: `openssl rand -base64 48`)
+- `TASKDECK_CONNECTORS_ENCRYPTION_KEY` (generate with: `openssl rand -base64 32`)
+
+```bash
 docker compose -f deploy/docker-compose.yml --env-file deploy/.env --profile baseline up -d --build
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,9 @@ From the repo root:
 
 ```bash
 cp deploy/.env.example deploy/.env
-# Edit deploy/.env and set a strong TASKDECK_JWT_SECRET before starting.
+# Edit deploy/.env and set BOTH required secrets before starting:
+#   TASKDECK_JWT_SECRET                (generate with: openssl rand -base64 48)
+#   TASKDECK_CONNECTORS_ENCRYPTION_KEY (generate with: openssl rand -base64 32)
 docker compose -f deploy/docker-compose.yml --env-file deploy/.env --profile baseline up -d --build
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Open `http://localhost:5173` to start. See [docs/START_HERE.md](docs/START_HERE.
 
 ```bash
 cp deploy/.env.example deploy/.env
-# Set a strong TASKDECK_JWT_SECRET value in deploy/.env before continuing.
+# Set BOTH required secrets in deploy/.env before continuing — compose refuses to start without them:
+#   TASKDECK_JWT_SECRET                (generate with: openssl rand -base64 48)
+#   TASKDECK_CONNECTORS_ENCRYPTION_KEY (generate with: openssl rand -base64 32)
 docker compose -f deploy/docker-compose.yml --env-file deploy/.env --profile baseline up -d --build
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ Open `http://localhost:5173` to start. See [docs/START_HERE.md](docs/START_HERE.
 
 ```bash
 cp deploy/.env.example deploy/.env
-# Set BOTH required secrets in deploy/.env before continuing — compose refuses to start without them:
-#   TASKDECK_JWT_SECRET                (generate with: openssl rand -base64 48)
-#   TASKDECK_CONNECTORS_ENCRYPTION_KEY (generate with: openssl rand -base64 32)
+```
+
+Set BOTH required secrets in `deploy/.env` before continuing — compose refuses to start without them:
+
+- `TASKDECK_JWT_SECRET` (generate with: `openssl rand -base64 48`)
+- `TASKDECK_CONNECTORS_ENCRYPTION_KEY` (generate with: `openssl rand -base64 32`)
+
+```bash
 docker compose -f deploy/docker-compose.yml --env-file deploy/.env --profile baseline up -d --build
 ```
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -1265,7 +1265,7 @@ Notes:
 ## Container Baseline Validation
 
 ```bash
-TASKDECK_JWT_SECRET=local-test-secret docker compose -f deploy/docker-compose.yml --profile baseline config
+TASKDECK_JWT_SECRET=local-test-secret TASKDECK_CONNECTORS_ENCRYPTION_KEY=local-test-key docker compose -f deploy/docker-compose.yml --profile baseline config
 docker build -f deploy/docker/backend.Dockerfile -t taskdeck-api:local .
 docker build --build-arg VITE_API_BASE_URL=/api -f deploy/docker/frontend.Dockerfile -t taskdeck-web:local .
 ```

--- a/docs/ops/DEPLOYMENT_CONTAINERS.md
+++ b/docs/ops/DEPLOYMENT_CONTAINERS.md
@@ -33,7 +33,11 @@ When Terraform is used, these compose assets remain the workload layer. The Terr
 ## Secrets
 
 Secret handling for all environments follows `docs/security/SECRETS_MANAGEMENT_BASELINE.md`.
-For compose deployments, `TASKDECK_JWT_SECRET` in `deploy/.env` is required and enforced at render time.
+For compose deployments, two variables in `deploy/.env` are required and enforced at render time
+(compose aborts with an error if either is unset):
+
+- `TASKDECK_JWT_SECRET` — JWT signing secret, minimum 32 bytes (generate with `openssl rand -base64 48`)
+- `TASKDECK_CONNECTORS_ENCRYPTION_KEY` — AES-256 key for connector credentials (generate with `openssl rand -base64 32`)
 
 ## Prerequisites
 

--- a/docs/ops/DEPLOYMENT_HARDENING_MATRIX.md
+++ b/docs/ops/DEPLOYMENT_HARDENING_MATRIX.md
@@ -28,7 +28,7 @@ If proxy port differs, use the configured value for `-Port`.
 Secret-gated compose render check:
 
 ```bash
-TASKDECK_JWT_SECRET=local-test-secret docker compose -f deploy/docker-compose.yml --profile baseline config
+TASKDECK_JWT_SECRET=local-test-secret TASKDECK_CONNECTORS_ENCRYPTION_KEY=local-test-key docker compose -f deploy/docker-compose.yml --profile baseline config
 ```
 
 Manual start/smoke/stop path:

--- a/docs/ops/rehearsal-scenarios/deployment-readiness-failure.md
+++ b/docs/ops/rehearsal-scenarios/deployment-readiness-failure.md
@@ -11,7 +11,7 @@ Simulate a Docker Compose deployment where the API container starts but fails re
 
 - Repository checked out at a known commit on `main`.
 - Docker Engine with `docker compose` support installed and running.
-- `deploy/.env` configured per `deploy/.env.example` (at minimum, `TASKDECK_JWT_SECRET` must be set).
+- `deploy/.env` configured per `deploy/.env.example` (both required secrets set: `TASKDECK_JWT_SECRET` and `TASKDECK_CONNECTORS_ENCRYPTION_KEY`).
 - No other services occupying the default proxy port (8080).
 - `curl` or equivalent HTTP client available.
 


### PR DESCRIPTION
## Summary
- `README.md` Docker quickstart now instructs setting **both** required secrets (`TASKDECK_JWT_SECRET` and `TASKDECK_CONNECTORS_ENCRYPTION_KEY`) with their generation commands.
- `docs/ops/DEPLOYMENT_CONTAINERS.md` Secrets section now lists both required variables instead of only the JWT secret.

## Context
First slice of #1139. `deploy/docker-compose.yml:41` hard-aborts (`:?` expansion) when `TASKDECK_CONNECTORS_ENCRYPTION_KEY` is unset, but both quickstart docs only mentioned `TASKDECK_JWT_SECRET` — following the README verbatim fails at `docker compose up`. The generation commands match what `deploy/.env.example:9-19` already documents.

## Verification
Docs-only change. Cross-checked variable names and `:?` enforcement against `deploy/docker-compose.yml:33,41` and the example env file.

Refs #1139 (AC1 — does not close the issue; the desktop-run docs and container-model reconciliation remain).
