### PR TITLE
feat(bootstrap): make the desktop exe self-runnable — auto-generate the connector key (#1131)

### DIFF
--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -448,6 +448,30 @@ public static class FirstRunBootstrapper
         }
     }
 
+    /// <summary>
+    /// Backs up an unparsable config file to a timestamped <c>.corrupt-*</c> sibling before it is rewritten,
+    /// so a previously-generated secret it may still hold (the connector key in particular) is recoverable
+    /// by an operator instead of being silently overwritten. Best-effort: failure to copy is logged, not fatal.
+    /// </summary>
+    private static void PreserveCorruptConfig(string path, Exception parseError)
+    {
+        var backupPath = $"{path}.corrupt-{DateTime.UtcNow:yyyyMMddHHmmssfff}";
+        try
+        {
+            File.Copy(path, backupPath, overwrite: false);
+            Console.Error.WriteLine(
+                $"[FirstRun] WARNING: {path} contains invalid JSON ({parseError.Message}). A copy was " +
+                $"preserved at {backupPath} for recovery -- it may hold a previously-generated key -- and the " +
+                "file will be rewritten.");
+        }
+        catch (Exception copyEx)
+        {
+            Console.Error.WriteLine(
+                $"[FirstRun] WARNING: {path} contains invalid JSON ({parseError.Message}) and could NOT be " +
+                $"backed up ({copyEx.Message}); it will be overwritten.");
+        }
+    }
+
     private static void PersistValue(string section, string key, string value)
     {
         var path = LocalConfigPath;
@@ -503,11 +527,12 @@ public static class FirstRunBootstrapper
                 }
                 catch (Exception ex)
                 {
-                    // Logger is not available at this pre-DI stage; warn to stderr and start fresh
-                    // rather than silently discarding the corrupt file.
-                    Console.Error.WriteLine(
-                        $"[FirstRun] WARNING: {path} contains invalid JSON and will be overwritten. " +
-                        $"Details: {ex.Message}");
+                    // The file is unparsable (e.g. an interrupted write or a hand-edit). It may still hold
+                    // the ONLY copy of a previously-generated secret -- losing the connector key in
+                    // particular orphans stored connector credentials -- so preserve it for operator recovery
+                    // before starting fresh, rather than silently overwriting it. Logger is not available at
+                    // this pre-DI stage, so warn to stderr.
+                    PreserveCorruptConfig(path, ex);
                     root = new JsonObject();
                 }
             }

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -274,8 +274,10 @@ public static class FirstRunBootstrapper
                 "and saved to {ConfigFile}. BACK UP THIS FILE alongside your database -- it is required to " +
                 "decrypt stored connector credentials; losing it makes them unrecoverable.", LocalConfigPath);
         }
-        catch (IOException ex)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
+            // PersistValue can throw UnauthorizedAccessException (e.g. a read-only install dir such as
+            // Program Files) as well as IOException (locked file, disk full, lock unavailable).
             if (requirePersistence)
             {
                 // A desktop (non-headless Production) install must persist the key. An in-memory key would

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -590,16 +590,20 @@ public static class FirstRunBootstrapper
             {
                 try
                 {
+                    // Parse with the config provider's leniency (comments / trailing commas). A hand-edited
+                    // but provider-loadable file must round-trip here -- a strict parse would treat it as
+                    // corrupt and drop its existing sections (e.g. the Connectors key) when a later first-run
+                    // write (EnsureDbPath / JWT) rewrites the file, orphaning stored connector credentials.
                     var existing = File.ReadAllText(path);
-                    root = JsonNode.Parse(existing)?.AsObject() ?? new JsonObject();
+                    root = JsonNode.Parse(existing, nodeOptions: null, documentOptions: LocalConfigJsonOptions)?.AsObject() ?? new JsonObject();
                 }
                 catch (Exception ex)
                 {
-                    // The file is unparsable (e.g. an interrupted write or a hand-edit). It may still hold
-                    // the ONLY copy of a previously-generated secret -- losing the connector key in
-                    // particular orphans stored connector credentials -- so preserve it for operator recovery
-                    // before starting fresh, rather than silently overwriting it. Logger is not available at
-                    // this pre-DI stage, so warn to stderr.
+                    // The file is genuinely unparsable (not even provider-loadable -- e.g. an interrupted
+                    // write). It may still hold the ONLY copy of a previously-generated secret -- losing the
+                    // connector key in particular orphans stored connector credentials -- so preserve it for
+                    // operator recovery before starting fresh, rather than silently overwriting it. Logger is
+                    // not available at this pre-DI stage, so warn to stderr.
                     PreserveCorruptConfig(path, ex);
                     root = new JsonObject();
                 }

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -104,10 +104,14 @@ public static class FirstRunBootstrapper
         // so that no hardcoded secret is required in appsettings.Development.json.
         EnsureJwtSecret(builder.Configuration, logger);
 
-        // Connector key auto-generation is skipped in Production to avoid
-        // ephemeral keys that cause data loss on container restart.
-        // Production must supply a stable key; ValidateProductionSecrets enforces this.
-        if (!builder.Environment.IsProduction())
+        // Auto-generate the connector encryption key unless this is a headless Production deployment
+        // (CI / cloud container). A desktop install persists the generated key to appsettings.local.json
+        // next to the exe, so it is stable across restarts and the self-contained exe is runnable without
+        // manually supplying Connectors__EncryptionKey. Headless Production is excluded: there the key may
+        // not survive a restart, so an auto-generated one would be ephemeral and silently lose the ability
+        // to decrypt stored connector credentials -- those deployments must supply a stable key, which
+        // ValidateProductionSecrets enforces. See ADR-0041.
+        if (ShouldAutoGenerateConnectorKey(builder.Environment.IsProduction(), IsHeadlessEnvironment()))
         {
             EnsureConnectorEncryptionKey(builder.Configuration, logger);
         }
@@ -188,6 +192,16 @@ public static class FirstRunBootstrapper
 
     internal static string GenerateSecret()
         => Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    /// <summary>
+    /// Decides whether to auto-generate the connector encryption key when it is not configured.
+    /// Enabled everywhere EXCEPT a headless Production deployment (CI / cloud container), where a
+    /// generated key may not survive a restart and would lose the ability to decrypt stored connector
+    /// credentials. A non-headless Production deployment (the desktop exe) persists the key locally,
+    /// so generation is safe and makes the self-contained exe runnable without a supplied key.
+    /// </summary>
+    internal static bool ShouldAutoGenerateConnectorKey(bool isProduction, bool isHeadless)
+        => !isProduction || !isHeadless;
 
     private static void EnsureJwtSecret(IConfiguration configuration, ILogger logger)
     {

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -41,6 +41,13 @@ public static class FirstRunBootstrapper
     /// </remarks>
     public static WebApplicationBuilder AddLocalConfigFile(this WebApplicationBuilder builder)
     {
+        // A present-but-unparsable appsettings.local.json would throw the moment the configuration is built
+        // (JsonConfigurationSource.Optional only suppresses a MISSING file, not a malformed one), crashing
+        // startup before the first-run checks ever run. Quarantine it first: preserve the corrupt file (it
+        // may hold a recoverable key) and remove the original so the optional source loads as "missing" and
+        // the desktop install self-heals instead of failing to launch on every restart.
+        QuarantineCorruptLocalConfig();
+
         var sources = builder.Configuration.Sources;
 
         // Find the first EnvironmentVariablesConfigurationSource so we can
@@ -75,6 +82,46 @@ public static class FirstRunBootstrapper
         }
 
         return builder;
+    }
+
+    /// <summary>
+    /// If the persisted local config file exists but does not parse as a JSON object, preserve it to a
+    /// <c>.corrupt-*</c> sibling (it may hold a recoverable key) and remove the original, so the optional
+    /// config source loads as "missing" instead of throwing at config-build time. This lets a desktop install
+    /// self-heal from a corrupt <c>appsettings.local.json</c> rather than crash on every launch. Best-effort:
+    /// a file that cannot be removed is reported to stderr.
+    /// </summary>
+    internal static void QuarantineCorruptLocalConfig() => QuarantineCorruptLocalConfigAt(LocalConfigPath);
+
+    /// <summary>Path-parameterized core of <see cref="QuarantineCorruptLocalConfig"/> (testable seam).</summary>
+    internal static void QuarantineCorruptLocalConfigAt(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        try
+        {
+            // JsonConfigurationProvider requires a JSON OBJECT at the root; AsObject() throws otherwise
+            // (and Parse throws on empty/truncated/invalid content), matching what would crash config build.
+            _ = JsonNode.Parse(File.ReadAllText(path))?.AsObject();
+            return; // Parses as a JSON object -> usable, leave it alone.
+        }
+        catch (Exception ex)
+        {
+            PreserveCorruptConfig(path, ex);
+            try
+            {
+                File.Delete(path);
+            }
+            catch (Exception delEx)
+            {
+                Console.Error.WriteLine(
+                    $"[FirstRun] WARNING: {path} is corrupt and could not be removed ({delEx.Message}); " +
+                    "startup may fail until it is deleted manually.");
+            }
+        }
     }
 
     /// <summary>
@@ -211,39 +258,35 @@ public static class FirstRunBootstrapper
     internal static bool ShouldAutoGenerateConnectorKey(bool isProduction, bool isHeadless)
         => !isProduction || !isHeadless;
 
-    /// <summary>The outcome of verifying that a freshly persisted connector key is the effective value.</summary>
-    internal enum ConnectorKeyPersistOutcome
-    {
-        /// <summary>The persisted (or already-present) key is the effective value — nothing more to do.</summary>
-        Effective,
-        /// <summary>A desktop install's persisted key is masked by a higher-priority empty value — fail loudly.</summary>
-        FailClosed,
-        /// <summary>A non-Production harness where the file reload did not propagate — patch the value in memory.</summary>
-        InMemoryFallback
-    }
-
     /// <summary>
-    /// After a generated connector key is persisted, decides the outcome from the key's effective
-    /// configuration value. A non-empty effective value means the persisted key is visible (the only
-    /// higher-priority source we could have had was empty/whitespace, since a real one would have
-    /// short-circuited generation). An empty/whitespace value means a higher-priority source — most likely
-    /// an empty <c>Connectors__EncryptionKey</c> environment variable — is masking the file we just wrote:
-    /// a desktop Production install must fail closed (the next launch would regenerate a DIFFERENT key and
-    /// orphan stored connector credentials), whereas a non-Production harness tolerates a process-local
-    /// in-memory value because the file-based reload may not propagate through every provider there.
+    /// Reads the connector encryption key directly from the persisted local config file at
+    /// <paramref name="path"/>, bypassing configuration-source precedence. This lets the bootstrapper
+    /// detect a key that a higher-priority empty/whitespace source (e.g. an empty
+    /// <c>Connectors__EncryptionKey</c> environment variable) is masking, so it can be REUSED rather than
+    /// overwritten by a freshly generated one. Returns <c>true</c> only when the file holds a non-empty key;
+    /// returns <c>false</c> for a missing, unparsable, non-object, or empty value (a corrupt file is handled
+    /// separately by <see cref="QuarantineCorruptLocalConfig"/>).
     /// </summary>
-    internal static ConnectorKeyPersistOutcome ResolveConnectorKeyPersistOutcome(
-        string? effectiveValue,
-        bool requirePersistence)
+    internal static bool TryReadPersistedConnectorKey(string path, out string? key)
     {
-        if (!string.IsNullOrWhiteSpace(effectiveValue))
+        key = null;
+        if (!File.Exists(path))
         {
-            return ConnectorKeyPersistOutcome.Effective;
+            return false;
         }
 
-        return requirePersistence
-            ? ConnectorKeyPersistOutcome.FailClosed
-            : ConnectorKeyPersistOutcome.InMemoryFallback;
+        try
+        {
+            var node = JsonNode.Parse(File.ReadAllText(path))?.AsObject();
+            key = node?["Connectors"]?.AsObject()?["EncryptionKey"]?.GetValue<string>();
+            return !string.IsNullOrWhiteSpace(key);
+        }
+        catch
+        {
+            // Missing/unparsable/non-object/non-string: treat as "no recoverable key persisted".
+            key = null;
+            return false;
+        }
     }
 
     private static void EnsureJwtSecret(IConfiguration configuration, ILogger logger)
@@ -295,6 +338,24 @@ public static class FirstRunBootstrapper
             return;
         }
 
+        // The effective value is empty. Before generating a new key (which PersistValue would write OVER the
+        // file in place, destroying any key already there), check whether a key is already persisted on disk.
+        // If so, a higher-priority empty/whitespace source -- most likely an empty Connectors__EncryptionKey
+        // environment variable -- is masking it. REUSE the persisted key instead of generating: regenerating
+        // would permanently destroy the only copy of the key the stored connector credentials were encrypted
+        // with. Reuse is stable across restarts (the next launch reads the same persisted key) and keeps the
+        // app working despite the misconfigured empty variable.
+        if (TryReadPersistedConnectorKey(LocalConfigPath, out var persisted))
+        {
+            configuration["Connectors:EncryptionKey"] = persisted;
+            logger.LogWarning(
+                "First-run: A higher-priority configuration source (likely an empty Connectors__EncryptionKey " +
+                "environment variable) is masking the connector key persisted in {ConfigFile}. Reusing the " +
+                "persisted key so stored connector credentials stay decryptable; unset the empty variable to " +
+                "silence this warning.", LocalConfigPath);
+            return;
+        }
+
         var generated = GenerateSecret();
         try
         {
@@ -335,28 +396,25 @@ public static class FirstRunBootstrapper
             return;
         }
 
-        // After persist+reload, the generated key should be the effective configuration value. If it is not
-        // visible, a higher-priority source -- most likely an empty Connectors__EncryptionKey environment
-        // variable from a copied env/service template -- is masking the file we just wrote. A desktop
-        // Production install (requirePersistence) must fail closed: the in-memory fallback below only fixes
-        // THIS process, so the next launch would regenerate a DIFFERENT key and silently orphan connector
-        // credentials saved this run. A non-Production harness instead patches the value in memory, because
-        // the file-based reload legitimately may not propagate through every provider there.
-        switch (ResolveConnectorKeyPersistOutcome(configuration["Connectors:EncryptionKey"], requirePersistence))
+        // The key is now persisted on disk. Make sure it is also the effective in-process value: a reload may
+        // not propagate through every provider (test harnesses), and an empty higher-priority source could
+        // mask the freshly written file. Either way the key IS persisted and recoverable -- the next launch
+        // reads it back (and reuses it via TryReadPersistedConnectorKey if still masked) -- so an in-memory
+        // value here is safe (no data loss), unlike overwriting an existing key would have been.
+        if (string.IsNullOrWhiteSpace(configuration["Connectors:EncryptionKey"]))
         {
-            case ConnectorKeyPersistOutcome.Effective:
-                break;
-            case ConnectorKeyPersistOutcome.FailClosed:
-                throw new InvalidOperationException(
-                    $"First-run: A connector encryption key was generated and persisted to {LocalConfigPath}, " +
-                    "but it is not the effective configuration value -- a higher-priority source (most likely " +
-                    "an empty 'Connectors__EncryptionKey' environment variable) is masking it. Each launch " +
-                    "would then generate a different key and make previously-stored connector credentials " +
-                    "unrecoverable. Unset the empty 'Connectors__EncryptionKey' environment variable, or set " +
-                    "it to a real, stable key.");
-            case ConnectorKeyPersistOutcome.InMemoryFallback:
-                configuration["Connectors:EncryptionKey"] = generated;
-                break;
+            configuration["Connectors:EncryptionKey"] = generated;
+            if (requirePersistence)
+            {
+                // In Production the only way the just-persisted key is not the effective value is a
+                // higher-priority empty source masking it. The key is safe on disk and will be reused on the
+                // next launch; surface the misconfiguration so the operator can clear it.
+                logger.LogWarning(
+                    "First-run: The connector key was persisted to {ConfigFile} but a higher-priority " +
+                    "configuration source (likely an empty Connectors__EncryptionKey environment variable) is " +
+                    "masking it. The persisted key will be reused on the next launch; unset the empty variable.",
+                    LocalConfigPath);
+            }
         }
     }
 

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -211,6 +211,41 @@ public static class FirstRunBootstrapper
     internal static bool ShouldAutoGenerateConnectorKey(bool isProduction, bool isHeadless)
         => !isProduction || !isHeadless;
 
+    /// <summary>The outcome of verifying that a freshly persisted connector key is the effective value.</summary>
+    internal enum ConnectorKeyPersistOutcome
+    {
+        /// <summary>The persisted (or already-present) key is the effective value — nothing more to do.</summary>
+        Effective,
+        /// <summary>A desktop install's persisted key is masked by a higher-priority empty value — fail loudly.</summary>
+        FailClosed,
+        /// <summary>A non-Production harness where the file reload did not propagate — patch the value in memory.</summary>
+        InMemoryFallback
+    }
+
+    /// <summary>
+    /// After a generated connector key is persisted, decides the outcome from the key's effective
+    /// configuration value. A non-empty effective value means the persisted key is visible (the only
+    /// higher-priority source we could have had was empty/whitespace, since a real one would have
+    /// short-circuited generation). An empty/whitespace value means a higher-priority source — most likely
+    /// an empty <c>Connectors__EncryptionKey</c> environment variable — is masking the file we just wrote:
+    /// a desktop Production install must fail closed (the next launch would regenerate a DIFFERENT key and
+    /// orphan stored connector credentials), whereas a non-Production harness tolerates a process-local
+    /// in-memory value because the file-based reload may not propagate through every provider there.
+    /// </summary>
+    internal static ConnectorKeyPersistOutcome ResolveConnectorKeyPersistOutcome(
+        string? effectiveValue,
+        bool requirePersistence)
+    {
+        if (!string.IsNullOrWhiteSpace(effectiveValue))
+        {
+            return ConnectorKeyPersistOutcome.Effective;
+        }
+
+        return requirePersistence
+            ? ConnectorKeyPersistOutcome.FailClosed
+            : ConnectorKeyPersistOutcome.InMemoryFallback;
+    }
+
     private static void EnsureJwtSecret(IConfiguration configuration, ILogger logger)
     {
         var configured = configuration["Jwt:SecretKey"] ?? string.Empty;
@@ -300,11 +335,28 @@ public static class FirstRunBootstrapper
             return;
         }
 
-        // Set in-memory as a fallback: the file-based reload may not propagate through all
-        // configuration providers (e.g. in test harnesses).
-        if (string.IsNullOrWhiteSpace(configuration["Connectors:EncryptionKey"]))
+        // After persist+reload, the generated key should be the effective configuration value. If it is not
+        // visible, a higher-priority source -- most likely an empty Connectors__EncryptionKey environment
+        // variable from a copied env/service template -- is masking the file we just wrote. A desktop
+        // Production install (requirePersistence) must fail closed: the in-memory fallback below only fixes
+        // THIS process, so the next launch would regenerate a DIFFERENT key and silently orphan connector
+        // credentials saved this run. A non-Production harness instead patches the value in memory, because
+        // the file-based reload legitimately may not propagate through every provider there.
+        switch (ResolveConnectorKeyPersistOutcome(configuration["Connectors:EncryptionKey"], requirePersistence))
         {
-            configuration["Connectors:EncryptionKey"] = generated;
+            case ConnectorKeyPersistOutcome.Effective:
+                break;
+            case ConnectorKeyPersistOutcome.FailClosed:
+                throw new InvalidOperationException(
+                    $"First-run: A connector encryption key was generated and persisted to {LocalConfigPath}, " +
+                    "but it is not the effective configuration value -- a higher-priority source (most likely " +
+                    "an empty 'Connectors__EncryptionKey' environment variable) is masking it. Each launch " +
+                    "would then generate a different key and make previously-stored connector credentials " +
+                    "unrecoverable. Unset the empty 'Connectors__EncryptionKey' environment variable, or set " +
+                    "it to a real, stable key.");
+            case ConnectorKeyPersistOutcome.InMemoryFallback:
+                configuration["Connectors:EncryptionKey"] = generated;
+                break;
         }
     }
 

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -110,16 +110,35 @@ public static class FirstRunBootstrapper
             return;
         }
 
+        // Separate the READ from the PARSE: a present-but-temporarily-unreadable file (transient I/O / share
+        // violation / permission glitch) may be perfectly valid and hold the only connector key, so it must
+        // NOT be quarantined/deleted -- only a genuine JSON parse failure means the file would crash config
+        // build and should be quarantined.
+        string content;
+        try
+        {
+            content = File.ReadAllText(path);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"[FirstRun] WARNING: could not read {path} ({ex.Message}); leaving it in place (not " +
+                "quarantining -- it may be a valid file holding the connector key).");
+            return;
+        }
+
         try
         {
             // JsonConfigurationProvider requires a JSON OBJECT at the root; AsObject() throws otherwise
             // (and Parse throws on empty/truncated/invalid content), matching what would crash config build.
             // Use the provider's leniency (comments / trailing commas) so a loadable file is not quarantined.
-            _ = JsonNode.Parse(File.ReadAllText(path), nodeOptions: null, documentOptions: LocalConfigJsonOptions)?.AsObject();
+            _ = JsonNode.Parse(content, nodeOptions: null, documentOptions: LocalConfigJsonOptions)?.AsObject();
             return; // Parses as a JSON object -> usable, leave it alone.
         }
         catch (Exception ex)
         {
+            // Genuine parse failure (malformed JSON / non-object root). Preserve for recovery, then remove
+            // so the optional config source loads as "missing" and the app self-heals.
             PreserveCorruptConfig(path, ex);
             try
             {
@@ -287,13 +306,18 @@ public static class FirstRunBootstrapper
 
         try
         {
-            var node = JsonNode.Parse(File.ReadAllText(path), nodeOptions: null, documentOptions: LocalConfigJsonOptions)?.AsObject();
-            key = node?["Connectors"]?.AsObject()?["EncryptionKey"]?.GetValue<string>();
+            // Read through a throwaway configuration builder so the lookup matches the REAL provider exactly:
+            // case-insensitive section/key names AND the comment/trailing-comma leniency. A direct JsonNode
+            // walk would miss a provider-valid case variant (e.g. "connectors": { "encryptionkey": ... }).
+            var config = new ConfigurationBuilder()
+                .AddJsonFile(path, optional: true, reloadOnChange: false)
+                .Build();
+            key = config["Connectors:EncryptionKey"];
             return !string.IsNullOrWhiteSpace(key);
         }
         catch
         {
-            // Missing/unparsable/non-object/non-string: treat as "no recoverable key persisted".
+            // Unparsable / unreadable: treat as "no recoverable key persisted".
             key = null;
             return false;
         }

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -113,7 +113,13 @@ public static class FirstRunBootstrapper
         // ValidateProductionSecrets enforces. See ADR-0041.
         if (ShouldAutoGenerateConnectorKey(builder.Environment.IsProduction(), IsHeadlessEnvironment()))
         {
-            EnsureConnectorEncryptionKey(builder.Configuration, logger);
+            // In non-headless Production (the desktop exe) the key MUST persist across restarts: a failed
+            // write has to be fatal, not silently degraded to an ephemeral in-memory key that the next
+            // launch replaces -- which would make stored connector credentials unrecoverable.
+            EnsureConnectorEncryptionKey(
+                builder.Configuration,
+                logger,
+                requirePersistence: builder.Environment.IsProduction());
         }
 
         // Remaining first-run checks are for the self-hosted packaged
@@ -169,7 +175,9 @@ public static class FirstRunBootstrapper
                 "SECURITY: The Connectors:EncryptionKey is not configured. " +
                 "Generate a base64-encoded 256-bit key with 'openssl rand -base64 32' and set it via the " +
                 "Connectors__EncryptionKey environment variable. The application cannot start without a " +
-                "real encryption key in Production.");
+                $"real encryption key in Production. (If this used to run as a desktop install, an existing " +
+                $"key may already be in {LocalConfigPath} -- reuse that value rather than generating a new " +
+                "one, or stored connector credentials will become unrecoverable.)");
         }
 
         logger.LogInformation("Production secret validation passed.");
@@ -240,7 +248,10 @@ public static class FirstRunBootstrapper
         }
     }
 
-    private static void EnsureConnectorEncryptionKey(IConfiguration configuration, ILogger logger)
+    private static void EnsureConnectorEncryptionKey(
+        IConfiguration configuration,
+        ILogger logger,
+        bool requirePersistence = false)
     {
         var configured = configuration["Connectors:EncryptionKey"] ?? string.Empty;
 
@@ -259,19 +270,36 @@ public static class FirstRunBootstrapper
             }
 
             logger.LogInformation(
-                "First-run: Connector encryption key was not configured. A random key has been " +
-                "generated and saved to {ConfigFile}.", LocalConfigPath);
+                "First-run: Connector encryption key was not configured. A random key has been generated " +
+                "and saved to {ConfigFile}. BACK UP THIS FILE alongside your database -- it is required to " +
+                "decrypt stored connector credentials; losing it makes them unrecoverable.", LocalConfigPath);
         }
         catch (IOException ex)
         {
+            if (requirePersistence)
+            {
+                // A desktop (non-headless Production) install must persist the key. An in-memory key would
+                // be lost on the next launch, which would then generate a different one and silently lose
+                // the ability to decrypt previously-stored connector credentials. Fail loudly instead.
+                throw new InvalidOperationException(
+                    $"First-run: Could not persist the connector encryption key to {LocalConfigPath} " +
+                    $"({ex.Message}). A run-once in-memory key would be lost on restart and make stored " +
+                    "connector credentials unrecoverable. Ensure the application directory is writable, or " +
+                    "set a stable key via the Connectors__EncryptionKey environment variable.", ex);
+            }
+
+            // Non-Production (dev/staging/test): a transient in-memory key is acceptable -- these do not
+            // carry credentials that must survive a restart, and parallel test harnesses can lock the file.
+            configuration["Connectors:EncryptionKey"] = generated;
             logger.LogWarning(
                 "First-run: Could not persist connector encryption key to {ConfigFile} ({Error}). " +
                 "A transient in-memory key has been generated instead.",
                 LocalConfigPath, ex.Message);
+            return;
         }
 
-        // Always set in-memory as a fallback: the file-based reload may not
-        // propagate through all configuration providers (e.g. in test harnesses).
+        // Set in-memory as a fallback: the file-based reload may not propagate through all
+        // configuration providers (e.g. in test harnesses).
         if (string.IsNullOrWhiteSpace(configuration["Connectors:EncryptionKey"]))
         {
             configuration["Connectors:EncryptionKey"] = generated;

--- a/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
+++ b/backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs
@@ -26,6 +26,15 @@ public static class FirstRunBootstrapper
             "CHANGE_ME_GENERATE_WITH_openssl_rand_base64_48"
         };
 
+    // Match the leniency of the JSON configuration provider (JsonConfigurationFileParser allows comments
+    // and trailing commas) so a hand-edited but provider-loadable appsettings.local.json is read the same
+    // way here -- and is NOT wrongly treated as corrupt (which would quarantine it) or as missing a key.
+    private static readonly System.Text.Json.JsonDocumentOptions LocalConfigJsonOptions = new()
+    {
+        CommentHandling = System.Text.Json.JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
     /// <summary>
     /// Registers <c>appsettings.local.json</c> as an optional configuration
     /// source so that previously generated secrets are picked up.
@@ -105,7 +114,8 @@ public static class FirstRunBootstrapper
         {
             // JsonConfigurationProvider requires a JSON OBJECT at the root; AsObject() throws otherwise
             // (and Parse throws on empty/truncated/invalid content), matching what would crash config build.
-            _ = JsonNode.Parse(File.ReadAllText(path))?.AsObject();
+            // Use the provider's leniency (comments / trailing commas) so a loadable file is not quarantined.
+            _ = JsonNode.Parse(File.ReadAllText(path), nodeOptions: null, documentOptions: LocalConfigJsonOptions)?.AsObject();
             return; // Parses as a JSON object -> usable, leave it alone.
         }
         catch (Exception ex)
@@ -277,7 +287,7 @@ public static class FirstRunBootstrapper
 
         try
         {
-            var node = JsonNode.Parse(File.ReadAllText(path))?.AsObject();
+            var node = JsonNode.Parse(File.ReadAllText(path), nodeOptions: null, documentOptions: LocalConfigJsonOptions)?.AsObject();
             key = node?["Connectors"]?.AsObject()?["EncryptionKey"]?.GetValue<string>();
             return !string.IsNullOrWhiteSpace(key);
         }

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -180,6 +180,21 @@ public class FirstRunBootstrapperTests
         finally { File.Delete(path); }
     }
 
+    [Fact]
+    public void TryReadPersistedConnectorKey_ReadsKey_CaseInsensitively()
+    {
+        // The configuration provider matches keys case-insensitively, so a provider-valid case variant must
+        // be found -- otherwise a masked key would be missed and a different one regenerated.
+        var path = Path.Combine(Path.GetTempPath(), $"td-connkey-case-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\"connectors\":{\"encryptionkey\":\"K1-lower\"}}");
+        try
+        {
+            Assert.True(FirstRunBootstrapper.TryReadPersistedConnectorKey(path, out var key));
+            Assert.Equal("K1-lower", key);
+        }
+        finally { File.Delete(path); }
+    }
+
     // ---- GetAppDataPath ------------------------------------------------------
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -71,6 +71,33 @@ public class FirstRunBootstrapperTests
             FirstRunBootstrapper.ShouldAutoGenerateConnectorKey(isProduction, isHeadless));
     }
 
+    // ---- ResolveConnectorKeyPersistOutcome -----------------------------------
+
+    // `expected` is the ConnectorKeyPersistOutcome name (the enum is internal, so a public [Theory] cannot
+    // take it directly -- compare on .ToString()).
+    [Theory]
+    // A visible (non-empty) effective value means the persisted key surfaced -- done, regardless of mode.
+    [InlineData("a-real-persisted-key", true, "Effective")]
+    [InlineData("a-real-persisted-key", false, "Effective")]
+    // A desktop Production install (requirePersistence) whose persisted key is masked by an empty/whitespace
+    // higher-priority value must fail closed -- otherwise the next launch regenerates a different key and
+    // orphans connector credentials saved this run.
+    [InlineData("", true, "FailClosed")]
+    [InlineData("   ", true, "FailClosed")]
+    [InlineData(null, true, "FailClosed")]
+    // A non-Production harness tolerates a process-local in-memory fallback when the file reload did not
+    // propagate through every provider.
+    [InlineData("", false, "InMemoryFallback")]
+    [InlineData("   ", false, "InMemoryFallback")]
+    [InlineData(null, false, "InMemoryFallback")]
+    public void ResolveConnectorKeyPersistOutcome_FailsClosedOnlyWhenMaskedInProduction(
+        string? effectiveValue, bool requirePersistence, string expected)
+    {
+        Assert.Equal(
+            expected,
+            FirstRunBootstrapper.ResolveConnectorKeyPersistOutcome(effectiveValue, requirePersistence).ToString());
+    }
+
     // ---- GetAppDataPath ------------------------------------------------------
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -71,31 +71,82 @@ public class FirstRunBootstrapperTests
             FirstRunBootstrapper.ShouldAutoGenerateConnectorKey(isProduction, isHeadless));
     }
 
-    // ---- ResolveConnectorKeyPersistOutcome -----------------------------------
+    // ---- TryReadPersistedConnectorKey (masked-key reuse: never overwrite a persisted key) ----------
 
-    // `expected` is the ConnectorKeyPersistOutcome name (the enum is internal, so a public [Theory] cannot
-    // take it directly -- compare on .ToString()).
-    [Theory]
-    // A visible (non-empty) effective value means the persisted key surfaced -- done, regardless of mode.
-    [InlineData("a-real-persisted-key", true, "Effective")]
-    [InlineData("a-real-persisted-key", false, "Effective")]
-    // A desktop Production install (requirePersistence) whose persisted key is masked by an empty/whitespace
-    // higher-priority value must fail closed -- otherwise the next launch regenerates a different key and
-    // orphans connector credentials saved this run.
-    [InlineData("", true, "FailClosed")]
-    [InlineData("   ", true, "FailClosed")]
-    [InlineData(null, true, "FailClosed")]
-    // A non-Production harness tolerates a process-local in-memory fallback when the file reload did not
-    // propagate through every provider.
-    [InlineData("", false, "InMemoryFallback")]
-    [InlineData("   ", false, "InMemoryFallback")]
-    [InlineData(null, false, "InMemoryFallback")]
-    public void ResolveConnectorKeyPersistOutcome_FailsClosedOnlyWhenMaskedInProduction(
-        string? effectiveValue, bool requirePersistence, string expected)
+    [Fact]
+    public void TryReadPersistedConnectorKey_ReturnsPersistedKey_WhenFileHasOne()
     {
-        Assert.Equal(
-            expected,
-            FirstRunBootstrapper.ResolveConnectorKeyPersistOutcome(effectiveValue, requirePersistence).ToString());
+        var path = Path.Combine(Path.GetTempPath(), $"td-connkey-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\"Connectors\":{\"EncryptionKey\":\"K1-persisted\"},\"Jwt\":{\"SecretKey\":\"j\"}}");
+        try
+        {
+            Assert.True(FirstRunBootstrapper.TryReadPersistedConnectorKey(path, out var key));
+            Assert.Equal("K1-persisted", key);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void TryReadPersistedConnectorKey_ReturnsFalse_WhenFileMissing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"td-connkey-missing-{Guid.NewGuid():N}.json");
+        Assert.False(FirstRunBootstrapper.TryReadPersistedConnectorKey(path, out var key));
+        Assert.Null(key);
+    }
+
+    [Theory]
+    [InlineData("not json at all {{{")]                          // unparsable -> not a clean key
+    [InlineData("[]")]                                           // non-object root
+    [InlineData("{\"Connectors\":{\"EncryptionKey\":\"\"}}")]    // empty value
+    [InlineData("{\"Connectors\":{\"EncryptionKey\":\"   \"}}")] // whitespace value
+    [InlineData("{\"Jwt\":{\"SecretKey\":\"j\"}}")]              // key absent
+    public void TryReadPersistedConnectorKey_ReturnsFalse_ForUnusableContent(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"td-connkey-bad-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, content);
+        try
+        {
+            Assert.False(FirstRunBootstrapper.TryReadPersistedConnectorKey(path, out var key));
+            Assert.True(string.IsNullOrWhiteSpace(key));
+        }
+        finally { File.Delete(path); }
+    }
+
+    // ---- QuarantineCorruptLocalConfigAt (corrupt-config self-heal) ----------
+
+    [Fact]
+    public void QuarantineCorruptLocalConfigAt_PreservesAndRemovesACorruptFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"td-corrupt-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{ this is : not valid json");
+        try
+        {
+            FirstRunBootstrapper.QuarantineCorruptLocalConfigAt(path);
+
+            Assert.False(File.Exists(path),
+                "the corrupt original must be removed so the optional config source loads as missing");
+            var preserved = Directory.GetFiles(
+                Path.GetDirectoryName(path)!, Path.GetFileName(path) + ".corrupt-*");
+            Assert.Single(preserved);
+            Assert.Contains("not valid json", File.ReadAllText(preserved[0]));
+            File.Delete(preserved[0]);
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void QuarantineCorruptLocalConfigAt_LeavesAValidObjectFileUntouched()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"td-valid-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\"Connectors\":{\"EncryptionKey\":\"K1\"}}");
+        try
+        {
+            FirstRunBootstrapper.QuarantineCorruptLocalConfigAt(path);
+            Assert.True(File.Exists(path), "a valid JSON object file must be left in place");
+            Assert.Empty(Directory.GetFiles(
+                Path.GetDirectoryName(path)!, Path.GetFileName(path) + ".corrupt-*"));
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
     }
 
     // ---- GetAppDataPath ------------------------------------------------------

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -149,6 +149,37 @@ public class FirstRunBootstrapperTests
         finally { if (File.Exists(path)) File.Delete(path); }
     }
 
+    [Fact]
+    public void QuarantineCorruptLocalConfigAt_LeavesACommentedTrailingCommaFileUntouched()
+    {
+        // The JSON configuration provider accepts comments and trailing commas, so a hand-edited but
+        // loadable file must NOT be quarantined (doing so would delete a recoverable connector key).
+        var path = Path.Combine(Path.GetTempPath(), $"td-lenient-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\n  // hand-edited\n  \"Connectors\": { \"EncryptionKey\": \"K1\", },\n}");
+        try
+        {
+            FirstRunBootstrapper.QuarantineCorruptLocalConfigAt(path);
+            Assert.True(File.Exists(path),
+                "a comment / trailing-comma file the config provider accepts must be left in place");
+            Assert.Empty(Directory.GetFiles(
+                Path.GetDirectoryName(path)!, Path.GetFileName(path) + ".corrupt-*"));
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    [Fact]
+    public void TryReadPersistedConnectorKey_ReadsKey_FromCommentedTrailingCommaFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"td-lenient-key-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{\n  // hand-edited\n  \"Connectors\": { \"EncryptionKey\": \"K1-lenient\", },\n}");
+        try
+        {
+            Assert.True(FirstRunBootstrapper.TryReadPersistedConnectorKey(path, out var key));
+            Assert.Equal("K1-lenient", key);
+        }
+        finally { File.Delete(path); }
+    }
+
     // ---- GetAppDataPath ------------------------------------------------------
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -317,6 +317,20 @@ public class FirstRunBootstrapperTests
         Assert.Contains(".corrupt-", source);
     }
 
+    [Fact]
+    public void PersistValue_ParsesExistingConfigLeniently_StructuralCheck()
+    {
+        // The read-modify-write must parse an existing appsettings.local.json with the config provider's
+        // leniency (LocalConfigJsonOptions), so a hand-edited comment / trailing-comma file is preserved --
+        // a strict parse would treat it as corrupt and rewrite the file WITHOUT its existing sections,
+        // dropping the connector key. Guards against a regression back to the strict single-arg parse.
+        var source = File.ReadAllText(
+            FindSourceFile("FirstRunBootstrapper.cs"));
+
+        Assert.Contains("LocalConfigJsonOptions", source);
+        Assert.DoesNotContain("JsonNode.Parse(existing)", source);
+    }
+
     private static string FindSourceFile(string fileName)
     {
         // Walk up from the test output directory to find the repo source.

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -222,6 +222,19 @@ public class FirstRunBootstrapperTests
         Assert.Contains("!OperatingSystem.IsWindows()", source);
     }
 
+    [Fact]
+    public void PersistValue_PreservesCorruptConfigBeforeOverwriting_StructuralCheck()
+    {
+        // A corrupt appsettings.local.json may hold the only copy of a previously-generated key (the
+        // connector key in particular). Before the file is rewritten it must be backed up to a
+        // timestamped .corrupt-* sibling for operator recovery -- not silently discarded.
+        var source = File.ReadAllText(
+            FindSourceFile("FirstRunBootstrapper.cs"));
+
+        Assert.Contains("PreserveCorruptConfig", source);
+        Assert.Contains(".corrupt-", source);
+    }
+
     private static string FindSourceFile(string fileName)
     {
         // Walk up from the test output directory to find the repo source.

--- a/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs
@@ -51,6 +51,26 @@ public class FirstRunBootstrapperTests
         Assert.Equal(secrets.Count, distinct.Count);
     }
 
+    // ---- ShouldAutoGenerateConnectorKey --------------------------------------
+
+    [Theory]
+    // Non-Production (dev/staging) always generates, regardless of headless.
+    [InlineData(false, false, true)]
+    [InlineData(false, true, true)]
+    // Production + NOT headless = the desktop exe: generate so the self-contained exe is runnable
+    // without manually supplying Connectors__EncryptionKey (the generated key persists locally).
+    [InlineData(true, false, true)]
+    // Production + headless = CI / cloud container: do NOT generate -- a generated key may be
+    // ephemeral there, so these deployments must supply a stable key.
+    [InlineData(true, true, false)]
+    public void ShouldAutoGenerateConnectorKey_GeneratesExceptInHeadlessProduction(
+        bool isProduction, bool isHeadless, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            FirstRunBootstrapper.ShouldAutoGenerateConnectorKey(isProduction, isHeadless));
+    }
+
     // ---- GetAppDataPath ------------------------------------------------------
 
     [Fact]

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -15,6 +15,12 @@ WORKDIR /app
 
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
+# Mark every container built from this image as a headless deployment. This makes the first-run
+# bootstrapper REQUIRE an operator-supplied Connectors__EncryptionKey (it does not auto-generate one),
+# so a container cannot silently create an ephemeral key that is lost on recreate and would make stored
+# connector credentials unrecoverable. Only the self-contained desktop exe (not built from this image)
+# auto-generates and persists the key locally. See ADR-0041.
+ENV TASKDECK_HEADLESS=true
 
 # Install curl for HEALTHCHECK probes. aspnet:8.0 is Debian-based and has no
 # HTTP client by default. util-linux (for setpriv) is already in the base

--- a/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
+++ b/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
@@ -112,6 +112,11 @@ services:
       Jwt__Issuer: $${TASKDECK_JWT_ISSUER}
       Jwt__Audience: $${TASKDECK_JWT_AUDIENCE}
       Jwt__ExpirationMinutes: $${TASKDECK_JWT_EXPIRATION_MINUTES}
+      # The container image is headless (ENV TASKDECK_HEADLESS=true), so the bootstrapper will NOT
+      # auto-generate a connector key -- it must be supplied and kept STABLE across instance replacement
+      # (a changing key makes stored connector credentials unrecoverable). Provision it like the JWT secret
+      # (e.g. from SSM into /opt/taskdeck/.env) before enabling connectors. See ADR-0041.
+      Connectors__EncryptionKey: $${TASKDECK_CONNECTORS_ENCRYPTION_KEY}
       DevelopmentSandbox__Enabled: "false"
     volumes:
       - /var/lib/taskdeck:/app/data

--- a/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
+++ b/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
@@ -93,7 +93,17 @@ fi
 # scripts/backup.sh copies it automatically, but a DB-only restore onto a fresh volume regenerates a
 # different key and orphans stored connector credentials (see docs/platform/CLOUD_DEPLOYMENT_GUIDE.md).
 connector_key_file="/var/lib/taskdeck/connector-encryption.key"
+connector_db_file="/var/lib/taskdeck/taskdeck.db"
 if [ ! -s "$connector_key_file" ]; then
+  if [ -s "$connector_db_file" ]; then
+    # An existing database is present but no connector key sits on the volume. This is an UPGRADE from a
+    # deployment that supplied the key another way (e.g. a manual TASKDECK_CONNECTORS_ENCRYPTION_KEY in
+    # /opt/taskdeck/.env before this module generated one). Generating a fresh key here would orphan the
+    # connector credentials already encrypted under the old key. Refuse and require the operator to migrate
+    # the existing key onto the volume.
+    echo "A Taskdeck database exists at $connector_db_file but no connector key at $connector_key_file. Generating a new key would make existing connector credentials unrecoverable. Place the deployment's existing connector encryption key at $connector_key_file (chmod 600) and re-apply, or remove the database to start fresh." >&2
+    exit 1
+  fi
   ( umask 077; openssl rand -base64 32 > "$connector_key_file" )
 fi
 chmod 600 "$connector_key_file"

--- a/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
+++ b/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
@@ -89,7 +89,9 @@ fi
 # data volume so it survives instance replacement together with the database it protects -- one failure
 # domain: if the volume is ever lost, both the SQLite DB and this key are gone together, so no connector
 # credential is ever left orphaned-but-undecryptable. The format matches the app convention
-# (base64-encoded 256-bit, i.e. `openssl rand -base64 32`).
+# (base64-encoded 256-bit, i.e. `openssl rand -base64 32`). BACK UP this file with taskdeck.db --
+# scripts/backup.sh copies it automatically, but a DB-only restore onto a fresh volume regenerates a
+# different key and orphans stored connector credentials (see docs/platform/CLOUD_DEPLOYMENT_GUIDE.md).
 connector_key_file="/var/lib/taskdeck/connector-encryption.key"
 if [ ! -s "$connector_key_file" ]; then
   ( umask 077; openssl rand -base64 32 > "$connector_key_file" )

--- a/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
+++ b/deploy/terraform/aws/modules/single_node/user_data.sh.tftpl
@@ -4,7 +4,7 @@ set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get install -y ca-certificates curl gnupg unzip
+apt-get install -y ca-certificates curl gnupg unzip openssl
 
 arch="$(uname -m)"
 if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
@@ -83,6 +83,24 @@ if ! JWT_SECRET="$(aws ssm get-parameter --name '${jwt_secret_ssm_parameter_name
   exit 1
 fi
 
+# Connector encryption key. The container image is headless (ENV TASKDECK_HEADLESS=true), so the API will
+# NOT auto-generate this key: a key that changed on each boot would silently lose the ability to decrypt
+# previously-stored connector credentials (see ADR-0041). Generate it ONCE and persist it on the durable
+# data volume so it survives instance replacement together with the database it protects -- one failure
+# domain: if the volume is ever lost, both the SQLite DB and this key are gone together, so no connector
+# credential is ever left orphaned-but-undecryptable. The format matches the app convention
+# (base64-encoded 256-bit, i.e. `openssl rand -base64 32`).
+connector_key_file="/var/lib/taskdeck/connector-encryption.key"
+if [ ! -s "$connector_key_file" ]; then
+  ( umask 077; openssl rand -base64 32 > "$connector_key_file" )
+fi
+chmod 600 "$connector_key_file"
+CONNECTORS_ENCRYPTION_KEY="$(cat "$connector_key_file")"
+if [ -z "$CONNECTORS_ENCRYPTION_KEY" ]; then
+  echo "Failed to load or generate the Taskdeck connector encryption key at $connector_key_file" >&2
+  exit 1
+fi
+
 install -m 0600 /dev/null /opt/taskdeck/.env
 cat > /opt/taskdeck/.env <<'EOF'
 TASKDECK_PROXY_PORT=${proxy_port}
@@ -93,8 +111,9 @@ TASKDECK_AWS_REGION=${aws_region}
 TASKDECK_BACKUP_BUCKET=${backup_bucket_name}
 EOF
 printf 'TASKDECK_JWT_SECRET=%s\n' "$JWT_SECRET" >> /opt/taskdeck/.env
+printf 'TASKDECK_CONNECTORS_ENCRYPTION_KEY=%s\n' "$CONNECTORS_ENCRYPTION_KEY" >> /opt/taskdeck/.env
 chmod 600 /opt/taskdeck/.env
-unset JWT_SECRET
+unset JWT_SECRET CONNECTORS_ENCRYPTION_KEY
 set -x
 
 cat > /opt/taskdeck/docker-compose.yml <<'EOF'
@@ -114,8 +133,9 @@ services:
       Jwt__ExpirationMinutes: $${TASKDECK_JWT_EXPIRATION_MINUTES}
       # The container image is headless (ENV TASKDECK_HEADLESS=true), so the bootstrapper will NOT
       # auto-generate a connector key -- it must be supplied and kept STABLE across instance replacement
-      # (a changing key makes stored connector credentials unrecoverable). Provision it like the JWT secret
-      # (e.g. from SSM into /opt/taskdeck/.env) before enabling connectors. See ADR-0041.
+      # (a changing key makes stored connector credentials unrecoverable). user_data above generates one
+      # ONCE and persists it on the durable data volume (/var/lib/taskdeck/connector-encryption.key), then
+      # injects it via TASKDECK_CONNECTORS_ENCRYPTION_KEY in .env. See ADR-0041.
       Connectors__EncryptionKey: $${TASKDECK_CONNECTORS_ENCRYPTION_KEY}
       DevelopmentSandbox__Enabled: "false"
     volumes:

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -106,6 +106,11 @@ generates the key first and then passes validation.
   *differently* — which would orphan connector credentials saved this run. The remediation (unset the empty
   variable or set a real key) is named in the exception. `ResolveConnectorKeyPersistOutcome` is unit-tested
   over the visible / masked-in-Production / masked-in-harness cases.
+- **A corrupt `appsettings.local.json` is preserved, not silently overwritten.** If the file exists but is
+  unparsable (an interrupted write or a hand-edit), it may still hold the only recoverable copy of the
+  connector key. `PersistValue` now copies it to a timestamped `.corrupt-*` sibling before rewriting, so an
+  operator can recover the old key rather than have it replaced by a freshly generated one (which would
+  orphan credentials in the reused database).
 - **Staging (and any non-Production environment) auto-generates the key and is never validated**
   (`ValidateProductionSecrets` early-returns for non-Production). So a cloud Staging container does **not**
   behave like Production — it relies on its local `appsettings.local.json` persisting, with the same

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -98,19 +98,24 @@ generates the key first and then passes validation.
   while the database (in `%LOCALAPPDATA%/Taskdeck`) is reused — the new exe regenerates a different key and
   cannot decrypt the reused credentials. Until this is addressed (relocate persisted secrets to the durable
   app-data location, tracked in #1242), back up `appsettings.local.json` and prefer in-place upgrades.
-- **An empty higher-priority `Connectors__EncryptionKey` fails closed — it does not silently churn keys.**
-  Because `appsettings.local.json` loads *before* environment variables (so env vars win), an env var set to
-  an empty/whitespace value (e.g. a copied service/env template) would mask the persisted key. The desktop
-  generate path verifies the persisted key is the effective value after reload and, when it is not, **throws**
-  in Production rather than running on a process-local in-memory key that the next launch would regenerate
-  *differently* — which would orphan connector credentials saved this run. The remediation (unset the empty
-  variable or set a real key) is named in the exception. `ResolveConnectorKeyPersistOutcome` is unit-tested
-  over the visible / masked-in-Production / masked-in-harness cases.
-- **A corrupt `appsettings.local.json` is preserved, not silently overwritten.** If the file exists but is
-  unparsable (an interrupted write or a hand-edit), it may still hold the only recoverable copy of the
-  connector key. `PersistValue` now copies it to a timestamped `.corrupt-*` sibling before rewriting, so an
-  operator can recover the old key rather than have it replaced by a freshly generated one (which would
-  orphan credentials in the reused database).
+- **An empty higher-priority `Connectors__EncryptionKey` reuses the persisted key — it never overwrites or
+  churns it.** Because `appsettings.local.json` loads *before* environment variables (so env vars win), an
+  env var set to an empty/whitespace value (e.g. a copied service/env template) would mask the persisted key.
+  Critically, the generate path must not regenerate in that case: `PersistValue` overwrites the file in
+  place, so a new key would *destroy* the masked one before any after-the-fact check could fire. Instead,
+  before generating, the bootstrapper reads the key directly from the file
+  (`TryReadPersistedConnectorKey`, bypassing source precedence) and, when one exists, **reuses it** for this
+  process — so the original key (and the credentials it protects) is never destroyed and the app keeps
+  working across restarts despite the misconfigured variable. A warning names the remediation (unset the
+  empty variable). `TryReadPersistedConnectorKey` is unit-tested over present/missing/corrupt/empty content.
+- **A corrupt `appsettings.local.json` self-heals; the corrupt file is preserved, not silently discarded.**
+  If the file exists but is unparsable (an interrupted write or a hand-edit) it may still hold the only
+  recoverable copy of the connector key — *and* a malformed optional JSON source throws at config-build time,
+  which would crash startup on every launch. `AddLocalConfigFile` therefore quarantines it first
+  (`QuarantineCorruptLocalConfig`): it copies the file to a timestamped `.corrupt-*` sibling for operator
+  recovery, then removes the original so the optional source loads as "missing" and the app starts fresh
+  (regenerating a key) rather than failing to launch. The same preservation also guards an in-process
+  overwrite in `PersistValue`.
 - **Staging (and any non-Production environment) auto-generates the key and is never validated**
   (`ValidateProductionSecrets` early-returns for non-Production). So a cloud Staging container does **not**
   behave like Production — it relies on its local `appsettings.local.json` persisting, with the same

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -1,0 +1,96 @@
+# ADR-0041: Auto-Generate the Connector Encryption Key for the Desktop Exe (Headless Production Excluded)
+
+- Status: Accepted
+- Date: 2026-06-20
+- Deciders: Repository maintainers
+- Related: #1131 (CLI/fresh-machine bootstrap), ADR-0038 (Paper UI canonical / self-contained exe is the personal run path), the archive-pivot run-story
+
+## Context
+
+Taskdeck encrypts stored connector credentials with a symmetric key read from
+`Connectors:EncryptionKey`. `Infrastructure/DependencyInjection.cs` throws at startup when that key is
+empty, so the application cannot start without one.
+
+`FirstRunBootstrapper.RunFirstRunChecks` already auto-generates secrets into `appsettings.local.json`
+(next to the executable, via `AppContext.BaseDirectory`) so a checked-out or packaged build runs
+without hand-edited config: the JWT secret is generated in **all** environments, but the connector
+encryption key was generated only when **not** Production:
+
+```csharp
+if (!builder.Environment.IsProduction())
+    EnsureConnectorEncryptionKey(...);
+```
+
+The original guard exists because a **headless cloud container** that auto-generated the key would get
+an *ephemeral* one — a restart on an ephemeral or rebuilt filesystem would produce a new key and
+silently lose the ability to decrypt previously-stored connector credentials. So Production was made to
+require an operator-supplied, stable key, which `ValidateProductionSecrets` enforces by throwing.
+
+The archive pivot (ADR-0038) makes the **self-contained desktop exe the canonical personal run path**,
+and that exe runs with `ASPNETCORE_ENVIRONMENT=Production`. Under the old guard it therefore crashes on
+first launch unless the user first exports `Connectors__EncryptionKey` — defeating the pivot's
+"trivially easy to run / double-clickable" goal. But the desktop case does **not** share the cloud
+container's hazard: a desktop install persists the generated key to `appsettings.local.json` on local
+disk, so the key is **stable across restarts**.
+
+The connector key's persistence is a security-relevant startup behavior, so per `CLAUDE.md` this
+warrants an ADR.
+
+## Decision
+
+Auto-generate the connector encryption key when it is not configured **unless** the deployment is a
+**headless Production** one. The decision is a pure, unit-tested policy:
+
+```csharp
+internal static bool ShouldAutoGenerateConnectorKey(bool isProduction, bool isHeadless)
+    => !isProduction || !isHeadless;
+```
+
+- **Desktop exe (Production, NOT headless):** generate a 256-bit key and persist it to
+  `appsettings.local.json` (created `0600` on Unix before the secret is written; reloaded on the next
+  launch via `AddLocalConfigFile`). The exe becomes runnable with no manual configuration.
+- **Headless Production (CI / cloud container):** detected via `CI` / `TF_BUILD` / `GITHUB_ACTIONS` /
+  `TASKDECK_HEADLESS`. The key is **not** generated; the deployment must supply a stable key, and
+  `ValidateProductionSecrets` hard-fails (throws) if it is missing — unchanged behavior.
+- **Non-Production (Development/Staging/Test):** generate as before — unchanged behavior.
+
+`RunFirstRunChecks` runs before `ValidateProductionSecrets` in `Program.cs`, so a desktop launch
+generates the key first and then passes validation.
+
+## Alternatives Considered
+
+- **Keep requiring an operator-supplied key in all Production.** Rejected: it is the status quo that
+  makes the canonical desktop exe non-double-clickable, directly blocking the pivot run-story.
+- **Auto-generate in all Production (including cloud containers).** Rejected: reintroduces the original
+  hazard — an ephemeral key on a container restart loses the ability to decrypt stored connector
+  credentials. The headless carve-out preserves that protection where it matters.
+- **Generate the key into an OS keychain / external secret store.** Rejected as over-engineered for a
+  single-user local tool; the existing `appsettings.local.json` mechanism (already used for the JWT
+  secret) is consistent and sufficient.
+- **Gate on a bespoke `FirstRun:AutoConnectorKey` flag instead of headless detection.** Rejected: adds
+  configuration surface; the existing `IsHeadlessEnvironment()` signal already distinguishes desktop
+  from CI/cloud and is reused here.
+
+## Consequences
+
+- The self-contained desktop exe runs on first launch with no manual key configuration (pivot goal:
+  trivially easy to run).
+- The generated connector key lives in `appsettings.local.json` next to the exe. **Operationally:** that
+  file must be backed up alongside the SQLite database — deleting it makes previously-stored connector
+  credentials undecryptable (the encrypted data remains but cannot be read). This is the same trade-off
+  that already applies to the auto-generated JWT secret.
+- Cloud/CI behavior is unchanged: headless Production still requires a supplied stable key and hard-fails
+  without one.
+- A desktop deployment intentionally run headless (operator sets `TASKDECK_HEADLESS`) opts into the
+  supply-your-own-key contract — an explicit, documented trade-off.
+- `ShouldAutoGenerateConnectorKey` is covered by a unit test over all four `(isProduction, isHeadless)`
+  combinations, decoupling the policy from the process's own environment (the CI runner is itself
+  "headless", which made the branch otherwise hard to test directly).
+
+## References
+
+- #1131 — CLI/fresh-machine bootstrap (this ADR addresses the API/desktop-exe connector-key half)
+- ADR-0038 — Paper UI Is the Canonical Frontend / self-contained exe is the personal run path
+- `backend/src/Taskdeck.Api/FirstRun/FirstRunBootstrapper.cs` — `RunFirstRunChecks`,
+  `ShouldAutoGenerateConnectorKey`, `EnsureConnectorEncryptionKey`, `ValidateProductionSecrets`
+- `backend/tests/Taskdeck.Api.Tests/FirstRun/FirstRunBootstrapperTests.cs` — policy unit test

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -47,11 +47,20 @@ internal static bool ShouldAutoGenerateConnectorKey(bool isProduction, bool isHe
 ```
 
 - **Desktop exe (Production, NOT headless):** generate a 256-bit key and persist it to
-  `appsettings.local.json` (created `0600` on Unix before the secret is written; reloaded on the next
-  launch via `AddLocalConfigFile`). The exe becomes runnable with no manual configuration.
+  `appsettings.local.json`, reloaded on the next launch via `AddLocalConfigFile`. The exe becomes
+  runnable with no manual configuration. On Unix the file is created `0600` before the secret is written;
+  **on Windows (the primary desktop target) the file is NOT permission-restricted** — at-rest protection
+  relies on the user-profile / disk security. Hardening the Windows ACL is tracked in #1241. If the write
+  fails (e.g. a read-only install directory), startup **fails loudly** (throws) rather than running with
+  an ephemeral in-memory key that would be lost on restart and orphan stored connector credentials.
 - **Headless Production (CI / cloud container):** detected via `CI` / `TF_BUILD` / `GITHUB_ACTIONS` /
   `TASKDECK_HEADLESS`. The key is **not** generated; the deployment must supply a stable key, and
-  `ValidateProductionSecrets` hard-fails (throws) if it is missing — unchanged behavior.
+  `ValidateProductionSecrets` hard-fails (throws) if it is missing — unchanged behavior. Because the
+  CI-marker set does not by itself identify a server/container, **the container image
+  (`deploy/docker/backend.Dockerfile`) sets `TASKDECK_HEADLESS=true`**, so every container — bare
+  `docker run`, compose, or terraform — is classified headless and cannot auto-generate an ephemeral key.
+  A desktop machine with an ambient `CI` variable is likewise treated as headless and will hard-fail
+  (fail-safe, not silent) until a key is supplied or `CI` is unset.
 - **Non-Production (Development/Staging/Test):** generate as before — unchanged behavior.
 
 `RunFirstRunChecks` runs before `ValidateProductionSecrets` in `Program.cs`, so a desktop launch
@@ -77,8 +86,17 @@ generates the key first and then passes validation.
   trivially easy to run).
 - The generated connector key lives in `appsettings.local.json` next to the exe. **Operationally:** that
   file must be backed up alongside the SQLite database — deleting it makes previously-stored connector
-  credentials undecryptable (the encrypted data remains but cannot be read). This is the same trade-off
-  that already applies to the auto-generated JWT secret.
+  credentials undecryptable (the encrypted data remains but cannot be read). The runtime log emitted at
+  generation states this. The JWT secret shares the same persistence/backup model, **but not the headless
+  behavior:** `EnsureJwtSecret` runs unconditionally (it auto-generates even in headless Production, where
+  an ephemeral JWT secret only forces re-login), whereas the connector key is deliberately *not*
+  auto-generated in headless Production because an ephemeral one would cause data loss, not just re-login.
+- **At rest, the key file is only `0600`-restricted on Unix; on Windows it inherits default NTFS ACLs**
+  (tracked in #1241). For the single-user desktop target this relies on the user's profile security.
+- **Staging (and any non-Production environment) auto-generates the key and is never validated**
+  (`ValidateProductionSecrets` early-returns for non-Production). So a cloud Staging container does **not**
+  behave like Production — it relies on its local `appsettings.local.json` persisting, with the same
+  backup caveat. This is unchanged by this ADR but worth stating explicitly.
 - Cloud/CI behavior is unchanged: headless Production still requires a supplied stable key and hard-fails
   without one.
 - A desktop deployment intentionally run headless (operator sets `TASKDECK_HEADLESS`) opts into the

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -104,6 +104,15 @@ generates the key first and then passes validation.
   backup caveat. This is unchanged by this ADR but worth stating explicitly.
 - Cloud/CI behavior is unchanged: headless Production still requires a supplied stable key and hard-fails
   without one.
+- **The bundled AWS single-node Terraform module supplies that stable key itself.** `user_data.sh.tftpl`
+  generates the connector key once (`openssl rand -base64 32`) and persists it to
+  `/var/lib/taskdeck/connector-encryption.key` on the durable EBS data volume — the same volume that holds
+  the SQLite database — then injects it into the container via `.env`. The key therefore survives instance
+  replacement (with `user_data_replace_on_change`) alongside the credentials it protects: one failure
+  domain, so the volume can never be retained with an undecryptable database, nor the key orphaned from it.
+  Unlike the JWT secret (sourced from SSM/KMS for central rotation), the connector key's natural lifecycle
+  is tied to the data volume, so co-locating it there is both simpler and avoids the empty-value crash that
+  an unprovisioned `Connectors__EncryptionKey` would otherwise cause once the image is headless.
 - A desktop deployment intentionally run headless (operator sets `TASKDECK_HEADLESS`) opts into the
   supply-your-own-key contract — an explicit, documented trade-off.
 - `ShouldAutoGenerateConnectorKey` is covered by a unit test over all four `(isProduction, isHeadless)`

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -93,6 +93,11 @@ generates the key first and then passes validation.
   auto-generated in headless Production because an ephemeral one would cause data loss, not just re-login.
 - **At rest, the key file is only `0600`-restricted on Unix; on Windows it inherits default NTFS ACLs**
   (tracked in #1241). For the single-user desktop target this relies on the user's profile security.
+- **The key persists next to the exe (`AppContext.BaseDirectory`), not in the app-data directory where
+  the database lives.** Moving or upgrading the exe to a *different folder* therefore orphans the key
+  while the database (in `%LOCALAPPDATA%/Taskdeck`) is reused — the new exe regenerates a different key and
+  cannot decrypt the reused credentials. Until this is addressed (relocate persisted secrets to the durable
+  app-data location, tracked in #1242), back up `appsettings.local.json` and prefer in-place upgrades.
 - **Staging (and any non-Production environment) auto-generates the key and is never validated**
   (`ValidateProductionSecrets` early-returns for non-Production). So a cloud Staging container does **not**
   behave like Production — it relies on its local `appsettings.local.json` persisting, with the same

--- a/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
+++ b/docs/decisions/ADR-0041-desktop-connector-key-autogeneration.md
@@ -98,6 +98,14 @@ generates the key first and then passes validation.
   while the database (in `%LOCALAPPDATA%/Taskdeck`) is reused — the new exe regenerates a different key and
   cannot decrypt the reused credentials. Until this is addressed (relocate persisted secrets to the durable
   app-data location, tracked in #1242), back up `appsettings.local.json` and prefer in-place upgrades.
+- **An empty higher-priority `Connectors__EncryptionKey` fails closed — it does not silently churn keys.**
+  Because `appsettings.local.json` loads *before* environment variables (so env vars win), an env var set to
+  an empty/whitespace value (e.g. a copied service/env template) would mask the persisted key. The desktop
+  generate path verifies the persisted key is the effective value after reload and, when it is not, **throws**
+  in Production rather than running on a process-local in-memory key that the next launch would regenerate
+  *differently* — which would orphan connector credentials saved this run. The remediation (unset the empty
+  variable or set a real key) is named in the exception. `ResolveConnectorKeyPersistOutcome` is unit-tested
+  over the visible / masked-in-Production / masked-in-harness cases.
 - **Staging (and any non-Production environment) auto-generates the key and is never validated**
   (`ValidateProductionSecrets` early-returns for non-Production). So a cloud Staging container does **not**
   behave like Production — it relies on its local `appsettings.local.json` persisting, with the same

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -42,3 +42,4 @@
 | [0038](ADR-0038-paper-ui-canonical.md) | Paper UI Is the Canonical Frontend (Legacy Frozen) | Accepted | 2026-06-13 |
 | [0039](ADR-0039-central-package-management-sdk-pin.md) | Central Package Management, SDK Pin, and 8.x Dependency Alignment | Accepted | 2026-06-13 |
 | [0040](ADR-0040-utc-datetime-materialization-convention.md) | Global UTC DateTime Materialization Convention for SQLite | Accepted | 2026-06-13 |
+| [0041](ADR-0041-desktop-connector-key-autogeneration.md) | Auto-Generate the Connector Encryption Key for the Desktop Exe (Headless Production Excluded) | Accepted | 2026-06-20 |

--- a/docs/platform/CLOUD_DEPLOYMENT_GUIDE.md
+++ b/docs/platform/CLOUD_DEPLOYMENT_GUIDE.md
@@ -245,6 +245,16 @@ Cloud platform volumes are not automatically backed up. Implement a backup strat
 > incomplete backup. Use the `sqlite3 .backup` command instead, which is safe
 > for online backups regardless of journal mode.
 
+> **Critical — back up the connector encryption key with the database.** The key that
+> decrypts stored connector credentials must be restored *unchanged*. If it is supplied via
+> `Connectors__EncryptionKey` (environment or secret store), keep that value safe. If the
+> deployment generated the key onto the data volume instead — the AWS single-node Terraform
+> module writes `connector-encryption.key` next to `taskdeck.db` — **that file must be backed
+> up and restored alongside the database**. Restoring only `taskdeck.db` onto a fresh volume
+> makes the app generate a *different* key, leaving every stored connector credential
+> undecryptable. `scripts/backup.sh` copies a sibling `connector-encryption.key` automatically;
+> the manual `sqlite3 .backup` steps below do **not**, so copy the key file yourself.
+
 1. **Railway**: Use the Railway CLI to open a shell, then run:
    ```bash
    sqlite3 /app/data/taskdeck.db ".backup /tmp/taskdeck-backup.db"

--- a/docs/platform/CLOUD_DEPLOYMENT_GUIDE.md
+++ b/docs/platform/CLOUD_DEPLOYMENT_GUIDE.md
@@ -254,6 +254,12 @@ Cloud platform volumes are not automatically backed up. Implement a backup strat
 > makes the app generate a *different* key, leaving every stored connector credential
 > undecryptable. `scripts/backup.sh` copies a sibling `connector-encryption.key` automatically;
 > the manual `sqlite3 .backup` steps below do **not**, so copy the key file yourself.
+>
+> **On restore**, the container reads `Connectors__EncryptionKey` from its *environment* (injected at
+> deploy time), not from the key file. So after restoring the paired key, you must also update the
+> injected value (`.env` / secret) to the restored key and **recreate** the service — a plain restart
+> keeps using the stale key. `scripts/restore.sh` / `restore.ps1` restore the key file and print this
+> reminder; on the AWS Terraform path, replacing the instance re-renders `.env` from the restored key file.
 
 1. **Railway**: Use the Railway CLI to open a shell, then run:
    ```bash

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -170,6 +170,26 @@ fi
 echo "Backup written: $BACKUP_FILE"
 
 # ---------------------------------------------------------------------------
+# Connector encryption key (container / Terraform deployments)
+# ---------------------------------------------------------------------------
+# Deployments that generate the connector key onto the data volume keep it as a
+# sibling of the database -- e.g. the AWS single-node Terraform module writes
+# /var/lib/taskdeck/connector-encryption.key next to taskdeck.db. That key is
+# REQUIRED to decrypt stored connector credentials, so a DB-only backup would
+# restore credentials that can no longer be read. Copy it alongside the DB
+# backup (paired by timestamp) whenever it is present next to the database.
+# (Desktop installs keep the key in appsettings.local.json instead -- back that
+# up separately; it is not a sibling of the DB so nothing is copied here.)
+DB_DIR="$(dirname "$DB_PATH")"
+CONNECTOR_KEY_FILE="${DB_DIR}/connector-encryption.key"
+if [[ -f "$CONNECTOR_KEY_FILE" ]]; then
+    KEY_BACKUP_FILE="${BACKUP_FILE%.db}.connector-encryption.key"
+    cp "$CONNECTOR_KEY_FILE" "$KEY_BACKUP_FILE"
+    chmod 600 "$KEY_BACKUP_FILE"
+    echo "Connector key backed up: $KEY_BACKUP_FILE"
+fi
+
+# ---------------------------------------------------------------------------
 # Retention: keep only the N most-recent backups; delete older ones
 # ---------------------------------------------------------------------------
 # List backups sorted newest-first (ls -t); delete all but the first $RETAIN entries.
@@ -188,6 +208,8 @@ if [[ "$TOTAL" -gt "$RETAIN" ]]; then
     for (( i = RETAIN; i < TOTAL; i++ )); do
         VICTIM="${ALL_BACKUPS[$i]}"
         rm -f "$VICTIM"
+        # Remove the paired connector-key copy, if any, so retention keeps DB+key pairs together.
+        rm -f "${VICTIM%.db}.connector-encryption.key"
         echo "Removed old backup: $VICTIM"
     done
     echo "Retention: kept $RETAIN of $TOTAL backups, removed $DELETE_COUNT."

--- a/scripts/restore.ps1
+++ b/scripts/restore.ps1
@@ -44,6 +44,25 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+# Restrict a file to the current owner only (no inherited/other-user access). Used for the restored DB,
+# the connector key, and their safety copies so a multi-user data directory does not expose secrets.
+function Set-OwnerOnlyAcl {
+    param([string]$Path)
+    try {
+        $acl = Get-Acl $Path
+        $acl.SetAccessRuleProtection($true, $false)
+        $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) | Out-Null }
+        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            [System.Security.Principal.WindowsIdentity]::GetCurrent().Name,
+            "FullControl", "None", "None", "Allow"
+        )
+        $acl.AddAccessRule($rule)
+        Set-Acl $Path $acl
+    } catch {
+        Write-Warning "Could not restrict ACL on ${Path}: $_"
+    }
+}
+
 # ---------------------------------------------------------------------------
 # Validate backup file exists
 # ---------------------------------------------------------------------------
@@ -258,8 +277,10 @@ if (Test-Path $PairedKey -PathType Leaf) {
     if (Test-Path $LiveKey -PathType Leaf) {
         $SafetyKey = Join-Path $SafetyDir "connector-encryption-pre-restore-$Timestamp.key"
         Copy-Item $LiveKey $SafetyKey -Force -ErrorAction SilentlyContinue
+        if (Test-Path $SafetyKey -PathType Leaf) { Set-OwnerOnlyAcl $SafetyKey }
     }
     Copy-Item $PairedKey $LiveKey -Force
+    Set-OwnerOnlyAcl $LiveKey
     Write-Host "Restored connector key: $PairedKey -> $LiveKey"
     Write-Warning "If this deployment INJECTS the connector key via an environment file or secret store (container/Compose deployments read Connectors__EncryptionKey from the environment, not from this file), update that injected value to match the restored key and RECREATE the service -- a plain restart keeps using the stale key and leaves restored credentials undecryptable."
 } elseif (Test-Path $LiveKey -PathType Leaf) {

--- a/scripts/restore.ps1
+++ b/scripts/restore.ps1
@@ -261,6 +261,7 @@ if (Test-Path $PairedKey -PathType Leaf) {
     }
     Copy-Item $PairedKey $LiveKey -Force
     Write-Host "Restored connector key: $PairedKey -> $LiveKey"
+    Write-Warning "If this deployment INJECTS the connector key via an environment file or secret store (container/Compose deployments read Connectors__EncryptionKey from the environment, not from this file), update that injected value to match the restored key and RECREATE the service -- a plain restart keeps using the stale key and leaves restored credentials undecryptable."
 } elseif (Test-Path $LiveKey -PathType Leaf) {
     Write-Warning "The backup has no paired connector key, but one exists at $LiveKey. If the restored database was encrypted under a different key, its connector credentials will be undecryptable. Ensure the correct connector-encryption.key is in place."
 }

--- a/scripts/restore.ps1
+++ b/scripts/restore.ps1
@@ -245,4 +245,24 @@ if ($Sqlite3) {
     Write-Host "Post-restore integrity check: ok"
 }
 
+# ---------------------------------------------------------------------------
+# Step 6: Restore the paired connector encryption key (if the backup has one)
+# ---------------------------------------------------------------------------
+# backup.sh writes a sibling <backup>.connector-encryption.key alongside the .db for deployments that keep
+# the key on the data volume. The restored DB's connector credentials are encrypted under THAT key, so it
+# must be restored next to the DB -- otherwise the app runs with a different/missing key and the credentials
+# are undecryptable.
+$PairedKey = ($BackupFile -replace '\.db$', '') + ".connector-encryption.key"
+$LiveKey   = Join-Path $DbDir "connector-encryption.key"
+if (Test-Path $PairedKey -PathType Leaf) {
+    if (Test-Path $LiveKey -PathType Leaf) {
+        $SafetyKey = Join-Path $SafetyDir "connector-encryption-pre-restore-$Timestamp.key"
+        Copy-Item $LiveKey $SafetyKey -Force -ErrorAction SilentlyContinue
+    }
+    Copy-Item $PairedKey $LiveKey -Force
+    Write-Host "Restored connector key: $PairedKey -> $LiveKey"
+} elseif (Test-Path $LiveKey -PathType Leaf) {
+    Write-Warning "The backup has no paired connector key, but one exists at $LiveKey. If the restored database was encrypted under a different key, its connector credentials will be undecryptable. Ensure the correct connector-encryption.key is in place."
+}
+
 Write-Host "Done. Restart the Taskdeck API to pick up the restored database."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -287,6 +287,10 @@ if [[ -f "$PAIRED_KEY" ]]; then
     cp "$PAIRED_KEY" "$LIVE_KEY"
     chmod 600 "$LIVE_KEY"
     echo "Restored connector key: $PAIRED_KEY -> $LIVE_KEY"
+    echo "NOTE: if this deployment INJECTS the connector key via an environment file or secret store" >&2
+    echo "      (container/Compose deployments read Connectors__EncryptionKey from the environment, not from" >&2
+    echo "      this file), update that injected value to match the restored key and RECREATE the service --" >&2
+    echo "      a plain restart keeps using the stale key and leaves restored credentials undecryptable." >&2
 elif [[ -f "$LIVE_KEY" ]]; then
     echo "WARNING: the backup has no paired connector key, but one exists at $LIVE_KEY." >&2
     echo "         If the restored database was encrypted under a different key, its connector credentials" >&2

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -270,4 +270,27 @@ if command -v sqlite3 &>/dev/null; then
     echo "Post-restore integrity check: ok"
 fi
 
+# ---------------------------------------------------------------------------
+# Step 6: Restore the paired connector encryption key (if the backup has one)
+# ---------------------------------------------------------------------------
+# backup.sh writes a sibling <backup>.connector-encryption.key alongside the .db for deployments that keep
+# the key on the data volume. The restored DB's connector credentials are encrypted under THAT key, so it
+# must be restored next to the DB -- otherwise the app runs with a different/missing key and the credentials
+# are undecryptable.
+PAIRED_KEY="${BACKUP_FILE%.db}.connector-encryption.key"
+LIVE_KEY="${DB_DIR}/connector-encryption.key"
+if [[ -f "$PAIRED_KEY" ]]; then
+    if [[ -f "$LIVE_KEY" ]]; then
+        SAFETY_KEY="${SAFETY_DIR}/connector-encryption-pre-restore-${TIMESTAMP}.key"
+        cp "$LIVE_KEY" "$SAFETY_KEY" 2>/dev/null && chmod 600 "$SAFETY_KEY" 2>/dev/null || true
+    fi
+    cp "$PAIRED_KEY" "$LIVE_KEY"
+    chmod 600 "$LIVE_KEY"
+    echo "Restored connector key: $PAIRED_KEY -> $LIVE_KEY"
+elif [[ -f "$LIVE_KEY" ]]; then
+    echo "WARNING: the backup has no paired connector key, but one exists at $LIVE_KEY." >&2
+    echo "         If the restored database was encrypted under a different key, its connector credentials" >&2
+    echo "         will be undecryptable. Ensure the correct connector-encryption.key is in place." >&2
+fi
+
 echo "Done. Restart the Taskdeck API to pick up the restored database."


### PR DESCRIPTION
## Summary
Addresses the run-story half of #1131 (Wave-5). The self-contained desktop exe runs with `ASPNETCORE_ENVIRONMENT=Production`, where `FirstRunBootstrapper` **skipped** connector-key auto-generation — so the exe crashed on first launch (`Connectors:EncryptionKey` empty → `DependencyInjection` throws / `ValidateProductionSecrets` hard-fails) unless the user first exported `Connectors__EncryptionKey`. That defeats the archive-pivot "double-clickable" goal (ADR-0038).

## Approach
The original Production skip exists to stop a **headless cloud container** from generating an *ephemeral* key (a restart would produce a new key and lose the ability to decrypt stored connector credentials). A **desktop** install doesn't share that hazard: it persists the generated key to `appsettings.local.json` next to the exe, so it's stable across restarts.

So auto-generation is now gated on a pure, testable policy:
```csharp
internal static bool ShouldAutoGenerateConnectorKey(bool isProduction, bool isHeadless)
    => !isProduction || !isHeadless;
```
- **Desktop exe** (Production, not headless) → generate + persist locally → self-runnable.
- **Headless Production** (CI / cloud, via `CI`/`TF_BUILD`/`GITHUB_ACTIONS`/`TASKDECK_HEADLESS`) → **not** generated; must supply a stable key; `ValidateProductionSecrets` still hard-fails without one (**unchanged**).
- **Non-Production** (dev/staging/test) → generate as before (**unchanged**).

`RunFirstRunChecks` runs before `ValidateProductionSecrets` in `Program.cs`, so a desktop launch generates the key then passes validation.

## Security / ADR
This is a startup security-posture decision → **ADR-0041** (Accepted) documents the rationale, the headless carve-out, and the operational note (the generated key in `appsettings.local.json` must be backed up alongside the SQLite DB — deleting it makes stored connector credentials undecryptable, same as the existing auto-generated JWT secret).

## Tests
- `ShouldAutoGenerateConnectorKey_GeneratesExceptInHeadlessProduction` — all four `(isProduction, isHeadless)` combinations. Pure function, so it's decoupled from the CI runner's own (headless) environment.

## Verification
- `dotnet build backend/src/Taskdeck.Api` (+ Api.Tests): clean.
- FirstRun + OptionsValidation + Bootstrap suites: **119 passed**.
- `node scripts/check-docs-governance.mjs`: passed.

## Scope note
This is the **API/desktop-exe** connector-key half of #1131. The issue's CLI half (CLI never runs the bootstrapper; CLI mutations bypass board-access authz) remains open and is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)