### PR TITLE
Tokenize 3 light-theme straggler modals for paper-night (ADR-0038, #1135)

### DIFF
--- a/frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue
+++ b/frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue
@@ -77,7 +77,7 @@ const categories: ShortcutCategory[] = [
         @click="handleBackdropClick"
         @keydown.escape="emit('close')"
       >
-        <div class="kbd-help-panel bg-surface-container rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div class="kbd-help-panel bg-surface-container rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto border border-outline-variant/30">
           <!-- Header -->
           <div class="sticky top-0 bg-surface-container border-b border-outline-variant/30 px-6 py-4 flex items-center justify-between">
             <div>

--- a/frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue
+++ b/frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue
@@ -77,16 +77,16 @@ const categories: ShortcutCategory[] = [
         @click="handleBackdropClick"
         @keydown.escape="emit('close')"
       >
-        <div class="bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        <div class="kbd-help-panel bg-surface-container rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
           <!-- Header -->
-          <div class="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+          <div class="sticky top-0 bg-surface-container border-b border-outline-variant/30 px-6 py-4 flex items-center justify-between">
             <div>
-              <h2 class="text-xl font-bold text-gray-900">Keyboard Shortcuts</h2>
-              <p class="text-sm text-gray-600 mt-1">Navigate and manage your boards faster</p>
+              <h2 class="text-xl font-bold text-on-surface">Keyboard Shortcuts</h2>
+              <p class="text-sm text-on-surface-variant mt-1">Navigate and manage your boards faster</p>
             </div>
             <button
               @click="emit('close')"
-              class="text-gray-400 hover:text-gray-600 transition-colors p-1 rounded hover:bg-gray-100"
+              class="text-on-surface-variant hover:text-on-surface transition-colors p-1 rounded hover:bg-surface-container-high"
               aria-label="Close"
             >
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -102,25 +102,25 @@ const categories: ShortcutCategory[] = [
               :key="category.title"
               class="space-y-3"
             >
-              <h3 class="text-lg font-semibold text-gray-900 flex items-center gap-2">
-                <span class="w-1 h-6 bg-blue-600 rounded"></span>
+              <h3 class="text-lg font-semibold text-on-surface flex items-center gap-2">
+                <span class="w-1 h-6 bg-primary rounded"></span>
                 {{ category.title }}
               </h3>
               <div class="space-y-2 ml-3">
                 <div
                   v-for="shortcut in category.shortcuts"
                   :key="`${category.title}-${shortcut.description}`"
-                  class="flex items-center justify-between py-2 px-3 rounded hover:bg-gray-50 transition-colors"
+                  class="flex items-center justify-between py-2 px-3 rounded hover:bg-surface-container-high transition-colors"
                 >
-                  <span class="text-gray-700">{{ shortcut.description }}</span>
+                  <span class="text-on-surface-variant">{{ shortcut.description }}</span>
                   <div class="flex items-center gap-1">
                     <template v-for="(key, keyIndex) in shortcut.keys" :key="`${shortcut.description}-${keyIndex}-${key}`">
                       <kbd
-                        class="px-2 py-1 text-sm font-semibold text-gray-800 bg-gray-100 border border-gray-300 rounded shadow-sm min-w-[2rem] text-center"
+                        class="px-2 py-1 text-sm font-semibold text-on-surface bg-surface-container-high border border-outline-variant/40 rounded shadow-sm min-w-[2rem] text-center"
                       >
                         {{ key }}
                       </kbd>
-                      <span v-if="keyIndex < shortcut.keys.length - 1" class="text-gray-400 text-sm">or</span>
+                      <span v-if="keyIndex < shortcut.keys.length - 1" class="text-on-surface-variant text-sm">or</span>
                     </template>
                   </div>
                 </div>
@@ -129,14 +129,14 @@ const categories: ShortcutCategory[] = [
           </div>
 
           <!-- Footer -->
-          <div class="sticky bottom-0 bg-gray-50 border-t border-gray-200 px-6 py-4">
+          <div class="sticky bottom-0 bg-surface-container-low border-t border-outline-variant/30 px-6 py-4">
             <div class="flex items-center justify-between">
-              <p class="text-sm text-gray-600">
-                Press <kbd class="px-2 py-1 text-xs font-semibold text-gray-800 bg-white border border-gray-300 rounded shadow-sm">?</kbd> anytime to show or hide this help
+              <p class="text-sm text-on-surface-variant">
+                Press <kbd class="px-2 py-1 text-xs font-semibold text-on-surface bg-surface-container-high border border-outline-variant/40 rounded shadow-sm">?</kbd> anytime to show or hide this help
               </p>
               <button
                 @click="emit('close')"
-                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+                class="px-4 py-2 bg-primary-container text-on-primary-container rounded-lg hover:brightness-110 transition-all font-medium"
               >
                 Got it!
               </button>
@@ -159,13 +159,13 @@ const categories: ShortcutCategory[] = [
   opacity: 0;
 }
 
-.modal-enter-active .bg-white,
-.modal-leave-active .bg-white {
+.modal-enter-active .kbd-help-panel,
+.modal-leave-active .kbd-help-panel {
   transition: transform 0.2s ease;
 }
 
-.modal-enter-from .bg-white,
-.modal-leave-to .bg-white {
+.modal-enter-from .kbd-help-panel,
+.modal-leave-to .kbd-help-panel {
   transform: scale(0.95);
 }
 

--- a/frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue
@@ -164,7 +164,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
               v-model="name"
               type="text"
               required
-              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="My Board"
             />
           </div>
@@ -178,7 +178,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
               id="board-description"
               v-model="description"
               rows="3"
-              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="What is this board for?"
             ></textarea>
           </div>

--- a/frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue
+++ b/frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue
@@ -41,8 +41,8 @@ const lifecycleActionLabel = computed(() => {
 
 const lifecycleActionButtonClass = computed(() => (
   props.board.isArchived
-    ? 'px-4 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50 border border-blue-300 rounded-md transition-colors'
-    : 'px-4 py-2 text-sm font-medium text-red-600 hover:text-red-700 hover:bg-red-50 border border-red-300 rounded-md transition-colors'
+    ? 'px-4 py-2 text-sm font-medium text-primary hover:bg-primary/10 border border-primary/40 rounded-md transition-colors'
+    : 'px-4 py-2 text-sm font-medium text-error hover:text-error/80 hover:bg-error/10 border border-error/40 rounded-md transition-colors'
 ))
 
 const lifecycleDescription = computed(() => (
@@ -137,13 +137,13 @@ useEscapeToClose(() => props.isOpen, handleClose)
 
     <!-- Modal -->
     <div class="flex min-h-full items-center justify-center p-4">
-      <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6" @click.stop>
+      <div class="relative bg-surface-container rounded-lg shadow-xl max-w-md w-full p-6 border border-outline-variant/30" @click.stop>
         <!-- Header -->
         <div class="flex items-start justify-between mb-4">
-          <h2 class="text-2xl font-semibold text-gray-900">Board Settings</h2>
+          <h2 class="text-2xl font-semibold text-on-surface">Board Settings</h2>
           <button
             @click="handleClose"
-            class="text-gray-400 hover:text-gray-600 transition-colors"
+            class="text-on-surface-variant hover:text-on-surface transition-colors"
             aria-label="Close board settings"
           >
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -156,7 +156,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
         <div class="space-y-4">
           <!-- Name -->
           <div>
-            <label for="board-name" class="block text-sm font-medium text-gray-700 mb-1">
+            <label for="board-name" class="block text-sm font-medium text-on-surface-variant mb-1">
               Board Name *
             </label>
             <input
@@ -164,41 +164,41 @@ useEscapeToClose(() => props.isOpen, handleClose)
               v-model="name"
               type="text"
               required
-              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
               placeholder="My Board"
             />
           </div>
 
           <!-- Description -->
           <div>
-            <label for="board-description" class="block text-sm font-medium text-gray-700 mb-1">
+            <label for="board-description" class="block text-sm font-medium text-on-surface-variant mb-1">
               Description
             </label>
             <textarea
               id="board-description"
               v-model="description"
               rows="3"
-              class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
               placeholder="What is this board for?"
             ></textarea>
           </div>
 
           <!-- Lifecycle State -->
-          <div class="border border-gray-200 rounded-md p-4">
+          <div class="border border-outline-variant/30 rounded-md p-4">
             <div class="flex flex-col gap-1">
-              <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Lifecycle</span>
-              <span class="text-sm text-gray-700">
+              <span class="text-xs font-semibold uppercase tracking-wide text-on-surface-variant">Lifecycle</span>
+              <span class="text-sm text-on-surface">
                 {{ board.isArchived ? 'Archived' : 'Active' }}
               </span>
             </div>
-            <p class="mt-1 text-xs text-gray-500">
+            <p class="mt-1 text-xs text-on-surface-variant">
               {{ lifecycleDescription }}
             </p>
           </div>
 
           <!-- Metadata -->
-          <div class="pt-4 border-t border-gray-200">
-            <div class="text-xs text-gray-500 space-y-1">
+          <div class="pt-4 border-t border-outline-variant/30">
+            <div class="text-xs text-on-surface-variant space-y-1">
               <p>Created: {{ new Date(board.createdAt).toLocaleString() }}</p>
               <p>Last updated: {{ new Date(board.updatedAt).toLocaleString() }}</p>
             </div>
@@ -219,7 +219,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
             <button
               @click="handleClose"
               type="button"
-              class="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 border border-gray-300 rounded-md transition-colors"
+              class="px-4 py-2 text-sm font-medium text-on-surface-variant hover:bg-surface-container-high border border-outline-variant/40 rounded-md transition-colors"
             >
               Cancel
             </button>
@@ -227,7 +227,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
               @click="handleSave"
               :disabled="!isFormValid()"
               type="button"
-              class="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-md transition-colors"
+              class="px-4 py-2 text-sm font-medium text-on-primary-container bg-primary-container hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed rounded-md transition-all"
             >
               Save Changes
             </button>

--- a/frontend/taskdeck-web/src/components/board/CardModal.vue
+++ b/frontend/taskdeck-web/src/components/board/CardModal.vue
@@ -173,7 +173,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
       <button
         type="button"
         :disabled="isDeleting"
-        class="px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 border border-gray-300 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        class="px-4 py-2 text-sm font-medium text-on-surface-variant hover:bg-surface-container-high border border-outline-variant/40 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         @click="handleDeleteCancel"
       >
         Cancel
@@ -181,7 +181,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
       <button
         type="button"
         :disabled="isDeleting"
-        class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 border border-transparent rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        class="px-4 py-2 text-sm font-medium text-on-error bg-error hover:brightness-110 border border-transparent rounded-md transition-all disabled:opacity-50 disabled:cursor-not-allowed"
         @click="handleDeleteConfirm"
       >
         {{ isDeleting ? 'Deleting…' : 'Delete' }}

--- a/frontend/taskdeck-web/src/tests/components/KeyboardShortcutsHelp.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/KeyboardShortcutsHelp.spec.ts
@@ -106,4 +106,23 @@ describe('KeyboardShortcutsHelp', () => {
     expect(text).toContain('anytime to show or hide this help')
     wrapper.unmount()
   })
+
+  it('uses design-token surfaces, not hardcoded light-theme classes', () => {
+    // Regression guard for ADR-0038 paper-night activation (#1135): this legacy
+    // overlay must survive the dark/paper canonical theme. Every surface, text,
+    // and accent color must come from the --td-*/Material token utilities, never
+    // from raw Tailwind light-theme classes that bake in a white background.
+    const wrapper = mountHelp(true)
+    const panel = document.body.querySelector('.kbd-help-panel') as HTMLElement
+    expect(panel).not.toBeNull()
+    expect(panel.className).toContain('bg-surface-container')
+
+    const markup = document.body.querySelector('[role="dialog"]')?.outerHTML ?? ''
+    expect(markup).not.toMatch(/\bbg-white\b/)
+    expect(markup).not.toMatch(/\btext-gray-\d/)
+    expect(markup).not.toMatch(/\bbg-gray-\d/)
+    expect(markup).not.toMatch(/\bborder-gray-\d/)
+    expect(markup).not.toMatch(/\b(?:bg|text|border)-blue-\d/)
+    wrapper.unmount()
+  })
 })

--- a/frontend/taskdeck-web/src/tests/components/KeyboardShortcutsHelp.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/KeyboardShortcutsHelp.spec.ts
@@ -123,6 +123,8 @@ describe('KeyboardShortcutsHelp', () => {
     expect(markup).not.toMatch(/\bbg-gray-\d/)
     expect(markup).not.toMatch(/\bborder-gray-\d/)
     expect(markup).not.toMatch(/\b(?:bg|text|border)-blue-\d/)
+    expect(markup).not.toMatch(/\b(?:bg|text|border)-red-\d/)
+    expect(markup).not.toMatch(/text-white\b/)
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary

Paper-night straggler tokenization (Slice A of the Paper-canonical activation, **ADR-0038**; relates to **#1135**/#1136).

Three legacy modals still hardcoded light-theme Tailwind color classes (`bg-white`, `text-gray-*`, `border-gray-*`, `bg-gray-*`, `bg-blue-*`, `text-red-*`, etc.) which bake in a white background and break under the canonical dark/paper theme. This PR replaces every hardcoded color class with the project's Material design tokens, matching the already-tokenized `ColumnEditModal.vue` pattern. **No layout or behavior changes — only color tokens.**

### Files tokenized
- `frontend/taskdeck-web/src/components/KeyboardShortcutsHelp.vue` (17 light-theme classes + scoped modal-transition CSS keyed on `.bg-white`)
- `frontend/taskdeck-web/src/components/board/BoardSettingsModal.vue` (15, template + `lifecycleActionButtonClass` computed)
- `frontend/taskdeck-web/src/components/board/CardModal.vue` (delete-confirm footer Cancel/Delete buttons)

### Token mapping (matches ColumnEditModal)
- `bg-white` → `bg-surface-container`
- `text-gray-900` → `text-on-surface`; `text-gray-700/600/500/400` → `text-on-surface-variant`
- `border-gray-200/300` → `border-outline-variant/30..40`
- `bg-gray-100/50` → `bg-surface-container-high` / `bg-surface-container-low`
- `bg-blue-600 text-white` (primary action) → `bg-primary-container text-on-primary-container hover:brightness-110`
- `bg-blue-600` (accent bar) → `bg-primary`
- `text-red-600 / bg-red-600 text-white` (destructive) → `text-error` / `bg-error text-on-error`

The scoped CSS transition in `KeyboardShortcutsHelp` that was keyed on the Tailwind utility `.bg-white` is now keyed on a stable `.kbd-help-panel` hook class.

## KeyboardShortcutsHelp reachability (investigated, no change needed)

The analysis flagged that the `?` shortcuts overlay E2E couldn't reach this legacy component. I traced the wiring:

- `KeyboardShortcutsHelp.vue` is mounted only via `BoardDialogHost.vue` → used by `BoardView.vue`, which renders the **standard (non-paper) board** under `v-else` (`!paperOn`).
- In the standard board it **is reachable**: the `?` key fires `toggleKeyboardHelp` (`BoardView.vue` line 342, gated by `standardBoardOnlyShortcutsEnabled = !paperOn`), and the `BoardToolbar` `?` button emits `show-keyboard-help` (`BoardToolbar.vue` line 96).
- The shell-level `?` handler in `AppShell.vue` (line 150) drives a **different** overlay (`ShellKeyboardHelp` / `PaperShortcutsOverlay`), not this legacy component. That is why the canonical-theme E2E reaches the shell overlay, not this one.

**Conclusion:** the component is genuinely reachable inside the legacy standard board; no rewiring is required. Per the task instruction ("if it IS reachable, note that and skip"), no wiring sub-change was made.

## Tests
- Added a regression test to `KeyboardShortcutsHelp.spec.ts` asserting the panel uses `bg-surface-container` and the dialog markup contains no `bg-white` / `text-gray-N` / `bg-gray-N` / `border-gray-N` / `*-blue-N` straggler classes (locks in ADR-0038 survivability).

## Verification
- `npm ci` — clean
- `npm run typecheck` — clean (no errors)
- `npm run lint` — 6 warnings (all pre-existing in unrelated AgentRuns/Agents views), 0 in changed files, under the 20 threshold
- `grep` over the 3 files — **zero** hardcoded `bg-white` / `text-gray-N` / `border-gray-N` / `bg-gray-N` (and no `*-blue-N` / `*-red-N` / `text-white`) remain
- `npx vitest --run` (maxWorkers=2) on `KeyboardShortcutsHelp.spec.ts` (11), `BoardDialogHost.spec.ts` (2), `BoardSettingsModal.spec.ts`, `CardModal.spec.ts` — all pass (59 tests total)

Relates to #1135.
