### PR TITLE
perf(queue): bound LlmQueueToProposalWorker status reads at the database (#1195)

### DIFF
--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -66,25 +66,28 @@ public class LlmQueueToProposalWorker : BackgroundService
     {
         using var scope = _scopeFactory.CreateScope();
         var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-        // Bound each status read at the DB instead of materializing the whole backlog.
-        // The 2x headroom over MaxBatchSize absorbs the in-memory request-type filter below
-        // (a status read mixes capture and non-capture rows), so the fair-batch builder still
-        // has at least MaxBatchSize candidates of the kind it wants in the common case.
-        var fetchLimit = Math.Max(1, _settings.MaxBatchSize) * 2;
-        var pendingItems = (await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Pending, fetchLimit, ct))
-            .Where(item => !CaptureRequestContract.IsCaptureRequestType(item.RequestType))
+        // Bound each read at the database to the work one tick can consume (BuildFairBatchItems emits at
+        // most MaxBatchSize items total, so it never needs more than MaxBatchSize of either kind). The
+        // capture/non-capture predicate is applied in-query by these methods, so the bound never fills with
+        // rows the worker would discard -- bounding raw status before an in-memory type filter could let
+        // older untriaged capture rows starve non-capture automation work (and vice-versa on Processing).
+        var fetchLimit = Math.Max(1, _settings.MaxBatchSize);
+        var pendingItems = (await unitOfWork.LlmQueue.GetOldestPendingNonCaptureAsync(fetchLimit, ct))
             .OrderBy(item => item.CreatedAt)
             .ToList();
-        var triagingCaptureItems = (await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Processing, fetchLimit, ct))
-            .Where(item => CaptureRequestContract.IsCaptureRequestType(item.RequestType))
+        var triagingCaptureItems = (await unitOfWork.LlmQueue.GetOldestProcessingCaptureAsync(fetchLimit, ct))
             .OrderBy(item => item.CreatedAt)
             .ToList();
 
+        // Backlog gauges report TRUE depth via count queries; recording the bounded lists' Count would
+        // saturate the gauge at the fetch limit and hide backlog growth -- the exact signal operators need.
+        var pendingBacklog = await unitOfWork.LlmQueue.CountPendingNonCaptureAsync(ct);
+        var captureBacklog = await unitOfWork.LlmQueue.CountProcessingCaptureAsync(ct);
         TaskdeckTelemetry.AutomationQueueBacklog.Record(
-            pendingItems.Count,
+            pendingBacklog,
             new KeyValuePair<string, object?>(TaskdeckTelemetryTags.QueueName, QueueNameLlm));
         TaskdeckTelemetry.AutomationQueueBacklog.Record(
-            triagingCaptureItems.Count,
+            captureBacklog,
             new KeyValuePair<string, object?>(TaskdeckTelemetryTags.QueueName, QueueNameCaptureTriage));
 
         var workBatch = BuildFairBatchItems(triagingCaptureItems, pendingItems, _settings.MaxBatchSize);

--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -66,11 +66,16 @@ public class LlmQueueToProposalWorker : BackgroundService
     {
         using var scope = _scopeFactory.CreateScope();
         var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-        var pendingItems = (await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Pending, ct))
+        // Bound each status read at the DB instead of materializing the whole backlog.
+        // The 2x headroom over MaxBatchSize absorbs the in-memory request-type filter below
+        // (a status read mixes capture and non-capture rows), so the fair-batch builder still
+        // has at least MaxBatchSize candidates of the kind it wants in the common case.
+        var fetchLimit = Math.Max(1, _settings.MaxBatchSize) * 2;
+        var pendingItems = (await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Pending, fetchLimit, ct))
             .Where(item => !CaptureRequestContract.IsCaptureRequestType(item.RequestType))
             .OrderBy(item => item.CreatedAt)
             .ToList();
-        var triagingCaptureItems = (await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Processing, ct))
+        var triagingCaptureItems = (await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Processing, fetchLimit, ct))
             .Where(item => CaptureRequestContract.IsCaptureRequestType(item.RequestType))
             .OrderBy(item => item.CreatedAt)
             .ToList();

--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -10,7 +10,22 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
         CancellationToken cancellationToken = default);
     Task<IEnumerable<LlmRequest>> GetPendingAsync(int limit = 100, CancellationToken cancellationToken = default);
     Task<IEnumerable<LlmRequest>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all requests with the given status, newest-first. Used by snapshot/count
+    /// callers (health backlog gauge, ops listing) that need the full set — do NOT add a
+    /// default cap here or those callers silently under-count.
+    /// </summary>
     Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns at most <paramref name="limit"/> requests with the given status, oldest-first
+    /// (FIFO work-drain order), bounding the query at the database. Background workers use this
+    /// to avoid materializing an unbounded backlog before applying their own batch cap; oldest-first
+    /// guarantees the longest-waiting items are drained first rather than starved under backlog.
+    /// </summary>
+    /// <param name="limit">Maximum rows to return; must be at least 1.</param>
+    Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default);
     Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default);
     Task<Dictionary<RequestStatus, int>> GetStatusCountsByUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<LlmRequest?> GetNextPendingAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -12,20 +12,35 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
     Task<IEnumerable<LlmRequest>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns all requests with the given status, newest-first. Used by snapshot/count
-    /// callers (health backlog gauge, ops listing) that need the full set — do NOT add a
-    /// default cap here or those callers silently under-count.
+    /// Returns all requests with the given status, newest-first, unbounded. Callers that need the
+    /// full set rely on this (the health backlog gauge and the ops queue listing count/inspect every
+    /// row), so do NOT add a default cap here. Bounded background work-drains must use the type-aware
+    /// <c>GetOldest*</c> methods below, which bound the read at the database.
     /// </summary>
     Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns at most <paramref name="limit"/> requests with the given status, oldest-first
-    /// (FIFO work-drain order), bounding the query at the database. Background workers use this
-    /// to avoid materializing an unbounded backlog before applying their own batch cap; oldest-first
-    /// guarantees the longest-waiting items are drained first rather than starved under backlog.
+    /// Returns at most <paramref name="limit"/> Pending non-capture (automation) requests, oldest-first,
+    /// with the non-capture predicate applied IN the query and bounded at the database. The predicate must
+    /// live in the query, not in a post-fetch filter: untriaged capture requests also sit in the Pending
+    /// queue and, being older, would otherwise fill an oldest-first window and starve automation work.
     /// </summary>
     /// <param name="limit">Maximum rows to return; must be at least 1.</param>
-    Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default);
+    Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns at most <paramref name="limit"/> Processing capture-triage requests, oldest-first, with the
+    /// capture predicate applied in the query and bounded at the database (same anti-starvation reasoning as
+    /// <see cref="GetOldestPendingNonCaptureAsync"/>: non-capture requests also transit Processing).
+    /// </summary>
+    /// <param name="limit">Maximum rows to return; must be at least 1.</param>
+    Task<IEnumerable<LlmRequest>> GetOldestProcessingCaptureAsync(int limit, CancellationToken cancellationToken = default);
+
+    /// <summary>Counts Pending non-capture (automation) requests for backlog telemetry, without materializing rows.</summary>
+    Task<int> CountPendingNonCaptureAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Counts Processing capture-triage requests for backlog telemetry, without materializing rows.</summary>
+    Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default);
     Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default);
     Task<Dictionary<RequestStatus, int>> GetStatusCountsByUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<LlmRequest?> GetNextPendingAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -143,6 +143,32 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default)
+    {
+        if (limit < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), limit, "Limit must be at least 1.");
+        }
+
+        if (_context.Database.IsSqlite())
+        {
+            return await _context.LlmRequests
+                .FromSqlInterpolated(
+                    $"SELECT * FROM LlmRequests WHERE Status = {(int)status} ORDER BY CreatedAt ASC LIMIT {limit}")
+                .Include(lr => lr.User)
+                .Include(lr => lr.Board)
+                .ToListAsync(cancellationToken);
+        }
+
+        return await _context.LlmRequests
+            .Include(lr => lr.User)
+            .Include(lr => lr.Board)
+            .Where(lr => lr.Status == status)
+            .OrderBy(lr => lr.CreatedAt)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default)
     {
         if (_context.Database.IsSqlite())

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -143,7 +143,17 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default)
+    public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)
+        => GetOldestByStatusAndCaptureKindAsync(RequestStatus.Pending, capture: false, limit, cancellationToken);
+
+    public Task<IEnumerable<LlmRequest>> GetOldestProcessingCaptureAsync(int limit, CancellationToken cancellationToken = default)
+        => GetOldestByStatusAndCaptureKindAsync(RequestStatus.Processing, capture: true, limit, cancellationToken);
+
+    private async Task<IEnumerable<LlmRequest>> GetOldestByStatusAndCaptureKindAsync(
+        RequestStatus status,
+        bool capture,
+        int limit,
+        CancellationToken cancellationToken)
     {
         if (limit < 1)
         {
@@ -152,21 +162,60 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
 
         if (_context.Database.IsSqlite())
         {
-            return await _context.LlmRequests
-                .FromSqlInterpolated(
-                    $"SELECT * FROM LlmRequests WHERE Status = {(int)status} ORDER BY CreatedAt ASC LIMIT {limit}")
+            // SQLite's EF provider cannot translate ORDER BY on a DateTimeOffset column, so the order +
+            // LIMIT live in raw SQL. FromSqlInterpolated + Include wraps this in a subquery that does not
+            // guarantee the raw ORDER BY survives to the final result (see GetByUserAsync); the inner LIMIT
+            // still selects the correct oldest-N rows, so re-sort in memory to make oldest-first a contract.
+            var rawQuery = capture
+                ? _context.LlmRequests.FromSqlInterpolated(
+                    $"SELECT * FROM LlmRequests WHERE Status = {(int)status} AND RequestType LIKE {CaptureRequestTypeLike} ORDER BY CreatedAt ASC LIMIT {limit}")
+                : _context.LlmRequests.FromSqlInterpolated(
+                    $"SELECT * FROM LlmRequests WHERE Status = {(int)status} AND RequestType NOT LIKE {CaptureRequestTypeLike} ORDER BY CreatedAt ASC LIMIT {limit}");
+
+            var rows = await rawQuery
                 .Include(lr => lr.User)
                 .Include(lr => lr.Board)
                 .ToListAsync(cancellationToken);
+            return rows.OrderBy(lr => lr.CreatedAt).ToList();
         }
 
-        return await _context.LlmRequests
+        // Non-SQLite providers (e.g. the Postgres Testcontainer path) translate the predicate + OrderBy +
+        // Take into a single bounded query with guaranteed ordering.
+        var query = _context.LlmRequests
             .Include(lr => lr.User)
             .Include(lr => lr.Board)
-            .Where(lr => lr.Status == status)
+            .Where(lr => lr.Status == status);
+
+        query = capture
+            ? query.Where(lr => EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike))
+            : query.Where(lr => !EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike));
+
+        return await query
             .OrderBy(lr => lr.CreatedAt)
             .Take(limit)
             .ToListAsync(cancellationToken);
+    }
+
+    public Task<int> CountPendingNonCaptureAsync(CancellationToken cancellationToken = default)
+        => CountByStatusAndCaptureKindAsync(RequestStatus.Pending, capture: false, cancellationToken);
+
+    public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
+        => CountByStatusAndCaptureKindAsync(RequestStatus.Processing, capture: true, cancellationToken);
+
+    private async Task<int> CountByStatusAndCaptureKindAsync(
+        RequestStatus status,
+        bool capture,
+        CancellationToken cancellationToken)
+    {
+        var query = _context.LlmRequests
+            .AsNoTracking()
+            .Where(lr => lr.Status == status);
+
+        query = capture
+            ? query.Where(lr => EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike))
+            : query.Where(lr => !EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike));
+
+        return await query.CountAsync(cancellationToken);
     }
 
     public async Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -88,6 +88,57 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
     }
 
     [Fact]
+    public async Task GetByStatusAsync_WithLimit_ReturnsOldestRequestsBounded()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<ILlmQueueRepository>();
+
+        var user = new User("llm-bounded-user", "llm-bounded@example.com", "hash");
+        db.Users.Add(user);
+
+        // Year-1990 timestamps make these the globally-oldest Failed rows in the shared
+        // test database, so the oldest-first bounded read is deterministic regardless of
+        // rows seeded by sibling test classes via the IClassFixture.
+        var baseTime = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var requests = new List<LlmRequest>();
+        for (var i = 0; i < 5; i++)
+        {
+            var request = new LlmRequest(user.Id, "test.bounded.read", $"{{\"i\":{i}}}");
+            request.MarkAsFailed("seed");
+            db.LlmRequests.Add(request);
+            requests.Add(request);
+        }
+        await db.SaveChangesAsync();
+
+        for (var i = 0; i < requests.Count; i++)
+        {
+            db.Entry(requests[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = baseTime.AddSeconds(i);
+        }
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var result = (await repo.GetByStatusAsync(RequestStatus.Failed, 3)).ToList();
+
+        // Bound is enforced at the database, not after materializing the full set.
+        result.Should().HaveCount(3);
+        // Oldest-first: the three oldest Failed rows are ours, in ascending CreatedAt order.
+        result.Select(r => r.Id).Should().Equal(requests[0].Id, requests[1].Id, requests[2].Id);
+        // The two newest seeded rows are excluded -- guards against a newest-first (DESC) regression.
+        result.Should().NotContain(r => r.Id == requests[3].Id || r.Id == requests[4].Id);
+    }
+
+    [Fact]
+    public async Task GetByStatusAsync_WithLimitBelowOne_Throws()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ILlmQueueRepository>();
+
+        await repo.Invoking(r => r.GetByStatusAsync(RequestStatus.Pending, 0))
+            .Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public async Task TryClaimProcessingCaptureAsync_ShouldSucceedOnFirstClaim_FailOnSecond()
     {
         using var scope = _factory.Services.CreateScope();

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -1,11 +1,17 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
+using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Enums;
 using Taskdeck.Infrastructure.Persistence;
+using Taskdeck.Infrastructure.Repositories;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -87,55 +93,154 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
         result.Count.Should().BeLessThanOrEqualTo(2);
     }
 
+    // The bounded work-drain reads target Pending-non-capture and Processing-capture rows -- exactly the
+    // rows the live worker claims. These tests therefore use an isolated, worker-free SQLite context
+    // (no web host) so the background worker cannot mutate the rows mid-assertion.
+
     [Fact]
-    public async Task GetByStatusAsync_WithLimit_ReturnsOldestRequestsBounded()
+    public async Task GetOldestPendingNonCaptureAsync_ReturnsOldestNonCaptureBounded_ExcludesCapturesAndBoundsAtSql()
     {
-        using var scope = _factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
-        var repo = scope.ServiceProvider.GetRequiredService<ILlmQueueRepository>();
-
-        var user = new User("llm-bounded-user", "llm-bounded@example.com", "hash");
-        db.Users.Add(user);
-
-        // Year-1990 timestamps make these the globally-oldest Failed rows in the shared
-        // test database, so the oldest-first bounded read is deterministic regardless of
-        // rows seeded by sibling test classes via the IClassFixture.
-        var baseTime = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var requests = new List<LlmRequest>();
-        for (var i = 0; i < 5; i++)
+        var interceptor = new CapturingReaderInterceptor();
+        await WithSqliteRepoAsync(async (db, repo) =>
         {
-            var request = new LlmRequest(user.Id, "test.bounded.read", $"{{\"i\":{i}}}");
-            request.MarkAsFailed("seed");
-            db.LlmRequests.Add(request);
-            requests.Add(request);
-        }
-        await db.SaveChangesAsync();
+            var user = new User("llm-pending-noncap", "llm-pending-noncap@example.com", "hash");
+            db.Users.Add(user);
 
-        for (var i = 0; i < requests.Count; i++)
-        {
-            db.Entry(requests[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = baseTime.AddSeconds(i);
-        }
-        await db.SaveChangesAsync();
-        db.ChangeTracker.Clear();
+            // Capture rows are OLDER than the automation rows. A naive bound on raw Pending status
+            // (oldest-first) would return only these, and a post-fetch non-capture filter would then
+            // yield nothing -- starving automation work. The in-query predicate must exclude them.
+            var captures = new List<LlmRequest>();
+            for (var i = 0; i < 3; i++)
+            {
+                var c = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, $"{{\"c\":{i}}}");
+                db.LlmRequests.Add(c);
+                captures.Add(c);
+            }
+            var automation = new List<LlmRequest>();
+            for (var i = 0; i < 5; i++)
+            {
+                var a = new LlmRequest(user.Id, "automation.command", $"{{\"a\":{i}}}");
+                db.LlmRequests.Add(a);
+                automation.Add(a);
+            }
+            // A non-capture row in another status must not leak into the Pending read.
+            var completed = new LlmRequest(user.Id, "automation.command", "{\"done\":true}");
+            completed.MarkAsProcessing();
+            completed.MarkAsCompleted();
+            db.LlmRequests.Add(completed);
+            await db.SaveChangesAsync();
 
-        var result = (await repo.GetByStatusAsync(RequestStatus.Failed, 3)).ToList();
+            var olderCapture = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var newerAutomation = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (var i = 0; i < captures.Count; i++)
+                db.Entry(captures[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = olderCapture.AddSeconds(i);
+            for (var i = 0; i < automation.Count; i++)
+                db.Entry(automation[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = newerAutomation.AddSeconds(i);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+            interceptor.Clear();
 
-        // Bound is enforced at the database, not after materializing the full set.
-        result.Should().HaveCount(3);
-        // Oldest-first: the three oldest Failed rows are ours, in ascending CreatedAt order.
-        result.Select(r => r.Id).Should().Equal(requests[0].Id, requests[1].Id, requests[2].Id);
-        // The two newest seeded rows are excluded -- guards against a newest-first (DESC) regression.
-        result.Should().NotContain(r => r.Id == requests[3].Id || r.Id == requests[4].Id);
+            var result = (await repo.GetOldestPendingNonCaptureAsync(3)).ToList();
+
+            result.Should().HaveCount(3);
+            result.Should().OnlyContain(r => !CaptureRequestContract.IsCaptureRequestType(r.RequestType));
+            // Oldest-first among NON-capture Pending rows; the older captures are excluded in-query
+            // (anti-starvation) and the Completed row is excluded by status.
+            result.Select(r => r.Id).Should().Equal(automation[0].Id, automation[1].Id, automation[2].Id);
+
+            // The bound is enforced at the database (LIMIT), not by materializing then slicing in memory.
+            interceptor.CapturedCommands
+                .Where(sql => sql.Contains("LlmRequests", StringComparison.OrdinalIgnoreCase)
+                              && sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase))
+                .Should().Contain(sql => sql.Contains("LIMIT", StringComparison.OrdinalIgnoreCase),
+                    "the bounded read must push LIMIT into SQL");
+        }, interceptor);
     }
 
     [Fact]
-    public async Task GetByStatusAsync_WithLimitBelowOne_Throws()
+    public async Task GetOldestProcessingCaptureAsync_ReturnsOldestCaptureBounded_ExcludesNonCapture()
     {
-        using var scope = _factory.Services.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<ILlmQueueRepository>();
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("llm-proc-cap", "llm-proc-cap@example.com", "hash");
+            db.Users.Add(user);
 
-        await repo.Invoking(r => r.GetByStatusAsync(RequestStatus.Pending, 0))
-            .Should().ThrowAsync<ArgumentOutOfRangeException>();
+            // Non-capture Processing rows are OLDER; the in-query capture predicate must exclude them so
+            // capture-triage is not starved behind claimed/orphaned non-capture Processing rows.
+            var nonCapture = new List<LlmRequest>();
+            for (var i = 0; i < 3; i++)
+            {
+                var r = new LlmRequest(user.Id, "automation.command", $"{{\"n\":{i}}}");
+                r.MarkAsProcessing();
+                db.LlmRequests.Add(r);
+                nonCapture.Add(r);
+            }
+            var captures = new List<LlmRequest>();
+            for (var i = 0; i < 5; i++)
+            {
+                var c = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, $"{{\"c\":{i}}}");
+                c.MarkAsProcessing();
+                db.LlmRequests.Add(c);
+                captures.Add(c);
+            }
+            await db.SaveChangesAsync();
+
+            var older = new DateTimeOffset(1990, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            var newer = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            for (var i = 0; i < nonCapture.Count; i++)
+                db.Entry(nonCapture[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = older.AddSeconds(i);
+            for (var i = 0; i < captures.Count; i++)
+                db.Entry(captures[i]).Property(nameof(Entity.CreatedAt)).CurrentValue = newer.AddSeconds(i);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var result = (await repo.GetOldestProcessingCaptureAsync(3)).ToList();
+
+            result.Should().HaveCount(3);
+            result.Should().OnlyContain(r => CaptureRequestContract.IsCaptureRequestType(r.RequestType));
+            result.Select(r => r.Id).Should().Equal(captures[0].Id, captures[1].Id, captures[2].Id);
+        });
+    }
+
+    [Fact]
+    public async Task GetOldestWorkReads_WithLimitBelowOne_Throw()
+    {
+        await WithSqliteRepoAsync(async (_, repo) =>
+        {
+            await repo.Invoking(r => r.GetOldestPendingNonCaptureAsync(0))
+                .Should().ThrowAsync<ArgumentOutOfRangeException>();
+            await repo.Invoking(r => r.GetOldestProcessingCaptureAsync(-1))
+                .Should().ThrowAsync<ArgumentOutOfRangeException>();
+        });
+    }
+
+    [Fact]
+    public async Task BacklogCounts_CountOnlyMatchingKind_Unbounded()
+    {
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("llm-counts", "llm-counts@example.com", "hash");
+            db.Users.Add(user);
+
+            for (var i = 0; i < 4; i++)
+                db.LlmRequests.Add(new LlmRequest(user.Id, "automation.command", "{}")); // Pending non-capture
+            for (var i = 0; i < 2; i++)
+                db.LlmRequests.Add(new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}")); // Pending capture
+            for (var i = 0; i < 3; i++)
+            {
+                var c = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}"); // Processing capture
+                c.MarkAsProcessing();
+                db.LlmRequests.Add(c);
+            }
+            var n = new LlmRequest(user.Id, "automation.command", "{}"); // Processing non-capture
+            n.MarkAsProcessing();
+            db.LlmRequests.Add(n);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            (await repo.CountPendingNonCaptureAsync()).Should().Be(4);
+            (await repo.CountProcessingCaptureAsync()).Should().Be(3);
+        });
     }
 
     [Fact]
@@ -555,5 +660,74 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
         retrieved.Should().NotBeNull();
         retrieved!.Id.Should().Be(originalId);
         retrieved.UserId.Should().Be(user.Id);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="body"/> against a fresh, isolated SQLite database with NO web host (and thus
+    /// no background worker), so tests that seed worker-claimable rows are deterministic. Each call uses a
+    /// unique temp file and migrates the real schema, then cleans up the db/wal/shm/journal files.
+    /// </summary>
+    private static async Task WithSqliteRepoAsync(
+        Func<TaskdeckDbContext, LlmQueueRepository, Task> body,
+        DbCommandInterceptor? interceptor = null)
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-llmqueue-bound-{Guid.NewGuid():N}.db");
+        try
+        {
+            var builder = new DbContextOptionsBuilder<TaskdeckDbContext>()
+                .UseSqlite($"Data Source={dbPath}");
+            if (interceptor != null)
+            {
+                builder.AddInterceptors(interceptor);
+            }
+
+            await using var db = new TaskdeckDbContext(builder.Options);
+            await db.Database.MigrateAsync();
+            await body(db, new LlmQueueRepository(db));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+            {
+                var path = dbPath + suffix;
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                try { File.Delete(path); }
+                catch (IOException) { /* best-effort cleanup */ }
+            }
+        }
+    }
+
+    /// <summary>Captures the SQL text of every reader command, so tests can assert LIMIT pushdown.</summary>
+    private sealed class CapturingReaderInterceptor : DbCommandInterceptor
+    {
+        private readonly ConcurrentQueue<string> _commands = new();
+
+        public IReadOnlyCollection<string> CapturedCommands => _commands;
+
+        public void Clear() => _commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -693,18 +693,31 @@ public class LlmQueueToProposalWorkerTests
             return Task.FromResult<IEnumerable<LlmRequest>>(result);
         }
 
-        public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
-            RequestStatus status,
-            int limit,
-            CancellationToken cancellationToken = default)
+        public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)
         {
             var result = _allItems
-                .Where(i => i.Status == status)
+                .Where(i => i.Status == RequestStatus.Pending && !CaptureRequestContract.IsCaptureRequestType(i.RequestType))
                 .OrderBy(i => i.CreatedAt)
                 .Take(limit)
                 .ToList();
             return Task.FromResult<IEnumerable<LlmRequest>>(result);
         }
+
+        public Task<IEnumerable<LlmRequest>> GetOldestProcessingCaptureAsync(int limit, CancellationToken cancellationToken = default)
+        {
+            var result = _allItems
+                .Where(i => i.Status == RequestStatus.Processing && CaptureRequestContract.IsCaptureRequestType(i.RequestType))
+                .OrderBy(i => i.CreatedAt)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult<IEnumerable<LlmRequest>>(result);
+        }
+
+        public Task<int> CountPendingNonCaptureAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_allItems.Count(i => i.Status == RequestStatus.Pending && !CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
+
+        public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_allItems.Count(i => i.Status == RequestStatus.Processing && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -693,6 +693,19 @@ public class LlmQueueToProposalWorkerTests
             return Task.FromResult<IEnumerable<LlmRequest>>(result);
         }
 
+        public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
+            RequestStatus status,
+            int limit,
+            CancellationToken cancellationToken = default)
+        {
+            var result = _allItems
+                .Where(i => i.Status == status)
+                .OrderBy(i => i.CreatedAt)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult<IEnumerable<LlmRequest>>(result);
+        }
+
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         {
             var item = _allItems.FirstOrDefault(i => i.Id == id);

--- a/backend/tests/Taskdeck.Api.Tests/Resilience/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Resilience/WorkerResilienceTests.cs
@@ -109,9 +109,7 @@ public class WorkerResilienceTests
     {
         // Arrange: the worker has nothing to process; we test clean cancellation.
         var mockLlmQueue = new Mock<ILlmQueueRepository>();
-        mockLlmQueue
-            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Enumerable.Empty<LlmRequest>());
+        StubEmptyQueue(mockLlmQueue);
 
         var mockUnitOfWork = new Mock<IUnitOfWork>();
         mockUnitOfWork.Setup(u => u.LlmQueue).Returns(mockLlmQueue.Object);
@@ -155,16 +153,23 @@ public class WorkerResilienceTests
     }
 
     [Fact]
-    public async Task LlmWorker_BoundsStatusReadsAtTwiceMaxBatchSize()
+    public async Task LlmWorker_BoundsWorkReadsAtMaxBatchSize()
     {
-        // Arrange: capture the limit the worker passes to the bounded status read so we can
-        // assert it stops materializing the entire backlog (#1195).
+        // Arrange: capture the limit the worker passes to each bounded, type-aware work read so we
+        // can assert it stops materializing the entire backlog (#1195). BuildFairBatchItems emits at
+        // most MaxBatchSize items total, so MaxBatchSize of each kind is the correct bound.
         var capturedLimits = new System.Collections.Concurrent.ConcurrentBag<int>();
         var mockLlmQueue = new Mock<ILlmQueueRepository>();
         mockLlmQueue
-            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .Callback<RequestStatus, int, CancellationToken>((_, limit, _) => capturedLimits.Add(limit))
+            .Setup(q => q.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((limit, _) => capturedLimits.Add(limit))
             .ReturnsAsync(Enumerable.Empty<LlmRequest>());
+        mockLlmQueue
+            .Setup(q => q.GetOldestProcessingCaptureAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<int, CancellationToken>((limit, _) => capturedLimits.Add(limit))
+            .ReturnsAsync(Enumerable.Empty<LlmRequest>());
+        mockLlmQueue.Setup(q => q.CountPendingNonCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        mockLlmQueue.Setup(q => q.CountProcessingCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
 
         var mockUnitOfWork = new Mock<IUnitOfWork>();
         mockUnitOfWork.Setup(u => u.LlmQueue).Returns(mockLlmQueue.Object);
@@ -195,9 +200,9 @@ public class WorkerResilienceTests
 
         await worker.StopAsync(CancellationToken.None);
 
-        // Assert: every status read was bounded at MaxBatchSize * 2, never unbounded.
-        capturedLimits.Should().NotBeEmpty("the worker should have performed at least one bounded status read");
-        capturedLimits.Should().OnlyContain(limit => limit == maxBatchSize * 2);
+        // Assert: every work read was bounded at MaxBatchSize, never unbounded.
+        capturedLimits.Should().NotBeEmpty("the worker should have performed at least one bounded work read");
+        capturedLimits.Should().OnlyContain(limit => limit == maxBatchSize);
     }
 
     [Fact]
@@ -205,10 +210,7 @@ public class WorkerResilienceTests
     {
         var mockLlmQueue = new Mock<ILlmQueueRepository>();
         var processCallCount = 0;
-        mockLlmQueue
-            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .Callback(() => processCallCount++)
-            .ReturnsAsync(Enumerable.Empty<LlmRequest>());
+        StubEmptyQueue(mockLlmQueue, onWorkRead: () => processCallCount++);
 
         var mockUnitOfWork = new Mock<IUnitOfWork>();
         mockUnitOfWork.Setup(u => u.LlmQueue).Returns(mockLlmQueue.Object);
@@ -293,5 +295,29 @@ public class WorkerResilienceTests
             .Returns(mockScope.Object);
 
         return mockScopeFactory.Object;
+    }
+
+    /// <summary>
+    /// Stubs the type-aware work reads to return no work and the backlog counts to return zero, so the
+    /// worker completes a clean idle tick. <paramref name="onWorkRead"/> fires on each work read, letting
+    /// callers assert whether the worker attempted to process at all.
+    /// </summary>
+    private static void StubEmptyQueue(Mock<ILlmQueueRepository> mockLlmQueue, Action? onWorkRead = null)
+    {
+        var pendingSetup = mockLlmQueue.Setup(q => q.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()));
+        var captureSetup = mockLlmQueue.Setup(q => q.GetOldestProcessingCaptureAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()));
+        if (onWorkRead != null)
+        {
+            pendingSetup.Callback(() => onWorkRead()).ReturnsAsync(Enumerable.Empty<LlmRequest>());
+            captureSetup.Callback(() => onWorkRead()).ReturnsAsync(Enumerable.Empty<LlmRequest>());
+        }
+        else
+        {
+            pendingSetup.ReturnsAsync(Enumerable.Empty<LlmRequest>());
+            captureSetup.ReturnsAsync(Enumerable.Empty<LlmRequest>());
+        }
+
+        mockLlmQueue.Setup(q => q.CountPendingNonCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        mockLlmQueue.Setup(q => q.CountProcessingCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/Resilience/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Resilience/WorkerResilienceTests.cs
@@ -110,7 +110,7 @@ public class WorkerResilienceTests
         // Arrange: the worker has nothing to process; we test clean cancellation.
         var mockLlmQueue = new Mock<ILlmQueueRepository>();
         mockLlmQueue
-            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Enumerable.Empty<LlmRequest>());
 
         var mockUnitOfWork = new Mock<IUnitOfWork>();
@@ -155,12 +155,58 @@ public class WorkerResilienceTests
     }
 
     [Fact]
+    public async Task LlmWorker_BoundsStatusReadsAtTwiceMaxBatchSize()
+    {
+        // Arrange: capture the limit the worker passes to the bounded status read so we can
+        // assert it stops materializing the entire backlog (#1195).
+        var capturedLimits = new System.Collections.Concurrent.ConcurrentBag<int>();
+        var mockLlmQueue = new Mock<ILlmQueueRepository>();
+        mockLlmQueue
+            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<RequestStatus, int, CancellationToken>((_, limit, _) => capturedLimits.Add(limit))
+            .ReturnsAsync(Enumerable.Empty<LlmRequest>());
+
+        var mockUnitOfWork = new Mock<IUnitOfWork>();
+        mockUnitOfWork.Setup(u => u.LlmQueue).Returns(mockLlmQueue.Object);
+
+        var scopeFactory = CreateScopeFactoryWithUnitOfWork(mockUnitOfWork.Object);
+        var logger = new InMemoryLogger<LlmQueueToProposalWorker>();
+        const int maxBatchSize = 7;
+        var settings = new WorkerSettings
+        {
+            QueuePollIntervalSeconds = 1,
+            EnableAutoQueueProcessing = true,
+            MaxBatchSize = maxBatchSize,
+            MaxConcurrency = 1,
+            RetryBackoffSeconds = new[] { 0 }
+        };
+        var heartbeat = new WorkerHeartbeatRegistry();
+        var worker = new LlmQueueToProposalWorker(scopeFactory, settings, heartbeat, logger);
+
+        using var cts = new CancellationTokenSource();
+        await worker.StartAsync(cts.Token);
+
+        // Poll until the worker has run at least one batch (bounded by a generous timeout).
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (capturedLimits.IsEmpty && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(50);
+        }
+
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert: every status read was bounded at MaxBatchSize * 2, never unbounded.
+        capturedLimits.Should().NotBeEmpty("the worker should have performed at least one bounded status read");
+        capturedLimits.Should().OnlyContain(limit => limit == maxBatchSize * 2);
+    }
+
+    [Fact]
     public async Task LlmWorker_WhenAutoQueueProcessingDisabled_SkipsProcessingButStillReportsHeartbeat()
     {
         var mockLlmQueue = new Mock<ILlmQueueRepository>();
         var processCallCount = 0;
         mockLlmQueue
-            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<CancellationToken>()))
+            .Setup(q => q.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .Callback(() => processCallCount++)
             .ReturnsAsync(Enumerable.Empty<LlmRequest>());
 

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -421,8 +421,13 @@ public class WorkerResilienceTests
         public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
             RequestStatus status, CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
-        public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
-            RequestStatus status, int limit, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<IEnumerable<LlmRequest>> GetOldestProcessingCaptureAsync(int limit, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<int> CountPendingNonCaptureAsync(CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
@@ -475,16 +480,31 @@ public class WorkerResilienceTests
                 all.Where(i => i.Status == status).ToList());
         }
 
-        public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
-            RequestStatus status, int limit, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)
         {
-            var all = _pending.Concat(_processing).ToList();
+            var all = _pending.Concat(_processing);
             return Task.FromResult<IEnumerable<LlmRequest>>(
-                all.Where(i => i.Status == status)
+                all.Where(i => i.Status == RequestStatus.Pending && !CaptureRequestContract.IsCaptureRequestType(i.RequestType))
                    .OrderBy(i => i.CreatedAt)
                    .Take(limit)
                    .ToList());
         }
+
+        public Task<IEnumerable<LlmRequest>> GetOldestProcessingCaptureAsync(int limit, CancellationToken cancellationToken = default)
+        {
+            var all = _pending.Concat(_processing);
+            return Task.FromResult<IEnumerable<LlmRequest>>(
+                all.Where(i => i.Status == RequestStatus.Processing && CaptureRequestContract.IsCaptureRequestType(i.RequestType))
+                   .OrderBy(i => i.CreatedAt)
+                   .Take(limit)
+                   .ToList());
+        }
+
+        public Task<int> CountPendingNonCaptureAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_pending.Concat(_processing).Count(i => i.Status == RequestStatus.Pending && !CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
+
+        public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_pending.Concat(_processing).Count(i => i.Status == RequestStatus.Processing && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult(_pending.Concat(_processing).FirstOrDefault(i => i.Id == id));

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -421,6 +421,9 @@ public class WorkerResilienceTests
         public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
             RequestStatus status, CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
+            RequestStatus status, int limit, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
@@ -470,6 +473,17 @@ public class WorkerResilienceTests
             var all = _pending.Concat(_processing).ToList();
             return Task.FromResult<IEnumerable<LlmRequest>>(
                 all.Where(i => i.Status == status).ToList());
+        }
+
+        public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
+            RequestStatus status, int limit, CancellationToken cancellationToken = default)
+        {
+            var all = _pending.Concat(_processing).ToList();
+            return Task.FromResult<IEnumerable<LlmRequest>>(
+                all.Where(i => i.Status == status)
+                   .OrderBy(i => i.CreatedAt)
+                   .Take(limit)
+                   .ToList());
         }
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
Closes #1195. `LlmQueueToProposalWorker.ProcessBatchAsync` called `GetByStatusAsync(Pending)` and `GetByStatusAsync(Processing)` with no limit, materializing the entire backlog into memory before `BuildFairBatchItems` applied its `MaxBatchSize` cap. Under backlog accumulation that is an unbounded read.

## Approach — bounded overload, not a default cap
Added a **new overload** `GetByStatusAsync(RequestStatus status, int limit, CancellationToken)` rather than adding a default `limit` to the existing method, for two reasons surfaced by a full caller audit:

- **Health regression avoided.** `HealthController` queue-depth gauge calls `GetByStatusAsync(Pending)` and counts the *full* set (`queueThreshold = MaxBatchSize*20`). A default finite cap on the existing method would silently under-count the backlog and never report `Degraded` past the cap. The existing unbounded method (newest-first) is left untouched for these snapshot/count callers (`HealthController`, `OpsCliService`, `LlmQueueService`).
- **Minimal blast radius.** No existing caller or mock signature changes; only the worker opts into the bound.

The bounded overload returns rows **oldest-first** (FIFO `ORDER BY CreatedAt ASC LIMIT n`, both the SQLite raw-SQL and EF/LINQ paths). Oldest-first is the correct work-drain order: under backlog the longest-waiting items are processed first rather than starved (a naive `LIMIT` on the existing newest-first query would have fetched the *newest* N and starved the tail).

The worker passes `Math.Max(1, MaxBatchSize) * 2`; the 2× headroom absorbs the in-memory request-type filter (a status read mixes capture/non-capture rows), matching the limit the issue suggested.

## Caller audit (why this is GDPR-safe)
`GetByStatusAsync` has **no** GDPR delete/export caller — `AccountDeletionService`/`DataExportService` use `GetByUserAsync`, which is **not** touched here (its bounding is tracked separately under #1193). So no completeness-sensitive path is capped by this change.

## Changes
- `ILlmQueueRepository` — new bounded overload with XML docs explaining the dual ordering and the "do not add a default cap" constraint.
- `LlmQueueRepository` — bounded impl for SQLite + EF; `limit < 1` throws `ArgumentOutOfRangeException`.
- `LlmQueueToProposalWorker` — both status reads use the bounded overload with `MaxBatchSize*2`.

## Tests
- Integration (real SQLite): `GetByStatusAsync_WithLimit_ReturnsOldestRequestsBounded` — seeds 5 year-1990 (globally-oldest) rows, asserts exactly the 3 oldest are returned in ascending order and the 2 newest are excluded (guards against a newest-first/DESC regression). `GetByStatusAsync_WithLimitBelowOne_Throws`.
- Worker: `LlmWorker_BoundsStatusReadsAtTwiceMaxBatchSize` — captures the limit argument and asserts every status read is bounded at `MaxBatchSize*2`.
- Updated 3 hand-written `ILlmQueueRepository` fakes + 2 Moq worker-test setups for the new overload.

## Verification
- `dotnet build` (src + Api.Tests): clean.
- Targeted suites (`LlmQueueRepositoryIntegrationTests`, `LlmQueueToProposalWorkerTests`, both `WorkerResilienceTests`): **58 passed / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)