### PR TITLE
Share review actionability rules across Paper and Legacy; drop fabricated meta

### DIFF
--- a/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
@@ -19,7 +19,10 @@ const props = defineProps<{
 // Reject are only available while the proposal is still pending and unexpired;
 // Apply-to-board is the Approved-and-actionable arm of apply-actionable.
 const canReject = computed(() => isProposalRejectActionable(props.proposal, props.isExpired))
-const canApprove = canReject
+// Approve and Reject share the same precondition (a still-live PendingReview
+// proposal), but keep them as independent computeds so they can diverge later
+// without a hidden alias coupling them (e.g. an approve-only permission gate).
+const canApprove = computed(() => isProposalRejectActionable(props.proposal, props.isExpired))
 const canExecute = computed(
   () =>
     isProposalApplyActionable(props.proposal, props.isExpired) &&

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
@@ -1,13 +1,30 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Proposal } from '../../types/automation'
 import { normalizeProposalStatus } from '../../utils/automation'
+import {
+  isProposalApplyActionable,
+  isProposalRejectActionable,
+} from '../../composables/useReviewProposals'
 
-defineProps<{
+const props = defineProps<{
   proposal: Proposal
   isExpired: boolean
   isBusy: boolean
   selectedDiffProposalId: string | null
 }>()
+
+// Decision gating comes from the shared review rules so the Legacy card and the
+// Paper deep-review surface can never drift (#1124 / ADR-0038). Approve and
+// Reject are only available while the proposal is still pending and unexpired;
+// Apply-to-board is the Approved-and-actionable arm of apply-actionable.
+const canReject = computed(() => isProposalRejectActionable(props.proposal, props.isExpired))
+const canApprove = canReject
+const canExecute = computed(
+  () =>
+    isProposalApplyActionable(props.proposal, props.isExpired) &&
+    normalizeProposalStatus(props.proposal.status) === 'Approved',
+)
 
 defineEmits<{
   (e: 'approve', proposalId: string): void
@@ -78,21 +95,21 @@ defineEmits<{
       </button>
       <button
         class="td-btn td-btn--primary td-btn--sm"
-        :disabled="isBusy || normalizeProposalStatus(proposal.status) !== 'PendingReview'"
+        :disabled="isBusy || !canApprove"
         @click="$emit('approve', proposal.id)"
       >
         Approve for board
       </button>
       <button
         class="td-btn td-btn--danger td-btn--sm"
-        :disabled="isBusy || normalizeProposalStatus(proposal.status) !== 'PendingReview'"
+        :disabled="isBusy || !canReject"
         @click="$emit('reject', proposal.id, proposal.riskLevel)"
       >
         Reject
       </button>
       <button
         class="td-btn td-btn--secondary td-btn--sm"
-        :disabled="isBusy || normalizeProposalStatus(proposal.status) !== 'Approved'"
+        :disabled="isBusy || !canExecute"
         @click="$emit('execute', proposal.id)"
       >
         Apply to board

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
@@ -4,6 +4,7 @@ import type { Proposal } from '../../types/automation'
 import { normalizeProposalStatus } from '../../utils/automation'
 import {
   isProposalApplyActionable,
+  isProposalApproveActionable,
   isProposalRejectActionable,
 } from '../../composables/useReviewProposals'
 
@@ -20,9 +21,9 @@ const props = defineProps<{
 // Apply-to-board is the Approved-and-actionable arm of apply-actionable.
 const canReject = computed(() => isProposalRejectActionable(props.proposal, props.isExpired))
 // Approve and Reject share the same precondition (a still-live PendingReview
-// proposal), but keep them as independent computeds so they can diverge later
-// without a hidden alias coupling them (e.g. an approve-only permission gate).
-const canApprove = computed(() => isProposalRejectActionable(props.proposal, props.isExpired))
+// proposal), but each routes through its own named helper so they can diverge
+// later without a hidden alias coupling them (e.g. an approve-only permission gate).
+const canApprove = computed(() => isProposalApproveActionable(props.proposal, props.isExpired))
 const canExecute = computed(
   () =>
     isProposalApplyActionable(props.proposal, props.isExpired) &&

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -44,6 +44,12 @@ export function isProposalRejectActionable(proposal: ApiProposal, isExpired: boo
   return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isExpired
 }
 
+// Approve shares Reject's precondition today (a live, non-expired PendingReview proposal),
+// but is named distinctly so the two can diverge without one silently aliasing the other.
+export function isProposalApproveActionable(proposal: ApiProposal, isExpired: boolean): boolean {
+  return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isExpired
+}
+
 export function isProposalStale(proposal: ApiProposal, nowMs: number): boolean {
   if (!proposal || normalizeProposalStatus(proposal.status) !== 'PendingReview') return false
   // Guard against missing/invalid createdAt: a falsy value (new Date(null) is

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -45,8 +45,14 @@ export function isProposalRejectActionable(proposal: ApiProposal, isExpired: boo
 }
 
 export function isProposalStale(proposal: ApiProposal, nowMs: number): boolean {
-  if (normalizeProposalStatus(proposal.status) !== 'PendingReview') return false
-  return nowMs - new Date(proposal.createdAt).getTime() >= STALE_PROPOSAL_MS
+  if (!proposal || normalizeProposalStatus(proposal.status) !== 'PendingReview') return false
+  // Guard against missing/invalid createdAt: a falsy value (new Date(null) is
+  // the epoch) or an unparseable string (new Date(...).getTime() is NaN) would
+  // otherwise mis-flag the proposal as wildly stale.
+  if (!proposal.createdAt) return false
+  const createdMs = new Date(proposal.createdAt).getTime()
+  if (Number.isNaN(createdMs)) return false
+  return nowMs - createdMs >= STALE_PROPOSAL_MS
 }
 
 export function useReviewProposals() {

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -16,6 +16,39 @@ import { getErrorDisplay } from './useErrorMapper'
 import { logError } from '../utils/errorReporting'
 import { usePerformanceMark } from './usePerformanceMark'
 
+/**
+ * A proposal counts as "stale" once it has sat in PendingReview for 24 hours.
+ * Centralised here so both the Paper and Legacy review surfaces agree (#1124
+ * drift class — ADR-0038).
+ */
+export const STALE_PROPOSAL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Decision rules shared by every review surface (Paper deep-review and the
+ * Legacy card). These are pure functions so the prop-driven Legacy components
+ * can reuse the exact same gating without importing the composable. The
+ * reactive instances exposed by `useReviewProposals` are thin wrappers that
+ * supply `isExpired`/`nowMs` from the composable's own reactive clock.
+ *
+ * `isExpired` is passed in explicitly because expiry depends on a reactive
+ * clock that only the composable (or the parent view) owns. Callers must pass
+ * the same `isProposalExpired(proposal)` value the rest of the surface uses,
+ * including the Approved+expired #1124 case.
+ */
+export function isProposalApplyActionable(proposal: ApiProposal, isExpired: boolean): boolean {
+  const status = normalizeProposalStatus(proposal.status)
+  return (status === 'PendingReview' || status === 'Approved') && !isExpired
+}
+
+export function isProposalRejectActionable(proposal: ApiProposal, isExpired: boolean): boolean {
+  return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isExpired
+}
+
+export function isProposalStale(proposal: ApiProposal, nowMs: number): boolean {
+  if (normalizeProposalStatus(proposal.status) !== 'PendingReview') return false
+  return nowMs - new Date(proposal.createdAt).getTime() >= STALE_PROPOSAL_MS
+}
+
 export function useReviewProposals() {
   const route = useRoute()
   const router = useRouter()
@@ -87,6 +120,20 @@ export function useReviewProposals() {
       return new Date(proposal.expiresAt).getTime() <= nowMs.value
     }
     return false
+  }
+
+  // Reactive wrappers over the shared pure decision rules. They bind the
+  // surface's own expiry/clock state so Paper and Legacy can never drift. #1124
+  function isApplyActionable(proposal: ApiProposal): boolean {
+    return isProposalApplyActionable(proposal, isProposalExpired(proposal))
+  }
+
+  function isRejectActionable(proposal: ApiProposal): boolean {
+    return isProposalRejectActionable(proposal, isProposalExpired(proposal))
+  }
+
+  function isStaleProposal(proposal: ApiProposal): boolean {
+    return isProposalStale(proposal, nowMs.value)
   }
 
   const visibleProposals = computed(() =>
@@ -366,6 +413,9 @@ export function useReviewProposals() {
     dismissableProposalIds,
     matchesActiveBoardFilter,
     isProposalExpired,
+    isApplyActionable,
+    isRejectActionable,
+    isStaleProposal,
     loadProposals,
     loadBoardOptions,
     startClock,

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalActions.spec.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import type { Proposal } from '../../../types/automation'
+import ReviewProposalActions from '../../../components/review/ReviewProposalActions.vue'
+
+// Locks the Legacy action gating to the shared review rules (ADR-0038 / #1124
+// drift class). Approve/Reject must only be enabled for a live PendingReview
+// proposal; Apply-to-board only for a live Approved proposal; an expired
+// proposal swaps to the dismiss affordance and never exposes apply/reject.
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  const now = new Date().toISOString()
+  return {
+    id: 'p-1',
+    sourceType: 'Chat',
+    sourceReferenceId: null,
+    boardId: 'board-1',
+    requestedByUserId: 'u-1',
+    status: 'PendingReview',
+    riskLevel: 'Low',
+    summary: 'Test proposal',
+    diffPreview: null,
+    validationIssues: null,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+    decidedAt: null,
+    decidedByUserId: null,
+    appliedAt: null,
+    failureReason: null,
+    correlationId: 'corr-1',
+    operations: [],
+    ...overrides,
+  } as Proposal
+}
+
+function mountActions(props: Partial<{
+  proposal: Proposal
+  isExpired: boolean
+  isBusy: boolean
+  selectedDiffProposalId: string | null
+}> = {}) {
+  return mount(ReviewProposalActions, {
+    props: {
+      proposal: props.proposal ?? makeProposal(),
+      isExpired: props.isExpired ?? false,
+      isBusy: props.isBusy ?? false,
+      selectedDiffProposalId: props.selectedDiffProposalId ?? null,
+    },
+  })
+}
+
+function findButton(wrapper: ReturnType<typeof mountActions>, label: string) {
+  const button = wrapper.findAll('button').find((b) => b.text() === label)
+  expect(button, `expected a "${label}" button`).toBeTruthy()
+  return button!
+}
+
+function isDisabled(wrapper: ReturnType<typeof mountActions>, label: string): boolean {
+  return findButton(wrapper, label).attributes('disabled') !== undefined
+}
+
+describe('ReviewProposalActions gating', () => {
+  it('enables approve and reject for a live PendingReview proposal, disables execute', () => {
+    const wrapper = mountActions({ proposal: makeProposal({ status: 'PendingReview' }) })
+    expect(isDisabled(wrapper, 'Approve for board')).toBe(false)
+    expect(isDisabled(wrapper, 'Reject')).toBe(false)
+    expect(isDisabled(wrapper, 'Apply to board')).toBe(true)
+  })
+
+  it('enables only execute for a live Approved proposal', () => {
+    const wrapper = mountActions({ proposal: makeProposal({ status: 'Approved' }) })
+    expect(isDisabled(wrapper, 'Approve for board')).toBe(true)
+    expect(isDisabled(wrapper, 'Reject')).toBe(true)
+    expect(isDisabled(wrapper, 'Apply to board')).toBe(false)
+  })
+
+  it('shows the dismiss affordance and hides apply/reject when expired (#1124)', () => {
+    const wrapper = mountActions({
+      proposal: makeProposal({ status: 'Approved' }),
+      isExpired: true,
+    })
+    expect(wrapper.text()).toContain('This proposal has expired and can no longer be applied.')
+    expect(wrapper.findAll('button').some((b) => b.text() === 'Dismiss')).toBe(true)
+    expect(wrapper.findAll('button').some((b) => b.text() === 'Approve for board')).toBe(false)
+    expect(wrapper.findAll('button').some((b) => b.text() === 'Apply to board')).toBe(false)
+    expect(wrapper.findAll('button').some((b) => b.text() === 'Reject')).toBe(false)
+  })
+
+  it('disables every transition button while busy', () => {
+    const wrapper = mountActions({
+      proposal: makeProposal({ status: 'PendingReview' }),
+      isBusy: true,
+    })
+    expect(isDisabled(wrapper, 'Approve for board')).toBe(true)
+    expect(isDisabled(wrapper, 'Reject')).toBe(true)
+    expect(isDisabled(wrapper, 'Apply to board')).toBe(true)
+  })
+
+  it('disables apply/reject/execute for terminal statuses', () => {
+    for (const status of ['Applied', 'Rejected', 'Failed'] as const) {
+      const wrapper = mountActions({ proposal: makeProposal({ status }) })
+      expect(isDisabled(wrapper, 'Approve for board')).toBe(true)
+      expect(isDisabled(wrapper, 'Reject')).toBe(true)
+      expect(isDisabled(wrapper, 'Apply to board')).toBe(true)
+    }
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -86,7 +86,28 @@ vi.mock('../../utils/errorReporting', () => ({
   logError: vi.fn(),
 }))
 
-import { useReviewProposals } from '../../composables/useReviewProposals'
+import {
+  STALE_PROPOSAL_MS,
+  isProposalApplyActionable,
+  isProposalRejectActionable,
+  isProposalStale,
+  useReviewProposals,
+} from '../../composables/useReviewProposals'
+
+// The PaperReviewView local copies that this slice replaced — kept verbatim
+// here so the shared helpers are pinned to the EXACT prior semantics
+// (ADR-0038 / #1124 drift class). If a shared rule diverges, these expectations
+// will disagree with the helper and the test fails.
+function localIsApplyActionable(status: string, expired: boolean): boolean {
+  return (status === 'PendingReview' || status === 'Approved') && !expired
+}
+function localIsRejectActionable(status: string, expired: boolean): boolean {
+  return status === 'PendingReview' && !expired
+}
+function localIsStaleProposal(status: string, createdAtMs: number, nowMs: number): boolean {
+  if (status !== 'PendingReview') return false
+  return nowMs - createdAtMs >= 24 * 60 * 60 * 1000
+}
 
 function watcherForCurrentSourceValue(expected: unknown) {
   const watcher = watchers.find(([source]) => typeof source === 'function' && (source as () => unknown)() === expected)
@@ -197,6 +218,108 @@ describe('useReviewProposals', () => {
       const rp = useReviewProposals()
       const p = makeProposal({ status: 'Applied' })
       expect(rp.isProposalExpired(p as any)).toBe(false)
+    })
+  })
+
+  // These prove the shared actionability helpers return the SAME verdict the
+  // old PaperReviewView/Legacy local functions did, across every status. They
+  // are the regression net for the #1124 drift class (ADR-0038): if the shared
+  // rule changes, the parity assertions against the inlined local logic fail.
+  describe('shared actionability helpers parity', () => {
+    const NOW = new Date('2026-06-04T00:00:00Z').getTime()
+    const PAST = '2026-05-01T00:00:00Z' // before NOW -> expired when status permits
+    const FUTURE = '2099-01-01T00:00:00Z' // after NOW -> not yet expired
+
+    // Status × expiry matrix covering the required scenarios:
+    // Pending, Approved, Approved+expired (#1124), Applied, Rejected, Expired.
+    const cases: Array<{ label: string; status: string; expiresAt: string }> = [
+      { label: 'Pending (live)', status: 'PendingReview', expiresAt: FUTURE },
+      { label: 'Pending (expired by clock)', status: 'PendingReview', expiresAt: PAST },
+      { label: 'Approved (live)', status: 'Approved', expiresAt: FUTURE },
+      { label: 'Approved + expired (#1124)', status: 'Approved', expiresAt: PAST },
+      { label: 'Applied', status: 'Applied', expiresAt: PAST },
+      { label: 'Rejected', status: 'Rejected', expiresAt: PAST },
+      { label: 'Expired', status: 'Expired', expiresAt: PAST },
+    ]
+
+    it.each(cases)(
+      'isApplyActionable matches prior local logic for $label',
+      ({ status, expiresAt }) => {
+        const rp = useReviewProposals()
+        rp.nowMs.value = NOW
+        const p = makeProposal({ status, expiresAt }) as any
+        const expired = rp.isProposalExpired(p)
+        const expected = localIsApplyActionable(status, expired)
+        expect(rp.isApplyActionable(p)).toBe(expected)
+        expect(isProposalApplyActionable(p, expired)).toBe(expected)
+      },
+    )
+
+    it.each(cases)(
+      'isRejectActionable matches prior local logic for $label',
+      ({ status, expiresAt }) => {
+        const rp = useReviewProposals()
+        rp.nowMs.value = NOW
+        const p = makeProposal({ status, expiresAt }) as any
+        const expired = rp.isProposalExpired(p)
+        const expected = localIsRejectActionable(status, expired)
+        expect(rp.isRejectActionable(p)).toBe(expected)
+        expect(isProposalRejectActionable(p, expired)).toBe(expected)
+      },
+    )
+
+    // Concrete verdicts (not just self-parity) so a logic flip is caught even
+    // if the local mirror is wrong too.
+    it('apply is actionable only for live Pending/Approved; reject only for live Pending', () => {
+      const rp = useReviewProposals()
+      rp.nowMs.value = NOW
+
+      const pendingLive = makeProposal({ status: 'PendingReview', expiresAt: FUTURE }) as any
+      const approvedLive = makeProposal({ status: 'Approved', expiresAt: FUTURE }) as any
+      const approvedExpired = makeProposal({ status: 'Approved', expiresAt: PAST }) as any
+      const applied = makeProposal({ status: 'Applied' }) as any
+      const rejected = makeProposal({ status: 'Rejected' }) as any
+      const expired = makeProposal({ status: 'Expired', expiresAt: PAST }) as any
+
+      expect(rp.isApplyActionable(pendingLive)).toBe(true)
+      expect(rp.isApplyActionable(approvedLive)).toBe(true)
+      expect(rp.isApplyActionable(approvedExpired)).toBe(false) // #1124: can't apply
+      expect(rp.isApplyActionable(applied)).toBe(false)
+      expect(rp.isApplyActionable(rejected)).toBe(false)
+      expect(rp.isApplyActionable(expired)).toBe(false)
+
+      expect(rp.isRejectActionable(pendingLive)).toBe(true)
+      expect(rp.isRejectActionable(approvedLive)).toBe(false)
+      expect(rp.isRejectActionable(approvedExpired)).toBe(false)
+      expect(rp.isRejectActionable(applied)).toBe(false)
+      expect(rp.isRejectActionable(rejected)).toBe(false)
+      expect(rp.isRejectActionable(expired)).toBe(false)
+    })
+
+    it('isStaleProposal flags only Pending proposals at/after the 24h cutoff', () => {
+      const rp = useReviewProposals()
+      rp.nowMs.value = NOW
+      const justUnder = new Date(NOW - (STALE_PROPOSAL_MS - 1000)).toISOString()
+      const exactly = new Date(NOW - STALE_PROPOSAL_MS).toISOString()
+      const wellOver = new Date(NOW - (STALE_PROPOSAL_MS + 60_000)).toISOString()
+
+      const freshPending = makeProposal({ status: 'PendingReview', createdAt: justUnder }) as any
+      const borderlinePending = makeProposal({ status: 'PendingReview', createdAt: exactly }) as any
+      const oldPending = makeProposal({ status: 'PendingReview', createdAt: wellOver }) as any
+      const oldApproved = makeProposal({ status: 'Approved', createdAt: wellOver }) as any
+
+      // Reactive instance wrapper
+      expect(rp.isStaleProposal(freshPending)).toBe(false)
+      expect(rp.isStaleProposal(borderlinePending)).toBe(true) // >= cutoff is inclusive
+      expect(rp.isStaleProposal(oldPending)).toBe(true)
+      expect(rp.isStaleProposal(oldApproved)).toBe(false) // only Pending is stale
+
+      // Parity with the prior local logic + the pure helper
+      for (const p of [freshPending, borderlinePending, oldPending, oldApproved]) {
+        const expected = localIsStaleProposal(p.status, new Date(p.createdAt).getTime(), NOW)
+        expect(rp.isStaleProposal(p)).toBe(expected)
+        expect(isProposalStale(p, NOW)).toBe(expected)
+      }
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -94,16 +94,11 @@ import {
   useReviewProposals,
 } from '../../composables/useReviewProposals'
 
-// The PaperReviewView local copies that this slice replaced — kept verbatim
-// here so the shared helpers are pinned to the EXACT prior semantics
-// (ADR-0038 / #1124 drift class). If a shared rule diverges, these expectations
-// will disagree with the helper and the test fails.
-function localIsApplyActionable(status: string, expired: boolean): boolean {
-  return (status === 'PendingReview' || status === 'Approved') && !expired
-}
-function localIsRejectActionable(status: string, expired: boolean): boolean {
-  return status === 'PendingReview' && !expired
-}
+// The apply/reject parity cases now assert against HARD-CODED truth tables (see
+// the cases array below) rather than a re-derived mirror, so a flipped rule
+// actually fails the test instead of self-confirming (ADR-0038 / #1124 drift
+// class). The one remaining local mirror is for stale, which is paired with its
+// own hard-coded .toBe() assertions in the stale test.
 function localIsStaleProposal(status: string, createdAtMs: number, nowMs: number): boolean {
   if (status !== 'PendingReview') return false
   return nowMs - createdAtMs >= 24 * 60 * 60 * 1000
@@ -221,50 +216,66 @@ describe('useReviewProposals', () => {
     })
   })
 
-  // These prove the shared actionability helpers return the SAME verdict the
-  // old PaperReviewView/Legacy local functions did, across every status. They
-  // are the regression net for the #1124 drift class (ADR-0038): if the shared
-  // rule changes, the parity assertions against the inlined local logic fail.
+  // These pin the shared actionability helpers to HARD-CODED expected verdicts
+  // across every status × expiry case (NOT a re-derived mirror of the same
+  // rule). A meaningful regression net for the #1124 drift class (ADR-0038): if
+  // a shared rule flips, the literal expectations below disagree and the test
+  // fails. The local* helpers stay imported only for the concrete-verdict test.
   describe('shared actionability helpers parity', () => {
     const NOW = new Date('2026-06-04T00:00:00Z').getTime()
     const PAST = '2026-05-01T00:00:00Z' // before NOW -> expired when status permits
     const FUTURE = '2099-01-01T00:00:00Z' // after NOW -> not yet expired
 
-    // Status × expiry matrix covering the required scenarios:
+    // Status × expiry matrix with the EXPECTED truth table baked in by hand, so
+    // the assertions can catch a rule change instead of self-confirming.
     // Pending, Approved, Approved+expired (#1124), Applied, Rejected, Expired.
-    const cases: Array<{ label: string; status: string; expiresAt: string }> = [
-      { label: 'Pending (live)', status: 'PendingReview', expiresAt: FUTURE },
-      { label: 'Pending (expired by clock)', status: 'PendingReview', expiresAt: PAST },
-      { label: 'Approved (live)', status: 'Approved', expiresAt: FUTURE },
-      { label: 'Approved + expired (#1124)', status: 'Approved', expiresAt: PAST },
-      { label: 'Applied', status: 'Applied', expiresAt: PAST },
-      { label: 'Rejected', status: 'Rejected', expiresAt: PAST },
-      { label: 'Expired', status: 'Expired', expiresAt: PAST },
+    const cases: Array<{
+      label: string
+      status: string
+      expiresAt: string
+      expectedExpired: boolean
+      expectedApply: boolean
+      expectedReject: boolean
+    }> = [
+      // Pending live: open for both apply and reject.
+      { label: 'Pending (live)', status: 'PendingReview', expiresAt: FUTURE, expectedExpired: false, expectedApply: true, expectedReject: true },
+      // Pending past expiresAt: clock-expired, so neither action is offered.
+      { label: 'Pending (expired by clock)', status: 'PendingReview', expiresAt: PAST, expectedExpired: true, expectedApply: false, expectedReject: false },
+      // Approved live: can still be applied/executed, but reject is gone.
+      { label: 'Approved (live)', status: 'Approved', expiresAt: FUTURE, expectedExpired: false, expectedApply: true, expectedReject: false },
+      // Approved + expired (#1124): can no longer be applied, and not rejectable.
+      { label: 'Approved + expired (#1124)', status: 'Approved', expiresAt: PAST, expectedExpired: true, expectedApply: false, expectedReject: false },
+      // Terminal states: never actionable, never (clock-)expired here.
+      { label: 'Applied', status: 'Applied', expiresAt: PAST, expectedExpired: false, expectedApply: false, expectedReject: false },
+      { label: 'Rejected', status: 'Rejected', expiresAt: PAST, expectedExpired: false, expectedApply: false, expectedReject: false },
+      // Expired status is expired by definition; nothing actionable.
+      { label: 'Expired', status: 'Expired', expiresAt: PAST, expectedExpired: true, expectedApply: false, expectedReject: false },
     ]
 
     it.each(cases)(
-      'isApplyActionable matches prior local logic for $label',
-      ({ status, expiresAt }) => {
+      'isApplyActionable returns the hard-coded verdict for $label',
+      ({ status, expiresAt, expectedExpired, expectedApply }) => {
         const rp = useReviewProposals()
         rp.nowMs.value = NOW
         const p = makeProposal({ status, expiresAt }) as any
         const expired = rp.isProposalExpired(p)
-        const expected = localIsApplyActionable(status, expired)
-        expect(rp.isApplyActionable(p)).toBe(expected)
-        expect(isProposalApplyActionable(p, expired)).toBe(expected)
+        // Pin the expiry derivation too, so a broken clock rule is also caught.
+        expect(expired).toBe(expectedExpired)
+        expect(rp.isApplyActionable(p)).toBe(expectedApply)
+        expect(isProposalApplyActionable(p, expired)).toBe(expectedApply)
       },
     )
 
     it.each(cases)(
-      'isRejectActionable matches prior local logic for $label',
-      ({ status, expiresAt }) => {
+      'isRejectActionable returns the hard-coded verdict for $label',
+      ({ status, expiresAt, expectedExpired, expectedReject }) => {
         const rp = useReviewProposals()
         rp.nowMs.value = NOW
         const p = makeProposal({ status, expiresAt }) as any
         const expired = rp.isProposalExpired(p)
-        const expected = localIsRejectActionable(status, expired)
-        expect(rp.isRejectActionable(p)).toBe(expected)
-        expect(isProposalRejectActionable(p, expired)).toBe(expected)
+        expect(expired).toBe(expectedExpired)
+        expect(rp.isRejectActionable(p)).toBe(expectedReject)
+        expect(isProposalRejectActionable(p, expired)).toBe(expectedReject)
       },
     )
 

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -332,6 +332,18 @@ describe('useReviewProposals', () => {
         expect(isProposalStale(p, NOW)).toBe(expected)
       }
     })
+
+    it('isProposalStale is defensive against null proposal and bad createdAt', () => {
+      // Malformed/partial data must not throw and must not mis-flag staleness.
+      // Build raw objects so makeProposal's `?? default` cannot resupply a valid
+      // createdAt and mask the guard.
+      const base = makeProposal({ status: 'PendingReview' })
+      expect(isProposalStale(null as any, NOW)).toBe(false)
+      expect(isProposalStale({ ...base, createdAt: undefined } as any, NOW)).toBe(false)
+      expect(isProposalStale({ ...base, createdAt: 'not-a-date' } as any, NOW)).toBe(false)
+      // new Date(null) -> epoch would otherwise read as wildly stale; rejected.
+      expect(isProposalStale({ ...base, createdAt: null } as any, NOW)).toBe(false)
+    })
   })
 
   describe('summaryCards', () => {

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -89,6 +89,7 @@ vi.mock('../../utils/errorReporting', () => ({
 import {
   STALE_PROPOSAL_MS,
   isProposalApplyActionable,
+  isProposalApproveActionable,
   isProposalRejectActionable,
   isProposalStale,
   useReviewProposals,
@@ -276,6 +277,21 @@ describe('useReviewProposals', () => {
         expect(expired).toBe(expectedExpired)
         expect(rp.isRejectActionable(p)).toBe(expectedReject)
         expect(isProposalRejectActionable(p, expired)).toBe(expectedReject)
+      },
+    )
+
+    it.each(cases)(
+      'isProposalApproveActionable returns the hard-coded verdict for $label (shares Reject precondition)',
+      ({ status, expiresAt, expectedExpired, expectedReject }) => {
+        const rp = useReviewProposals()
+        rp.nowMs.value = NOW
+        const p = makeProposal({ status, expiresAt }) as any
+        const expired = rp.isProposalExpired(p)
+        expect(expired).toBe(expectedExpired)
+        // Approve currently mirrors Reject (live, unexpired PendingReview) but is
+        // asserted against the hard-coded table independently so a future divergence
+        // in either helper is caught.
+        expect(isProposalApproveActionable(p, expired)).toBe(expectedReject)
       },
     )
 

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -194,14 +194,13 @@ const awaitingCount = computed(() => {
   ).length
 })
 
-const staleCount = computed(() => {
-  // A proposal is "stale" when older than 24h and still pending review.
-  const cutoff = nowMs.value - 24 * 60 * 60 * 1000
-  return visibleProposals.value.filter((p) => {
-    if (normalizeProposalStatus(p.status) !== 'PendingReview') return false
-    return new Date(p.createdAt).getTime() < cutoff
-  }).length
-})
+const staleCount = computed(() =>
+  // Route through the SHARED isStaleProposal (PendingReview + inclusive >=24h)
+  // so the badge count and the 'stale' queue filter always agree — no third
+  // inline copy that could drift at the 24h boundary (#1124 / ADR-0038).
+  // visibleProposals is already board-scoped via matchesActiveBoardFilter.
+  visibleProposals.value.filter(isStaleProposal).length,
+)
 
 function ageLabel(iso: string): string {
   const ms = nowMs.value - new Date(iso).getTime()

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -55,6 +55,9 @@ const {
   dismissableProposalIds,
   matchesActiveBoardFilter,
   isProposalExpired,
+  isApplyActionable,
+  isRejectActionable,
+  isStaleProposal,
   loadProposals,
   loadBoardOptions,
   startClock,
@@ -86,11 +89,6 @@ const hashProposalId = computed(() => {
     return null
   }
 })
-
-function isStaleProposal(proposal: ApiProposal): boolean {
-  if (normalizeProposalStatus(proposal.status) !== 'PendingReview') return false
-  return nowMs.value - new Date(proposal.createdAt).getTime() >= 24 * 60 * 60 * 1000
-}
 
 const filteredVisibleProposals = computed(() => {
   switch (queueFilter.value) {
@@ -444,8 +442,10 @@ const proposedNum = computed(() => {
 })
 
 const authorMeta = computed(() => {
+  // Only the confidence score is real wire data. Latency and token counts are
+  // not yet surfaced by the backend, so we do not fabricate them here. #1136
   const c = selectors.confidenceBreakdown.value
-  return `${c.overall.toFixed(2)} confidence · 4s · 1.2k tokens`
+  return `${c.overall.toFixed(2)} confidence`
 })
 
 const authorName = computed(() => {
@@ -465,15 +465,6 @@ const whyNowBody = computed(() => {
 
 const revisionBusy = computed(() => revisionEditing.value || revisionSaving.value)
 const busy = computed(() => proposalActionBusyId.value !== null || revisionBusy.value)
-
-function isApplyActionable(proposal: ApiProposal): boolean {
-  const status = normalizeProposalStatus(proposal.status)
-  return (status === 'PendingReview' || status === 'Approved') && !isProposalExpired(proposal)
-}
-
-function isRejectActionable(proposal: ApiProposal): boolean {
-  return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isProposalExpired(proposal)
-}
 
 function onApply() {
   const p = activeProposal.value

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -224,7 +224,9 @@ const queueItems = computed<QueueRailItem[]>(() =>
       serial: `#${p.id.slice(0, 4).toUpperCase()}`,
       title: p.summary || '(no summary)',
       who: normalizeProposalSourceType(p.sourceType) === 'Chat' ? 'haiku' : 'capture',
-      // Confidence is not yet on the wire — leave null until the gap lands.
+      // Per-item rail confidence is not yet wired per-proposal — leave null until
+      // the gap lands. Not contradictory with `authorMeta` below, which shows the
+      // REAL aggregate /confidence breakdown for the single active proposal.
       confidence: null,
       age: ageLabel(p.createdAt),
       reach: summariseReach(p),

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -446,6 +446,9 @@ const authorMeta = computed(() => {
   // Only the confidence score is real wire data. Latency and token counts are
   // not yet surfaced by the backend, so we do not fabricate them here. #1136
   const c = selectors.confidenceBreakdown.value
+  // Defensive: the type says overall is always a number, but guard against a
+  // malformed/NaN value so toFixed can never throw on the deep-review surface.
+  if (!c || !Number.isFinite(c.overall)) return ''
   return `${c.overall.toFixed(2)} confidence`
 })
 


### PR DESCRIPTION
## Summary

Kills the Paper/Legacy review-actionability **drift** and removes fabricated
metadata in the Paper deep-review surface — a Paper-canonical activation
prerequisite (forthcoming ADR-0038; the #1124 bug class is currently fixed
twice). This is **Slice B**.

`PaperReviewView.vue` carried local copies of `isApplyActionable`,
`isRejectActionable`, and `isStaleProposal` that duplicated decision rules
Legacy derives elsewhere. Two copies can diverge — exactly the kind of split
that re-introduces the #1124 Approved-but-expired bug on only one surface.

### Task 1 — one source of truth

`src/composables/useReviewProposals.ts` now owns the review decision rules:

- **Pure, exported** (reusable by prop-driven components):
  `isProposalApplyActionable(proposal, isExpired)`,
  `isProposalRejectActionable(proposal, isExpired)`,
  `isProposalStale(proposal, nowMs)`, plus `STALE_PROPOSAL_MS` (24h).
- **Reactive instance wrappers** exposed by the composable:
  `isApplyActionable`, `isRejectActionable`, `isStaleProposal` — they bind the
  surface's own `isProposalExpired` / `nowMs` clock so expiry (incl. the
  Approved+expired #1124 case) is evaluated identically everywhere.

Consumers now point at the shared rules:
- `PaperReviewView.vue` — local copies deleted; uses the composable helpers.
- Legacy `ReviewProposalActions.vue` — approve/reject/apply button gating now
  flows through `isProposalApplyActionable` / `isProposalRejectActionable`
  instead of inline status checks. Behavior is preserved exactly (the
  approve/reject block already renders only when `!isExpired`, so the prior
  `status !== 'PendingReview'` checks are equivalent to the shared rule).

### Task 2 — de-stub fabricated metadata

`authorMeta` previously rendered
`` `${overall} confidence · 4s · 1.2k tokens` ``. The latency/token suffix was
**invented** — the backend does not surface it. Removed; the real confidence
score stays. (Wiring a real `/confidence` latency/token feed is out of scope.)

## Verification

From `frontend/taskdeck-web`:

- `npm run typecheck` — clean.
- `npx eslint <changed files>` — clean.
- `npx vitest --run src/tests/composables/useReviewProposals.spec.ts --maxWorkers=2`
  — **56 passed**. New status x expiry parity matrix proves the shared helpers
  return the **same verdict** the old local functions did for **Pending,
  Approved, Approved+expired (#1124), Applied, Rejected, Expired**, asserting
  against verbatim copies of the prior local logic plus concrete verdicts.
- `npx vitest --run src/tests/views/paper/review/PaperReviewView.spec.ts --maxWorkers=2`
  — **23 passed** (no behavior change in PaperReviewView).
- New `src/tests/components/review/ReviewProposalActions.spec.ts` — **5 passed**
  (Legacy button gating locked across the status matrix + expired/busy).
- **Mutation check**: temporarily breaking `isProposalApplyActionable`
  (dropping the `Approved` arm) failed 2 tests, confirming the suite fails when
  the rule is wrong; reverted.

## Scope / notes

- `staleCount` in `PaperReviewView` keeps its existing strict `< cutoff`
  boundary (left untouched to preserve exact behavior); it differs from the
  inclusive `>= 24h` stale rule by one tick at the exact boundary — a
  pre-existing nuance, not introduced here.
- **Foundation for #1161** (Paper review has no dismiss affordance): with one
  shared decision source, the dismiss affordance can reuse
  `isProposalDismissable` / these helpers instead of adding a third copy.

## Refs

- Forthcoming **ADR-0038** (Paper-canonical activation prerequisite)
- #1124 drift class (Approved+expired) · #1136 (Paper vs Legacy ADR / dead-code)
- Foundation for #1161 (dismiss affordance)
