### PR TITLE
feat(paper-review): wire onPreviewDiff to render the proposal diff inline

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -815,4 +815,50 @@ describe('PaperReviewView', () => {
 
     wrapper.unmount()
   })
+
+  it('shows the empty-diff state without fetching for a no-operation proposal', async () => {
+    const wrapper = await mountView([
+      makeProposal({ id: 'diff-noop', diffPreview: null, operations: [] }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    // No diffPreview + no operations → the backend `/diff` would 404, so the view
+    // shows the empty state directly without firing the request.
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff-empty"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('shows a revision caveat in the diff preview when a saved revision exists', async () => {
+    const now = new Date().toISOString()
+    mocks.getRevisions.mockResolvedValue([
+      {
+        id: 'rev-1',
+        proposalId: 'diff-rev',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    mocks.getProposalDiff.mockResolvedValueOnce('--- before\n+++ after\n+x')
+    const wrapper = await mountView([makeProposal({ id: 'diff-rev' })])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').exists()).toBe(true)
+    // The preview reflects the ORIGINAL proposal, so a pending saved revision must
+    // be flagged (the diff does not reflect the revision that Apply will run).
+    const caveat = wrapper.find('[data-testid="paper-review-diff-revision-caveat"]')
+    expect(caveat.exists()).toBe(true)
+    expect(caveat.text()).toContain('original')
+
+    wrapper.unmount()
+  })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -861,4 +861,23 @@ describe('PaperReviewView', () => {
 
     wrapper.unmount()
   })
+
+  it('surfaces an error (not an empty diff) when a 404 occurs for an operations-bearing proposal', async () => {
+    // A proposal with operations bypasses the no-op guard and fetches; a 404 here
+    // means the proposal was deleted/dismissed elsewhere, so it must error rather
+    // than silently render an empty diff.
+    mocks.getProposalDiff.mockRejectedValueOnce({
+      response: { data: { errorCode: 'NotFound', message: 'Proposal not found' } },
+    })
+    const wrapper = await mountView([makeProposal({ id: 'diff-gone' })])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-gone')
+    expect(mocks.errorToast).toHaveBeenCalledWith('Proposal not found')
+    expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
 })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -745,16 +745,73 @@ describe('PaperReviewView', () => {
     expect(mocks.infoToast).toHaveBeenCalledWith('Report queued for this suggestion.')
   })
 
-  it('surfaces feedback when preview diff is invoked before visible diff UI exists', async () => {
-    const wrapper = await mountView([makeProposal()])
+  it('loads and renders the proposal diff inline when preview diff is invoked', async () => {
+    mocks.getProposalDiff.mockResolvedValueOnce('--- before\n+++ after\n+Add column "Done"')
+    const wrapper = await mountView([makeProposal({ id: 'diff-001' })])
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
     await flushPromises()
 
-    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
-    expect(mocks.infoToast).toHaveBeenCalledWith(
+    expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-001')
+    const diffPre = wrapper.find('[data-testid="paper-review-diff-pre"]')
+    expect(diffPre.exists()).toBe(true)
+    expect(diffPre.text()).toContain('Add column "Done"')
+    // No stub toast — the diff is wired now.
+    expect(mocks.infoToast).not.toHaveBeenCalledWith(
       'Preview diff is not wired yet; no diff was loaded.',
     )
+
+    wrapper.unmount()
+  })
+
+  it('hides the inline diff when preview diff is invoked again for the same proposal', async () => {
+    mocks.getProposalDiff.mockResolvedValueOnce('--- before\n+++ after\n+Add column "Done"')
+    const wrapper = await mountView([makeProposal({ id: 'diff-002' })])
+
+    // First press: load + render the diff.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').exists()).toBe(true)
+    expect(mocks.getProposalDiff).toHaveBeenCalledTimes(1)
+
+    // Second press: toggle the diff off (no re-fetch).
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+    expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(false)
+    expect(mocks.getProposalDiff).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+
+  it('renders an empty-diff state when the proposal has no changes to preview', async () => {
+    mocks.getProposalDiff.mockResolvedValueOnce('')
+    const wrapper = await mountView([makeProposal({ id: 'diff-empty' })])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-empty')
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').exists()).toBe(false)
+    const empty = wrapper.find('[data-testid="paper-review-diff-empty"]')
+    expect(empty.exists()).toBe(true)
+    expect(empty.text()).toContain('No changes to preview')
+
+    wrapper.unmount()
+  })
+
+  it('surfaces a toast and does not crash when the diff request fails', async () => {
+    mocks.getProposalDiff.mockRejectedValueOnce(new Error('boom'))
+    const wrapper = await mountView([makeProposal({ id: 'diff-err' })])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-err')
+    expect(mocks.errorToast).toHaveBeenCalledWith('boom')
+    // The inline diff surface is torn back down on error — no stale region.
+    expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(false)
+    // The view is still mounted and interactive.
+    expect(wrapper.find('[data-testid="paper-review-view"]').exists()).toBe(true)
 
     wrapper.unmount()
   })

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -638,6 +638,18 @@ async function onPreviewDiff() {
     return
   }
 
+  // No-op proposals: the backend `/diff` (GetProposalDiffAsync) returns 404 when
+  // there is no stored DiffPreview AND no operations. The view already renders a
+  // "No operation preview" change section for that state, so show the empty-diff
+  // surface directly rather than firing a request that 404s.
+  if (!p.diffPreview && (p.operations?.length ?? 0) === 0) {
+    latestDiffRequestId += 1
+    previewDiffProposalId.value = p.id
+    previewDiff.value = ''
+    previewDiffLoading.value = false
+    return
+  }
+
   const requestId = ++latestDiffRequestId
   previewDiffProposalId.value = p.id
   previewDiff.value = null
@@ -650,9 +662,16 @@ async function onPreviewDiff() {
     previewDiff.value = diff
   } catch (e: unknown) {
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
+    const { message, code } = getErrorDisplay(e, 'Failed to load proposal diff')
+    // A 404 means the backend has no diff to show (no-op proposal) — render the
+    // empty-diff state rather than surfacing it as an error.
+    if (code === 'NotFound') {
+      previewDiff.value = ''
+      return
+    }
     previewDiffProposalId.value = null
     previewDiff.value = null
-    toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)
+    toast.error(message)
   } finally {
     if (requestId === latestDiffRequestId) {
       previewDiffLoading.value = false
@@ -762,6 +781,15 @@ function onQueueFilterChange(filter: QueueFilter) {
           <h3 class="tk-h3 paper-review-deep__diff-title">Operation details</h3>
           <span class="tk-meta paper-review-deep__diff-sub">Press Space to hide</span>
         </header>
+        <p
+          v-if="revisionCount > 0"
+          class="paper-review-deep__diff-caveat tk-meta"
+          data-testid="paper-review-diff-revision-caveat"
+        >
+          ⚠ This preview shows the <strong>original</strong> proposal. A saved edit
+          (revision) will be applied instead, so the diff below may not reflect your
+          pending change (revision-aware diff tracked in #1235).
+        </p>
         <div class="card paper-review-deep__diff-card">
           <p
             v-if="previewDiffLoading"
@@ -879,6 +907,10 @@ function onQueueFilterChange(filter: QueueFilter) {
 .paper-review-deep__diff-card {
   padding: 0;
   overflow: hidden;
+}
+.paper-review-deep__diff-caveat {
+  margin: 0 0 8px;
+  color: var(--ink-2);
 }
 .paper-review-deep__diff-empty {
   padding: 16px;

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -666,6 +666,9 @@ async function onPreviewDiff() {
   previewDiffProposalId.value = p.id
   previewDiff.value = null
   previewDiffLoading.value = true
+  // Scroll to the loading state immediately so a slow `/diff` doesn't look like a
+  // no-op on a long review surface (the final result re-scrolls when it lands).
+  scrollDiffIntoView()
 
   try {
     const diff = await automationApi.getProposalDiff(p.id)

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import ReviewQueueRail, {
   type QueueFilter,
   type QueueRailItem,
@@ -184,7 +184,18 @@ const selectors = usePaperReviewSelectors(activeProposal)
 const previewDiff = ref<string | null>(null)
 const previewDiffProposalId = ref<string | null>(null)
 const previewDiffLoading = ref(false)
+const previewDiffSection = ref<HTMLElement | null>(null)
 let latestDiffRequestId = 0
+
+// Space can be pressed while the reviewer is looking at the top of a long
+// review surface; the diff renders below the (often tall) deep-review content,
+// so scroll it into view once it appears. Guarded for jsdom where the method
+// is absent.
+function scrollDiffIntoView() {
+  void nextTick(() => {
+    previewDiffSection.value?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
+  })
+}
 
 // Clear the preview whenever the active proposal changes so a diff loaded
 // for one proposal never leaks onto the next (mirrors legacy behaviour).
@@ -647,6 +658,7 @@ async function onPreviewDiff() {
     previewDiffProposalId.value = p.id
     previewDiff.value = ''
     previewDiffLoading.value = false
+    scrollDiffIntoView()
     return
   }
 
@@ -660,18 +672,16 @@ async function onPreviewDiff() {
     // Ignore stale responses and ones whose target proposal has changed.
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
     previewDiff.value = diff
+    scrollDiffIntoView()
   } catch (e: unknown) {
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
-    const { message, code } = getErrorDisplay(e, 'Failed to load proposal diff')
-    // A 404 means the backend has no diff to show (no-op proposal) — render the
-    // empty-diff state rather than surfacing it as an error.
-    if (code === 'NotFound') {
-      previewDiff.value = ''
-      return
-    }
+    // The no-op case (no diff to show) is handled by the guard above BEFORE
+    // fetching, so a failure here is a real error — most often a 404 because the
+    // proposal was deleted/dismissed from another session. Surface it rather than
+    // silently rendering an empty diff for a proposal that no longer exists.
     previewDiffProposalId.value = null
     previewDiff.value = null
-    toast.error(message)
+    toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)
   } finally {
     if (requestId === latestDiffRequestId) {
       previewDiffLoading.value = false
@@ -773,6 +783,7 @@ function onQueueFilterChange(filter: QueueFilter) {
       />
       <section
         v-if="previewDiffProposalId === activeProposal.id"
+        ref="previewDiffSection"
         class="paper-review-deep__diff"
         data-testid="paper-review-diff"
       >

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -13,6 +13,8 @@ import { useReviewActions } from '../../composables/useReviewActions'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
 import { useReviewKeymap } from '../../composables/useReviewKeymap'
 import { useProposalRevisions } from '../../composables/useProposalRevisions'
+import { getErrorDisplay } from '../../composables/useErrorMapper'
+import { automationApi } from '../../api/automationApi'
 import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
 import { normalizeProposalSourceType, normalizeProposalStatus } from '../../utils/automation'
@@ -171,6 +173,32 @@ watch(
 )
 
 const selectors = usePaperReviewSelectors(activeProposal)
+
+// --- Inline diff preview ----------------------------------------------
+//
+// Mirrors useReviewActions.handleToggleDiff: a per-proposal toggle that
+// (a) hides the diff if it is already shown for the active proposal,
+// (b) ignores stale async responses via a monotonic request counter, and
+// (c) clears itself when the active proposal changes. The diff renders
+// inline in the deep-review surface below the change section — no drawer.
+const previewDiff = ref<string | null>(null)
+const previewDiffProposalId = ref<string | null>(null)
+const previewDiffLoading = ref(false)
+let latestDiffRequestId = 0
+
+// Clear the preview whenever the active proposal changes so a diff loaded
+// for one proposal never leaks onto the next (mirrors legacy behaviour).
+watch(
+  () => activeProposal.value?.id ?? null,
+  (id) => {
+    if (previewDiffProposalId.value && previewDiffProposalId.value !== id) {
+      latestDiffRequestId += 1
+      previewDiffProposalId.value = null
+      previewDiff.value = null
+      previewDiffLoading.value = false
+    }
+  },
+)
 
 const {
   editing: revisionEditing,
@@ -597,10 +625,39 @@ function onToggleProvenance() {
   toast.info('Provenance toggle is not wired yet; provenance is rendered inline below.')
 }
 
-function onPreviewDiff() {
+async function onPreviewDiff() {
   const p = activeProposal.value
   if (!p) return
-  toast.info('Preview diff is not wired yet; no diff was loaded.')
+
+  // Already showing this proposal's diff → toggle it off.
+  if (previewDiffProposalId.value === p.id) {
+    latestDiffRequestId += 1
+    previewDiffProposalId.value = null
+    previewDiff.value = null
+    previewDiffLoading.value = false
+    return
+  }
+
+  const requestId = ++latestDiffRequestId
+  previewDiffProposalId.value = p.id
+  previewDiff.value = null
+  previewDiffLoading.value = true
+
+  try {
+    const diff = await automationApi.getProposalDiff(p.id)
+    // Ignore stale responses and ones whose target proposal has changed.
+    if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
+    previewDiff.value = diff
+  } catch (e: unknown) {
+    if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
+    previewDiffProposalId.value = null
+    previewDiff.value = null
+    toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)
+  } finally {
+    if (requestId === latestDiffRequestId) {
+      previewDiffLoading.value = false
+    }
+  }
 }
 
 function onReportBadSuggestion(proposalId: string) {
@@ -695,6 +752,40 @@ function onQueueFilterChange(filter: QueueFilter) {
         @dismiss="onFileAway"
         @report="onReportBadSuggestion"
       />
+      <section
+        v-if="previewDiffProposalId === activeProposal.id"
+        class="paper-review-deep__diff"
+        data-testid="paper-review-diff"
+      >
+        <header class="paper-review-deep__diff-head">
+          <span class="tk-serial paper-review-deep__diff-serial">§ DIFF</span>
+          <h3 class="tk-h3 paper-review-deep__diff-title">Operation details</h3>
+          <span class="tk-meta paper-review-deep__diff-sub">Press Space to hide</span>
+        </header>
+        <div class="card paper-review-deep__diff-card">
+          <p
+            v-if="previewDiffLoading"
+            class="paper-review-deep__diff-empty tk-meta"
+            data-testid="paper-review-diff-loading"
+          >
+            Loading diff…
+          </p>
+          <p
+            v-else-if="!previewDiff"
+            class="paper-review-deep__diff-empty tk-meta"
+            data-testid="paper-review-diff-empty"
+          >
+            No changes to preview for this proposal.
+          </p>
+          <pre
+            v-else
+            class="paper-review-deep__diff-pre"
+            role="region"
+            aria-label="Proposal operation diff"
+            data-testid="paper-review-diff-pre"
+          >{{ previewDiff }}</pre>
+        </div>
+      </section>
       <ReviewRevisionEditor
         v-if="revisionEditing"
         :operations-payload="editablePayload"
@@ -764,6 +855,44 @@ function onQueueFilterChange(filter: QueueFilter) {
 .paper-review-deep__empty {
   padding: 80px 56px;
   text-align: left;
+}
+.paper-review-deep__diff {
+  margin: 0 36px 28px;
+}
+.paper-review-deep__diff-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.paper-review-deep__diff-serial {
+  color: var(--faint);
+}
+.paper-review-deep__diff-title {
+  margin: 0;
+}
+.paper-review-deep__diff-sub {
+  margin-left: auto;
+}
+.paper-review-deep__diff-card {
+  padding: 0;
+  overflow: hidden;
+}
+.paper-review-deep__diff-empty {
+  padding: 16px;
+}
+.paper-review-deep__diff-pre {
+  margin: 0;
+  padding: 16px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink-2, var(--ink));
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .paper-review-deep__rail-empty {
   border-left: 1px solid var(--line);


### PR DESCRIPTION
## Summary

De-stubs the `onPreviewDiff` handler in the Paper deep-review surface (`PaperReviewView.vue`) — a Wave-2 activation slice. Previously the handler only fired a placeholder toast (`Preview diff is not wired yet; no diff was loaded.`). It now loads the real proposal diff and renders it **inline** in the review surface.

- Calls `automationApi.getProposalDiff(id)` (GET `/automation/proposals/{id}/diff`) and renders the returned diff text inline, below the change section — **no drawer/modal** (inline is the settled UX decision, consistent with how provenance and side-effects render in the same surface).
- Behaviour mirrors the legacy `useReviewActions.handleToggleDiff` pattern:
  - **Toggle off** when invoked again for the same proposal (no re-fetch).
  - **Stale-response guard** via a monotonic `latestDiffRequestId` counter — a slow response for a since-changed proposal is dropped.
  - **Clears preview state** when the active proposal changes (a `watch` on the active proposal id).
  - **Error handling**: `toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)` and tears the inline surface back down — matching how other handlers in this file/area surface errors.
  - **Empty-diff state**: an explicit "No changes to preview" message when the diff string is empty (the legacy `&& selectedDiff` truthy gate would have shown nothing).
- The diff `<pre>` block is styled with Paper deep-review tokens (`--mono`, `--line-soft`, `--ink-2`, `tk-serial`/`tk-h3`/`tk-meta`) so it sits consistently in the surface. Trigger is the existing **Space** keymap shortcut.
- Out of scope (untouched): `onDefer` and `onReportBadSuggestion` — those need net-new backend and are separate slices.

## Test Plan

Extended `src/tests/views/paper/review/PaperReviewView.spec.ts`. The obsolete stub-toast assertion was replaced with four cases:

- **loads and renders the proposal diff inline when preview diff is invoked** — Space calls `getProposalDiff` with the active proposal id and renders the returned diff in the inline `<pre>`; no stub toast.
- **hides the inline diff when preview diff is invoked again for the same proposal** — second Space toggles the diff off and does not re-fetch.
- **renders an empty-diff state when the proposal has no changes to preview** — an empty diff string renders the "No changes to preview" state instead of an empty `<pre>`.
- **surfaces a toast and does not crash when the diff request fails** — a rejected request fires `toast.error` and leaves the view mounted with no stale diff region.

Verification (from `frontend/taskdeck-web`):
- `npm run typecheck` — pass (no errors).
- `npx vitest --run src/tests/views/paper/review/PaperReviewView.spec.ts` — **35 passed** (4 new).
- `npx eslint` on the two changed files — clean.