### PR TITLE
fix(queue): bound the two remaining unbounded LlmQueue Pending reads (#1237)

### DIFF
--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -24,10 +24,11 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
     Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns all requests with the given status, newest-first, unbounded. Callers that genuinely need
-    /// the full set rely on this (the health backlog gauge measures total depth), so do NOT add a default
-    /// cap here. Bounded background work-drains must use the type-aware <c>GetOldest*</c> methods below;
-    /// a bounded DISPLAY listing must use <see cref="GetByStatusForDisplayAsync"/>.
+    /// Returns all requests with the given status, newest-first, unbounded. The health backlog gauge
+    /// currently inspects every row through this (it should move to count primitives — tracked in #1251),
+    /// so do NOT add a default cap here. Bounded background work-drains must use the type-aware
+    /// <c>GetOldest*</c> methods below; a bounded DISPLAY listing must use
+    /// <see cref="GetByStatusForDisplayAsync"/>.
     /// </summary>
     Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, CancellationToken cancellationToken = default);
 

--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -24,12 +24,20 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
     Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns all requests with the given status, newest-first, unbounded. Callers that need the
-    /// full set rely on this (the health backlog gauge and the ops queue listing count/inspect every
-    /// row), so do NOT add a default cap here. Bounded background work-drains must use the type-aware
-    /// <c>GetOldest*</c> methods below, which bound the read at the database.
+    /// Returns all requests with the given status, newest-first, unbounded. Callers that genuinely need
+    /// the full set rely on this (the health backlog gauge measures total depth), so do NOT add a default
+    /// cap here. Bounded background work-drains must use the type-aware <c>GetOldest*</c> methods below;
+    /// a bounded DISPLAY listing must use <see cref="GetByStatusForDisplayAsync"/>.
     /// </summary>
     Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns at most <paramref name="limit"/> requests in a status, newest-first, bounded at the
+    /// database — for DISPLAY / diagnostics (the CLI ops queue listing). Claim/processing paths must NOT
+    /// use this: they require the type-aware <c>GetOldest*</c> primitives so bounding never starves
+    /// non-capture work (#1195).
+    /// </summary>
+    Task<IEnumerable<LlmRequest>> GetByStatusForDisplayAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns at most <paramref name="limit"/> Pending non-capture (automation) requests, oldest-first,

--- a/backend/src/Taskdeck.Application/Services/LlmQueueService.cs
+++ b/backend/src/Taskdeck.Application/Services/LlmQueueService.cs
@@ -13,6 +13,12 @@ public class LlmQueueService : ILlmQueueService
     private readonly IAuthorizationService _authorizationService;
     private readonly DevelopmentSandboxSettings _sandboxSettings;
 
+    // ProcessNextRequestAsync claims the single oldest claimable non-capture request, so it only
+    // needs the oldest N candidates — not the full Pending backlog. Bounds the claim-scan window
+    // (#1237). 100 leaves ample headroom for lost optimistic-claim races before falling through to
+    // "no pending requests" (the caller retries).
+    private const int ClaimScanLimit = 100;
+
     public LlmQueueService(
         IUnitOfWork unitOfWork,
         IAuthorizationService authorizationService,
@@ -115,11 +121,9 @@ public class LlmQueueService : ILlmQueueService
     {
         try
         {
-            var pendingRequests = await _unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Pending);
-            var candidates = pendingRequests
-                .Where(candidate => !CaptureRequestContract.IsCaptureRequestType(candidate.RequestType))
-                .OrderBy(candidate => candidate.CreatedAt)
-                .ToList();
+            // Bounded, type-aware, oldest-first at the database (reuses the #1236 primitive) instead
+            // of loading the entire Pending backlog and filtering/sorting non-capture in memory (#1237).
+            var candidates = await _unitOfWork.LlmQueue.GetOldestPendingNonCaptureAsync(ClaimScanLimit);
 
             foreach (var candidate in candidates)
             {

--- a/backend/src/Taskdeck.Application/Services/OpsCliService.cs
+++ b/backend/src/Taskdeck.Application/Services/OpsCliService.cs
@@ -192,8 +192,10 @@ public class OpsCliService : IOpsCliService
 
     private async Task<string> ExecuteQueuePendingAsync(CancellationToken ct)
     {
-        var pending = await _unitOfWork.LlmQueue.GetByStatusAsync(Domain.Enums.RequestStatus.Pending, ct);
-        var pendingList = pending.Take(50).ToList();
+        // Bounded at the database (display-only; #1237) instead of materializing the full Pending
+        // backlog and taking 50 in memory. Newest-first, capped at 50.
+        var pendingList = (await _unitOfWork.LlmQueue.GetByStatusForDisplayAsync(
+            Domain.Enums.RequestStatus.Pending, limit: 50, ct)).ToList();
         return $"Pending queue items: {pendingList.Count}\n" + string.Join("\n", pendingList.Select(r => $"- {r.Id}: {r.RequestType} (created: {r.CreatedAt})"));
     }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -167,23 +167,44 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, CancellationToken cancellationToken = default)
+    public Task<IEnumerable<LlmRequest>> GetByStatusAsync(RequestStatus status, CancellationToken cancellationToken = default)
+        => GetByStatusCoreAsync(status, limit: null, cancellationToken);
+
+    public Task<IEnumerable<LlmRequest>> GetByStatusForDisplayAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default)
+    {
+        if (limit < 1)
+            throw new ArgumentOutOfRangeException(nameof(limit), limit, "Limit must be at least 1.");
+        return GetByStatusCoreAsync(status, limit, cancellationToken);
+    }
+
+    private async Task<IEnumerable<LlmRequest>> GetByStatusCoreAsync(RequestStatus status, int? limit, CancellationToken cancellationToken)
     {
         if (_context.Database.IsSqlite())
         {
+            // SQLite's EF provider can't ORDER BY a DateTimeOffset column in LINQ, so the order
+            // (and the optional display bound) live in raw SQL.
+            FormattableString sql;
+            if (limit is int n)
+                sql = $"SELECT * FROM LlmRequests WHERE Status = {(int)status} ORDER BY CreatedAt DESC LIMIT {n}";
+            else
+                sql = $"SELECT * FROM LlmRequests WHERE Status = {(int)status} ORDER BY CreatedAt DESC";
+
             return await _context.LlmRequests
-                .FromSqlInterpolated($"SELECT * FROM LlmRequests WHERE Status = {(int)status} ORDER BY CreatedAt DESC")
+                .FromSqlInterpolated(sql)
                 .Include(lr => lr.User)
                 .Include(lr => lr.Board)
                 .ToListAsync(cancellationToken);
         }
 
-        return await _context.LlmRequests
+        var query = _context.LlmRequests
             .Include(lr => lr.User)
             .Include(lr => lr.Board)
             .Where(lr => lr.Status == status)
-            .OrderByDescending(lr => lr.CreatedAt)
-            .ToListAsync(cancellationToken);
+            .OrderByDescending(lr => lr.CreatedAt);
+
+        return limit is int take
+            ? await query.Take(take).ToListAsync(cancellationToken)
+            : await query.ToListAsync(cancellationToken);
     }
 
     public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -189,11 +189,15 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             else
                 sql = $"SELECT * FROM LlmRequests WHERE Status = {(int)status} ORDER BY CreatedAt DESC";
 
-            return await _context.LlmRequests
+            var rows = await _context.LlmRequests
                 .FromSqlInterpolated(sql)
                 .Include(lr => lr.User)
                 .Include(lr => lr.Board)
                 .ToListAsync(cancellationToken);
+            // FromSqlInterpolated + Include wraps the raw SQL in a subquery whose outer ORDER BY is
+            // not guaranteed to survive to the final result; re-sort newest-first in memory so the
+            // documented contract holds (same workaround as GetOldestByStatusAndCaptureKindAsync).
+            return rows.OrderByDescending(lr => lr.CreatedAt).ToList();
         }
 
         var query = _context.LlmRequests

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -93,6 +93,51 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
         result.Count.Should().BeLessThanOrEqualTo(2);
     }
 
+    [Fact]
+    public async Task GetByStatusForDisplayAsync_BoundsAtSql_NewestFirst_IncludesAllTypes()
+    {
+        // The display read (#1237) is for the ops queue listing: bounded at the database, newest-first,
+        // and -- unlike the work-drain GetOldest* reads -- it must NOT exclude capture rows.
+        var interceptor = new CapturingReaderInterceptor();
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("llm-display", "llm-display@example.com", "hash");
+            db.Users.Add(user);
+
+            var capture = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{\"c\":1}");
+            var oldAutomation = new LlmRequest(user.Id, "automation.command", "{\"a\":0}");
+            var midAutomation = new LlmRequest(user.Id, "automation.command", "{\"a\":1}");
+            var newestAutomation = new LlmRequest(user.Id, "automation.command", "{\"a\":2}");
+            db.LlmRequests.AddRange(capture, oldAutomation, midAutomation, newestAutomation);
+            await db.SaveChangesAsync();
+
+            var t0 = new DateTimeOffset(2001, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            db.Entry(oldAutomation).Property(nameof(Entity.CreatedAt)).CurrentValue = t0;
+            db.Entry(capture).Property(nameof(Entity.CreatedAt)).CurrentValue = t0.AddSeconds(1);
+            db.Entry(midAutomation).Property(nameof(Entity.CreatedAt)).CurrentValue = t0.AddSeconds(2);
+            db.Entry(newestAutomation).Property(nameof(Entity.CreatedAt)).CurrentValue = t0.AddSeconds(3);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+            interceptor.Clear();
+
+            // Bounded to 2, newest-first -- the newest two regardless of type.
+            var bounded = (await repo.GetByStatusForDisplayAsync(RequestStatus.Pending, limit: 2)).ToList();
+            bounded.Select(r => r.Id).Should().Equal(newestAutomation.Id, midAutomation.Id);
+
+            // The bound is pushed to SQL (LIMIT), not sliced in memory.
+            interceptor.CapturedCommands
+                .Where(sql => sql.Contains("LlmRequests", StringComparison.OrdinalIgnoreCase)
+                              && sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase))
+                .Should().Contain(sql => sql.Contains("LIMIT", StringComparison.OrdinalIgnoreCase),
+                    "the display read must push LIMIT into SQL");
+
+            // A generous limit returns all four, INCLUDING the capture row (display is type-agnostic).
+            var all = (await repo.GetByStatusForDisplayAsync(RequestStatus.Pending, limit: 100)).ToList();
+            all.Should().HaveCount(4);
+            all.Should().Contain(r => CaptureRequestContract.IsCaptureRequestType(r.RequestType));
+        }, interceptor);
+    }
+
     // The bounded work-drain reads target Pending-non-capture and Processing-capture rows -- exactly the
     // rows the live worker claims. These tests therefore use an isolated, worker-free SQLite context
     // (no web host) so the background worker cannot mutate the rows mid-assertion.
@@ -210,6 +255,8 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
             await repo.Invoking(r => r.GetOldestPendingNonCaptureAsync(0))
                 .Should().ThrowAsync<ArgumentOutOfRangeException>();
             await repo.Invoking(r => r.GetOldestProcessingCaptureAsync(-1))
+                .Should().ThrowAsync<ArgumentOutOfRangeException>();
+            await repo.Invoking(r => r.GetByStatusForDisplayAsync(RequestStatus.Pending, 0))
                 .Should().ThrowAsync<ArgumentOutOfRangeException>();
         });
     }

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -693,6 +693,12 @@ public class LlmQueueToProposalWorkerTests
             return Task.FromResult<IEnumerable<LlmRequest>>(result);
         }
 
+        public Task<IEnumerable<LlmRequest>> GetByStatusForDisplayAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default)
+        {
+            var result = _allItems.Where(i => i.Status == status).OrderByDescending(i => i.CreatedAt).Take(limit).ToList();
+            return Task.FromResult<IEnumerable<LlmRequest>>(result);
+        }
+
         public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)
         {
             var result = _allItems

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -421,6 +421,8 @@ public class WorkerResilienceTests
         public Task<IEnumerable<LlmRequest>> GetByStatusAsync(
             RequestStatus status, CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<IEnumerable<LlmRequest>> GetByStatusForDisplayAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
         public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
         public Task<IEnumerable<LlmRequest>> GetOldestProcessingCaptureAsync(int limit, CancellationToken cancellationToken = default)
@@ -480,6 +482,13 @@ public class WorkerResilienceTests
             var all = _pending.Concat(_processing).ToList();
             return Task.FromResult<IEnumerable<LlmRequest>>(
                 all.Where(i => i.Status == status).ToList());
+        }
+
+        public Task<IEnumerable<LlmRequest>> GetByStatusForDisplayAsync(RequestStatus status, int limit, CancellationToken cancellationToken = default)
+        {
+            var all = _pending.Concat(_processing).ToList();
+            return Task.FromResult<IEnumerable<LlmRequest>>(
+                all.Where(i => i.Status == status).OrderByDescending(i => i.CreatedAt).Take(limit).ToList());
         }
 
         public Task<IEnumerable<LlmRequest>> GetOldestPendingNonCaptureAsync(int limit, CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Application.Tests/Services/LlmQueueServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LlmQueueServiceTests.cs
@@ -361,7 +361,9 @@ public class LlmQueueServiceTests
         var request = new LlmRequest(userId, "voicenote", "payload text");
         var pendingUpdatedAt = request.UpdatedAt;
 
-        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
+        // The repository now returns the bounded, oldest-first, NON-capture candidates at the
+        // database (#1237); the service just claims the first claimable one.
+        _llmQueueRepoMock.Setup(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default))
             .ReturnsAsync(new[] { request });
 
         // Per the ILlmQueueRepository contract, a successful claim refreshes the
@@ -377,13 +379,16 @@ public class LlmQueueServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Status.Should().Be(RequestStatus.Processing);
         _llmQueueRepoMock.Verify(r => r.TryClaimProcessingAsync(request.Id, pendingUpdatedAt, default), Times.Once);
+        // Bounded, type-aware read -- never the unbounded full-backlog GetByStatusAsync.
+        _llmQueueRepoMock.Verify(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default), Times.Once);
+        _llmQueueRepoMock.Verify(r => r.GetByStatusAsync(It.IsAny<RequestStatus>(), default), Times.Never);
     }
 
     [Fact]
     public async Task ProcessNextRequestAsync_ShouldReturnNotFound_WhenQueueIsEmpty()
     {
         // Arrange
-        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
+        _llmQueueRepoMock.Setup(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default))
             .ReturnsAsync(Array.Empty<LlmRequest>());
 
         // Act
@@ -395,36 +400,36 @@ public class LlmQueueServiceTests
     }
 
     [Fact]
-    public async Task ProcessNextRequestAsync_ShouldSkipCaptureRequests()
+    public async Task ProcessNextRequestAsync_UsesNonCapturePrimitive_SoCaptureRequestsAreNeverClaimed()
     {
-        var userId = Guid.NewGuid();
-        var captureRequest = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "capture payload");
-
-        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
-            .ReturnsAsync(new[] { captureRequest });
+        // Capture-skipping now lives IN the query: the service calls GetOldestPendingNonCaptureAsync,
+        // which excludes capture rows at the database (#1236/#1237). When only capture work is pending,
+        // that bounded read returns empty, so nothing is claimed -- and GetByStatusAsync is never used.
+        _llmQueueRepoMock.Setup(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default))
+            .ReturnsAsync(Array.Empty<LlmRequest>());
 
         var result = await _service.ProcessNextRequestAsync();
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.NotFound);
-        captureRequest.Status.Should().Be(RequestStatus.Pending);
         _llmQueueRepoMock.Verify(r => r.TryClaimProcessingAsync(It.IsAny<Guid>(), It.IsAny<DateTimeOffset>(), default), Times.Never);
+        _llmQueueRepoMock.Verify(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default), Times.Once);
+        _llmQueueRepoMock.Verify(r => r.GetByStatusAsync(It.IsAny<RequestStatus>(), default), Times.Never);
     }
 
     [Fact]
-    public async Task ProcessNextRequestAsync_ShouldPreserveFifo_WhenSkippingCaptureRequests()
+    public async Task ProcessNextRequestAsync_ShouldClaimOldest_InTheOrderReturned()
     {
+        // The repository returns non-capture candidates oldest-first; the service claims the first claimable.
         var userId = Guid.NewGuid();
         var oldestNonCapture = new LlmRequest(userId, "summarize", "oldest non-capture");
-        var captureRequest = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "capture payload");
         var newestNonCapture = new LlmRequest(userId, "summarize", "newest non-capture");
         var baseTime = DateTimeOffset.UtcNow;
         SetCreatedAt(oldestNonCapture, baseTime);
-        SetCreatedAt(captureRequest, baseTime.AddMilliseconds(1));
         SetCreatedAt(newestNonCapture, baseTime.AddMilliseconds(2));
 
-        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
-            .ReturnsAsync(new[] { newestNonCapture, captureRequest, oldestNonCapture });
+        _llmQueueRepoMock.Setup(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default))
+            .ReturnsAsync(new[] { oldestNonCapture, newestNonCapture });
         _llmQueueRepoMock.Setup(r => r.TryClaimProcessingAsync(oldestNonCapture.Id, oldestNonCapture.UpdatedAt, default))
             .Callback(() => oldestNonCapture.MarkAsProcessing())
             .ReturnsAsync(true);
@@ -443,7 +448,7 @@ public class LlmQueueServiceTests
         var userId = Guid.NewGuid();
         var request = new LlmRequest(userId, "voicenote", "payload text");
 
-        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
+        _llmQueueRepoMock.Setup(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default))
             .ReturnsAsync(new[] { request });
         _llmQueueRepoMock.Setup(r => r.TryClaimProcessingAsync(request.Id, request.UpdatedAt, default))
             .ReturnsAsync(false);
@@ -467,7 +472,7 @@ public class LlmQueueServiceTests
         SetCreatedAt(first, baseTime);
         SetCreatedAt(second, baseTime.AddMilliseconds(1));
 
-        _llmQueueRepoMock.Setup(r => r.GetByStatusAsync(RequestStatus.Pending, default))
+        _llmQueueRepoMock.Setup(r => r.GetOldestPendingNonCaptureAsync(It.IsAny<int>(), default))
             .ReturnsAsync(new[] { first, second });
         _llmQueueRepoMock.Setup(r => r.TryClaimProcessingAsync(first.Id, first.UpdatedAt, default))
             .ReturnsAsync(false);

--- a/backend/tests/Taskdeck.Application.Tests/Services/OpsCliServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/OpsCliServiceTests.cs
@@ -71,6 +71,31 @@ public class OpsCliServiceTests
     }
 
     [Fact]
+    public async Task RunCommandAsync_QueuePending_UsesBoundedDisplayRead_CappedAtFifty()
+    {
+        // #1250 review: lock the queue.pending listing to the bounded display read (cap 50) so the
+        // limit constant can't silently drift back to the unbounded full-backlog GetByStatusAsync.
+        var userId = Guid.NewGuid();
+        var adminUser = new User("admin", "admin-queue@example.com", "hash", UserRole.Admin);
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(adminUser);
+
+        var newest = new LlmRequest(userId, "automation.command", "{\"n\":1}");
+        var older = new LlmRequest(userId, "automation.command", "{\"o\":1}");
+        _queueRepoMock
+            .Setup(r => r.GetByStatusForDisplayAsync(RequestStatus.Pending, 50, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { newest, older });
+
+        var result = await _service.RunCommandAsync(userId, new RunCommandDto("queue.pending"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.OutputPreview.Should().Contain("Pending queue items: 2");
+        result.Value.OutputPreview.Should().Contain(newest.Id.ToString());
+        // The bounded display read is used; the unbounded full-backlog read is never called.
+        _queueRepoMock.Verify(r => r.GetByStatusForDisplayAsync(RequestStatus.Pending, 50, It.IsAny<CancellationToken>()), Times.Once);
+        _queueRepoMock.Verify(r => r.GetByStatusAsync(It.IsAny<RequestStatus>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task RunCommandAsync_ShouldReturnValidationError_ForUnknownTemplateParameter()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
Closes #1237.

Surfaced by the #1236 (#1195) adversarial review: two non-worker call sites still materialized the full LlmQueue Pending backlog with the same unbounded-then-filter pattern #1195 fixed for the worker.

## Changes
- **`LlmQueueService.ProcessNextRequestAsync`** — claims from the bounded, type-aware `GetOldestPendingNonCaptureAsync(ClaimScanLimit=100)` (reuses the #1236 primitive) instead of loading the entire Pending backlog and filtering `!IsCaptureRequestType` + sorting in memory. It only needs the oldest claimable non-capture item; 100 leaves ample headroom for lost optimistic-claim races before falling through to "no pending requests" (the caller retries).
- **`OpsCliService` queue-pending listing** — uses a new bounded `GetByStatusForDisplayAsync(Pending, limit: 50)` instead of `GetByStatusAsync(...).Take(50)`.
- **New `ILlmQueueRepository.GetByStatusForDisplayAsync(status, limit)`** — mirrors `GetByStatusAsync` (newest-first) but pushes a SQL `LIMIT`; **display/diagnostics only**. The SQLite raw-SQL + LINQ paths are refactored into a shared `GetByStatusCoreAsync(status, int? limit)`. Documented that claim/process paths must use the type-aware `GetOldest*` primitives so a bound never starves non-capture work (#1195). `GetByStatusAsync` (unbounded) is unchanged — the health backlog gauge still needs the full depth.

## Tests
- New repository integration test: SQL `LIMIT` pushdown (command interceptor), newest-first, and that the display read **includes** capture types (unlike the work-drain reads) + `limit < 1` guard.
- `ProcessNextRequestAsync` service tests restructured: capture-skipping / oldest-first now live in the query, so the tests mock the non-capture primitive and assert the unbounded `GetByStatusAsync` is **never** called.
- The new method threaded through the 3 `ILlmQueueRepository` test fakes.

## Verification
- `dotnet build backend/Taskdeck.sln -c Release` → 0 errors.
- Targeted suite (`~LlmQueue|~OpsCli|~WorkerResilience`): 23 Application + 88 Api = **0 failures**.

The OpsCli queue-pending command was previously untested (thin formatting wrapper); the bounded read it now calls is covered by the new repository test.