### PR TITLE
deps(npm): cap @types/node to the Node 24 runtime major (closes #1230)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,6 +104,19 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # @types/node must track the pinned Node RUNTIME major, not float ahead of
+      # it. The frontend pins Node to the 24.x line (package.json engines
+      # ">=24.13.1 <25", .nvmrc 24.13.1, every CI job on node-version 24.13.1).
+      # @types/node's major tracks the Node major it describes, so on Node 24 the
+      # correct types line is 24.x. Without this cap dependabot drifted it to 25.x
+      # (one major ahead) and then proposed 26.0.0 (two ahead, PR #1230), widening
+      # the gap between the typed and the executed Node API surface. This is the
+      # frontend analog of the runtime-coupled NuGet caps (ADR-0034/ADR-0039):
+      # block the major, let 24.x minor/patch flow. Remove only when the Node
+      # runtime pin is deliberately moved to a new major (engines + .nvmrc + CI).
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps(npm)"
 

--- a/docs/decisions/ADR-0034-dependency-version-caps.md
+++ b/docs/decisions/ADR-0034-dependency-version-caps.md
@@ -67,10 +67,27 @@ is discoverable and removed deliberately rather than incidentally.
 - Caps are intentionally narrow (named packages, major-only) to avoid masking other
   legitimate updates.
 
+## Amendments
+
+- **2026-06-26 — extended to npm (`@types/node` ↔ Node runtime pin).** The same
+  cap mechanism now applies to the frontend npm ecosystem, not only backend NuGet.
+  `@types/node` is capped to **major-only `ignore`** so it tracks the pinned Node
+  **runtime** major (24.x: `engines ">=24.13.1 <25"`, `.nvmrc 24.13.1`, every CI job
+  on `node-version 24.13.1`) instead of floating ahead of it. `@types/node`'s major
+  tracks the Node major it describes, so on Node 24 the correct types line is 24.x;
+  dependabot had drifted it to 25.x and then proposed 26.0.0 (PR #1230 — closed in
+  favour of this cap), widening the gap between the typed and the executed Node API
+  surface. The decision and removal condition (only when the Node runtime pin moves
+  to a new major — `engines` + `.nvmrc` + CI `node-version` together) are recorded in
+  the `DEPENDENCY_UPDATE_POLICY.md` cap table alongside the NuGet caps. This is the
+  same pattern (narrow, major-only, declarative) applied to a runtime-coupled
+  **dev-time** type package; the rationale mirrors the runtime-pin caps of ADR-0039.
+
 ## References
 
 - `.github/dependabot.yml` (the `ignore` rules)
 - `docs/ops/DEPENDENCY_UPDATE_POLICY.md` (Pinned / version-capped dependencies table)
-- PRs: #1102, #1106 (EF pins), #1112 (EF ignore rule), #1088 (FluentAssertions 7.x), #1118 (FluentAssertions ignore rule); #1117 (closed v8 bump)
+- PRs: #1102, #1106 (EF pins), #1112 (EF ignore rule), #1088 (FluentAssertions 7.x), #1118 (FluentAssertions ignore rule); #1117 (closed v8 bump); #1230 (closed `@types/node` 26 bump superseded by the npm cap)
 - Prior EF pin rationale: #760/#767
+- Runtime-pin caps and CPM/SDK pin rationale: ADR-0039
 - `docs/agentic/FAILURE_LEDGER.md` (2026-05-29 entries)

--- a/docs/ops/DEPENDENCY_UPDATE_POLICY.md
+++ b/docs/ops/DEPENDENCY_UPDATE_POLICY.md
@@ -1,6 +1,6 @@
 # Dependency Update Policy
 
-Last Updated: 2026-06-13
+Last Updated: 2026-06-26
 Owner: Repository maintainers
 Linked issue: `#148` (OPS-18)
 
@@ -136,6 +136,7 @@ coordinated migration), not incidentally.
 | `Microsoft.AspNetCore.SignalR.Client`, `Microsoft.Extensions.Hosting`, `Microsoft.Extensions.Http.Polly`, `Microsoft.Extensions.Logging.Abstractions` | major bumps blocked (stay on 8.x) | These had drifted to 10.0.8 while the backend targets `net8.0`. CPM aligned them to the 8.0.x family (#1127, ADR-0039); without major caps the next weekly Dependabot run re-proposes 9.x/10.x and reverts the alignment. | The backend is migrated off `net8.0` as one coordinated migration. |
 | `FluentAssertions` | major bumps blocked (stay on 7.x) | FluentAssertions 8.x+ requires a paid commercial license (Xceed); 7.x is the last free line. Maintainer decision on #1088. | The project purchases the Xceed license, or migrates to a free assertion library. |
 | `StackExchange.Redis`, `Microsoft.AspNetCore.SignalR.StackExchangeRedis` | major bumps blocked | Both direct Redis packages back the SignalR backplane (ADR-0025) and the optional Redis cache service (`RedisCacheService`), both config-gated and **dormant** in the single-instance default (`Cache:Provider=InMemory`, empty `SignalR:Redis` connection string). Under the archive pivot a major bump carries breaking-change risk on never-exercised runtime paths with no benefit (PR #1224 closed for proposing `StackExchange.Redis` 3.0.0); the backplane package is capped alongside the client so its own major can't reopen the same churn (#1225). | Redis is ever deliberately activated (multi-instance scale-out or Redis cache), as a coordinated change. |
+| `@types/node` (npm, frontend) | major bumps blocked (stay on 24.x) | `@types/node` must track the pinned Node **runtime** major, not float ahead of it. The frontend pins Node to the 24.x line (`engines: ">=24.13.1 <25"`, `.nvmrc` `24.13.1`, every CI job on `node-version: 24.13.1`); `@types/node`'s major tracks the Node major it describes, so on Node 24 the correct types line is `24.x`. Without the cap dependabot drifted it to 25.x (one major ahead) and then proposed 26.0.0 (two ahead, PR #1230 — closed in favour of this cap), widening the gap between the typed and the executed Node API surface. This is the frontend analog of the runtime-coupled NuGet caps below/above (ADR-0034). Minor/patch within 24.x still flow. | The Node runtime pin is deliberately moved to a new major — update `engines`, `.nvmrc`, and the CI `node-version` together, then realign `@types/node` to match. |
 
 ## Central Package Management (backend NuGet)
 

--- a/frontend/taskdeck-web/package-lock.json
+++ b/frontend/taskdeck-web/package-lock.json
@@ -27,7 +27,7 @@
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@tailwindcss/postcss": "^4.3.1",
         "@types/dompurify": "^3.2.0",
-        "@types/node": "^25.9.3",
+        "@types/node": "^24.13.1",
         "@typescript-eslint/eslint-plugin": "^8.61.1",
         "@typescript-eslint/parser": "^8.46.2",
         "@vitejs/plugin-vue": "^6.0.7",
@@ -5213,13 +5213,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -12690,9 +12690,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/frontend/taskdeck-web/package.json
+++ b/frontend/taskdeck-web/package.json
@@ -60,7 +60,7 @@
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@tailwindcss/postcss": "^4.3.1",
     "@types/dompurify": "^3.2.0",
-    "@types/node": "^25.9.3",
+    "@types/node": "^24.13.1",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.46.2",
     "@vitejs/plugin-vue": "^6.0.7",


### PR DESCRIPTION
## Summary

Resolves the deferred posture question on **#1230** (`@types/node` 25→26 bump) by adopting the **cap-to-runtime** option — the consistency-preserving choice the #1230 assessment flagged as preferred.

`@types/node` must track the pinned Node **runtime** major, not float ahead of it. The frontend pins Node to the 24.x line:
- `package.json` `engines`: `">=24.13.1 <25"`
- `.nvmrc`: `24.13.1`
- every CI job: `node-version: 24.13.1`

`@types/node`'s major tracks the Node major it describes, so on Node 24 the correct types line is **24.x**. Dependabot (which had no npm `ignore` rules) drifted it to **25.x** — one major ahead of the runtime — and #1230 proposed **26.0.0**, two ahead, widening the gap between the *typed* and the *executed* Node API surface (it also dragged `undici-types` to a new major).

This is the frontend analog of the runtime-coupled NuGet caps (ADR-0034 / ADR-0039): re-align **down** to the runtime major and add a **major-only** dependabot `ignore` so the cap is durable, not a one-off close that dependabot re-proposes every week.

## Changes

| File | Change |
|---|---|
| `frontend/taskdeck-web/package.json` | `@types/node` `^25.9.3` → `^24.13.1` |
| `frontend/taskdeck-web/package-lock.json` | regenerated → `@types/node@24.13.2` (latest 24.x) |
| `.github/dependabot.yml` | npm `ignore`: `@types/node` `version-update:semver-major` (minor/patch still flow) |
| `docs/ops/DEPENDENCY_UPDATE_POLICY.md` | cap-table row + `Last Updated: 2026-06-26` |
| `docs/decisions/ADR-0034-...md` | amendment recording the cap mechanism extending to npm (first frontend cap) |

## Removal condition

The cap is removed **deliberately** only when the Node runtime pin moves to a new major — update `engines` + `.nvmrc` + CI `node-version` together, then realign `@types/node` to match.

## Verification

From `frontend/taskdeck-web`:
- `npm install` → `@types/node` resolves to `24.13.2`
- `npm run typecheck` → **clean** (no vue-tsc errors)
- `npm run build` → **green** (PWA generated; only pre-existing Rolldown bundling warnings, unrelated to types)

Closes #1230.