### PR TITLE
fix(a11y): sweep focus:ring-primary/50 to full-opacity ring for WCAG AA contrast (#1218)

### DIFF
--- a/frontend/taskdeck-web/src/components/board/ColumnEditModal.vue
+++ b/frontend/taskdeck-web/src/components/board/ColumnEditModal.vue
@@ -122,7 +122,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
               v-model="name"
               type="text"
               required
-              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="To Do"
             />
           </div>
@@ -134,7 +134,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
                 id="column-has-wip-limit"
                 v-model="hasWipLimit"
                 type="checkbox"
-                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
               />
               <label for="column-has-wip-limit" class="ml-2 text-sm font-medium text-on-surface-variant">
                 Set WIP limit
@@ -150,7 +150,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
                 type="number"
                 min="1"
                 required
-                class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+                class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="e.g., 3"
               />
               <p class="mt-1 text-xs text-on-surface-variant">

--- a/frontend/taskdeck-web/src/components/board/ColumnEditModal.vue
+++ b/frontend/taskdeck-web/src/components/board/ColumnEditModal.vue
@@ -134,7 +134,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
                 id="column-has-wip-limit"
                 v-model="hasWipLimit"
                 type="checkbox"
-                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
+                class="w-4 h-4 text-primary border-outline-variant rounded"
               />
               <label for="column-has-wip-limit" class="ml-2 text-sm font-medium text-on-surface-variant">
                 Set WIP limit

--- a/frontend/taskdeck-web/src/components/board/FilterPanel.vue
+++ b/frontend/taskdeck-web/src/components/board/FilterPanel.vue
@@ -128,7 +128,7 @@ const hasActiveFilters = computed(() => {
             @input="updateFilters"
             type="text"
             placeholder="Search cards..."
-            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-lg text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50 text-sm"
+            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-lg text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary text-sm"
           />
         </div>
 
@@ -138,7 +138,7 @@ const hasActiveFilters = computed(() => {
             id="filter-due-date"
             v-model="localFilters.dueDateFilter"
             @change="updateFilters"
-            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-lg text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50 text-sm"
+            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-lg text-on-surface focus:outline-none focus:ring-2 focus:ring-primary text-sm"
           >
             <option value="all">All cards</option>
             <option value="overdue">Overdue</option>
@@ -155,7 +155,7 @@ const hasActiveFilters = computed(() => {
               v-model="localFilters.showBlockedOnly"
               @change="updateFilters"
               type="checkbox"
-              class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+              class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
             />
             <span class="ml-2 text-sm text-on-surface">Show blocked only</span>
           </label>
@@ -181,7 +181,7 @@ const hasActiveFilters = computed(() => {
                 :checked="isLabelSelected(label.id)"
                 @change="toggleLabel(label.id)"
                 type="checkbox"
-                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
               />
               <span
                 class="ml-2 px-2 py-0.5 rounded text-xs font-medium text-white td-dynamic-bg"

--- a/frontend/taskdeck-web/src/components/board/FilterPanel.vue
+++ b/frontend/taskdeck-web/src/components/board/FilterPanel.vue
@@ -155,7 +155,7 @@ const hasActiveFilters = computed(() => {
               v-model="localFilters.showBlockedOnly"
               @change="updateFilters"
               type="checkbox"
-              class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
+              class="w-4 h-4 text-primary border-outline-variant rounded"
             />
             <span class="ml-2 text-sm text-on-surface">Show blocked only</span>
           </label>
@@ -181,7 +181,7 @@ const hasActiveFilters = computed(() => {
                 :checked="isLabelSelected(label.id)"
                 @change="toggleLabel(label.id)"
                 type="checkbox"
-                class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
+                class="w-4 h-4 text-primary border-outline-variant rounded"
               />
               <span
                 class="ml-2 px-2 py-0.5 rounded text-xs font-medium text-white td-dynamic-bg"

--- a/frontend/taskdeck-web/src/components/board/LabelManagerModal.vue
+++ b/frontend/taskdeck-web/src/components/board/LabelManagerModal.vue
@@ -158,7 +158,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
                 v-model="labelName"
                 type="text"
                 required
-                class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+                class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="e.g., Bug, Feature, Priority"
               />
             </div>
@@ -194,7 +194,7 @@ useEscapeToClose(() => props.isOpen, handleClose)
                   v-model="labelColor"
                   type="text"
                   pattern="^#[0-9A-Fa-f]{6}$"
-                  class="flex-1 px-3 py-1.5 bg-surface-container-high border border-outline-variant/40 rounded-md text-sm text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+                  class="flex-1 px-3 py-1.5 bg-surface-container-high border border-outline-variant/40 rounded-md text-sm text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="#3B82F6"
                 />
               </div>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalComments.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalComments.vue
@@ -36,7 +36,7 @@ function updateReplyDraft(commentId: string, value: string) {
         id="new-card-comment"
         v-model="newCommentContent"
         rows="2"
-        class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+        class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
         placeholder="Write a comment... Use @username to mention teammates."
       ></textarea>
       <div class="flex justify-end">
@@ -92,7 +92,7 @@ function updateReplyDraft(commentId: string, value: string) {
             :value="editingCommentContent"
             aria-label="Edit comment"
             rows="2"
-            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50"
+            class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary"
             @input="$emit('update:editingCommentContent', ($event.target as HTMLTextAreaElement).value)"
           ></textarea>
           <div class="flex justify-end gap-2">
@@ -146,7 +146,7 @@ function updateReplyDraft(commentId: string, value: string) {
               :value="replyDraftByParent[comment.id] ?? ''"
               aria-label="Reply to comment"
               rows="2"
-              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+              class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="Reply..."
               @input="updateReplyDraft(comment.id, ($event.target as HTMLTextAreaElement).value)"
             ></textarea>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalForm.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalForm.vue
@@ -82,7 +82,7 @@ defineEmits<{
         id="card-is-blocked"
         v-model="isBlocked"
         type="checkbox"
-        class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
+        class="w-4 h-4 text-primary border-outline-variant rounded"
       />
       <label for="card-is-blocked" class="ml-2 text-sm font-medium text-on-surface-variant">
         Mark as blocked

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalForm.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalForm.vue
@@ -29,7 +29,7 @@ defineEmits<{
       v-model="title"
       type="text"
       required
-      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
       placeholder="Card title"
     />
   </div>
@@ -43,7 +43,7 @@ defineEmits<{
       id="card-description"
       v-model="description"
       rows="4"
-      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+      class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
       placeholder="Add a more detailed description..."
     ></textarea>
   </div>
@@ -58,7 +58,7 @@ defineEmits<{
         id="card-due-date"
         v-model="dueDate"
         type="date"
-        class="flex-1 px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/50"
+        class="flex-1 px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface focus:outline-none focus:ring-2 focus:ring-primary"
       />
       <button
         v-if="dueDate"
@@ -82,7 +82,7 @@ defineEmits<{
         id="card-is-blocked"
         v-model="isBlocked"
         type="checkbox"
-        class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+        class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
       />
       <label for="card-is-blocked" class="ml-2 text-sm font-medium text-on-surface-variant">
         Mark as blocked
@@ -97,7 +97,7 @@ defineEmits<{
         v-model="blockReason"
         rows="2"
         required
-        class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary/50"
+        class="w-full px-3 py-2 bg-surface-container-high border border-outline-variant/40 rounded-md text-on-surface placeholder-on-surface-variant/50 focus:outline-none focus:ring-2 focus:ring-primary"
         placeholder="Why is this card blocked?"
       ></textarea>
     </div>

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalLabels.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalLabels.vue
@@ -20,7 +20,7 @@ const selectedLabelIds = defineModel<string[]>('selectedLabelIds', { required: t
         class="inline-flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-all cursor-pointer"
         :class="[
           selectedLabelIds.includes(label.id)
-            ? 'text-white ring-2 ring-offset-2 ring-primary/50 td-dynamic-bg'
+            ? 'text-white ring-2 ring-offset-2 ring-primary td-dynamic-bg'
             : 'text-on-surface bg-surface-container-high hover:bg-surface-container-highest',
         ]"
         :style="selectedLabelIds.includes(label.id) ? { '--td-dynamic-color': label.colorHex } : undefined"
@@ -30,7 +30,7 @@ const selectedLabelIds = defineModel<string[]>('selectedLabelIds', { required: t
           v-model="selectedLabelIds"
           type="checkbox"
           :value="label.id"
-          class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
+          class="w-4 h-4 text-primary border-outline-variant rounded"
         />
         <!-- Color swatch always visible so users can identify labels before selecting -->
         <span

--- a/frontend/taskdeck-web/src/components/board/card-modal/CardModalLabels.vue
+++ b/frontend/taskdeck-web/src/components/board/card-modal/CardModalLabels.vue
@@ -30,7 +30,7 @@ const selectedLabelIds = defineModel<string[]>('selectedLabelIds', { required: t
           v-model="selectedLabelIds"
           type="checkbox"
           :value="label.id"
-          class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary/50"
+          class="w-4 h-4 text-primary border-outline-variant rounded focus:ring-primary"
         />
         <!-- Color swatch always visible so users can identify labels before selecting -->
         <span


### PR DESCRIPTION
Closes #1218.

## What
Sweeps every remaining `ring-primary/50` usage (18 `focus:` + 1 selected-state; 0 left repo-wide) to the full-opacity treatment PR #1216 established on `BoardSettingsModal`, and removes 5 compile-proven dead `focus:ring-primary` classes from checkboxes (no ring-width utility + no forms plugin ⇒ the class never painted; checkbox focus is compliantly indicated by the global `*:focus-visible` rule at 4.52:1).

## Why
Issue #1218: a 50%-opacity primary ring on the dark surfaces is marginal — adversarial review of this PR computed 3.00–3.49:1 against the actual adjacent surfaces (the issue's '~2.8:1' was overstated, but the treatment was at/near the WCAG 2.1 AA 3:1 floor for UI component indicators). Full opacity lifts the rendered indicators to **8.41–10.07:1** on every adjacent surface, verified across all shipped themes (ring color + surfaces are build-time-static Tailwind hex; theme switches only remap `--td-*`/`--paper` vars).

## Files (6, all in `components/board/`)
- `ColumnEditModal.vue` (canonical token pattern) — 2 rings full-opacity, 1 dead class removed
- `FilterPanel.vue` — 2 rings, 2 dead classes removed
- `LabelManagerModal.vue` — 2 rings
- `card-modal/CardModalForm.vue` — 4 rings, 1 dead class removed
- `card-modal/CardModalComments.vue` — 3 rings
- `card-modal/CardModalLabels.vue` — 1 selected-state ring full-opacity, 1 dead class removed

## Review
Two independent adversarial reviews (a11y/theme lens + completeness/regression lens) posted below; **all findings of every severity fixed in-PR or tracked (#1266)**.

## Verification
- `grep -rn "ring-primary/50" frontend/taskdeck-web/src` → **0 hits** (incl. non-focus usages)
- `npm run typecheck` → 0 errors; `npm run lint` → 0 errors (6 pre-existing warnings)
- Targeted specs for all touched components: **137/137 pass**
- No unit/E2E/visual spec, snapshot baseline, Tailwind safelist, or CI color-audit couples to these class strings (review-verified)
