### PR TITLE
perf(capture): push the raw-board pre-filter into SQL for board-filtered lists (#1239)

### DIFF
--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -21,7 +21,14 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
     /// </summary>
     /// <param name="limit">Page size; must be at least 1.</param>
     /// <param name="offset">Rows to skip; must be non-negative.</param>
-    Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default);
+    /// <param name="boardId">
+    /// Optional raw-board pre-filter (#1239). When supplied, the scan keeps only captures whose raw
+    /// <c>BoardId</c> equals it OR is NULL — null-board captures are retained because they may still
+    /// resolve to the target board via applied-conversion provenance, which is computed in the
+    /// service layer. This sharply narrows board-filtered scans by excluding other boards' captures
+    /// at the database. The effective-board (provenance) and status filters remain in the service.
+    /// </param>
+    Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, Guid? boardId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns all requests with the given status, newest-first, unbounded. The health backlog gauge

--- a/backend/src/Taskdeck.Application/Services/CaptureService.cs
+++ b/backend/src/Taskdeck.Application/Services/CaptureService.cs
@@ -99,18 +99,18 @@ public class CaptureService : ICaptureService
         var limit = Math.Min(filter.Limit == 0 ? DefaultListLimit : filter.Limit, MaxListLimit);
 
         // Page the user's captures from the database (newest-first) instead of materializing every
-        // request. Board/status filters and applied-conversion provenance can only be evaluated after
+        // request. The raw-board pre-filter is pushed into SQL (#1239): a board-filtered query scans only
+        // the target board's captures plus null-board captures (which may still resolve to that board via
+        // applied-conversion provenance). The effective-board (provenance) and status filters still need
         // the per-item resolution below, so we keep fetching pages until `limit` matching summaries are
         // collected or the captures are exhausted -- a bound on the first page alone would silently
-        // under-fill filtered queries. The common (unfiltered) case is satisfied by a single page; a sparse
-        // board/status filter still scans the user's captures page-by-page (same total work as before, no
-        // worse) -- pushing those filters into SQL to cut round-trips is tracked in #1239.
+        // under-fill filtered queries. The common (unfiltered) case is satisfied by a single page.
         var summaries = new List<CaptureItemSummaryDto>(limit);
         var seenIds = new HashSet<Guid>();
         var offset = 0;
         while (summaries.Count < limit)
         {
-            var page = (await _unitOfWork.LlmQueue.GetCapturesByUserAsync(userId, limit, offset, cancellationToken)).ToList();
+            var page = (await _unitOfWork.LlmQueue.GetCapturesByUserAsync(userId, limit, offset, filter.BoardId, cancellationToken)).ToList();
             if (page.Count == 0)
             {
                 break;
@@ -127,11 +127,8 @@ public class CaptureService : ICaptureService
                     continue;
                 }
 
-                if (filter.BoardId.HasValue && item.BoardId.HasValue && item.BoardId != filter.BoardId.Value)
-                {
-                    continue;
-                }
-
+                // The raw-board mismatch (item.BoardId set and != filter.BoardId) is already excluded by
+                // the SQL pre-filter above; the effective-board check happens post-provenance below.
                 batch.Add((item, ParsePayload(item)));
             }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -124,7 +124,7 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, Guid? boardId = null, CancellationToken cancellationToken = default)
     {
         if (limit < 1)
         {
@@ -145,10 +145,18 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             // it matches SQLite's TEXT comparison of the stored Guid exactly (the raw SQL's `ORDER BY Id`),
             // rather than Guid.CompareTo, which orders by a different key. No Include: the only caller
             // (CaptureService.ListAsync) reads the scalar BoardId, never the Board navigation.
-            var rows = await _context.LlmRequests
-                .FromSqlInterpolated(
-                    $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}")
-                .ToListAsync(cancellationToken);
+            // #1239: when a board filter is supplied, keep captures whose raw BoardId matches OR is
+            // NULL (null-board captures may still resolve to the target board via provenance, resolved
+            // in the service). This excludes other boards' captures from the scan at the database.
+            var rows = boardId.HasValue
+                ? await _context.LlmRequests
+                    .FromSqlInterpolated(
+                        $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} AND (BoardId IS NULL OR BoardId = {boardId.Value}) ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}")
+                    .ToListAsync(cancellationToken)
+                : await _context.LlmRequests
+                    .FromSqlInterpolated(
+                        $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}")
+                    .ToListAsync(cancellationToken);
             return rows
                 .OrderByDescending(lr => lr.CreatedAt)
                 .ThenBy(lr => lr.Id.ToString(), StringComparer.Ordinal)
@@ -158,8 +166,14 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
         // Non-SQLite providers (e.g. the Postgres Testcontainer path) order in the database. EF.Functions.Like
         // mirrors the capture predicate used across this repository (e.g. GetCaptureSummaryByUserAsync); on a
         // case-sensitive provider it is stricter than IsCaptureRequestType, but production is SQLite-only.
-        return await _context.LlmRequests
-            .Where(lr => lr.UserId == userId && EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike))
+        var query = _context.LlmRequests
+            .Where(lr => lr.UserId == userId && EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike));
+        if (boardId.HasValue)
+        {
+            // Same raw-board pre-filter as the SQLite path (#1239): match the board or keep null-board rows.
+            query = query.Where(lr => lr.BoardId == null || lr.BoardId == boardId.Value);
+        }
+        return await query
             .OrderByDescending(lr => lr.CreatedAt)
             .ThenBy(lr => lr.Id)
             .Skip(offset)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -147,16 +147,22 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             // (CaptureService.ListAsync) reads the scalar BoardId, never the Board navigation.
             // #1239: when a board filter is supplied, keep captures whose raw BoardId matches OR is
             // NULL (null-board captures may still resolve to the target board via provenance, resolved
-            // in the service). This excludes other boards' captures from the scan at the database.
-            var rows = boardId.HasValue
-                ? await _context.LlmRequests
-                    .FromSqlInterpolated(
-                        $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} AND (BoardId IS NULL OR BoardId = {boardId.Value}) ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}")
-                    .ToListAsync(cancellationToken)
-                : await _context.LlmRequests
-                    .FromSqlInterpolated(
-                        $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}")
-                    .ToListAsync(cancellationToken);
+            // in the service). This excludes other boards' captures from the scan at the database. The
+            // interpolation holes are parameterized by FromSqlInterpolated (no SQL injection).
+            // if/else (not a ternary): each branch must be target-typed to FormattableString so the
+            // interpolation holes stay parameters; a ternary would infer string and lose parameterization.
+            FormattableString sql;
+            if (boardId.HasValue)
+            {
+                sql = $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} AND (BoardId IS NULL OR BoardId = {boardId.Value}) ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}";
+            }
+            else
+            {
+                sql = $"SELECT * FROM LlmRequests WHERE UserId = {userId} AND RequestType LIKE {CaptureRequestTypeLike} ORDER BY CreatedAt DESC, Id LIMIT {limit} OFFSET {offset}";
+            }
+            var rows = await _context.LlmRequests
+                .FromSqlInterpolated(sql)
+                .ToListAsync(cancellationToken);
             return rows
                 .OrderByDescending(lr => lr.CreatedAt)
                 .ThenBy(lr => lr.Id.ToString(), StringComparer.Ordinal)

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -426,6 +426,43 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
     }
 
     [Fact]
+    public async Task GetCapturesByUserAsync_BoardFilter_KeepsTargetAndNullBoard_ExcludesOtherBoards()
+    {
+        // #1239: the raw-board pre-filter keeps captures whose BoardId matches OR is NULL (null-board
+        // rows may resolve to the target board via provenance, resolved in the service), and excludes
+        // captures belonging to other boards at the database.
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("cap-board-filter", "cap-board-filter@example.com", "hash");
+            db.Users.Add(user);
+            // Real boards: LlmRequest.BoardId is an enforced FK, so the target/other boards must exist.
+            var boardXEntity = new Board("Board X", ownerId: user.Id);
+            var boardYEntity = new Board("Board Y", ownerId: user.Id);
+            db.Boards.AddRange(boardXEntity, boardYEntity);
+            var boardX = boardXEntity.Id;
+            var boardY = boardYEntity.Id;
+
+            var x1 = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}", boardX);
+            var x2 = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}", boardX);
+            var y1 = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}", boardY);
+            var n1 = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}"); // null board
+            var n2 = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}"); // null board
+            db.LlmRequests.AddRange(x1, x2, y1, n1, n2);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var filtered = (await repo.GetCapturesByUserAsync(user.Id, 50, 0, boardId: boardX)).ToList();
+
+            // boardX (2) + null-board (2) kept; boardY (1) excluded at the database.
+            filtered.Select(r => r.Id).Should().BeEquivalentTo(new[] { x1.Id, x2.Id, n1.Id, n2.Id });
+            filtered.Should().NotContain(r => r.Id == y1.Id);
+
+            // Unfiltered read still returns all 5 (regression guard that boardId is genuinely optional).
+            (await repo.GetCapturesByUserAsync(user.Id, 50, 0)).Should().HaveCount(5);
+        });
+    }
+
+    [Fact]
     public async Task TryClaimProcessingCaptureAsync_ShouldSucceedOnFirstClaim_FailOnSecond()
     {
         using var scope = _factory.Services.CreateScope();

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -784,9 +784,10 @@ public class LlmQueueToProposalWorkerTests
         public Task<IEnumerable<LlmRequest>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<LlmRequest>>([]);
 
-        public Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, Guid? boardId = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<LlmRequest>>(_allItems
                 .Where(i => i.UserId == userId && CaptureRequestContract.IsCaptureRequestType(i.RequestType))
+                .Where(i => !boardId.HasValue || i.BoardId == null || i.BoardId == boardId.Value)
                 .OrderByDescending(i => i.CreatedAt).ThenBy(i => i.Id)
                 .Skip(offset).Take(limit).ToList());
 

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -451,7 +451,7 @@ public class WorkerResilienceTests
             => throw new NotSupportedException();
         public Task<IEnumerable<LlmRequest>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
-        public Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, Guid? boardId = null, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
         public Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
@@ -539,9 +539,10 @@ public class WorkerResilienceTests
             => Task.FromResult<IEnumerable<LlmRequest>>(_pending.Where(i => i.Status == RequestStatus.Pending).Take(limit).ToList());
         public Task<IEnumerable<LlmRequest>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)
             => Task.FromResult(_pending.Concat(_processing).Where(i => i.UserId == userId));
-        public Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, CancellationToken cancellationToken = default)
+        public Task<IEnumerable<LlmRequest>> GetCapturesByUserAsync(Guid userId, int limit, int offset, Guid? boardId = null, CancellationToken cancellationToken = default)
             => Task.FromResult<IEnumerable<LlmRequest>>(_pending.Concat(_processing)
                 .Where(i => i.UserId == userId && CaptureRequestContract.IsCaptureRequestType(i.RequestType))
+                .Where(i => !boardId.HasValue || i.BoardId == null || i.BoardId == boardId.Value)
                 .OrderByDescending(i => i.CreatedAt).ThenBy(i => i.Id)
                 .Skip(offset).Take(limit).ToList());
         public Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Application.Tests/Services/CaptureServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CaptureServiceTests.cs
@@ -44,10 +44,12 @@ public class CaptureServiceTests
     {
         var all = requests.ToList();
         _llmQueueRepositoryMock
-            .Setup(r => r.GetCapturesByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), default))
-            .Returns((Guid _, int limit, int offset, CancellationToken _) =>
+            .Setup(r => r.GetCapturesByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid _, int limit, int offset, Guid? boardId, CancellationToken _) =>
                 Task.FromResult<IEnumerable<LlmRequest>>(
                     all.Where(x => CaptureRequestContract.IsCaptureRequestType(x.RequestType))
+                       // Mirror the repo's #1239 raw-board pre-filter: match the board or keep null-board rows.
+                       .Where(x => !boardId.HasValue || x.BoardId == null || x.BoardId == boardId.Value)
                        .OrderByDescending(x => x.CreatedAt)
                        .ThenBy(x => x.Id)
                        .Skip(offset)
@@ -439,27 +441,31 @@ public class CaptureServiceTests
     public async Task ListAsync_PagesUntilEnoughMatches_WhenFilterUnderfillsEarlyPages()
     {
         var userId = Guid.NewGuid();
-        var boardA = Guid.NewGuid();
         var boardB = Guid.NewGuid();
 
-        // Newest-first; only the two oldest match the boardB filter, so the loop must advance through
-        // multiple limit-sized pages to collect them.
+        // Newest-first; the three newest have a NULL raw board, so they pass the repo's #1239 board
+        // pre-filter (null-board rows are kept for provenance) but fail the in-service effective-board
+        // check (no applied proposal -> effective board null != boardB). Only the two oldest actually
+        // match, so the loop must still advance through multiple limit-sized pages to collect them.
         var captures = new List<LlmRequest>
         {
-            new(userId, CaptureRequestContract.RequestTypeV1, "newest", boardA),
-            new(userId, CaptureRequestContract.RequestTypeV1, "second", boardA),
-            new(userId, CaptureRequestContract.RequestTypeV1, "third", boardA),
+            new(userId, CaptureRequestContract.RequestTypeV1, "newest"),
+            new(userId, CaptureRequestContract.RequestTypeV1, "second"),
+            new(userId, CaptureRequestContract.RequestTypeV1, "third"),
             new(userId, CaptureRequestContract.RequestTypeV1, "fourth", boardB),
             new(userId, CaptureRequestContract.RequestTypeV1, "oldest", boardB),
         };
 
         var requestedOffsets = new List<int>();
         _llmQueueRepositoryMock
-            .Setup(r => r.GetCapturesByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), default))
-            .Returns((Guid _, int limit, int offset, CancellationToken _) =>
+            .Setup(r => r.GetCapturesByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid _, int limit, int offset, Guid? boardId, CancellationToken _) =>
             {
                 requestedOffsets.Add(offset);
-                return Task.FromResult<IEnumerable<LlmRequest>>(captures.Skip(offset).Take(limit).ToList());
+                // null-board + boardB rows all pass the board pre-filter; the service filters the null ones.
+                return Task.FromResult<IEnumerable<LlmRequest>>(
+                    captures.Where(x => !boardId.HasValue || x.BoardId == null || x.BoardId == boardId.Value)
+                            .Skip(offset).Take(limit).ToList());
             });
 
         var result = await _service.ListAsync(userId, new CaptureListFilterDto(BoardId: boardB, Limit: 2));
@@ -478,7 +484,10 @@ public class CaptureServiceTests
     {
         var userId = Guid.NewGuid();
         var boardB = Guid.NewGuid();
-        var a = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "a", Guid.NewGuid()); // non-matching board
+        // `a` has a NULL raw board: it passes the repo's #1239 board pre-filter (kept for provenance)
+        // but the service filters it out (effective board null != boardB), so it pads the first page
+        // without contributing a match -- the same role the old non-matching-board row played.
+        var a = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "a");
         var b = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "b", boardB);
         var c = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "c", boardB);
         var d = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1, "d", boardB);
@@ -486,8 +495,8 @@ public class CaptureServiceTests
         // Simulate a concurrent insert between page reads: the offset-3 page re-surfaces `c`
         // (a boundary row already returned on the offset-0 page).
         _llmQueueRepositoryMock
-            .Setup(r => r.GetCapturesByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), default))
-            .Returns((Guid _, int limit, int offset, CancellationToken _) =>
+            .Setup(r => r.GetCapturesByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid _, int limit, int offset, Guid? boardId, CancellationToken _) =>
             {
                 IEnumerable<LlmRequest> page = offset switch
                 {


### PR DESCRIPTION
## #1239 — push the raw-board pre-filter into SQL

`CaptureService.ListAsync` evaluated the board filter **in memory** after paging, so a board-filtered query scanned the user's whole capture history page-by-page (`~O(captures/limit)` round-trips).

### Change
- `GetCapturesByUserAsync` gains an optional `Guid? boardId`. When supplied it applies `(BoardId IS NULL OR BoardId = @boardId)` in SQL (both the SQLite raw and EF paths) — excluding **other boards'** captures at the database while **keeping null-board captures** (which may still resolve to the target board via applied-conversion provenance, resolved in the service).
- `ListAsync` passes `filter.BoardId`; the now-redundant in-service raw pre-filter is removed. The effective-board (provenance) and status filters stay in the service.
- **Status SQL-pushdown is intentionally left in-service** — `summary.Status` is provenance-derived (`ResolveCaptureStatus` + applied-conversion), not a straight `RequestStatus` column.

### Why null-board rows are kept
A capture with `BoardId == null` can be promoted to an effective board by an applied proposal; excluding nulls in SQL would drop legitimate matches. So SQL keeps `null` + target-board rows, and the service's effective-board check finalizes the match.

### Tests
- New repo integration test: `boardX` + null-board kept, `boardY` excluded at the DB; unfiltered read still returns all (boardId genuinely optional).
- The two `ListAsync` paging tests (`PagesUntilEnoughMatches`, `DeduplicatesRows`) now use **null-board** rows for the padding/under-fill role the old non-matching-board rows played — they pass the SQL pre-filter but fail the effective-board check, so the exact offset sequences (`[0,2,4]`, the `c`-dedup) are preserved.
- 3 `ILlmQueueRepository` fakes + the `CaptureService` mocks honor the new `boardId` arg.

Verified: full sln builds clean; `CaptureServiceTests` 33, repo integration + worker fakes 66, capture/inbox API 151 — all green.

Refs #1239 (board done; status pushdown deliberately deferred as provenance-derived).
