### PR TITLE
Remove Thread.Sleep and blocking connect from RedisCacheService lock (#1189)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Services/RedisCacheService.cs
+++ b/backend/src/Taskdeck.Infrastructure/Services/RedisCacheService.cs
@@ -27,6 +27,23 @@ public sealed class RedisCacheService : ICacheService, IDisposable
 
     private DateTime _lastConnectAttemptUtc = DateTime.MinValue;
 
+    /// <summary>
+    /// Test-only seam: invoked on the connecting thread immediately before the blocking
+    /// <see cref="ConnectionMultiplexer.Connect(ConfigurationOptions, System.IO.TextWriter?)"/>
+    /// call. Used by regression tests to observe — from another thread — whether
+    /// <see cref="_connectionLock"/> is held while the connect blocks. Null (and zero-cost)
+    /// in production.
+    /// </summary>
+    internal Action? OnBeforeConnect { get; set; }
+
+    /// <summary>
+    /// Test-only seam: exposes the connection lock so a regression test can probe, from a
+    /// separate thread, whether the lock is held across the blocking connect. The fixed code
+    /// performs the connect OUTSIDE this lock, so a probe acquires it promptly; the pre-#1189
+    /// code held it across the connect, so a probe would be serialized behind the connect.
+    /// </summary>
+    internal object ConnectionLock => _connectionLock;
+
     public RedisCacheService(string connectionString, ILogger<RedisCacheService> logger, string keyPrefix = "td")
     {
         _connectionString = connectionString;
@@ -261,6 +278,11 @@ public sealed class RedisCacheService : ICacheService, IDisposable
             options.ConnectTimeout = 3000;       // 3 second connect timeout
             options.SyncTimeout = 1000;          // 1 second sync timeout
             options.AsyncTimeout = 1000;         // 1 second async timeout
+
+            // Test seam: lets a regression test observe (from another thread) whether
+            // _connectionLock is held while this blocking connect runs. No-op in production.
+            OnBeforeConnect?.Invoke();
+
             var candidate = ConnectionMultiplexer.Connect(options);
 
             if (candidate.IsConnected)

--- a/backend/src/Taskdeck.Infrastructure/Services/RedisCacheService.cs
+++ b/backend/src/Taskdeck.Infrastructure/Services/RedisCacheService.cs
@@ -25,16 +25,6 @@ public sealed class RedisCacheService : ICacheService, IDisposable
     /// </summary>
     private static readonly TimeSpan ReconnectMinInterval = TimeSpan.FromSeconds(15);
 
-    /// <summary>
-    /// Maximum number of immediate retry attempts when establishing a connection.
-    /// </summary>
-    private const int MaxConnectionRetries = 3;
-
-    /// <summary>
-    /// Base delay between connection retry attempts (doubles with each retry).
-    /// </summary>
-    private static readonly TimeSpan RetryBaseDelay = TimeSpan.FromMilliseconds(500);
-
     private DateTime _lastConnectAttemptUtc = DateTime.MinValue;
 
     public RedisCacheService(string connectionString, ILogger<RedisCacheService> logger, string keyPrefix = "td")
@@ -205,9 +195,12 @@ public sealed class RedisCacheService : ICacheService, IDisposable
     }
 
     /// <summary>
-    /// Gets or establishes the Redis connection. Unlike the previous Lazy-based approach,
-    /// this retries connection on failure (with a backoff interval) so transient Redis
-    /// outages do not permanently disable caching.
+    /// Gets or establishes the Redis connection. A single connection attempt is made per
+    /// <see cref="ReconnectMinInterval"/> window so transient Redis outages do not permanently
+    /// disable caching, while the throttle prevents reconnection storms. On failure the method
+    /// returns <c>null</c> immediately so callers fall through to the no-cache path — it never
+    /// throws and never blocks while holding <see cref="_connectionLock"/> for the connect
+    /// (the lock guards only the minimal check-and-assign of <see cref="_connection"/>).
     /// </summary>
     private ConnectionMultiplexer? GetConnection()
     {
@@ -217,14 +210,21 @@ public sealed class RedisCacheService : ICacheService, IDisposable
         if (conn is not null && conn.IsConnected)
             return conn;
 
-        // Throttle reconnection attempts to avoid storms
+        // Throttle reconnection attempts to avoid storms. A single attempt per window means a
+        // failed Connect degrades to no-cache immediately rather than blocking on retries.
         if (DateTime.UtcNow - _lastConnectAttemptUtc < ReconnectMinInterval)
             return conn; // Return stale connection (or null) — don't retry yet
 
-        lock (_connectionLock)
+        // Hold the lock only around the minimal check-and-assign so a single connecting thread
+        // updates shared state while concurrent callers fall straight through to the no-cache path.
+        if (!Monitor.TryEnter(_connectionLock))
+            return conn; // Another thread is already attempting — don't pile up.
+
+        ConnectionMultiplexer? old;
+        try
         {
-            // Double-check after acquiring lock
             if (_disposed) return null;
+
             conn = _connection;
             if (conn is not null && conn.IsConnected)
                 return conn;
@@ -234,57 +234,80 @@ public sealed class RedisCacheService : ICacheService, IDisposable
 
             _lastConnectAttemptUtc = DateTime.UtcNow;
 
-            // Dispose old broken connection before attempting reconnect
-            var old = _connection;
-            Exception? lastException = null;
+            // Capture the (possibly broken) old connection to dispose after we release the lock.
+            old = _connection;
+        }
+        finally
+        {
+            Monitor.Exit(_connectionLock);
+        }
 
-            // Retry connection with exponential backoff
-            for (var attempt = 1; attempt <= MaxConnectionRetries; attempt++)
+        // Single connection attempt performed OUTSIDE the lock: the 3s ConnectTimeout must never
+        // block other callers, and the outer throttle already guarantees at most one attempt per
+        // ReconnectMinInterval window.
+        ConnectionMultiplexer? established = null;
+        try
+        {
+            var options = ConfigurationOptions.Parse(_connectionString);
+            options.AbortOnConnectFail = false;  // Allow startup without Redis
+            options.ConnectTimeout = 3000;       // 3 second connect timeout
+            options.SyncTimeout = 1000;          // 1 second sync timeout
+            options.AsyncTimeout = 1000;         // 1 second async timeout
+            var candidate = ConnectionMultiplexer.Connect(options);
+
+            if (candidate.IsConnected)
             {
-                try
-                {
-                    var options = ConfigurationOptions.Parse(_connectionString);
-                    options.AbortOnConnectFail = false;  // Allow startup without Redis
-                    options.ConnectTimeout = 3000;       // 3 second connect timeout
-                    options.SyncTimeout = 1000;          // 1 second sync timeout
-                    options.AsyncTimeout = 1000;         // 1 second async timeout
-                    _connection = ConnectionMultiplexer.Connect(options);
+                established = candidate;
+            }
+            else
+            {
+                // With AbortOnConnectFail=false, Connect returns a non-connected multiplexer
+                // instead of throwing. Discard it and surface degraded mode to operators.
+                candidate.Dispose();
+                _logger.LogWarning("Redis cache connection unavailable — operating in degraded (no-cache) mode");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Redis cache connection failed — operating in degraded (no-cache) mode");
+        }
 
-                    if (_connection.IsConnected)
-                    {
-                        _logger.LogInformation("Redis cache connected successfully on attempt {Attempt}", attempt);
-
-                        // Dispose old connection after successful replacement
-                        if (old is not null && !ReferenceEquals(old, _connection))
-                        {
-                            try { old.Dispose(); }
-                            catch (Exception) { /* best-effort cleanup */ }
-                        }
-
-                        return _connection;
-                    }
-
-                    // Connection object created but not connected — dispose and retry
-                    _connection.Dispose();
-                    _connection = null;
-                }
-                catch (Exception ex)
-                {
-                    lastException = ex;
-                    _logger.LogDebug(ex, "Redis connection attempt {Attempt}/{MaxAttempts} failed", attempt, MaxConnectionRetries);
-                }
-
-                // Wait before retry (exponential backoff: 500ms, 1s, 2s, ...)
-                if (attempt < MaxConnectionRetries)
-                {
-                    var delay = TimeSpan.FromMilliseconds(RetryBaseDelay.TotalMilliseconds * Math.Pow(2, attempt - 1));
-                    Thread.Sleep(delay);
-                }
+        // Publish the result under the lock (minimal check-and-assign only).
+        lock (_connectionLock)
+        {
+            if (_disposed)
+            {
+                established?.Dispose();
+                return null;
             }
 
-            _logger.LogWarning(lastException, "Redis cache connection failed after {MaxAttempts} attempts — operating in degraded (no-cache) mode", MaxConnectionRetries);
-            return null;
+            // Another thread may have established a live connection while we were connecting.
+            var current = _connection;
+            if (current is not null && current.IsConnected && !ReferenceEquals(current, established))
+            {
+                established?.Dispose();
+                return current;
+            }
+
+            if (established is not null)
+            {
+                _connection = established;
+                _logger.LogInformation("Redis cache connected successfully");
+            }
+            else
+            {
+                _connection = null;
+            }
         }
+
+        // Dispose the previous broken connection outside the lock (best-effort cleanup).
+        if (old is not null && !ReferenceEquals(old, established))
+        {
+            try { old.Dispose(); }
+            catch (Exception) { /* best-effort cleanup */ }
+        }
+
+        return established;
     }
 
     private string BuildKey(string key) => $"{_keyPrefix}:{key}";

--- a/backend/src/Taskdeck.Infrastructure/Services/RedisCacheService.cs
+++ b/backend/src/Taskdeck.Infrastructure/Services/RedisCacheService.cs
@@ -161,12 +161,20 @@ public sealed class RedisCacheService : ICacheService, IDisposable
 
     public void Dispose()
     {
-        if (_disposed) return;
-        _disposed = true;
+        // Take the connection lock so a concurrent GetConnection() publish cannot assign a
+        // freshly-established multiplexer after we read _connection, which would leak it.
+        ConnectionMultiplexer? toDispose;
+        lock (_connectionLock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            toDispose = _connection;
+            _connection = null;
+        }
 
         try
         {
-            _connection?.Dispose();
+            toDispose?.Dispose();
         }
         catch (Exception ex)
         {

--- a/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
@@ -76,38 +76,119 @@ public sealed class RedisCacheServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task ConcurrentCallers_AreNotSerializedBehindBlockingConnect()
+    public async Task ConnectionLock_IsNotHeld_WhileBlockingConnectRuns()
     {
-        // Regression guard for #1189: the connect attempt (up to a 3s timeout) must NOT be
-        // performed while holding _connectionLock. If it were, N concurrent callers would each
-        // block on the lock for the full connect duration and total wall-clock time would scale
-        // with N. With the lock held only around the minimal check-and-assign, the throttle lets
-        // exactly one thread attempt the connect while the rest fall straight through to no-cache,
-        // so total time stays close to a single connect attempt.
-        const int callers = 16;
+        // DETERMINISTIC regression guard for #1189 (does not rely on wall-clock margins).
+        //
+        // The pre-#1189 code performed the blocking ConnectionMultiplexer.Connect (up to a 3s
+        // ConnectTimeout, plus Thread.Sleep backoff) INSIDE lock (_connectionLock). Any other
+        // caller that needed the lock was therefore serialized behind the whole connect, starving
+        // the thread pool. The fix performs the connect OUTSIDE the lock (the lock guards only the
+        // minimal check-and-assign of _connection).
+        //
+        // We prove this directly: the OnBeforeConnect seam fires on the connecting thread at the
+        // exact moment the connect is about to block. From a SEPARATE probe thread we try to take
+        // _connectionLock. (TryEnter is re-entrant on the connecting thread, so the probe MUST run
+        // on another thread to observe the real held/not-held state.)
+        //   - Fixed code:    lock already released -> probe acquires it -> lockWasFree == true.
+        //   - Pre-#1189 code: lock held across connect -> probe times out -> lockWasFree == false.
+        var probeAcquiredLock = false;
+        var probeElapsed = TimeSpan.MaxValue;
+        var probeCompleted = new ManualResetEventSlim(false);
+        var seamFired = new ManualResetEventSlim(false);
 
-        var sw = Stopwatch.StartNew();
-
-        var tasks = Enumerable.Range(0, callers).Select(i => Task.Run(async () =>
+        _cache.OnBeforeConnect = () =>
         {
-            // Mix of operations all routed through GetConnection/GetDatabase.
-            var got = await _cache.GetAsync<TestData>($"k{i}");
-            got.Should().BeNull();
-            await _cache.SetAsync($"k{i}", new TestData("v", i), TimeSpan.FromMinutes(1));
-        }));
+            // Runs on the connecting thread, immediately before the blocking connect. Hand off to a
+            // foreign thread so the lock probe reflects the lock's real state, not re-entrancy.
+            seamFired.Set();
+            var probe = new Thread(() =>
+            {
+                // If the connect is OUTSIDE the lock (fixed), this succeeds immediately. If it is
+                // INSIDE the lock (old), the connecting thread holds it for the whole connect, so
+                // this 2s TryEnter times out (the old code holds the lock for the full 3s+ connect).
+                var sw = Stopwatch.StartNew();
+                if (Monitor.TryEnter(_cache.ConnectionLock, TimeSpan.FromSeconds(2)))
+                {
+                    try { probeAcquiredLock = true; }
+                    finally { Monitor.Exit(_cache.ConnectionLock); }
+                }
+                sw.Stop();
+                probeElapsed = sw.Elapsed;
+                probeCompleted.Set();
+            })
+            { IsBackground = true, Name = "redis-lock-probe" };
+            probe.Start();
 
-        var act = async () => await Task.WhenAll(tasks);
+            // Block the connecting thread here until the probe has finished its TryEnter window so
+            // the observation happens entirely within the connect's hold window. Bounded so the
+            // test can never hang.
+            probeCompleted.Wait(TimeSpan.FromSeconds(6));
+        };
 
-        await act.Should().NotThrowAsync("unreachable Redis must never surface exceptions to callers");
+        // Trigger exactly one connect attempt. GetConnection routes through GetDatabase here.
+        var result = await _cache.GetAsync<TestData>("trigger");
+        result.Should().BeNull();
 
+        seamFired.IsSet.Should().BeTrue("the connect seam must fire — otherwise the test proves nothing");
+        probeAcquiredLock.Should().BeTrue(
+            "the blocking connect must run OUTSIDE _connectionLock so other callers are not serialized behind it (#1189)");
+        // Deterministic timing margin: on the fixed path the lock is free, so the probe acquires it
+        // almost instantly (well under 500ms). The old lock-around-connect path would block the
+        // probe for the entire ~3s connect, so this assertion fails hard there.
+        probeElapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(500),
+            "a concurrent caller must acquire _connectionLock promptly, not block for the full connect duration");
+    }
+
+    [Fact]
+    public void Dispose_IsNotSerialized_BehindAnInFlightConnect()
+    {
+        // Second revert-sensitive guard for #1189, from a real caller's perspective. Dispose() takes
+        // lock (_connectionLock) UNCONDITIONALLY — unlike GetAsync, it has no ReconnectMinInterval
+        // throttle gate in front of the lock, so it is the cleanest public path that genuinely
+        // contends for _connectionLock. (A throttled GetAsync caller would early-return before the
+        // lock in BOTH old and new code, so it cannot distinguish the regression — which is exactly
+        // why the old wall-clock concurrency test was not a real guard.)
+        //
+        // While one thread is parked mid-connect (via the OnBeforeConnect seam), Dispose() must
+        // acquire the lock and complete promptly.
+        //   - Fixed code:    the connecting thread released _connectionLock before the connect, so
+        //                    Dispose acquires it immediately.
+        //   - Pre-#1189 code: the connecting thread holds _connectionLock across the multi-second
+        //                    connect, so Dispose blocks behind it for the whole connect.
+        var releaseConnect = new ManualResetEventSlim(false);
+        var connectEntered = new ManualResetEventSlim(false);
+
+        _cache.OnBeforeConnect = () =>
+        {
+            connectEntered.Set();
+            // Simulate the multi-second blocking connect. Bounded so the test cannot hang. The
+            // fixed code has already released _connectionLock by this point; the old code has not.
+            releaseConnect.Wait(TimeSpan.FromSeconds(5));
+        };
+
+        // Park a connecting thread inside the seam (simulated mid-connect).
+        var connectingCall = Task.Run(() => _cache.GetAsync<TestData>("connector").GetAwaiter().GetResult());
+
+        connectEntered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
+            "the connect seam must be reached so Dispose is timed against a real mid-connect window");
+
+        // Time Dispose() while the connecting thread is parked mid-connect.
+        var sw = Stopwatch.StartNew();
+        _cache.Dispose();
         sw.Stop();
+        var disposeElapsed = sw.Elapsed;
 
-        // A single connect attempt is bounded by the 3s ConnectTimeout. If the connect were
-        // serialized under the lock, 16 callers could take many multiples of that. We assert the
-        // aggregate stays within roughly two connect windows — generous enough to avoid CI
-        // flakiness but far below the serialized-blocking failure mode.
-        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(8),
-            "concurrent callers must not each block for the full connect timeout under the lock");
+        // Let the parked connecting thread proceed and finish (it must not throw post-dispose).
+        releaseConnect.Set();
+        var connectorResult = connectingCall.GetAwaiter().GetResult();
+        connectorResult.Should().BeNull("an unreachable Redis degrades the connector to a miss");
+
+        // On the fixed path Dispose acquires the free lock in microseconds. On the old path it would
+        // block ~the full connect (seconds). 500ms is a wide, CI-robust margin that the fixed path
+        // clears easily and the serialized path cannot.
+        disposeElapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(500),
+            "Dispose must not be serialized behind another thread's in-flight connect (#1189)");
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
@@ -1,0 +1,114 @@
+using System.Diagnostics;
+using FluentAssertions;
+using Taskdeck.Infrastructure.Services;
+using Taskdeck.Tests.Support;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Behavior tests for <see cref="RedisCacheService"/> when Redis is unreachable.
+/// These assert the regression fixed in #1189: a failed connection degrades to the
+/// no-cache path without throwing, and the single connect attempt is NOT performed while
+/// holding the connection lock (so concurrent callers are not serialized behind a
+/// multi-second blocking connect, which previously starved the thread pool).
+/// </summary>
+public sealed class RedisCacheServiceTests : IDisposable
+{
+    // Loopback + a port that nothing listens on so Connect fails fast with connection refused.
+    // AbortOnConnectFail=false (set by the service) means Connect returns a non-connected
+    // multiplexer rather than throwing, exercising the degrade-to-no-cache path.
+    private const string UnreachableRedis = "127.0.0.1:1,connectRetry=0,abortConnect=false";
+
+    private readonly InMemoryLogger<RedisCacheService> _logger = new();
+    private readonly RedisCacheService _cache;
+
+    public RedisCacheServiceTests()
+    {
+        _cache = new RedisCacheService(UnreachableRedis, _logger, "test");
+    }
+
+    public void Dispose() => _cache.Dispose();
+
+    [Fact]
+    public async Task GetAsync_ReturnsNull_WhenRedisUnreachable()
+    {
+        var result = await _cache.GetAsync<TestData>("anykey");
+
+        result.Should().BeNull("an unreachable Redis must degrade to a cache miss, not throw");
+    }
+
+    [Fact]
+    public async Task SetAsync_DoesNotThrow_WhenRedisUnreachable()
+    {
+        // Must complete without throwing — writes silently no-op when the cache is down.
+        await _cache.SetAsync("key", new TestData("v", 1), TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_DoesNotThrow_WhenRedisUnreachable()
+    {
+        await _cache.RemoveAsync("key");
+    }
+
+    [Fact]
+    public async Task RemoveByPrefixAsync_DoesNotThrow_WhenRedisUnreachable()
+    {
+        await _cache.RemoveByPrefixAsync("prefix:");
+    }
+
+    [Fact]
+    public async Task FailedConnect_DegradesToNoCache_AndLogsWarningWithoutThrowing()
+    {
+        // First call triggers the single connect attempt; it must surface a degraded-mode warning
+        // (not an exception) and return the no-cache result.
+        var result = await _cache.GetAsync<TestData>("warm");
+
+        result.Should().BeNull();
+
+        var warnings = _logger.Entries
+            .Where(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning)
+            .Select(e => e.Message)
+            .ToList();
+
+        warnings.Should().Contain(m => m.Contains("degraded", StringComparison.OrdinalIgnoreCase),
+            "a failed connect should log a degraded-mode warning rather than throw");
+    }
+
+    [Fact]
+    public async Task ConcurrentCallers_AreNotSerializedBehindBlockingConnect()
+    {
+        // Regression guard for #1189: the connect attempt (up to a 3s timeout) must NOT be
+        // performed while holding _connectionLock. If it were, N concurrent callers would each
+        // block on the lock for the full connect duration and total wall-clock time would scale
+        // with N. With the lock held only around the minimal check-and-assign, the throttle lets
+        // exactly one thread attempt the connect while the rest fall straight through to no-cache,
+        // so total time stays close to a single connect attempt.
+        const int callers = 16;
+
+        var sw = Stopwatch.StartNew();
+
+        var tasks = Enumerable.Range(0, callers).Select(i => Task.Run(async () =>
+        {
+            // Mix of operations all routed through GetConnection/GetDatabase.
+            var got = await _cache.GetAsync<TestData>($"k{i}");
+            got.Should().BeNull();
+            await _cache.SetAsync($"k{i}", new TestData("v", i), TimeSpan.FromMinutes(1));
+        }));
+
+        var act = async () => await Task.WhenAll(tasks);
+
+        await act.Should().NotThrowAsync("unreachable Redis must never surface exceptions to callers");
+
+        sw.Stop();
+
+        // A single connect attempt is bounded by the 3s ConnectTimeout. If the connect were
+        // serialized under the lock, 16 callers could take many multiples of that. We assert the
+        // aggregate stays within roughly two connect windows — generous enough to avoid CI
+        // flakiness but far below the serialized-blocking failure mode.
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(8),
+            "concurrent callers must not each block for the full connect timeout under the lock");
+    }
+
+    private sealed record TestData(string Name, int Value);
+}

--- a/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
@@ -110,5 +110,21 @@ public sealed class RedisCacheServiceTests : IDisposable
             "concurrent callers must not each block for the full connect timeout under the lock");
     }
 
+    [Fact]
+    public async Task Dispose_IsIdempotent_AndSubsequentCallsDegradeWithoutThrowing()
+    {
+        // Establish the degraded state, then dispose. Dispose takes the connection lock, so a
+        // concurrent connect cannot leak a multiplexer past disposal; calling it twice must no-op.
+        await _cache.GetAsync<TestData>("warm");
+
+        _cache.Dispose();
+        _cache.Dispose(); // second call must be a no-op, not throw
+
+        // After disposal the service stays in the no-cache path and never throws.
+        var result = await _cache.GetAsync<TestData>("after-dispose");
+        result.Should().BeNull();
+        await _cache.SetAsync("after-dispose", new TestData("v", 1), TimeSpan.FromMinutes(1));
+    }
+
     private sealed record TestData(string Name, int Value);
 }


### PR DESCRIPTION
## Summary

Fixes #1189. `RedisCacheService.GetConnection()` held `lock (_connectionLock)` across a retry loop that contained both `Thread.Sleep(delay)` (500 ms / 1 s backoff) and a blocking `ConnectionMultiplexer.Connect` (3 s `ConnectTimeout`). With Redis configured but unreachable, the lock was held for multiple seconds while every concurrent caller blocked on it — starving the ASP.NET Core thread pool.

Redis is opt-in (Mock / InMemory is the default cache provider), so this is a latent defect rather than a default-path bug, but the lock-held-while-blocking pattern is real.

## Change

- **Removed the inner retry loop entirely** (and the now-unused `MaxConnectionRetries` / `RetryBaseDelay` constants, eliminating the `Thread.Sleep`).
- **A single `Connect` attempt per throttle window**, performed **outside** `_connectionLock`. The existing outer `ReconnectMinInterval` (15 s) throttle already prevents reconnect storms, so the inner loop was redundant.
- **The lock now guards only the minimal check-and-assign of `_connection`.** A concurrent caller that finds the lock held (`Monitor.TryEnter`) falls straight through to the no-cache path instead of blocking.
- **Graceful degradation preserved**: a failed connect returns `null` immediately so callers use the no-cache path; the method never throws. Logging stays at the existing level (`LogWarning` for degraded mode, `LogInformation` on successful connect).

### Behavior notes
- Previously, concurrent callers during an outage *blocked* on the lock until the connecting thread finished (up to ~4.5 s with retries). Now they return immediately — the intended fix for thread-pool starvation.
- With `AbortOnConnectFail=false`, `Connect` can return a *non-connected* multiplexer instead of throwing; that path now also logs the degraded-mode warning so operator visibility is preserved.

## Tests

`backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs` (8 `[Fact]`s; points the service at an unreachable `127.0.0.1:1`):

- `GetAsync` / `SetAsync` / `RemoveAsync` / `RemoveByPrefixAsync` degrade without throwing.
- `FailedConnect_DegradesToNoCache_AndLogsWarningWithoutThrowing` — failed connect yields the no-cache result and a degraded-mode warning.
- `Dispose_IsIdempotent_AndSubsequentCallsDegradeWithoutThrowing` — hardened-`Dispose` idempotency path.

**Deterministic, revert-sensitive regression guards for #1189** (added after review — the earlier wall-clock concurrency test was *not* a real guard because the `ReconnectMinInterval` throttle gates connects to one attempt per window in both the old connect-inside-lock and new connect-outside-lock code, so it passed even against the reverted old code):

- `ConnectionLock_IsNotHeld_WhileBlockingConnectRuns` — via an `OnBeforeConnect` test seam fired immediately before the blocking connect, a probe thread tries to take `_connectionLock` at the exact moment the connect is about to block. Fixed code: lock free → acquired in < 500 ms. Old code: lock held across the connect → probe times out.
- `Dispose_IsNotSerialized_BehindAnInFlightConnect` — `Dispose()` takes `_connectionLock` with no throttle gate (the cleanest public path that genuinely contends for the lock). While a connect is parked mid-flight, `Dispose` must complete in < 500 ms. Old lock-around-connect code serialized it behind the connect (~7 s observed).

Both new tests were proven revert-sensitive: temporarily restoring the old lock-around-connect shape makes both **FAIL** (`probeAcquiredLock == false`; `disposeElapsed ≈ 7 s`); the fix makes both **PASS**.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release` → **0 errors**.
- `dotnet test ... --filter "FullyQualifiedName~Redis"` → **17/17 passed** in `Taskdeck.Api.Tests` (8 in `RedisCacheServiceTests` + 9 existing SignalR/Redis-backplane); 19 total across the solution including 1 each in `Application.Tests` and `Cli.Tests`.
- `dotnet test ... --filter "FullyQualifiedName~Cache"` → **50/50 passed** (no cache regressions).
- Revert-sensitivity proof: old lock-around-connect shape restored → both deterministic guards FAIL; fix restored → both PASS.
