### PR TITLE
fix(queue): recover non-capture LlmRequests stuck in Processing (#1209)

### DIFF
--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -13,6 +13,11 @@ public class LlmQueueToProposalWorker : BackgroundService
     private const string QueueNameLlm = "llm";
     private const string QueueNameCaptureTriage = "capture-triage";
 
+    // Floor on the stuck-recovery lease so an aggressively-low ProcessingLeaseSeconds can never sweep a
+    // request that was claimed seconds ago and is still legitimately in flight. Mirrors the floor the
+    // OutboundWebhookDeliveryWorker recovery sweep uses.
+    private const int MinStuckRecoveryLeaseSeconds = 30;
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly WorkerSettings _settings;
     private readonly WorkerHeartbeatRegistry _workerHeartbeatRegistry;
@@ -64,6 +69,12 @@ public class LlmQueueToProposalWorker : BackgroundService
 
     private async Task ProcessBatchAsync(CancellationToken ct)
     {
+        // Reclaim non-capture requests abandoned in Processing by a crashed worker before draining the
+        // queue (#1209), so a recovered item becomes eligible again within this same tick. Capture-triage
+        // items self-heal via the Processing re-claim path below, so the sweep targets non-capture work
+        // only -- the one kind read solely from Pending and otherwise stuck forever.
+        await RecoverStuckProcessingItemsAsync(ct);
+
         using var scope = _scopeFactory.CreateScope();
         var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
         // Bound each read at the database to the work one tick can consume (BuildFairBatchItems emits at
@@ -136,6 +147,72 @@ public class LlmQueueToProposalWorker : BackgroundService
         }
 
         await Task.WhenAll(tasks);
+    }
+
+    private async Task RecoverStuckProcessingItemsAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        // A non-capture request that has sat in Processing longer than the processing lease is treated as
+        // abandoned: the worker that claimed it (stamping UpdatedAt to now) never reached a terminal
+        // transition. Re-claiming a live, just-claimed request is prevented because its UpdatedAt is fresh.
+        var leaseSeconds = Math.Max(MinStuckRecoveryLeaseSeconds, _settings.ProcessingLeaseSeconds);
+        var staleBefore = DateTimeOffset.UtcNow.AddSeconds(-leaseSeconds);
+        var fetchLimit = Math.Max(1, _settings.MaxBatchSize);
+
+        var stuckItems = await unitOfWork.LlmQueue.GetStuckProcessingNonCaptureAsync(staleBefore, fetchLimit, ct);
+        if (stuckItems.Count == 0)
+        {
+            return;
+        }
+
+        var requeued = 0;
+        var failedPermanently = 0;
+        foreach (var item in stuckItems)
+        {
+            // Recovery counts against the retry budget so a request that repeatedly crashes the worker
+            // eventually fails permanently instead of looping forever. MarkAsFailed (Processing -> Failed,
+            // RetryCount++) then ResetForRetry (Failed -> Pending) reuses the same transitions and budget
+            // check as HandleFailureWithRetryAsync, keeping recovery and in-band failure consistent.
+            var budgetRemains = item.RetryCount + 1 < _settings.MaxRetries;
+            item.MarkAsFailed("Recovered from a stale Processing state; the worker that claimed this request did not complete it.");
+            if (budgetRemains)
+            {
+                item.ResetForRetry();
+                requeued++;
+            }
+            else
+            {
+                failedPermanently++;
+            }
+        }
+
+        await unitOfWork.SaveChangesAsync(ct);
+
+        _logger.LogWarning(
+            "Recovered {StuckCount} non-capture queue item(s) stuck in Processing beyond {LeaseSeconds}s: {RequeuedCount} returned to Pending, {FailedCount} failed (retry budget exhausted).",
+            stuckItems.Count,
+            leaseSeconds,
+            requeued,
+            failedPermanently);
+
+        if (requeued > 0)
+        {
+            RecordRecoveryMetrics(requeued, "recovered_stuck_requeued");
+        }
+        if (failedPermanently > 0)
+        {
+            RecordRecoveryMetrics(failedPermanently, "recovered_stuck_failed");
+        }
+    }
+
+    private static void RecordRecoveryMetrics(int count, string outcome)
+    {
+        TaskdeckTelemetry.WorkerItemsProcessed.Add(
+            count,
+            new KeyValuePair<string, object?>(TaskdeckTelemetryTags.WorkerName, nameof(LlmQueueToProposalWorker)),
+            new KeyValuePair<string, object?>(TaskdeckTelemetryTags.Outcome, outcome));
     }
 
     private async Task ProcessSingleItemAsync(Guid itemId, DateTimeOffset expectedUpdatedAt, CancellationToken ct)

--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -287,6 +287,27 @@ public class LlmQueueToProposalWorker : BackgroundService
             activity?.SetTag(TaskdeckTelemetryTags.BoardId, item.BoardId.Value.ToString());
         }
 
+        // Idempotency guard (#1209 review): a prior attempt may have created and committed the proposal,
+        // then crashed (or failed mid-save and been requeued) before this request was marked completed.
+        // Re-running the planner would create a DUPLICATE PendingReview proposal (proposal creation is not
+        // idempotent on SourceReferenceId), so if a Queue-sourced proposal already exists for this request,
+        // complete it instead of reprocessing. Mirrors the capture path's existing-proposal short-circuit.
+        var existingProposal = await unitOfWork.AutomationProposals.GetBySourceReferenceAsync(
+            ProposalSourceType.Queue, item.Id.ToString(), ct);
+        if (existingProposal != null)
+        {
+            item.MarkAsCompleted();
+            await unitOfWork.SaveChangesAsync(ct);
+            _logger.LogInformation(
+                "Queue item {ItemId} already linked to proposal {ProposalId}; marking completed without reprocessing",
+                item.Id,
+                existingProposal.Id);
+            outcome = "completed_existing";
+            stopWatch.Stop();
+            RecordWorkerProcessingMetrics(stopWatch.Elapsed.TotalMilliseconds, outcome);
+            return;
+        }
+
         try
         {
             var proposalResult = await planner.ParseInstructionAsync(

--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -186,10 +186,25 @@ public class LlmQueueToProposalWorker : BackgroundService
             return;
         }
 
+        var completed = 0;
         var requeued = 0;
         var failedPermanently = 0;
         foreach (var item in stuckItems)
         {
+            // If the crashed attempt already committed this request's proposal, the work actually succeeded
+            // -- only the completing status flip was lost. Complete it regardless of the retry budget,
+            // rather than requeueing (which the drain's guard would complete anyway, after a wasted cycle)
+            // or, on the last attempt, failing it -- which would mislabel a request that DID produce its
+            // proposal as Failed and never route it through the drain's completion guard.
+            var existingProposal = await unitOfWork.AutomationProposals.GetBySourceReferenceAsync(
+                ProposalSourceType.Queue, item.Id.ToString(), ct);
+            if (existingProposal != null)
+            {
+                item.MarkAsCompleted();
+                completed++;
+                continue;
+            }
+
             // Recovery counts against the retry budget so a request that repeatedly crashes the worker
             // eventually fails permanently instead of looping forever. MarkAsFailed (Processing -> Failed,
             // RetryCount++) then ResetForRetry (Failed -> Pending) reuses the same transitions and the same
@@ -214,12 +229,17 @@ public class LlmQueueToProposalWorker : BackgroundService
         await unitOfWork.SaveChangesAsync(ct);
 
         _logger.LogWarning(
-            "Recovered {StuckCount} non-capture queue item(s) stuck in Processing beyond {LeaseSeconds}s: {RequeuedCount} returned to Pending, {FailedCount} failed (retry budget exhausted).",
+            "Recovered {StuckCount} non-capture queue item(s) stuck in Processing beyond {LeaseSeconds}s: {CompletedCount} already had a proposal and were completed, {RequeuedCount} returned to Pending, {FailedCount} failed (retry budget exhausted).",
             stuckItems.Count,
             leaseSeconds,
+            completed,
             requeued,
             failedPermanently);
 
+        if (completed > 0)
+        {
+            RecordRecoveryMetrics(completed, "recovered_stuck_completed");
+        }
         if (requeued > 0)
         {
             RecordRecoveryMetrics(requeued, "recovered_stuck_requeued");

--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -72,8 +72,23 @@ public class LlmQueueToProposalWorker : BackgroundService
         // Reclaim non-capture requests abandoned in Processing by a crashed worker before draining the
         // queue (#1209), so a recovered item becomes eligible again within this same tick. Capture-triage
         // items self-heal via the Processing re-claim path below, so the sweep targets non-capture work
-        // only -- the one kind read solely from Pending and otherwise stuck forever.
-        await RecoverStuckProcessingItemsAsync(ct);
+        // only -- the one kind read solely from Pending and otherwise stuck forever. The sweep is isolated
+        // in its own try/catch so a recovery hiccup (e.g. a transient SaveChanges failure) can never starve
+        // the tick's normal queue draining; the failure is logged and retried on the next poll.
+        try
+        {
+            await RecoverStuckProcessingItemsAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                "Stuck-Processing recovery sweep failed; continuing with normal queue draining. {ExceptionSummary}",
+                SensitiveDataRedactor.SummarizeException(ex));
+        }
 
         using var scope = _scopeFactory.CreateScope();
         var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
@@ -156,7 +171,11 @@ public class LlmQueueToProposalWorker : BackgroundService
 
         // A non-capture request that has sat in Processing longer than the processing lease is treated as
         // abandoned: the worker that claimed it (stamping UpdatedAt to now) never reached a terminal
-        // transition. Re-claiming a live, just-claimed request is prevented because its UpdatedAt is fresh.
+        // transition. Re-claiming a live, just-claimed request is prevented because its UpdatedAt is fresh,
+        // and because ProcessBatchAsync runs this sweep before -- and is awaited sequentially with -- the
+        // batch drain, so a single worker process can never sweep its own in-flight work. The sweep assumes
+        // a single worker process (the local-first deployment): like the webhook recovery sweep it has no
+        // optimistic-concurrency guard, so two processes against one DB could double-recover a row.
         var leaseSeconds = Math.Max(MinStuckRecoveryLeaseSeconds, _settings.ProcessingLeaseSeconds);
         var staleBefore = DateTimeOffset.UtcNow.AddSeconds(-leaseSeconds);
         var fetchLimit = Math.Max(1, _settings.MaxBatchSize);
@@ -173,8 +192,12 @@ public class LlmQueueToProposalWorker : BackgroundService
         {
             // Recovery counts against the retry budget so a request that repeatedly crashes the worker
             // eventually fails permanently instead of looping forever. MarkAsFailed (Processing -> Failed,
-            // RetryCount++) then ResetForRetry (Failed -> Pending) reuses the same transitions and budget
-            // check as HandleFailureWithRetryAsync, keeping recovery and in-band failure consistent.
+            // RetryCount++) then ResetForRetry (Failed -> Pending) reuses the same transitions and the same
+            // pre-increment budget check (RetryCount + 1 < MaxRetries) as HandleFailureWithRetryAsync. It
+            // deliberately omits that path's IsTransientFailure gate: a stale-Processing row means the
+            // worker crashed mid-flight (no error code to classify), which we always treat as retryable.
+            // The lease itself spaces successive recoveries of a poison-pill payload >= the lease apart, so
+            // no explicit retry backoff is needed here.
             var budgetRemains = item.RetryCount + 1 < _settings.MaxRetries;
             item.MarkAsFailed("Recovered from a stale Processing state; the worker that claimed this request did not complete it.");
             if (budgetRemains)

--- a/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ILlmQueueRepository.cs
@@ -72,6 +72,21 @@ public interface ILlmQueueRepository : IRepository<LlmRequest>
 
     /// <summary>Counts Pending capture-triage requests for the readiness gauge, without materializing rows.</summary>
     Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns at most <paramref name="limit"/> NON-capture (automation) requests stuck in
+    /// <see cref="RequestStatus.Processing"/> whose <c>UpdatedAt</c> is at or before
+    /// <paramref name="staleBefore"/>, oldest-first, bounded at the database. These are requests a worker
+    /// claimed (flipping them to Processing) but never completed or failed — typically because the worker
+    /// crashed mid-flight — so nothing re-enqueues them and they are otherwise abandoned forever (#1209).
+    /// Capture-triage requests are excluded by the in-query predicate: they are read from Processing every
+    /// poll and re-claimed, so they self-heal; only non-capture work (read solely from Pending) needs a
+    /// recovery sweep. The predicate must live in the query, not a post-fetch filter, so the bound never
+    /// fills with rows the sweeper would discard.
+    /// </summary>
+    /// <param name="staleBefore">Only rows with <c>UpdatedAt &lt;= staleBefore</c> are returned.</param>
+    /// <param name="limit">Maximum rows to return; must be at least 1.</param>
+    Task<IReadOnlyList<LlmRequest>> GetStuckProcessingNonCaptureAsync(DateTimeOffset staleBefore, int limit, CancellationToken cancellationToken = default);
     Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default);
     Task<Dictionary<RequestStatus, int>> GetStatusCountsByUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<LlmRequest?> GetNextPendingAsync(CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -330,20 +330,18 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
             // FromSqlInterpolated + Include wraps this in a subquery that does not guarantee the raw
             // ORDER BY survives (see GetByUserAsync); the inner LIMIT still selects the correct oldest-N
             // rows, so re-sort oldest-first in memory to make the ordering a contract.
+            // No Include: the recovery sweep only mutates scalar fields (Status/ErrorMessage/RetryCount/
+            // UpdatedAt) and never reads the User/Board navigations, so loading them is wasted work.
             var rows = await _context.LlmRequests
                 .FromSqlInterpolated(
                     $"SELECT * FROM LlmRequests WHERE Status = {(int)RequestStatus.Processing} AND RequestType NOT LIKE {CaptureRequestTypeLike} AND UpdatedAt <= {staleBefore} ORDER BY UpdatedAt ASC LIMIT {limit}")
-                .Include(lr => lr.User)
-                .Include(lr => lr.Board)
                 .ToListAsync(cancellationToken);
             return rows.OrderBy(lr => lr.UpdatedAt).ToList();
         }
 
         // Non-SQLite providers (e.g. the Postgres Testcontainer path) translate the predicate + OrderBy +
-        // Take into a single bounded query with guaranteed ordering.
+        // Take into a single bounded query with guaranteed ordering. No Include (see SQLite path above).
         return await _context.LlmRequests
-            .Include(lr => lr.User)
-            .Include(lr => lr.Board)
             .Where(lr => lr.Status == RequestStatus.Processing
                 && !EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike)
                 && lr.UpdatedAt <= staleBefore)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -322,9 +322,11 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
         if (_context.Database.IsSqlite())
         {
             // SQLite's EF provider cannot translate WHERE/ORDER BY on a DateTimeOffset column, so the
-            // staleness comparison + order + LIMIT live in raw SQL (UpdatedAt is stamped from UtcNow and
-            // materializes UTC per ADR-0040, so its stored TEXT compares chronologically -- the same
-            // shape the shipped OutboundWebhookDeliveryRepository.GetStuckProcessingAsync relies on).
+            // staleness comparison + order + LIMIT live in raw SQL. The TEXT comparison is chronological
+            // because every UpdatedAt writer (Entity ctor/Touch and the raw claim UPDATEs) and staleBefore
+            // are all DateTimeOffset.UtcNow, so they share a fixed-width "+00:00" offset and lexical order
+            // equals chronological order -- the same shape the shipped
+            // OutboundWebhookDeliveryRepository.GetStuckProcessingAsync relies on.
             // FromSqlInterpolated + Include wraps this in a subquery that does not guarantee the raw
             // ORDER BY survives (see GetByUserAsync); the inner LIMIT still selects the correct oldest-N
             // rows, so re-sort oldest-first in memory to make the ordering a contract.

--- a/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/LlmQueueRepository.cs
@@ -309,6 +309,47 @@ public class LlmQueueRepository : Repository<LlmRequest>, ILlmQueueRepository
         return await query.CountAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyList<LlmRequest>> GetStuckProcessingNonCaptureAsync(
+        DateTimeOffset staleBefore,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        if (limit < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), limit, "Limit must be at least 1.");
+        }
+
+        if (_context.Database.IsSqlite())
+        {
+            // SQLite's EF provider cannot translate WHERE/ORDER BY on a DateTimeOffset column, so the
+            // staleness comparison + order + LIMIT live in raw SQL (UpdatedAt is stamped from UtcNow and
+            // materializes UTC per ADR-0040, so its stored TEXT compares chronologically -- the same
+            // shape the shipped OutboundWebhookDeliveryRepository.GetStuckProcessingAsync relies on).
+            // FromSqlInterpolated + Include wraps this in a subquery that does not guarantee the raw
+            // ORDER BY survives (see GetByUserAsync); the inner LIMIT still selects the correct oldest-N
+            // rows, so re-sort oldest-first in memory to make the ordering a contract.
+            var rows = await _context.LlmRequests
+                .FromSqlInterpolated(
+                    $"SELECT * FROM LlmRequests WHERE Status = {(int)RequestStatus.Processing} AND RequestType NOT LIKE {CaptureRequestTypeLike} AND UpdatedAt <= {staleBefore} ORDER BY UpdatedAt ASC LIMIT {limit}")
+                .Include(lr => lr.User)
+                .Include(lr => lr.Board)
+                .ToListAsync(cancellationToken);
+            return rows.OrderBy(lr => lr.UpdatedAt).ToList();
+        }
+
+        // Non-SQLite providers (e.g. the Postgres Testcontainer path) translate the predicate + OrderBy +
+        // Take into a single bounded query with guaranteed ordering.
+        return await _context.LlmRequests
+            .Include(lr => lr.User)
+            .Include(lr => lr.Board)
+            .Where(lr => lr.Status == RequestStatus.Processing
+                && !EF.Functions.Like(lr.RequestType, CaptureRequestTypeLike)
+                && lr.UpdatedAt <= staleBefore)
+            .OrderBy(lr => lr.UpdatedAt)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IEnumerable<LlmRequest>> GetByUserAndStatusAsync(Guid userId, RequestStatus status, CancellationToken cancellationToken = default)
     {
         if (_context.Database.IsSqlite())

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -463,6 +463,70 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
     }
 
     [Fact]
+    public async Task GetStuckProcessingNonCaptureAsync_ReturnsOnlyNonCaptureProcessingRowsAtOrBeforeThreshold()
+    {
+        // #1209: the recovery query selects non-capture requests stuck in Processing past the lease and
+        // excludes (a) capture-triage rows (they self-heal), (b) Pending/terminal rows, all at the database.
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("stuck-recovery", "stuck-recovery@example.com", "hash");
+            db.Users.Add(user);
+
+            var stuck1 = new LlmRequest(user.Id, "instruction", "{}");
+            stuck1.MarkAsProcessing();
+            var stuck2 = new LlmRequest(user.Id, "instruction", "{}");
+            stuck2.MarkAsProcessing();
+            var pending = new LlmRequest(user.Id, "instruction", "{}"); // non-capture, Pending -> excluded
+            var completed = new LlmRequest(user.Id, "instruction", "{}");
+            completed.MarkAsProcessing();
+            completed.MarkAsCompleted(); // terminal -> excluded
+            var captureProcessing = new LlmRequest(user.Id, CaptureRequestContract.RequestTypeV1, "{}");
+            captureProcessing.MarkAsProcessing(); // capture in Processing -> excluded (self-heals)
+            db.LlmRequests.AddRange(stuck1, stuck2, pending, completed, captureProcessing);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            // staleBefore in the future, so every current Processing row counts as "older than" the cutoff.
+            var staleBefore = DateTimeOffset.UtcNow.AddMinutes(1);
+            var stuck = await repo.GetStuckProcessingNonCaptureAsync(staleBefore, 50);
+
+            stuck.Select(r => r.Id).Should().BeEquivalentTo(new[] { stuck1.Id, stuck2.Id });
+        });
+    }
+
+    [Fact]
+    public async Task GetStuckProcessingNonCaptureAsync_ExcludesRowsNewerThanThreshold()
+    {
+        // A freshly-claimed Processing row (UpdatedAt ~ now) is within the lease and must not be swept.
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("fresh-processing", "fresh-processing@example.com", "hash");
+            db.Users.Add(user);
+            var fresh = new LlmRequest(user.Id, "instruction", "{}");
+            fresh.MarkAsProcessing();
+            db.LlmRequests.Add(fresh);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            // staleBefore in the past, so the just-updated row is newer than the cutoff and is excluded.
+            var staleBefore = DateTimeOffset.UtcNow.AddMinutes(-1);
+            var stuck = await repo.GetStuckProcessingNonCaptureAsync(staleBefore, 50);
+
+            stuck.Should().BeEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task GetStuckProcessingNonCaptureAsync_RejectsNonPositiveLimit()
+    {
+        await WithSqliteRepoAsync(async (_, repo) =>
+        {
+            var act = async () => await repo.GetStuckProcessingNonCaptureAsync(DateTimeOffset.UtcNow, 0);
+            await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+        });
+    }
+
+    [Fact]
     public async Task TryClaimProcessingCaptureAsync_ShouldSucceedOnFirstClaim_FailOnSecond()
     {
         using var scope = _factory.Services.CreateScope();

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -495,6 +495,38 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicati
     }
 
     [Fact]
+    public async Task GetStuckProcessingNonCaptureAsync_ReturnsOldestFirstAndRespectsLimit()
+    {
+        // #1209: proves the raw-SQL DateTimeOffset comparison across DISTINCT timestamps, the
+        // ORDER BY UpdatedAt ASC contract (incl. the in-memory re-sort guard), and that LIMIT bounds the
+        // sweep to the OLDEST rows -- so a bounded sweep never drops the oldest abandoned work.
+        await WithSqliteRepoAsync(async (db, repo) =>
+        {
+            var user = new User("stuck-order", "stuck-order@example.com", "hash");
+            db.Users.Add(user);
+            var oldest = new LlmRequest(user.Id, "instruction", "{}");
+            oldest.MarkAsProcessing();
+            var middle = new LlmRequest(user.Id, "instruction", "{}");
+            middle.MarkAsProcessing();
+            var newest = new LlmRequest(user.Id, "instruction", "{}");
+            newest.MarkAsProcessing();
+            db.LlmRequests.AddRange(oldest, middle, newest);
+            // Distinct UpdatedAt values so oldest-first ordering and LIMIT are genuinely discriminated.
+            var t0 = DateTimeOffset.UtcNow.AddHours(-3);
+            db.Entry(oldest).Property(nameof(Entity.UpdatedAt)).CurrentValue = t0;
+            db.Entry(middle).Property(nameof(Entity.UpdatedAt)).CurrentValue = t0.AddMinutes(30);
+            db.Entry(newest).Property(nameof(Entity.UpdatedAt)).CurrentValue = t0.AddMinutes(60);
+            await db.SaveChangesAsync();
+            db.ChangeTracker.Clear();
+
+            var stuck = await repo.GetStuckProcessingNonCaptureAsync(DateTimeOffset.UtcNow, limit: 2);
+
+            // LIMIT 2 returns the two OLDEST, in ascending UpdatedAt order (newest excluded).
+            stuck.Select(r => r.Id).Should().Equal(oldest.Id, middle.Id);
+        });
+    }
+
+    [Fact]
     public async Task GetStuckProcessingNonCaptureAsync_ExcludesRowsNewerThanThreshold()
     {
         // A freshly-claimed Processing row (UpdatedAt ~ now) is within the lease and must not be swept.

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -59,7 +59,8 @@ public class LlmQueueToProposalWorkerTests
         int maxBatchSize = 10,
         int maxConcurrency = 1,
         int maxRetries = 3,
-        int[]? retryBackoff = null)
+        int[]? retryBackoff = null,
+        int processingLeaseSeconds = 120)
     {
         return new WorkerSettings
         {
@@ -68,7 +69,8 @@ public class LlmQueueToProposalWorkerTests
             MaxBatchSize = maxBatchSize,
             MaxConcurrency = maxConcurrency,
             MaxRetries = maxRetries,
-            RetryBackoffSeconds = retryBackoff ?? [0]
+            RetryBackoffSeconds = retryBackoff ?? [0],
+            ProcessingLeaseSeconds = processingLeaseSeconds
         };
     }
 
@@ -768,6 +770,68 @@ public class LlmQueueToProposalWorkerTests
         await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
 
         captureItem.Status.Should().Be(RequestStatus.Processing, "capture items are excluded from the non-capture recovery sweep");
+    }
+
+    [Theory]
+    // ProcessingLeaseSeconds is floored at 30s: a 10s lease still protects an item only 20s old, while a
+    // 40s-old item exceeds the floor and is swept -- proving the floor branch (#1209 AC4).
+    [InlineData(10, 20, false)]
+    [InlineData(10, 40, true)]
+    // A larger lease genuinely raises the threshold: a 150s-old item (which the default 120s lease WOULD
+    // sweep) is protected at 300s, while a 400s-old item is swept -- proving the threshold tracks the setting.
+    [InlineData(300, 150, false)]
+    [InlineData(300, 400, true)]
+    public async Task RecoverStuck_HonorsProcessingLeaseThresholdAndFloor(int processingLeaseSeconds, int itemAgeSeconds, bool expectedSwept)
+    {
+        var item = CreateStuckProcessingNonCaptureItem(retryCount: 0, ageSeconds: itemAgeSeconds);
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(maxRetries: 3, processingLeaseSeconds: processingLeaseSeconds));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(
+            expectedSwept ? RequestStatus.Pending : RequestStatus.Processing,
+            "the effective lease is Math.Max(30, ProcessingLeaseSeconds={0}) and the item is {1}s old",
+            processingLeaseSeconds,
+            itemAgeSeconds);
+    }
+
+    [Fact]
+    public async Task RecoverStuck_RunTwice_DoesNotDoubleConsumeBudget()
+    {
+        // A second sweep must be idempotent: after the first sweep the item is Pending (not Processing), so
+        // it is excluded from the next sweep and its retry budget is not consumed twice.
+        var item = CreateStuckProcessingNonCaptureItem(retryCount: 0);
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+        item.RetryCount.Should().Be(1);
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Pending);
+        item.RetryCount.Should().Be(1, "the already-requeued item is no longer in Processing, so the second sweep is a no-op");
+    }
+
+    [Fact]
+    public async Task RecoverStuck_MixedCaptureAndNonCapture_OnlyNonCaptureSwept()
+    {
+        var nonCapture = CreateStuckProcessingNonCaptureItem(retryCount: 0);
+        var capture = CreateCaptureTriageItem();
+        BackdateUpdatedAt(capture, DateTimeOffset.UtcNow.AddSeconds(-10_000));
+        var queueRepo = new FakeLlmQueueRepository([], [nonCapture, capture]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        nonCapture.Status.Should().Be(RequestStatus.Pending, "the non-capture stuck item is recovered");
+        capture.Status.Should().Be(RequestStatus.Processing, "the stuck capture item is excluded from the non-capture sweep");
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Microsoft.Extensions.Logging.Abstractions;
 using Taskdeck.Api.Workers;
 using Taskdeck.Application.DTOs;
@@ -88,10 +89,11 @@ public class LlmQueueToProposalWorkerTests
     private static ServiceProvider BuildServiceProvider(
         FakeLlmQueueRepository queueRepo,
         FakeAutomationPlannerService? planner = null,
-        FakeCaptureTriageService? triageService = null)
+        FakeCaptureTriageService? triageService = null,
+        IAutomationProposalRepository? automationProposals = null)
     {
         var services = new ServiceCollection();
-        var unitOfWork = new FakeUnitOfWork(queueRepo);
+        var unitOfWork = new FakeUnitOfWork(queueRepo, automationProposals);
         services.AddSingleton<IUnitOfWork>(unitOfWork);
         services.AddSingleton<IAutomationPlannerService>(planner ?? new FakeAutomationPlannerService());
         services.AddSingleton<ICaptureTriageService>(triageService ?? new FakeCaptureTriageService());
@@ -850,6 +852,41 @@ public class LlmQueueToProposalWorkerTests
         item.Status.Should().Be(RequestStatus.Completed, "the recovered item is re-enqueued and processed to completion within the tick");
     }
 
+    [Fact]
+    public async Task ProcessSingleItem_WithExistingQueueProposal_CompletesWithoutReprocessing()
+    {
+        // #1209 review (Codex): a prior attempt created + committed the proposal then crashed before the
+        // request was marked completed. Reprocessing would create a DUPLICATE PendingReview proposal, so the
+        // worker must complete the request without calling the planner when a Queue-sourced proposal already
+        // exists for it.
+        var item = CreatePendingItem();
+        var queueRepo = new FakeLlmQueueRepository([item]);
+        var existing = new AutomationProposal(
+            ProposalSourceType.Queue,
+            item.UserId,
+            "Existing proposal from the crashed attempt",
+            RiskLevel.Low,
+            item.Id.ToString(),
+            boardId: null,
+            sourceReferenceId: item.Id.ToString());
+        var proposals = new Mock<IAutomationProposalRepository>();
+        proposals
+            .Setup(p => p.GetBySourceReferenceAsync(ProposalSourceType.Queue, item.Id.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        // The planner would FAIL if called -> proves the guard short-circuits before reprocessing.
+        var planner = new FakeAutomationPlannerService
+        {
+            ResultFactory = _ => Result.Failure<ProposalDto>(ErrorCodes.UnexpectedError, "planner must not be called")
+        };
+        using var sp = BuildServiceProvider(queueRepo, planner, automationProposals: proposals.Object);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await InvokeProcessBatchAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Completed, "the request already produced its proposal, so it is completed not reprocessed");
+        planner.CallCount.Should().Be(0, "the existing-proposal guard must short-circuit before the planner");
+    }
+
     #endregion
 
     #region Fakes
@@ -1099,9 +1136,12 @@ public class LlmQueueToProposalWorkerTests
 
     private sealed class FakeUnitOfWork : IUnitOfWork
     {
-        public FakeUnitOfWork(ILlmQueueRepository llmQueue)
+        public FakeUnitOfWork(ILlmQueueRepository llmQueue, IAutomationProposalRepository? automationProposals = null)
         {
             LlmQueue = llmQueue;
+            // Default to a loose mock whose GetBySourceReferenceAsync returns null, so the worker's
+            // existing-proposal idempotency guard is a no-op for the normal (first-time) drain path.
+            AutomationProposals = automationProposals ?? Mock.Of<IAutomationProposalRepository>();
         }
 
         public IBoardRepository Boards => null!;
@@ -1113,7 +1153,7 @@ public class LlmQueueToProposalWorkerTests
         public IBoardAccessRepository BoardAccesses => null!;
         public IAuditLogRepository AuditLogs => null!;
         public ILlmQueueRepository LlmQueue { get; }
-        public IAutomationProposalRepository AutomationProposals => null!;
+        public IAutomationProposalRepository AutomationProposals { get; }
         public IArchiveItemRepository ArchiveItems => null!;
         public IChatSessionRepository ChatSessions => null!;
         public IChatMessageRepository ChatMessages => null!;

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -887,6 +887,36 @@ public class LlmQueueToProposalWorkerTests
         planner.CallCount.Should().Be(0, "the existing-proposal guard must short-circuit before the planner");
     }
 
+    [Theory]
+    [InlineData(0)] // retry budget remains
+    [InlineData(2)] // retry budget exhausted (MaxRetries=3): the Codex-flagged case -- must complete, not fail
+    public async Task RecoverStuck_ProposalAlreadyExists_CompletesRegardlessOfBudget(int retryCount)
+    {
+        // #1209 review round 2 (Codex): if the crashed attempt already committed the proposal, the request
+        // succeeded; recovery must complete it even on its last attempt, rather than marking it Failed (which
+        // would mislabel a successful request and bypass the drain's completion guard).
+        var item = CreateStuckProcessingNonCaptureItem(retryCount: retryCount);
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        var existing = new AutomationProposal(
+            ProposalSourceType.Queue,
+            item.UserId,
+            "Existing proposal from the crashed attempt",
+            RiskLevel.Low,
+            item.Id.ToString(),
+            boardId: null,
+            sourceReferenceId: item.Id.ToString());
+        var proposals = new Mock<IAutomationProposalRepository>();
+        proposals
+            .Setup(p => p.GetBySourceReferenceAsync(ProposalSourceType.Queue, item.Id.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+        using var sp = BuildServiceProvider(queueRepo, automationProposals: proposals.Object);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Completed, "an already-created proposal means the request succeeded; recovery completes it regardless of retry budget");
+    }
+
     #endregion
 
     #region Fakes

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -666,6 +666,128 @@ public class LlmQueueToProposalWorkerTests
 
     #endregion
 
+    #region Stuck-Processing recovery (#1209)
+
+    private static async Task InvokeRecoverStuckProcessingItemsAsync(
+        LlmQueueToProposalWorker worker,
+        CancellationToken ct)
+    {
+        var method = typeof(LlmQueueToProposalWorker).GetMethod(
+            "RecoverStuckProcessingItemsAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Should().NotBeNull("RecoverStuckProcessingItemsAsync must exist");
+        var task = method!.Invoke(worker, [ct]);
+        task.Should().NotBeNull();
+        await (Task)task!;
+    }
+
+    private static void BackdateUpdatedAt(LlmRequest item, DateTimeOffset updatedAt)
+    {
+        typeof(LlmRequest)
+            .GetProperty(nameof(LlmRequest.UpdatedAt))!
+            .SetValue(item, updatedAt);
+    }
+
+    /// <summary>
+    /// Builds a non-capture request left in Processing (as if a worker claimed it then crashed), with
+    /// <paramref name="retryCount"/> prior failures driven through the real transitions and its UpdatedAt
+    /// backdated <paramref name="ageSeconds"/> into the past so it is older than the recovery lease.
+    /// </summary>
+    private static LlmRequest CreateStuckProcessingNonCaptureItem(int retryCount = 0, int ageSeconds = 10_000)
+    {
+        var item = CreatePendingItem();
+        for (var i = 0; i < retryCount; i++)
+        {
+            item.MarkAsProcessing();
+            item.MarkAsFailed("prior failure");
+            item.ResetForRetry();
+        }
+        item.MarkAsProcessing();
+        BackdateUpdatedAt(item, DateTimeOffset.UtcNow.AddSeconds(-ageSeconds));
+        return item;
+    }
+
+    [Fact]
+    public async Task RecoverStuck_NonCaptureStuckInProcessing_WithRetryBudget_ReturnsToPendingAndConsumesBudget()
+    {
+        var item = CreateStuckProcessingNonCaptureItem(retryCount: 0);
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Pending, "a stuck item with retry budget remaining is re-enqueued");
+        item.RetryCount.Should().Be(1, "recovery counts against the retry budget so a repeatedly-crashing item cannot loop forever");
+    }
+
+    [Fact]
+    public async Task RecoverStuck_NonCaptureStuckInProcessing_BudgetExhausted_MarkedFailed()
+    {
+        // MaxRetries=3, RetryCount=2 -> 2 + 1 < 3 is false -> no budget left -> permanent failure.
+        var item = CreateStuckProcessingNonCaptureItem(retryCount: 2);
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Failed, "a stuck item with no retry budget left fails permanently");
+        item.RetryCount.Should().Be(3);
+        item.ErrorMessage.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task RecoverStuck_FreshProcessingItem_NotSwept()
+    {
+        // A non-capture item just claimed (UpdatedAt = now) is still legitimately in flight and must not
+        // be reclaimed mid-processing.
+        var item = CreatePendingItem();
+        item.MarkAsProcessing();
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Processing, "a fresh Processing item is within its lease and must be left alone");
+        item.RetryCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RecoverStuck_CaptureItemStuckInProcessing_NotSwept()
+    {
+        // Capture-triage items self-heal via the Processing re-claim path, so the non-capture recovery
+        // sweep must never touch them.
+        var captureItem = CreateCaptureTriageItem();
+        BackdateUpdatedAt(captureItem, DateTimeOffset.UtcNow.AddSeconds(-10_000));
+        var queueRepo = new FakeLlmQueueRepository([], [captureItem]);
+        using var sp = BuildServiceProvider(queueRepo);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(), DefaultSettings(maxRetries: 3));
+
+        await InvokeRecoverStuckProcessingItemsAsync(worker, CancellationToken.None);
+
+        captureItem.Status.Should().Be(RequestStatus.Processing, "capture items are excluded from the non-capture recovery sweep");
+    }
+
+    [Fact]
+    public async Task ProcessBatch_StuckNonCaptureItem_RecoveredAndReprocessedToCompletion()
+    {
+        // End-to-end (#1209 acceptance): a non-capture item abandoned in Processing is recovered to Pending
+        // and then drained by the same tick, proving the item is eventually reclaimed rather than lost.
+        var item = CreateStuckProcessingNonCaptureItem(retryCount: 0);
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        var planner = new FakeAutomationPlannerService();
+        using var sp = BuildServiceProvider(queueRepo, planner);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>());
+
+        await InvokeProcessBatchAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Completed, "the recovered item is re-enqueued and processed to completion within the tick");
+    }
+
+    #endregion
+
     #region Fakes
 
     private sealed class FakeLlmQueueRepository : ILlmQueueRepository
@@ -727,6 +849,18 @@ public class LlmQueueToProposalWorkerTests
 
         public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(_allItems.Count(i => i.Status == RequestStatus.Pending && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
+
+        public Task<IReadOnlyList<LlmRequest>> GetStuckProcessingNonCaptureAsync(DateTimeOffset staleBefore, int limit, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<LlmRequest> result = _allItems
+                .Where(i => i.Status == RequestStatus.Processing
+                    && !CaptureRequestContract.IsCaptureRequestType(i.RequestType)
+                    && i.UpdatedAt <= staleBefore)
+                .OrderBy(i => i.UpdatedAt)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult(result);
+        }
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
         {

--- a/backend/tests/Taskdeck.Api.Tests/Resilience/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Resilience/WorkerResilienceTests.cs
@@ -170,6 +170,8 @@ public class WorkerResilienceTests
             .ReturnsAsync(Enumerable.Empty<LlmRequest>());
         mockLlmQueue.Setup(q => q.CountPendingNonCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
         mockLlmQueue.Setup(q => q.CountProcessingCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        mockLlmQueue.Setup(q => q.GetStuckProcessingNonCaptureAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<LlmRequest>());
 
         var mockUnitOfWork = new Mock<IUnitOfWork>();
         mockUnitOfWork.Setup(u => u.LlmQueue).Returns(mockLlmQueue.Object);
@@ -319,5 +321,7 @@ public class WorkerResilienceTests
 
         mockLlmQueue.Setup(q => q.CountPendingNonCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
         mockLlmQueue.Setup(q => q.CountProcessingCaptureAsync(It.IsAny<CancellationToken>())).ReturnsAsync(0);
+        mockLlmQueue.Setup(q => q.GetStuckProcessingNonCaptureAsync(It.IsAny<DateTimeOffset>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<LlmRequest>());
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -433,6 +433,8 @@ public class WorkerResilienceTests
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
         public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
             => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
+        public Task<IReadOnlyList<LlmRequest>> GetStuckProcessingNonCaptureAsync(DateTimeOffset staleBefore, int limit, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Database unavailable — simulated for resilience test");
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
@@ -521,6 +523,18 @@ public class WorkerResilienceTests
 
         public Task<int> CountPendingCaptureAsync(CancellationToken cancellationToken = default)
             => Task.FromResult(_pending.Concat(_processing).Count(i => i.Status == RequestStatus.Pending && CaptureRequestContract.IsCaptureRequestType(i.RequestType)));
+
+        public Task<IReadOnlyList<LlmRequest>> GetStuckProcessingNonCaptureAsync(DateTimeOffset staleBefore, int limit, CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<LlmRequest> result = _pending.Concat(_processing)
+                .Where(i => i.Status == RequestStatus.Processing
+                    && !CaptureRequestContract.IsCaptureRequestType(i.RequestType)
+                    && i.UpdatedAt <= staleBefore)
+                .OrderBy(i => i.UpdatedAt)
+                .Take(limit)
+                .ToList();
+            return Task.FromResult(result);
+        }
 
         public Task<LlmRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
             => Task.FromResult(_pending.Concat(_processing).FirstOrDefault(i => i.Id == id));

--- a/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkerResilienceTests.cs
@@ -691,7 +691,7 @@ public class WorkerResilienceTests
         public Task<IEnumerable<AutomationProposal>> GetByRiskLevelAsync(RiskLevel riskLevel, int limit = 100, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
         public Task<AutomationProposal?> GetBySourceReferenceAsync(ProposalSourceType sourceType, string referenceId, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+            => Task.FromResult(_proposals.FirstOrDefault(p => p.SourceType == sourceType && p.SourceReferenceId == referenceId));
         public Task<AutomationProposal?> GetByCorrelationIdAsync(string correlationId, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();
         public Task<AutomationProposal?> GetLatestByOperationTargetAsync(string targetType, string targetId, CancellationToken cancellationToken = default)
@@ -716,7 +716,8 @@ public class WorkerResilienceTests
         public IBoardAccessRepository BoardAccesses => null!;
         public IAuditLogRepository AuditLogs => null!;
         public ILlmQueueRepository LlmQueue { get; }
-        public IAutomationProposalRepository AutomationProposals => null!;
+        // Empty proposal repo so the drain's existing-proposal idempotency guard returns null (no duplicate).
+        public IAutomationProposalRepository AutomationProposals { get; } = new FakeAutomationProposalRepository([]);
         public IArchiveItemRepository ArchiveItems => null!;
         public IChatSessionRepository ChatSessions => null!;
         public IChatMessageRepository ChatMessages => null!;

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -265,7 +265,7 @@ Bound to `WorkerSettings`. Registered in
 | `Workers:MaxConcurrency` | `int` | `2` | Max concurrent worker slots. | No |
 | `Workers:MaxRetries` | `int` | `3` | Max retries before a queue item is failed. | No |
 | `Workers:RetryBackoffSeconds` | `int[]` | `[10, 30, 90]` | Delay per retry attempt. Length should be at least `MaxRetries`. | No |
-| `Workers:ProcessingLeaseSeconds` | `int` | `120` | Visibility lease held by a worker while processing a queue item. | No |
+| `Workers:ProcessingLeaseSeconds` | `int` | `120` | Visibility lease held by a worker while processing a queue item. Also the threshold (floored at 30s) after which a non-capture queue item left in `Processing` by a crashed worker is reclaimed — returned to `Pending` while retry budget remains, else `Failed` (#1209). Capture-triage items self-heal via their re-claim path and are not swept. | No |
 | `Workers:ProposalExpiryMinutes` | `int` | `1440` (24h) | How long pending proposals remain before being marked expired by the housekeeping worker. | No |
 | `Workers:EnableAutoQueueProcessing` | `bool` | `true` | When false, the background queue worker is registered but does not pull work (manual/CI scenarios). | No |
 


### PR DESCRIPTION
## Summary

Fixes #1209. A non-capture `LlmRequest` claimed for processing (flipped to `Processing`) by a worker that then **crashed before completing or failing it** was left in `Processing` forever — capture-triage items self-heal because they are read from `Processing` and re-claimed every poll, but non-capture (automation) items are read **only from `Pending`**, so once stuck they were silently abandoned. This was the residual half of finding M1 on #1200.

## What changed

- **`LlmQueueToProposalWorker`** runs a recovery pass (`RecoverStuckProcessingItemsAsync`) at the top of each `ProcessBatchAsync` tick, mirroring the shipped `OutboundWebhookDeliveryWorker.RecoverStuckProcessingDeliveriesAsync` pattern the issue cites. A recovered item becomes eligible again within the same tick.
- **`ILlmQueueRepository.GetStuckProcessingNonCaptureAsync(staleBefore, limit)`** — new dual SQLite-raw / EF query returning non-capture rows in `Processing` whose `UpdatedAt <= staleBefore`, oldest-first, bounded. Capture rows are excluded in-query (they self-heal). The `UpdatedAt <= staleBefore` shape matches the shipped webhook stuck-query.
- **Retry budget respected:** each stuck item is `MarkAsFailed` (RetryCount++) then `ResetForRetry` back to `Pending` **while budget remains** (`RetryCount + 1 < MaxRetries`, the same check as `HandleFailureWithRetryAsync`), else left `Failed`. A request that repeatedly crashes the worker therefore exhausts its budget and fails permanently instead of looping forever.
- **Threshold** = `Math.Max(30, Workers:ProcessingLeaseSeconds)` (reused setting, like the webhook sweep; the 30s floor stops an aggressively-low lease from reclaiming an in-flight request). Documented in `docs/platform/CONFIGURATION_REFERENCE.md`.
- **Telemetry:** recovered/failed counts via `WorkerItemsProcessed` (`outcome=recovered_stuck_requeued` / `recovered_stuck_failed`) + a warning log.

## Acceptance criteria

- [x] Background sweeper recovers non-capture rows stuck in `Processing` beyond a configurable threshold.
- [x] Retry budget respected (Pending until max retries, then Failed).
- [x] Covered by tests (worker crash after claim -> eventually reclaimed).
- [x] Threshold configurable via `WorkerSettings` + documented in `CONFIGURATION_REFERENCE.md`.

## Testing

- **Worker tests** (`LlmQueueToProposalWorkerTests`): stuck item -> Pending + budget consumed; budget-exhausted -> Failed; fresh `Processing` item not swept; stuck **capture** item not swept; **end-to-end** tick recovers then reprocesses a stuck item to `Completed`.
- **Repository integration tests** (real SQLite): selects only non-capture `Processing` rows at/before the threshold; excludes rows newer than the threshold; rejects `limit < 1`.
- Local (Release): targeted Api.Tests (worker + repo + resilience) 74/74; Application.Tests LlmQueue-related 96/96; Architecture.Tests 20/21 (1 pre-existing skip); backend build clean. Full suite runs in CI (the full Api.Tests suite stack-overflows locally on Windows under parallelism — environmental, unrelated; the implicated `AuditRetention` class passes in isolation).

## Notes

- Adding an interface method updated the 3 hand-written `ILlmQueueRepository` fakes; Moq mocks auto-stub.
- The >lease legitimate-processing double-run window is inherent to lease-based recovery and pre-exists in the webhook worker; review-first proposals bound any worst case. Not newly introduced.
