### PR TITLE
feat(paper-review): File away — dismiss affordance for settled proposals (#1161)

### DIFF
--- a/frontend/taskdeck-web/src/composables/useReviewActions.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewActions.ts
@@ -16,6 +16,11 @@ export function useReviewActions(
   const diffRenderPerf = usePerformanceMark('proposal-diff-render')
 
   const proposalActionBusyId = ref<string | null>(null)
+  // Bulk dismiss has no single proposal id to track, so it gets its own
+  // in-flight flag. Surfaced into the shared `busy` state so the bulk button
+  // disables, re-entry is blocked, and the keymap/per-proposal actions are
+  // gated while a bulk clear is running. #1161
+  const bulkDismissBusy = ref(false)
   const selectedDiffProposalId = ref<string | null>(null)
   const selectedDiff = ref<string | null>(null)
   let latestDiffRequestId = 0
@@ -125,6 +130,10 @@ export function useReviewActions(
   }
 
   async function handleDismissApplied() {
+    // Block re-entry: a second bulk request while the first is in flight would
+    // race on proposals.value and fire duplicate dismiss calls.
+    if (bulkDismissBusy.value) return
+
     const ids = dismissableProposalIds.value
     if (ids.length === 0) {
       toast.info('No completed proposals to clear.')
@@ -132,6 +141,7 @@ export function useReviewActions(
     }
 
     try {
+      bulkDismissBusy.value = true
       const result = await automationApi.dismissProposals(ids)
       if (result.dismissed === ids.length) {
         const dismissedSet = new Set(ids)
@@ -142,11 +152,14 @@ export function useReviewActions(
       toast.success(`Cleared ${result.dismissed} completed proposal${result.dismissed === 1 ? '' : 's'}.`)
     } catch (e: unknown) {
       toast.error(getErrorDisplay(e, 'Failed to clear proposals').message)
+    } finally {
+      bulkDismissBusy.value = false
     }
   }
 
   return {
     proposalActionBusyId,
+    bulkDismissBusy,
     selectedDiffProposalId,
     selectedDiff,
     handleApproveProposal,

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -427,6 +427,7 @@ export function useReviewProposals() {
     isProposalExpired,
     isApplyActionable,
     isRejectActionable,
+    isProposalDismissable,
     isStaleProposal,
     loadProposals,
     loadBoardOptions,

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -417,7 +417,7 @@ describe('PaperReviewView', () => {
     expect(railText.indexOf('Newer applied work')).toBeLessThan(railText.indexOf('Older applied work'))
   })
 
-  it('does not send apply or reject transitions for expired proposals', async () => {
+  it('replaces decision buttons with "File away" for an expired proposal', async () => {
     const wrapper = await mountView([
       makeProposal({
         status: 'Expired',
@@ -426,16 +426,92 @@ describe('PaperReviewView', () => {
       }),
     ])
 
-    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
-    await wrapper.find('[data-testid="decision-reject"]').trigger('click')
+    // A settled proposal can no longer be applied/rejected/edited/deferred, so
+    // those buttons are gone entirely — the rail becomes a filing rail. #1161
+    expect(wrapper.find('[data-testid="decision-apply"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-reject"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-edit"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-defer"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-file-away"]').exists()).toBe(true)
+  })
+
+  it('files away an expired proposal when File away is clicked', async () => {
+    mocks.dismissProposals.mockResolvedValueOnce({ dismissed: 1 })
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'expired-001',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'Expired proposal',
+      }),
+    ])
+
+    await wrapper.find('[data-testid="decision-file-away"]').trigger('click')
     await flushPromises()
 
+    expect(mocks.dismissProposals).toHaveBeenCalledWith(['expired-001'])
     expect(mocks.approveProposal).not.toHaveBeenCalled()
-    expect(mocks.executeProposal).not.toHaveBeenCalled()
     expect(mocks.rejectProposal).not.toHaveBeenCalled()
-    expect(mocks.infoToast).toHaveBeenCalledWith(
-      'This proposal is no longer actionable. Refresh review to see current status.',
-    )
+  })
+
+  it('files away a settled proposal with the ⌫ key', async () => {
+    mocks.dismissProposals.mockResolvedValueOnce({ dismissed: 1 })
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'expired-002',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'Expired proposal',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.dismissProposals).toHaveBeenCalledWith(['expired-002'])
+    expect(mocks.rejectProposal).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('shows a bulk "File away" action and clears every settled proposal on click', async () => {
+    mocks.dismissProposals.mockResolvedValueOnce({ dismissed: 2 })
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'expired-a',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'Expired A',
+      }),
+      makeProposal({
+        id: 'expired-b',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 120_000).toISOString(),
+        summary: 'Expired B',
+      }),
+    ])
+
+    const bulk = wrapper.find('[data-testid="queue-file-away-all"]')
+    expect(bulk.exists()).toBe(true)
+    expect(bulk.text()).toContain('File away 2 settled')
+
+    await bulk.trigger('click')
+    await flushPromises()
+
+    expect(mocks.dismissProposals).toHaveBeenCalledWith(['expired-a', 'expired-b'])
+  })
+
+  it('does not show the bulk "File away" action with fewer than two settled proposals', async () => {
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'expired-only',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'Lone expired',
+      }),
+    ])
+
+    expect(wrapper.find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
   })
 
   it('surfaces feedback when defer is invoked before backend support exists', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -508,7 +508,9 @@ describe('PaperReviewView', () => {
     expect(mocks.dismissProposals).toHaveBeenCalledWith(['expired-a', 'expired-b'])
   })
 
-  it('does not show the bulk "File away" action with fewer than two settled proposals', async () => {
+  it('shows the bulk "File away" action for a single settled proposal so it is never unclearable', async () => {
+    // A single hidden settled proposal (e.g. Applied) has no per-proposal rail
+    // in Paper, so the bulk affordance must appear at count 1. #1161 (review)
     const wrapper = await mountView([
       makeProposal({
         id: 'expired-only',
@@ -518,7 +520,44 @@ describe('PaperReviewView', () => {
       }),
     ])
 
+    const bulk = wrapper.find('[data-testid="queue-file-away-all"]')
+    expect(bulk.exists()).toBe(true)
+    expect(bulk.text()).toContain('File away 1 settled')
+  })
+
+  it('hides the bulk "File away" action when there are no settled proposals', async () => {
+    const wrapper = await mountView([
+      makeProposal({ id: 'pending-only', status: 'PendingReview', summary: 'Still pending' }),
+    ])
+
     expect(wrapper.find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
+  })
+
+  it('omits collaborator-owned settled proposals from the bulk file-away set (avoids a 403)', async () => {
+    // The dismiss endpoint 403s the whole request if any id is not owned by the
+    // caller, so a board-filtered queue with another user's settled proposal must
+    // not include it in the bulk set. #1161 (review)
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'mine-expired',
+        status: 'Expired',
+        requestedByUserId: 'u-1',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'My expired',
+      }),
+      makeProposal({
+        id: 'theirs-expired',
+        status: 'Expired',
+        requestedByUserId: 'u-2',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'Their expired',
+      }),
+    ])
+
+    // Only the caller's own settled proposal counts → "1 settled", not 2.
+    const bulk = wrapper.find('[data-testid="queue-file-away-all"]')
+    expect(bulk.exists()).toBe(true)
+    expect(bulk.text()).toContain('File away 1 settled')
   })
 
   it('treats an Approved-then-expired proposal as dismissable (File away)', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mount, flushPromises } from '@vue/test-utils'
+import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import type { Proposal } from '../../../../types/automation'
 import PaperReviewView from '../../../../views/paper/PaperReviewView.vue'
@@ -148,6 +148,13 @@ async function mountView(proposals: Proposal[], path = '/workspace/review') {
 }
 
 describe('PaperReviewView', () => {
+  // Unmount every mounted wrapper after each test. PaperReviewView attaches a
+  // window keydown listener (review keymap) and a 60s clock interval; without
+  // teardown those leak across tests, so a keydown dispatched in one test
+  // reaches leftover components from earlier tests (e.g. firing stray File
+  // away dismissals). #1161 / #1128
+  enableAutoUnmount(afterEach)
+
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.sessionState.userId = 'u-1'
@@ -512,6 +519,77 @@ describe('PaperReviewView', () => {
     ])
 
     expect(wrapper.find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
+  })
+
+  it('treats an Approved-then-expired proposal as dismissable (File away)', async () => {
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'approved-expired',
+        status: 'Approved',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        summary: 'Approved but expired before execution',
+      }),
+    ])
+
+    expect(wrapper.find('[data-testid="decision-file-away"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="decision-apply"]').exists()).toBe(false)
+  })
+
+  it('rejects (not files away) with the ⌫ key when the proposal is still actionable', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('')
+    mocks.rejectProposal.mockResolvedValueOnce(makeProposal({ id: 'pending-xyz', status: 'Rejected' }))
+    const wrapper = await mountView([
+      makeProposal({ id: 'pending-xyz', status: 'PendingReview', summary: 'Still actionable' }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.rejectProposal).toHaveBeenCalled()
+    expect(mocks.dismissProposals).not.toHaveBeenCalled()
+
+    promptSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('swaps the decision rail to "File away" when a focused proposal expires on the clock tick', async () => {
+    vi.useFakeTimers()
+    try {
+      const base = new Date('2026-06-13T12:00:00.000Z').getTime()
+      vi.setSystemTime(base)
+      mocks.dismissProposals.mockResolvedValueOnce({ dismissed: 1 })
+
+      const wrapper = await mountView([
+        makeProposal({
+          id: 'approved-soon',
+          status: 'Approved',
+          // Live now (base), but expires in 30s — before the first 60s tick.
+          expiresAt: new Date(base + 30_000).toISOString(),
+          summary: 'Approved, expiring shortly',
+        }),
+      ])
+
+      // Still actionable at mount: decision buttons present, no File away.
+      expect(wrapper.find('[data-testid="decision-apply"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="decision-file-away"]').exists()).toBe(false)
+
+      // One 60s clock tick advances nowMs past expiry; the rail must swap
+      // reactively without a reload (#1161).
+      await vi.advanceTimersByTimeAsync(60_000)
+      await flushPromises()
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('[data-testid="decision-file-away"]').exists()).toBe(true)
+      expect(wrapper.find('[data-testid="decision-apply"]').exists()).toBe(false)
+
+      await wrapper.find('[data-testid="decision-file-away"]').trigger('click')
+      await flushPromises()
+      expect(mocks.dismissProposals).toHaveBeenCalledWith(['approved-soon'])
+
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('surfaces feedback when defer is invoked before backend support exists', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewDecisionRail.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewDecisionRail.spec.ts
@@ -44,10 +44,10 @@ describe('ReviewDecisionRail', () => {
 
     const fileAway = wrapper.find('[data-testid="decision-file-away"]')
     expect(fileAway.exists()).toBe(true)
-    // Visible label stays in the paper voice; accessible name matches the
-    // backend/API dismiss vocabulary so tests and a11y tooling agree.
+    // Accessible name must CONTAIN the visible label "File away" (WCAG 2.5.3
+    // Label in Name) — it reads "File away proposal", not "Dismiss proposal".
     expect(fileAway.text()).toContain('File away')
-    expect(fileAway.attributes('aria-label')).toBe('Dismiss proposal')
+    expect(fileAway.attributes('aria-label')).toBe('File away proposal')
     expect(wrapper.find('[role="toolbar"]').attributes('aria-label')).toBe('Filing actions')
     expect(wrapper.text()).toContain('SETTLED')
   })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewDecisionRail.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewDecisionRail.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ReviewDecisionRail from '../../../../views/paper/review/ReviewDecisionRail.vue'
+
+function mountRail(props: Partial<{ summary: string; busy: boolean; dismissable: boolean }> = {}) {
+  return mount(ReviewDecisionRail, {
+    props: {
+      summary: '1 operation · undo 6h · atomic',
+      ...props,
+    },
+  })
+}
+
+describe('ReviewDecisionRail', () => {
+  it('renders the four decision actions in the default (actionable) state', () => {
+    const wrapper = mountRail()
+    expect(wrapper.find('[data-testid="decision-reject"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="decision-edit"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="decision-defer"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="decision-apply"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="decision-file-away"]').exists()).toBe(false)
+    expect(wrapper.find('[role="toolbar"]').attributes('aria-label')).toBe('Decision actions')
+    expect(wrapper.text()).toContain('DECISION')
+  })
+
+  it('emits each decision event when its button is clicked', async () => {
+    const wrapper = mountRail()
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await wrapper.find('[data-testid="decision-reject"]').trigger('click')
+    await wrapper.find('[data-testid="decision-edit"]').trigger('click')
+    await wrapper.find('[data-testid="decision-defer"]').trigger('click')
+    expect(wrapper.emitted('apply')).toHaveLength(1)
+    expect(wrapper.emitted('reject')).toHaveLength(1)
+    expect(wrapper.emitted('request-edit')).toHaveLength(1)
+    expect(wrapper.emitted('defer')).toHaveLength(1)
+  })
+
+  it('becomes a filing rail with a single "File away" button when dismissable', () => {
+    const wrapper = mountRail({ dismissable: true })
+    expect(wrapper.find('[data-testid="decision-reject"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-edit"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-defer"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="decision-apply"]').exists()).toBe(false)
+
+    const fileAway = wrapper.find('[data-testid="decision-file-away"]')
+    expect(fileAway.exists()).toBe(true)
+    // Visible label stays in the paper voice; accessible name matches the
+    // backend/API dismiss vocabulary so tests and a11y tooling agree.
+    expect(fileAway.text()).toContain('File away')
+    expect(fileAway.attributes('aria-label')).toBe('Dismiss proposal')
+    expect(wrapper.find('[role="toolbar"]').attributes('aria-label')).toBe('Filing actions')
+    expect(wrapper.text()).toContain('SETTLED')
+  })
+
+  it('emits dismiss when File away is clicked', async () => {
+    const wrapper = mountRail({ dismissable: true })
+    await wrapper.find('[data-testid="decision-file-away"]').trigger('click')
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+  })
+
+  it('disables the File away button while a network action is in flight', () => {
+    const wrapper = mountRail({ dismissable: true, busy: true })
+    expect(wrapper.find('[data-testid="decision-file-away"]').attributes('disabled')).toBeDefined()
+  })
+})

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewQueueRail.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewQueueRail.spec.ts
@@ -25,6 +25,7 @@ function mountRail(props?: Partial<{
   activeId: string | null
   recentlyApplied: RecentlyAppliedRow[]
   dismissableCount: number
+  busy: boolean
 }>) {
   return mount(ReviewQueueRail, {
     props: {
@@ -33,6 +34,7 @@ function mountRail(props?: Partial<{
       awaitingCount: 3,
       staleCount: 2,
       dismissableCount: props?.dismissableCount ?? 0,
+      busy: props?.busy ?? false,
       recentlyApplied: props?.recentlyApplied ?? [],
     },
   })
@@ -137,6 +139,11 @@ describe('ReviewQueueRail', () => {
 
     await bulk.trigger('click')
     expect(wrapper.emitted('file-away-all')).toHaveLength(1)
+  })
+
+  it('disables the bulk file-away action while a review action is in flight', () => {
+    const wrapper = mountRail({ dismissableCount: 3, busy: true })
+    expect(wrapper.find('[data-testid="queue-file-away-all"]').attributes('disabled')).toBeDefined()
   })
 
   it('renders recently-applied rows when provided', () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewQueueRail.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewQueueRail.spec.ts
@@ -125,9 +125,14 @@ describe('ReviewQueueRail', () => {
     expect(wrapper.text()).toContain('2 stale')
   })
 
-  it('hides the bulk file-away action below two settled proposals', () => {
+  it('hides the bulk file-away action only when there are no settled proposals', () => {
     expect(mountRail({ dismissableCount: 0 }).find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
-    expect(mountRail({ dismissableCount: 1 }).find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
+  })
+
+  it('shows the bulk file-away action for a single settled proposal', () => {
+    const bulk = mountRail({ dismissableCount: 1 }).find('[data-testid="queue-file-away-all"]')
+    expect(bulk.exists()).toBe(true)
+    expect(bulk.text()).toContain('File away 1 settled')
   })
 
   it('shows the bulk file-away action with the count and emits file-away-all on click', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewQueueRail.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewQueueRail.spec.ts
@@ -24,6 +24,7 @@ function mountRail(props?: Partial<{
   items: QueueRailItem[]
   activeId: string | null
   recentlyApplied: RecentlyAppliedRow[]
+  dismissableCount: number
 }>) {
   return mount(ReviewQueueRail, {
     props: {
@@ -31,6 +32,7 @@ function mountRail(props?: Partial<{
       activeId: props?.activeId ?? null,
       awaitingCount: 3,
       staleCount: 2,
+      dismissableCount: props?.dismissableCount ?? 0,
       recentlyApplied: props?.recentlyApplied ?? [],
     },
   })
@@ -119,6 +121,22 @@ describe('ReviewQueueRail', () => {
     const wrapper = mountRail()
     expect(wrapper.text()).toContain('3 awaiting')
     expect(wrapper.text()).toContain('2 stale')
+  })
+
+  it('hides the bulk file-away action below two settled proposals', () => {
+    expect(mountRail({ dismissableCount: 0 }).find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
+    expect(mountRail({ dismissableCount: 1 }).find('[data-testid="queue-file-away-all"]').exists()).toBe(false)
+  })
+
+  it('shows the bulk file-away action with the count and emits file-away-all on click', async () => {
+    const wrapper = mountRail({ dismissableCount: 3 })
+    const bulk = wrapper.find('[data-testid="queue-file-away-all"]')
+    expect(bulk.exists()).toBe(true)
+    expect(bulk.text()).toContain('File away 3 settled')
+    expect(bulk.attributes('aria-label')).toBe('File away 3 settled proposals')
+
+    await bulk.trigger('click')
+    expect(wrapper.emitted('file-away-all')).toHaveLength(1)
   })
 
   it('renders recently-applied rows when provided', () => {

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -68,6 +68,20 @@ const session = useSessionStore()
 const toast = useToastStore()
 const route = useRoute()
 
+// The dismiss endpoint rejects the WHOLE request with 403 if any id isn't owned
+// by the caller, and a board-filtered proposal list deliberately includes other
+// users' proposals on shared boards. So the file-away affordance (per-proposal
+// and bulk) must be scoped to the caller's own settled proposals. #1161 (review)
+function isOwnProposal(proposal: ApiProposal): boolean {
+  return !!session.userId && proposal.requestedByUserId === session.userId
+}
+const ownedDismissableIds = computed(() =>
+  dismissableProposalIds.value.filter((id) => {
+    const proposal = proposals.value.find((p) => p.id === id)
+    return !!proposal && isOwnProposal(proposal)
+  }),
+)
+
 const {
   proposalActionBusyId,
   bulkDismissBusy,
@@ -76,7 +90,7 @@ const {
   handleExecuteProposal,
   handleDismissProposal,
   handleDismissApplied,
-} = useReviewActions(proposals, dismissableProposalIds, loadProposals)
+} = useReviewActions(proposals, ownedDismissableIds, loadProposals)
 
 // --- Active proposal ---------------------------------------------------
 
@@ -482,15 +496,19 @@ const busy = computed(
 // isProposalDismissable → isProposalExpired, so the rail swaps to "File away"
 // the moment a focused proposal expires (#1161). #1161
 const activeDismissable = computed(
-  () => !!activeProposal.value && isProposalDismissable(activeProposal.value),
+  () =>
+    !!activeProposal.value &&
+    isProposalDismissable(activeProposal.value) &&
+    isOwnProposal(activeProposal.value),
 )
 
-// Count of EVERY settled proposal on the active board — including ones the
-// queue currently hides (Applied/Rejected/Failed when showCompleted is off,
-// or items outside the active 'mine'/'stale' filter). Bulk file-away is
+// Count of the caller's own settled proposals on the active board — including
+// ones the queue currently hides (Applied/Rejected/Failed when showCompleted is
+// off, or items outside the active 'mine'/'stale' filter). Bulk file-away is
 // board-scoped housekeeping, not queue-scoped, so the count can exceed what's
-// visible. ≥2 reveals the bulk affordance in the queue header. #1161
-const bulkDismissableCount = computed(() => dismissableProposalIds.value.length)
+// visible — and ≥1 reveals it so a single hidden settled proposal (which has no
+// per-proposal rail in Paper) is never left unclearable. #1161
+const bulkDismissableCount = computed(() => ownedDismissableIds.value.length)
 
 function onFileAway() {
   const p = activeProposal.value

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -70,6 +70,7 @@ const route = useRoute()
 
 const {
   proposalActionBusyId,
+  bulkDismissBusy,
   handleApproveProposal,
   handleRejectProposal,
   handleExecuteProposal,
@@ -471,7 +472,9 @@ const whyNowBody = computed(() => {
 // --- Action wiring -----------------------------------------------------
 
 const revisionBusy = computed(() => revisionEditing.value || revisionSaving.value)
-const busy = computed(() => proposalActionBusyId.value !== null || revisionBusy.value)
+const busy = computed(
+  () => proposalActionBusyId.value !== null || revisionBusy.value || bulkDismissBusy.value,
+)
 
 // True once the active proposal is settled (Applied/Rejected/Failed/Expired/
 // Approved-then-expired). Reads the SHARED rule so Paper and Legacy never
@@ -482,8 +485,11 @@ const activeDismissable = computed(
   () => !!activeProposal.value && isProposalDismissable(activeProposal.value),
 )
 
-// Board-scoped count of settled proposals; drives the bulk "File away N
-// settled" affordance in the queue header (≥2). #1161
+// Count of EVERY settled proposal on the active board — including ones the
+// queue currently hides (Applied/Rejected/Failed when showCompleted is off,
+// or items outside the active 'mine'/'stale' filter). Bulk file-away is
+// board-scoped housekeeping, not queue-scoped, so the count can exceed what's
+// visible. ≥2 reveals the bulk affordance in the queue header. #1161
 const bulkDismissableCount = computed(() => dismissableProposalIds.value.length)
 
 function onFileAway() {
@@ -493,6 +499,8 @@ function onFileAway() {
     toast.info('Save or cancel the revision before filing this proposal away.')
     return
   }
+  // Another dismiss/approve/reject/bulk action is already in flight.
+  if (busy.value) return
   if (!activeDismissable.value) {
     toast.info('This proposal is still active and cannot be filed away yet.')
     return
@@ -501,7 +509,10 @@ function onFileAway() {
 }
 
 function onFileAwayBulk() {
-  if (busy.value) return
+  if (busy.value) {
+    toast.info('Wait for the current action to finish before filing more away.')
+    return
+  }
   void handleDismissApplied()
 }
 
@@ -626,6 +637,7 @@ function onQueueFilterChange(filter: QueueFilter) {
       :awaiting-count="awaitingCount"
       :stale-count="staleCount"
       :dismissable-count="bulkDismissableCount"
+      :busy="busy"
       :recently-applied="recentlyApplied"
       @filter-change="onQueueFilterChange"
       @select="selectProposal"

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -57,6 +57,7 @@ const {
   isProposalExpired,
   isApplyActionable,
   isRejectActionable,
+  isProposalDismissable,
   isStaleProposal,
   loadProposals,
   loadBoardOptions,
@@ -72,6 +73,8 @@ const {
   handleApproveProposal,
   handleRejectProposal,
   handleExecuteProposal,
+  handleDismissProposal,
+  handleDismissApplied,
 } = useReviewActions(proposals, dismissableProposalIds, loadProposals)
 
 // --- Active proposal ---------------------------------------------------
@@ -470,6 +473,38 @@ const whyNowBody = computed(() => {
 const revisionBusy = computed(() => revisionEditing.value || revisionSaving.value)
 const busy = computed(() => proposalActionBusyId.value !== null || revisionBusy.value)
 
+// True once the active proposal is settled (Applied/Rejected/Failed/Expired/
+// Approved-then-expired). Reads the SHARED rule so Paper and Legacy never
+// drift (#1124 / ADR-0038). Reactive to the 60s expiry clock via
+// isProposalDismissable → isProposalExpired, so the rail swaps to "File away"
+// the moment a focused proposal expires (#1161). #1161
+const activeDismissable = computed(
+  () => !!activeProposal.value && isProposalDismissable(activeProposal.value),
+)
+
+// Board-scoped count of settled proposals; drives the bulk "File away N
+// settled" affordance in the queue header (≥2). #1161
+const bulkDismissableCount = computed(() => dismissableProposalIds.value.length)
+
+function onFileAway() {
+  const p = activeProposal.value
+  if (!p) return
+  if (revisionBusy.value) {
+    toast.info('Save or cancel the revision before filing this proposal away.')
+    return
+  }
+  if (!activeDismissable.value) {
+    toast.info('This proposal is still active and cannot be filed away yet.')
+    return
+  }
+  void handleDismissProposal(p.id)
+}
+
+function onFileAwayBulk() {
+  if (busy.value) return
+  void handleDismissApplied()
+}
+
 function onApply() {
   const p = activeProposal.value
   if (!p) return
@@ -492,6 +527,13 @@ function onApply() {
 function onReject() {
   const p = activeProposal.value
   if (!p) return
+  // ⌫ is dual-purpose: on a settled proposal the rail shows "File away", so
+  // the same key files it away instead of rejecting (single-key consistency
+  // for "remove this from my queue"). #1161
+  if (activeDismissable.value) {
+    onFileAway()
+    return
+  }
   if (revisionBusy.value) {
     toast.info('Save or cancel the revision before rejecting this proposal.')
     return
@@ -583,9 +625,11 @@ function onQueueFilterChange(filter: QueueFilter) {
       :active-id="activeProposal?.id ?? null"
       :awaiting-count="awaitingCount"
       :stale-count="staleCount"
+      :dismissable-count="bulkDismissableCount"
       :recently-applied="recentlyApplied"
       @filter-change="onQueueFilterChange"
       @select="selectProposal"
+      @file-away-all="onFileAwayBulk"
     />
 
     <div v-if="activeProposal" class="paper-review-deep__main-col">
@@ -613,10 +657,12 @@ function onQueueFilterChange(filter: QueueFilter) {
         :side-effects="selectors.sideEffects.value"
         :conflicts="selectors.conflicts.value"
         :history="selectors.history.value"
+        :dismissable="activeDismissable"
         @apply="onApply"
         @reject="onReject"
         @request-edit="onRequestEdit"
         @defer="onDefer"
+        @dismiss="onFileAway"
         @report="onReportBadSuggestion"
       />
       <ReviewRevisionEditor

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewDecisionRail.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewDecisionRail.vue
@@ -7,10 +7,19 @@ import PaperTagstamp from '../../../components/paper/PaperTagstamp.vue'
  * (Reject ⌫ · Request edit E · Defer D · Apply ⏎). Apply is rendered in
  * the ember variant. Disabled state propagates while a network call is in
  * flight.
+ *
+ * In a terminal state (`dismissable` — the proposal is Applied / Rejected /
+ * Failed / Expired / Approved-then-expired per the shared
+ * `isProposalDismissable` rule, #1124 / ADR-0038 / #1161) the four decision
+ * buttons are meaningless, so the rail becomes a *filing* rail: a single
+ * "File away" button reuses the ⌫ key. The status stamp already tells the
+ * story, so the eyebrow stamp reads SETTLED.
  */
 defineProps<{
   summary: string
   busy?: boolean
+  /** When true the proposal is settled; the rail shows only "File away". */
+  dismissable?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -18,6 +27,7 @@ const emit = defineEmits<{
   (event: 'reject'): void
   (event: 'request-edit'): void
   (event: 'defer'): void
+  (event: 'dismiss'): void
 }>()
 </script>
 
@@ -25,41 +35,53 @@ const emit = defineEmits<{
   <div
     class="card-lift halo-ember paper-review-decision"
     role="toolbar"
-    aria-label="Decision actions"
+    :aria-label="dismissable ? 'Filing actions' : 'Decision actions'"
   >
-    <PaperTagstamp tone="ember">DECISION</PaperTagstamp>
+    <PaperTagstamp :tone="dismissable ? 'mute' : 'ember'">{{ dismissable ? 'SETTLED' : 'DECISION' }}</PaperTagstamp>
     <span class="tk-meta paper-review-decision__summary">{{ summary }}</span>
     <span class="paper-review-decision__spacer" />
 
-    <PaperHLBtn
-      label="Reject"
-      kbd="⌫"
-      :disabled="busy"
-      data-testid="decision-reject"
-      @click="emit('reject')"
-    />
-    <PaperHLBtn
-      label="Request edit"
-      kbd="E"
-      :disabled="busy"
-      data-testid="decision-edit"
-      @click="emit('request-edit')"
-    />
-    <PaperHLBtn
-      label="Defer"
-      kbd="D"
-      :disabled="busy"
-      data-testid="decision-defer"
-      @click="emit('defer')"
-    />
-    <PaperHLBtn
-      label="Apply"
-      kbd="⏎"
-      variant="ember"
-      :disabled="busy"
-      data-testid="decision-apply"
-      @click="emit('apply')"
-    />
+    <template v-if="dismissable">
+      <PaperHLBtn
+        label="File away"
+        kbd="⌫"
+        :disabled="busy"
+        data-testid="decision-file-away"
+        aria-label="Dismiss proposal"
+        @click="emit('dismiss')"
+      />
+    </template>
+    <template v-else>
+      <PaperHLBtn
+        label="Reject"
+        kbd="⌫"
+        :disabled="busy"
+        data-testid="decision-reject"
+        @click="emit('reject')"
+      />
+      <PaperHLBtn
+        label="Request edit"
+        kbd="E"
+        :disabled="busy"
+        data-testid="decision-edit"
+        @click="emit('request-edit')"
+      />
+      <PaperHLBtn
+        label="Defer"
+        kbd="D"
+        :disabled="busy"
+        data-testid="decision-defer"
+        @click="emit('defer')"
+      />
+      <PaperHLBtn
+        label="Apply"
+        kbd="⏎"
+        variant="ember"
+        :disabled="busy"
+        data-testid="decision-apply"
+        @click="emit('apply')"
+      />
+    </template>
   </div>
 </template>
 

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewDecisionRail.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewDecisionRail.vue
@@ -47,7 +47,7 @@ const emit = defineEmits<{
         kbd="⌫"
         :disabled="busy"
         data-testid="decision-file-away"
-        aria-label="Dismiss proposal"
+        aria-label="File away proposal"
         @click="emit('dismiss')"
       />
     </template>

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewMain.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewMain.vue
@@ -52,6 +52,8 @@ const props = defineProps<{
   sideEffects: SideEffects
   conflicts: ConflictRow[]
   history: HistoryRow[]
+  /** When true the active proposal is settled; the rail offers "File away" only. */
+  dismissable?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -59,6 +61,7 @@ const emit = defineEmits<{
   (event: 'reject'): void
   (event: 'request-edit'): void
   (event: 'defer'): void
+  (event: 'dismiss'): void
   (event: 'report', proposalId: string): void
 }>()
 
@@ -101,11 +104,13 @@ const dialSubline = computed(() =>
     <ReviewDecisionRail
       :summary="decisionSummary"
       :busy="busy"
+      :dismissable="dismissable"
       data-testid="paper-review-decision-rail"
       @apply="emit('apply')"
       @reject="emit('reject')"
       @request-edit="emit('request-edit')"
       @defer="emit('defer')"
+      @dismiss="emit('dismiss')"
     />
 
     <ReviewChangeSection
@@ -122,7 +127,7 @@ const dialSubline = computed(() =>
 
     <footer class="paper-review-main__footer">
       <span class="tk-serial">REVIEW · {{ serial }} · LOCAL-FIRST · LEDGER</span>
-      <span class="tk-serial">PRESS ⏎ TO APPLY · ⌫ TO REJECT</span>
+      <span class="tk-serial">{{ dismissable ? 'PRESS ⌫ TO FILE AWAY' : 'PRESS ⏎ TO APPLY · ⌫ TO REJECT' }}</span>
     </footer>
   </div>
 </template>

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewQueueRail.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewQueueRail.vue
@@ -25,7 +25,7 @@ const props = withDefaults(
     activeId: string | null
     awaitingCount: number
     staleCount: number
-    /** Board-scoped count of settled proposals; ≥2 reveals the bulk file-away action. */
+    /** Caller-owned settled proposals on this board; ≥1 reveals the bulk file-away action. */
     dismissableCount?: number
     /** Disables the bulk file-away action while any review action is in flight. */
     busy?: boolean
@@ -91,7 +91,7 @@ function setFilter(next: QueueFilter) {
         >{{ key === 'all' ? 'All' : key === 'mine' ? 'Mine' : 'Stale' }}</button>
       </div>
       <button
-        v-if="dismissableCount >= 2"
+        v-if="dismissableCount >= 1"
         type="button"
         class="paper-review-rail__file-away"
         data-testid="queue-file-away-all"

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewQueueRail.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewQueueRail.vue
@@ -27,6 +27,8 @@ const props = withDefaults(
     staleCount: number
     /** Board-scoped count of settled proposals; ≥2 reveals the bulk file-away action. */
     dismissableCount?: number
+    /** Disables the bulk file-away action while any review action is in flight. */
+    busy?: boolean
     recentlyApplied: RecentlyAppliedRow[]
     cadence?: number[]
     applyRate?: number
@@ -34,6 +36,7 @@ const props = withDefaults(
   }>(),
   {
     dismissableCount: 0,
+    busy: false,
     cadence: () => [4, 3, 5, 2, 4, 1, 3],
     applyRate: 0.71,
     undoRate: 0.04,
@@ -92,6 +95,7 @@ function setFilter(next: QueueFilter) {
         type="button"
         class="paper-review-rail__file-away"
         data-testid="queue-file-away-all"
+        :disabled="busy"
         :aria-label="`File away ${dismissableCount} settled proposals`"
         @click="emit('file-away-all')"
       >File away {{ dismissableCount }} settled</button>
@@ -171,9 +175,13 @@ function setFilter(next: QueueFilter) {
   cursor: pointer;
   text-align: left;
 }
-.paper-review-rail__file-away:hover {
+.paper-review-rail__file-away:hover:not(:disabled) {
   color: var(--ink);
   border-color: var(--ink);
+}
+.paper-review-rail__file-away:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .paper-review-rail__empty {
   padding: 14px 18px;

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewQueueRail.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewQueueRail.vue
@@ -25,12 +25,15 @@ const props = withDefaults(
     activeId: string | null
     awaitingCount: number
     staleCount: number
+    /** Board-scoped count of settled proposals; ≥2 reveals the bulk file-away action. */
+    dismissableCount?: number
     recentlyApplied: RecentlyAppliedRow[]
     cadence?: number[]
     applyRate?: number
     undoRate?: number
   }>(),
   {
+    dismissableCount: 0,
     cadence: () => [4, 3, 5, 2, 4, 1, 3],
     applyRate: 0.71,
     undoRate: 0.04,
@@ -40,6 +43,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   (event: 'select', id: string): void
   (event: 'filter-change', filter: QueueFilter): void
+  (event: 'file-away-all'): void
 }>()
 
 const filter = ref<QueueFilter>('all')
@@ -83,6 +87,14 @@ function setFilter(next: QueueFilter) {
           @click="setFilter(key)"
         >{{ key === 'all' ? 'All' : key === 'mine' ? 'Mine' : 'Stale' }}</button>
       </div>
+      <button
+        v-if="dismissableCount >= 2"
+        type="button"
+        class="paper-review-rail__file-away"
+        data-testid="queue-file-away-all"
+        :aria-label="`File away ${dismissableCount} settled proposals`"
+        @click="emit('file-away-all')"
+      >File away {{ dismissableCount }} settled</button>
     </div>
 
     <div v-if="visible.length === 0" class="paper-review-rail__empty tk-meta">
@@ -145,6 +157,23 @@ function setFilter(next: QueueFilter) {
   background: var(--paper-card);
   color: var(--ink);
   border-color: var(--line);
+}
+.paper-review-rail__file-away {
+  margin-top: 10px;
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  padding: 5px 8px;
+  background: transparent;
+  border: 1px dashed var(--line);
+  color: var(--mute);
+  cursor: pointer;
+  text-align: left;
+}
+.paper-review-rail__file-away:hover {
+  color: var(--ink);
+  border-color: var(--ink);
 }
 .paper-review-rail__empty {
   padding: 14px 18px;


### PR DESCRIPTION
## What & why

Closes #1161 — the Paper deep-Review surface had **no dismiss affordance for any proposal status**, so terminal proposals (Applied / Rejected / Failed / Expired / Approved-then-expired — the #1124 class) lingered in the queue forever. ADR-0038 makes Paper canonical, so this is now a core-loop regression risk, not cosmetic. Legacy already had dismiss via `useReviewProposals`; `PaperReviewView.vue` destructured `dismissableProposalIds` but never used it.

Implements the **"File away"** design posted on the issue (design-first, approved-by-default).

## What changed

**Per-proposal — the decision rail becomes a *filing* rail in terminal states.** When the shared `isProposalDismissable(proposal)` is true, the four decision buttons (Reject ⌫ · Request edit E · Defer D · Apply ⏎) — meaningless on a settled proposal — are replaced by a single hairline **File away** button. The eyebrow stamp flips `DECISION` → `SETTLED`, the toolbar `aria-label` flips to `Filing actions`, and the footer hint reads `PRESS ⌫ TO FILE AWAY`.

- Visible label **"File away"** (paper voice); `aria-label="Dismiss proposal"` so the accessible name matches the backend/API vocabulary (`CanBeDismissed`, dismiss endpoint).
- Activation reuses the **same** `handleDismissProposal` Legacy uses — same endpoint, store update, toasts. No backend changes.
- The ⌫ key is dual-purpose: **Reject** when actionable, **File away** when settled — single-key consistency for "remove this from my queue".

**Bulk — "File away N settled".** When ≥2 dismissable proposals match the active board filter, the queue header shows a hairline bulk action driven by the already-computed `dismissableProposalIds` → `handleDismissApplied`. Non-destructive (proposals stay in history/audit), so no confirmation.

**Drift-kill (ADR-0038 §5).** Consumes the **shared** `isProposalDismissable` from `useReviewProposals` (newly exported — it existed but wasn't returned). No local re-derivation in Paper. Reactive to the 60 s expiry clock, so a focused Approved proposal that expires swaps its rail to File away without a reload.

## Scope boundary

The functional dismiss affordance (the #1161 gap) is fully resolved. The design's *card slide-and-settle exit motion* is intentionally deferred to **Wave 4 (Paper polish / Ink Bleed)** where motion work is concentrated — kept out of this PR to keep the diff focused and low-risk. File away has its own press/hover micro-state; `prefers-reduced-motion` is respected by the token CSS.

## Tests

- `ReviewDecisionRail.spec.ts` (new) — actionable state renders 4 buttons + emits; dismissable state renders only File away (`aria-label`, SETTLED stamp) + emits `dismiss`; disabled while busy.
- `PaperReviewView.spec.ts` — settled proposal swaps the rail to File away; click + ⌫ both call `dismissProposals([id])`; bulk action appears at ≥2 and clears all settled; hidden below 2.
- `ReviewQueueRail.spec.ts` — bulk button visibility threshold (0/1 hidden, ≥2 shown) + count label + `file-away-all` emit.

## Verification (local)

- `npm run typecheck` — clean
- `npx vitest --run` on the 6 affected/new specs — **123 passed**
- `npx eslint` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
