### PR TITLE
perf(health): readiness gauge uses count primitives instead of materializing Pending rows (#1251)

### DIFF
--- a/backend/src/Taskdeck.Api/Controllers/HealthController.cs
+++ b/backend/src/Taskdeck.Api/Controllers/HealthController.cs
@@ -80,10 +80,12 @@ public class HealthController : ControllerBase
         {
             using var scope = _serviceProvider.CreateScope();
             var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-            var pending = await unitOfWork.LlmQueue.GetByStatusAsync(RequestStatus.Pending, ct);
-            var pendingList = pending.ToList();
-            var queueDepth = pendingList.Count(item => !CaptureRequestContract.IsCaptureRequestType(item.RequestType));
-            var captureDepth = pendingList.Count - queueDepth;
+            // Count primitives instead of materializing every Pending row on this frequently-polled
+            // readiness probe (#1251): queueDepth = Pending non-capture (the automation backlog the
+            // threshold gates on), captureDepth = Pending capture-triage, totalDepth = their sum.
+            var queueDepth = await unitOfWork.LlmQueue.CountPendingNonCaptureAsync(ct);
+            var captureDepth = await unitOfWork.LlmQueue.CountPendingCaptureAsync(ct);
+            var totalDepth = queueDepth + captureDepth;
             var queueThreshold = Math.Max(_workerSettings.MaxBatchSize * 20, 100);
             var queueHealthy = queueDepth <= queueThreshold;
 
@@ -91,7 +93,7 @@ public class HealthController : ControllerBase
             {
                 status = queueHealthy ? "Healthy" : "Degraded",
                 depth = queueDepth,
-                totalDepth = pendingList.Count,
+                totalDepth,
                 captureDepth,
                 threshold = queueThreshold
             };

--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -62,6 +62,9 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
 
     /// <summary>Counts Processing capture-triage requests for backlog telemetry, without materializing rows.</summary>
     Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Counts Pending capture-triage requests for the readiness gauge, without materializing rows.</summary>
+    Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default);
     Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default);
     Task<Dictionary<RequestStatus, int>> GetStatusCountsByUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<LlmRequest?> GetNextPendingAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -270,6 +270,9 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
     public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
         => CountByStatusAndCaptureKindAsync(RequestStatus.Processing, capture: true, cancellationToken);
 
+    public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
+        => CountByStatusAndCaptureKindAsync(RequestStatus.Pending, capture: true, cancellationToken);
+
     private async Task<int> CountByStatusAndCaptureKindAsync(
         RequestStatus status,
         bool capture,

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -287,6 +287,9 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
 
             (await repo.CountPendingNonCaptureAsync()).Should().Be(4);
             (await repo.CountProcessingCaptureAsync()).Should().Be(3);
+            // #1251: the readiness gauge's captureDepth — Pending capture only (not the 3 Processing
+            // captures, not the 4 Pending non-captures).
+            (await repo.CountPendingCaptureAsync()).Should().Be(2);
         });
     }
 

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -725,6 +725,9 @@ public class LlmQueueToProposalWorkerTests
         public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(_allItems.Count(i => i.Status == RequestStatus.Processing && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
 
+        public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_allItems.Count(i => i.Status == RequestStatus.Pending && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
+
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         {
             var item = _allItems.FirstOrDefault(i => i.Id == id);

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -431,6 +431,8 @@ public class WorkerResilienceTests
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
         public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
@@ -516,6 +518,9 @@ public class WorkerResilienceTests
 
         public Task<int> CountProcessingCaptureAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(_pending.Concat(_processing).Count(i => i.Status == RequestStatus.Processing && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
+
+        public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
+            => Task.FromResult(_pending.Concat(_processing).Count(i => i.Status == RequestStatus.Pending && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult(_pending.Concat(_processing).FirstOrDefault(i => i.Id == id));


### PR DESCRIPTION
## #1251 — readiness gauge uses count primitives

`HealthController`'s queue check called the unbounded `GetByStatusAsync(RequestStatus.Pending)` and `.ToList()`/grouped it only to compute three integers (`depth`, `captureDepth`, `totalDepth`). On a frequently-polled readiness/liveness probe with a large backlog, that materialized every Pending row just to count them.

### Change
- `queueDepth` ← `CountPendingNonCaptureAsync()` (already existed; the automation backlog the threshold gates on)
- `captureDepth` ← new `CountPendingCaptureAsync()` (Pending capture-triage, in-query count)
- `totalDepth` ← `queueDepth + captureDepth`
- `GetByStatusAsync` stays unbounded for genuine full-set callers; only the gauge stops using it.

### Tests
- `LlmQueueRepositoryIntegrationTests.BacklogCounts_*` now also asserts `CountPendingCaptureAsync() == 2` (Pending captures only — not the 3 Processing captures, not the 4 Pending non-captures).
- `HealthApiTests` already seeds Pending capture rows and asserts the gauge depths → exercises the rewired controller end-to-end.
- The three hand-written `ILlmQueueRepository` fakes (worker tests) implement the new method.

Verified: full sln builds clean (0 errors); targeted suite (count integration + HealthApi gauge + worker fakes) 70/70.

Closes #1251. Completes the query-bounds quality line started in #1195/#1236/#1237.
