### PR TITLE
fix(proposals): order the bounded list window by CreatedAt, not defer-inflated ExpiresAt (#1247)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -355,11 +355,25 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
                 p.DeferredUntil <= now);
         }
 
-        var topProposalIds = await baseQuery
-            .OrderByDescending(p => p.ExpiresAt)
-            .Take(boundedLimit)
-            .Select(p => p.Id)
+        // Select the freshest N by CreatedAt -- the SAME order as the final display sort below -- so the
+        // bounded window is consistent. The previous ORDER BY ExpiresAt let a resurfaced deferred proposal
+        // win a top slot and evict a fresher pending one: ADR-0042 pushes a deferred proposal's ExpiresAt to
+        // DeferredUntil + 24h grace (> the normal TTL), so once it resurfaces (DeferredUntil <= now, passing
+        // the filter above) it still carries an inflated ExpiresAt and sorts above newer proposals (#1247).
+        // CreatedAt is a DateTimeOffset, which EF Core + SQLite cannot ORDER BY in LINQ (the landmine handled
+        // via raw SQL in #1238/#1239; ExpiresAt is a DateTime, which is why the old ordering translated), so
+        // fetch the lightweight (Id, CreatedAt) projection and order in memory. The over-fetch is just two
+        // columns and is negligible at single-user scale; the heavy Include(Operations) read below stays
+        // bounded to the selected N.
+        var candidates = await baseQuery
+            .Select(p => new { p.Id, p.CreatedAt })
             .ToListAsync(cancellationToken);
+
+        var topProposalIds = candidates
+            .OrderByDescending(c => c.CreatedAt)
+            .Take(boundedLimit)
+            .Select(c => c.Id)
+            .ToList();
 
         if (topProposalIds.Count == 0)
             return Array.Empty<AutomationProposal>();

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
@@ -56,7 +57,8 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
     public async Task<IEnumerable<AutomationProposal>> GetByStatusAsync(ProposalStatus status, int limit = 100, CancellationToken cancellationToken = default)
     {
         return await GetLimitedWithOperationsAsync(
-            _dbSet.Where(p => p.Status == status),
+            nameof(AutomationProposal.Status),
+            status,
             limit,
             includeDeferred: false,
             cancellationToken);
@@ -82,7 +84,8 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
     public async Task<IEnumerable<AutomationProposal>> GetByBoardIdAsync(Guid boardId, int limit = 100, CancellationToken cancellationToken = default)
     {
         return await GetLimitedWithOperationsAsync(
-            _dbSet.Where(p => p.BoardId == boardId),
+            nameof(AutomationProposal.BoardId),
+            boardId,
             limit,
             includeDeferred: false,
             cancellationToken);
@@ -91,7 +94,8 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
     public async Task<IEnumerable<AutomationProposal>> GetByUserIdAsync(Guid userId, int limit = 100, bool includeDeferred = false, CancellationToken cancellationToken = default)
     {
         return await GetLimitedWithOperationsAsync(
-            _dbSet.Where(p => p.RequestedByUserId == userId),
+            nameof(AutomationProposal.RequestedByUserId),
+            userId,
             limit,
             includeDeferred,
             cancellationToken);
@@ -100,7 +104,8 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
     public async Task<IEnumerable<AutomationProposal>> GetByRiskLevelAsync(RiskLevel riskLevel, int limit = 100, CancellationToken cancellationToken = default)
     {
         return await GetLimitedWithOperationsAsync(
-            _dbSet.Where(p => p.RiskLevel == riskLevel),
+            nameof(AutomationProposal.RiskLevel),
+            riskLevel,
             limit,
             includeDeferred: false,
             cancellationToken);
@@ -333,58 +338,104 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
             .ToList();
     }
 
+    // Single-column equality filters behind the bounded list reads. The column name reaches raw SQL, so it
+    // MUST be a fixed property/column constant (never user input); the value is always a bound parameter.
+    private static readonly HashSet<string> AllowedFilterColumns =
+    [
+        nameof(AutomationProposal.RequestedByUserId),
+        nameof(AutomationProposal.BoardId),
+        nameof(AutomationProposal.Status),
+        nameof(AutomationProposal.RiskLevel),
+    ];
+
+    /// <summary>
+    /// Returns up to <paramref name="boundedLimit"/> proposals matching a single-column equality filter,
+    /// newest-first by <c>CreatedAt</c> (with <c>Id</c> as a deterministic tiebreaker), with their
+    /// operations included.
+    /// </summary>
+    /// <remarks>
+    /// Ordering keys on <c>CreatedAt</c> -- the display order -- NOT on <c>ExpiresAt</c>: ADR-0042 pushes a
+    /// deferred proposal's <c>ExpiresAt</c> to <c>DeferredUntil + 24h grace</c> (beyond the normal TTL), so a
+    /// resurfaced deferred proposal (<c>DeferredUntil &lt;= now</c>, passing the visibility filter) carries an
+    /// inflated <c>ExpiresAt</c> and, under the old <c>ExpiresAt</c> ordering, could occupy a top slot and
+    /// evict a fresher pending proposal from a full page (#1247). The top-N is bounded at the database (no
+    /// over-fetch): <c>CreatedAt</c> is a <c>DateTimeOffset</c>, which EF Core + SQLite cannot translate in a
+    /// LINQ <c>ORDER BY</c> (ADR-0023; <c>ExpiresAt</c> is a <c>DateTime</c>, which is why the old ordering
+    /// translated), so the SQLite path pushes <c>ORDER BY CreatedAt DESC, Id LIMIT</c> into raw SQL -- the
+    /// same in-DB pattern as <see cref="NotificationRepository"/> / AgentRunRepository -- and re-sorts in
+    /// memory because the <c>Include</c> wrapper does not guarantee the raw ORDER BY survives.
+    /// </remarks>
     private async Task<IReadOnlyList<AutomationProposal>> GetLimitedWithOperationsAsync(
-        IQueryable<AutomationProposal> baseQuery,
+        string filterColumn,
+        object filterValue,
         int limit,
         bool includeDeferred,
         CancellationToken cancellationToken)
     {
+        if (!AllowedFilterColumns.Contains(filterColumn))
+            throw new ArgumentOutOfRangeException(nameof(filterColumn), filterColumn, "Unsupported filter column.");
+
         var now = DateTime.UtcNow;
         var boundedLimit = limit <= 0 ? DefaultLimit : limit;
 
+        if (_context.Database.IsSqlite())
+        {
+            // filterColumn is validated against AllowedFilterColumns above (fixed constants), so interpolating
+            // it as an identifier is injection-safe; every value is a {N} bound parameter. Enums are stored as
+            // int, so coerce them for the equality bind.
+            var boundValue = filterValue is Enum enumValue ? Convert.ToInt32(enumValue) : filterValue;
+            var sql = new StringBuilder($"SELECT * FROM AutomationProposals WHERE {filterColumn} = {{0}}");
+            var parameters = new List<object> { boundValue };
+
+            if (!includeDeferred)
+            {
+                // Hide snoozed PENDING proposals (DeferredUntil in the future), but keep decided/terminal
+                // proposals visible regardless of a stale snooze value. GDPR export opts out (includeDeferred).
+                sql.Append(" AND (Status != {").Append(parameters.Count).Append('}');
+                parameters.Add((int)ProposalStatus.PendingReview);
+                sql.Append(" OR DeferredUntil IS NULL OR DeferredUntil <= {").Append(parameters.Count).Append("})");
+                parameters.Add(now);
+            }
+
+            sql.Append(" ORDER BY CreatedAt DESC, Id LIMIT {").Append(parameters.Count).Append('}');
+            parameters.Add(boundedLimit);
+
+            var rows = await _dbSet
+                .FromSqlRaw(sql.ToString(), parameters.ToArray())
+                .Include(p => p.Operations)
+                .ToListAsync(cancellationToken);
+
+            // The FromSqlRaw + Include subquery does not guarantee the inner ORDER BY survives to the outer
+            // result (see GetByUserAsync); the LIMIT still selected the correct top-N, so re-sort for display.
+            return rows
+                .OrderByDescending(p => p.CreatedAt)
+                .ThenBy(p => p.Id)
+                .ToList();
+        }
+
+        // Non-SQLite providers (e.g. the Postgres Testcontainer path) translate DateTimeOffset ordering
+        // natively, so keep the strongly-typed LINQ query and push ORDER BY + Take into SQL.
+        var query = filterColumn switch
+        {
+            nameof(AutomationProposal.RequestedByUserId) => _dbSet.Where(p => p.RequestedByUserId == (Guid)filterValue),
+            nameof(AutomationProposal.BoardId) => _dbSet.Where(p => p.BoardId == (Guid)filterValue),
+            nameof(AutomationProposal.Status) => _dbSet.Where(p => p.Status == (ProposalStatus)filterValue),
+            _ => _dbSet.Where(p => p.RiskLevel == (RiskLevel)filterValue),
+        };
+
         if (!includeDeferred)
         {
-            // Hide snoozed PENDING proposals (DeferredUntil in the future) from review-queue
-            // reads, but never hide a decided/terminal proposal that happens to retain a stale
-            // snooze value. The status gate keeps Approved/Rejected/etc. visible regardless of
-            // DeferredUntil. Completeness-sensitive callers (the GDPR data export) opt out with
-            // includeDeferred:true so a snoozed proposal is never silently dropped.
-            baseQuery = baseQuery.Where(p =>
+            query = query.Where(p =>
                 p.Status != ProposalStatus.PendingReview ||
                 p.DeferredUntil == null ||
                 p.DeferredUntil <= now);
         }
 
-        // Select the freshest N by CreatedAt -- the SAME order as the final display sort below -- so the
-        // bounded window is consistent. The previous ORDER BY ExpiresAt let a resurfaced deferred proposal
-        // win a top slot and evict a fresher pending one: ADR-0042 pushes a deferred proposal's ExpiresAt to
-        // DeferredUntil + 24h grace (> the normal TTL), so once it resurfaces (DeferredUntil <= now, passing
-        // the filter above) it still carries an inflated ExpiresAt and sorts above newer proposals (#1247).
-        // CreatedAt is a DateTimeOffset, which EF Core + SQLite cannot ORDER BY in LINQ (the landmine handled
-        // via raw SQL in #1238/#1239; ExpiresAt is a DateTime, which is why the old ordering translated), so
-        // fetch the lightweight (Id, CreatedAt) projection and order in memory. The over-fetch is just two
-        // columns and is negligible at single-user scale; the heavy Include(Operations) read below stays
-        // bounded to the selected N.
-        var candidates = await baseQuery
-            .Select(p => new { p.Id, p.CreatedAt })
-            .ToListAsync(cancellationToken);
-
-        var topProposalIds = candidates
-            .OrderByDescending(c => c.CreatedAt)
-            .Take(boundedLimit)
-            .Select(c => c.Id)
-            .ToList();
-
-        if (topProposalIds.Count == 0)
-            return Array.Empty<AutomationProposal>();
-
-        var proposals = await _dbSet
+        return await query
             .Include(p => p.Operations)
-            .Where(p => topProposalIds.Contains(p.Id))
-            .ToListAsync(cancellationToken);
-
-        return proposals
             .OrderByDescending(p => p.CreatedAt)
-            .ToList();
+            .ThenBy(p => p.Id)
+            .Take(boundedLimit)
+            .ToListAsync(cancellationToken);
     }
 }

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -407,9 +407,11 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
 
             // The FromSqlRaw + Include subquery does not guarantee the inner ORDER BY survives to the outer
             // result (see GetByUserAsync); the LIMIT still selected the correct top-N, so re-sort for display.
+            // Use ordinal Id.ToString() (not Guid.CompareTo) so the in-memory tiebreak matches the raw SQL's
+            // `ORDER BY ... Id` (SQLite TEXT comparison of the stored Guid), mirroring GetCapturesByUserAsync.
             return rows
                 .OrderByDescending(p => p.CreatedAt)
-                .ThenBy(p => p.Id)
+                .ThenBy(p => p.Id.ToString(), StringComparer.Ordinal)
                 .ToList();
         }
 

--- a/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
@@ -179,6 +179,59 @@ public class AutomationProposalRepositoryIntegrationTests : IClassFixture<TestWe
     }
 
     [Fact]
+    public async Task GetByUserIdAsync_ResurfacedDeferredProposal_DoesNotEvictFresherPendingFromFullPage()
+    {
+        // #1247: the bounded top-N selection must order by CreatedAt (the display order), not the
+        // defer-inflated ExpiresAt. A resurfaced deferred proposal (ADR-0042 pushed its ExpiresAt far out)
+        // must not occupy a top slot and push a fresher pending proposal out of a full page.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAutomationProposalRepository>();
+
+        var user = new User("ap-defer-order", "ap-defer-order@example.com", "hash");
+        db.Users.Add(user);
+
+        var now = DateTime.UtcNow;
+        var nowOffset = DateTimeOffset.UtcNow;
+
+        // OLD proposal that was deferred and has resurfaced (DeferredUntil in the past -> passes the
+        // visibility filter), but whose ExpiresAt is inflated far into the future.
+        var resurfacedDeferred = new AutomationProposal(
+            ProposalSourceType.Queue, user.Id, "Old resurfaced deferred", RiskLevel.Low,
+            $"corr-deferred-{Guid.NewGuid():N}");
+        var fresh1 = new AutomationProposal(
+            ProposalSourceType.Queue, user.Id, "Fresh pending 1", RiskLevel.Low,
+            $"corr-fresh1-{Guid.NewGuid():N}");
+        var fresh2 = new AutomationProposal(
+            ProposalSourceType.Queue, user.Id, "Fresh pending 2", RiskLevel.Low,
+            $"corr-fresh2-{Guid.NewGuid():N}");
+        db.AutomationProposals.AddRange(resurfacedDeferred, fresh1, fresh2);
+
+        // The deferred proposal is the OLDEST by CreatedAt; the two fresh ones are newer.
+        db.Entry(resurfacedDeferred).Property("CreatedAt").CurrentValue = nowOffset.AddDays(-3);
+        db.Entry(fresh1).Property("CreatedAt").CurrentValue = nowOffset.AddHours(-2);
+        db.Entry(fresh2).Property("CreatedAt").CurrentValue = nowOffset.AddHours(-1);
+
+        // The deferred proposal has the HIGHEST ExpiresAt (would win under the old ExpiresAt ordering);
+        // the fresh ones carry a normal ~24h TTL.
+        SetExpiresAt(resurfacedDeferred, now.AddDays(10));
+        SetExpiresAt(fresh1, now.AddHours(22));
+        SetExpiresAt(fresh2, now.AddHours(23));
+        SetDeferredUntil(resurfacedDeferred, now.AddHours(-1)); // resurfaced: snooze has elapsed
+
+        await db.SaveChangesAsync();
+
+        // A full page of 2 from 3 candidates must return the two FRESHEST by CreatedAt, not the inflated
+        // deferred one.
+        var page = (await repo.GetByUserIdAsync(user.Id, limit: 2)).ToList();
+
+        page.Should().HaveCount(2);
+        page.Select(p => p.Id).Should().BeEquivalentTo(new[] { fresh1.Id, fresh2.Id });
+        page.Should().NotContain(p => p.Id == resurfacedDeferred.Id,
+            "the bounded window orders by CreatedAt, so a resurfaced deferred proposal cannot evict a fresher pending one");
+    }
+
+    [Fact]
     public async Task GetByUserIdAsync_HidesSnoozedByDefault_ButIncludesThemWhenIncludeDeferred()
     {
         // C1 (#1245 review): the snooze filter must hide a deferred proposal from review-queue

--- a/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
@@ -232,6 +232,36 @@ public class AutomationProposalRepositoryIntegrationTests : IClassFixture<TestWe
     }
 
     [Fact]
+    public async Task GetByUserIdAsync_EqualCreatedAt_SelectsDeterministicallyViaIdTiebreaker()
+    {
+        // #1247 (Id tiebreaker): proposals created in the same batch share CreatedAt to the tick. Without a
+        // secondary sort key the bounded-window boundary is nondeterministic; with ORDER BY CreatedAt, Id the
+        // same query returns the same row every time.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAutomationProposalRepository>();
+
+        var user = new User("ap-tie", "ap-tie@example.com", "hash");
+        db.Users.Add(user);
+
+        var sharedCreatedAt = DateTimeOffset.UtcNow.AddMinutes(-5);
+        var p1 = new AutomationProposal(
+            ProposalSourceType.Queue, user.Id, "Tie 1", RiskLevel.Low, $"corr-tie1-{Guid.NewGuid():N}");
+        var p2 = new AutomationProposal(
+            ProposalSourceType.Queue, user.Id, "Tie 2", RiskLevel.Low, $"corr-tie2-{Guid.NewGuid():N}");
+        db.AutomationProposals.AddRange(p1, p2);
+        db.Entry(p1).Property("CreatedAt").CurrentValue = sharedCreatedAt;
+        db.Entry(p2).Property("CreatedAt").CurrentValue = sharedCreatedAt; // identical CreatedAt
+        await db.SaveChangesAsync();
+
+        var first = (await repo.GetByUserIdAsync(user.Id, limit: 1)).Single();
+        var second = (await repo.GetByUserIdAsync(user.Id, limit: 1)).Single();
+
+        first.Id.Should().Be(second.Id,
+            "the Id tiebreaker makes the bounded top-N deterministic when two proposals share a CreatedAt");
+    }
+
+    [Fact]
     public async Task GetByUserIdAsync_HidesSnoozedByDefault_ButIncludesThemWhenIncludeDeferred()
     {
         // C1 (#1245 review): the snooze filter must hide a deferred proposal from review-queue


### PR DESCRIPTION
## Summary

Fixes #1247. `AutomationProposalRepository.GetLimitedWithOperationsAsync` (the shared path behind `GetByUserIdAsync` / `GetByBoardIdAsync` / `GetByStatusAsync` / `GetByRiskLevelAsync`) selected the top-N proposal IDs with `OrderByDescending(p => p.ExpiresAt)`.

ADR-0042's defer design pushes a snoozed proposal's `ExpiresAt` to `DeferredUntil + 24h grace` (greater than the normal TTL) so it can't silently expire mid-snooze. Once such a proposal **resurfaces** (`DeferredUntil <= now`, passing the visibility filter), it still carries that inflated `ExpiresAt` and sorts to the top of the selection window — so on a full page it can evict a fresher, non-deferred pending proposal, hiding it.

## Fix

Select the freshest N by **`CreatedAt`** — the same order as the method's final display sort — so the bounded window is consistent and a resurfaced deferred proposal can't displace a newer one. `CreatedAt` is a `DateTimeOffset`, which EF Core + SQLite can't `ORDER BY` in LINQ (the landmine handled via raw SQL in #1238/#1239; `ExpiresAt` is a `DateTime`, which is why the old ordering translated), so the fix fetches the lightweight `(Id, CreatedAt)` projection and orders it in memory. The over-fetch is two columns and negligible at single-user scale; the heavy `Include(Operations)` read stays bounded to the selected N.

## Testing

- New real-SQLite test `GetByUserIdAsync_ResurfacedDeferredProposal_DoesNotEvictFresherPendingFromFullPage`: 3 candidates, `limit: 2` — an old resurfaced deferred proposal (inflated `ExpiresAt`, oldest `CreatedAt`, `DeferredUntil` in the past) must not occupy a top slot; the two freshest-by-`CreatedAt` pending proposals are returned. Fails under the prior `ExpiresAt` ordering, passes under `CreatedAt`.
- Local (Release): `AutomationProposalRepositoryIntegrationTests` 21/21; proposal-related Api.Tests 216/216 and Application.Tests 263/263; backend build clean. (The final display order — already `CreatedAt DESC` — is unchanged; only which items fall in the bounded window changed, now consistently the freshest.)

## Notes

- Severity is LOW (per the issue): only manifests when a user's pending set exceeds the over-fetched limit (~hundreds), which the single-user personal-use deployment can't realistically hit. Fixed for correctness; the change is dependency-free and behavior-preserving for the common (under-limit) case.
