### PR TITLE
fix(automation): revision-aware proposal diff so preview == apply (#1235)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -379,29 +379,76 @@ public class AutomationProposalService : IAutomationProposalService
         if (proposal == null)
             return Result.Failure<string>(ErrorCodes.NotFound, $"Proposal with ID {id} not found");
 
+        // When a reviewer has saved a revision, Apply executes THAT payload — the
+        // executor materializes the latest ProposalRevision via
+        // AutomationExecutorService.MaterializeEffectiveProposalAsync, not the
+        // original operations. Build the diff from the same effective operations so
+        // the approval-gate preview equals what Apply will run (#1235). The stored
+        // DiffPreview is deliberately bypassed on this path because it describes the
+        // original proposal, which is exactly the stale-preview bug we are fixing.
+        var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(id, cancellationToken);
+        if (latestRevision is not null)
+        {
+            if (!ProposalRevisionPayload.TryParseOperations(
+                    id,
+                    latestRevision.RevisedPayload,
+                    out var revisedOperations,
+                    out var errorMessage))
+            {
+                // A saved revision is validated when it is created, so this is
+                // defensive: if the effective payload cannot be materialized, Apply
+                // would fail the same way — surface that rather than a stale diff.
+                return Result.Failure<string>(ErrorCodes.ValidationError, errorMessage);
+            }
+
+            var revisedViews = revisedOperations
+                .OrderBy(o => o.Sequence)
+                .Select(o => new DiffOperationView(o.Sequence, o.ActionType, o.TargetType, o.TargetId, o.Parameters))
+                .ToList();
+
+            var revisedDiff = await BuildReadableDiffAsync(proposal.BoardId, revisedViews, cancellationToken);
+            return Result.Success(revisedDiff);
+        }
+
         if (!string.IsNullOrWhiteSpace(proposal.DiffPreview))
             return Result.Success(proposal.DiffPreview);
 
         if (proposal.Operations.Count == 0)
             return Result.Failure<string>(ErrorCodes.NotFound, "Diff preview not available for this proposal");
 
-        var orderedOperations = proposal.Operations
+        var orderedViews = proposal.Operations
             .OrderBy(o => o.Sequence)
+            .Select(o => new DiffOperationView(o.Sequence, o.ActionType, o.TargetType, o.TargetId, o.Parameters))
             .ToList();
 
+        var generatedDiff = await BuildReadableDiffAsync(proposal.BoardId, orderedViews, cancellationToken);
+        return Result.Success(generatedDiff);
+    }
+
+    /// <summary>
+    /// Builds the human-readable multi-line diff for an ordered operation set,
+    /// resolving column/card IDs to names via a best-effort board lookup. Shared by
+    /// the original-operations path and the revision-aware path so both render
+    /// identically (#1235).
+    /// </summary>
+    private async Task<string> BuildReadableDiffAsync(
+        Guid? boardId,
+        IReadOnlyList<DiffOperationView> orderedOperations,
+        CancellationToken cancellationToken)
+    {
         // Batch-load entity names for resolving IDs to human-readable labels
         var columnNames = new Dictionary<Guid, string>();
         var cardTitles = new Dictionary<Guid, string>();
 
-        if (proposal.BoardId.HasValue)
+        if (boardId.HasValue)
         {
             try
             {
-                var columns = await _unitOfWork.Columns.GetByBoardIdAsync(proposal.BoardId.Value, cancellationToken);
+                var columns = await _unitOfWork.Columns.GetByBoardIdAsync(boardId.Value, cancellationToken);
                 foreach (var column in columns)
                     columnNames[column.Id] = column.Name;
 
-                var cards = await _unitOfWork.Cards.GetByBoardIdAsync(proposal.BoardId.Value, cancellationToken);
+                var cards = await _unitOfWork.Cards.GetByBoardIdAsync(boardId.Value, cancellationToken);
                 foreach (var card in cards)
                     cardTitles[card.Id] = card.Title;
             }
@@ -411,11 +458,9 @@ public class AutomationProposalService : IAutomationProposalService
             }
         }
 
-        var generatedDiff = string.Join(
+        return string.Join(
             Environment.NewLine,
             orderedOperations.Select(o => DescribeOperationReadable(o, columnNames, cardTitles)));
-
-        return Result.Success(generatedDiff);
     }
 
     public async Task<Result<int>> DismissProposalsAsync(IReadOnlyList<Guid> ids, CancellationToken cancellationToken = default)
@@ -643,11 +688,23 @@ public class AutomationProposalService : IAutomationProposalService
     }
 
     /// <summary>
+    /// Lightweight, source-agnostic view of a proposal operation used for diff
+    /// rendering. Both the entity operations and the revised-payload DTO operations
+    /// map onto this so the readable diff renders identically regardless of source (#1235).
+    /// </summary>
+    private readonly record struct DiffOperationView(
+        int Sequence,
+        string ActionType,
+        string TargetType,
+        string? TargetId,
+        string Parameters);
+
+    /// <summary>
     /// Produces a human-readable diff line for a single operation, resolving
     /// card IDs to titles and column IDs to names where possible.
     /// </summary>
     private static string DescribeOperationReadable(
-        AutomationProposalOperation operation,
+        DiffOperationView operation,
         IReadOnlyDictionary<Guid, string> columnNames,
         IReadOnlyDictionary<Guid, string> cardTitles)
     {

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -710,7 +710,7 @@ public class AutomationProposalService : IAutomationProposalService
     {
         var verb = HumanizeActionVerb(operation.ActionType);
         var targetType = HumanizeTargetType(operation.TargetType).ToLowerInvariant();
-        var isCardTarget = operation.TargetType.Equals("card", StringComparison.OrdinalIgnoreCase);
+        var isCardTarget = string.Equals(operation.TargetType, "card", StringComparison.OrdinalIgnoreCase);
         var namedTarget = ExtractNamedTarget(operation.Parameters);
 
         // Try to resolve card title from lookup when not embedded in parameters

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -217,6 +217,39 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task GetProposalDiff_AfterSavingRevision_ShouldReflectRevisedOperations()
+    {
+        // #1235, exit criterion (b): the approval-gate diff must equal what Apply
+        // executes. Paired with ExecuteProposal_WithLatestRevision_ShouldApplyRevisedOperations
+        // (which proves Apply runs the revised "Edited Card"), this proves preview == apply.
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-diff-aware");
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-diff-aware-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id, "Original Card");
+
+        // Baseline: with no revision, the diff describes the original proposal.
+        var beforeResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
+        beforeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var beforeDiff = (await beforeResponse.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("diff").GetString();
+        beforeDiff.Should().Contain("Original Card");
+
+        // Edit-before-approve: save a revision changing the card title.
+        var revisionResponse = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = BuildRevisionPayload("Edited Card", board.Id, column.Id), reason = "Use edited title" });
+        revisionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // The diff must now reflect the revised operations, not the original.
+        var afterResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
+        afterResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var afterDiff = (await afterResponse.Content.ReadFromJsonAsync<JsonElement>())
+            .GetProperty("diff").GetString();
+        afterDiff.Should().Contain("Edited Card");
+        afterDiff.Should().NotContain("Original Card");
+    }
+
+    [Fact]
     public async Task CreateRevision_ShouldReturnForbidden_WhenCallerCannotWriteProposalBoard()
     {
         var ownerClient = _factory.CreateClient();

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -17,6 +17,7 @@ public class AutomationProposalServiceTests
     private readonly Mock<IAutomationProposalRepository> _proposalRepoMock;
     private readonly Mock<INotificationService> _notificationServiceMock;
     private readonly Mock<IProposalProvenanceRepository> _provenanceRepoMock;
+    private readonly Mock<IProposalRevisionRepository> _revisionRepoMock;
     private readonly AutomationProposalService _service;
 
     public AutomationProposalServiceTests()
@@ -25,8 +26,15 @@ public class AutomationProposalServiceTests
         _proposalRepoMock = new Mock<IAutomationProposalRepository>();
         _notificationServiceMock = new Mock<INotificationService>();
         _provenanceRepoMock = new Mock<IProposalProvenanceRepository>();
+        _revisionRepoMock = new Mock<IProposalRevisionRepository>();
 
         _unitOfWorkMock.Setup(u => u.AutomationProposals).Returns(_proposalRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.ProposalRevisions).Returns(_revisionRepoMock.Object);
+        // Default: no saved revision, so GetProposalDiffAsync uses the original path.
+        // The revision-aware test overrides this per-proposal.
+        _revisionRepoMock
+            .Setup(r => r.GetLatestByProposalIdAsync(It.IsAny<Guid>(), default))
+            .ReturnsAsync((ProposalRevision?)null);
         _notificationServiceMock
             .Setup(s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), default))
             .ReturnsAsync(Result.Success(true));
@@ -1087,6 +1095,116 @@ public class AutomationProposalServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().Contain("Create");
         result.Value.Should().Contain("My card title");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldReflectSavedRevision_NotOriginalOperationsOrStoredPreview()
+    {
+        // Arrange: a proposal whose ORIGINAL operation AND stored DiffPreview both
+        // describe "Original card", plus a saved revision whose operation describes
+        // "Revised card". Apply materializes the latest revision
+        // (AutomationExecutorService.MaterializeEffectiveProposalAsync), so the diff
+        // preview must describe the REVISED operation — not the original ops and not
+        // the stale stored preview (#1235, exit criterion (b): preview == apply).
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var column = new Column(boardId, "To Do", 0);
+        var columnId = column.Id;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Create card",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var originalParams = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            title = "Original card",
+            columnId,
+            boardId
+        });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", originalParams, Guid.NewGuid().ToString()));
+        proposal.SetDiffPreview("0. Create card \"Original card\"");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        var revisedParams = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            title = "Revised card",
+            columnId,
+            boardId
+        });
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "create",
+                    targetType = "card",
+                    parameters = revisedParams,
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default))
+            .ReturnsAsync(revision);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default))
+            .ReturnsAsync(new[] { column });
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default))
+            .ReturnsAsync(Array.Empty<Card>());
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: the diff describes the revised operation, not the original.
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Contain("Revised card");
+        result.Value.Should().NotContain("Original card");
+        result.Value.Should().Contain("To Do");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldReturnValidationError_WhenSavedRevisionPayloadIsInvalid()
+    {
+        // Arrange: a saved revision whose payload cannot be materialized into
+        // operations. Apply would fail the same way, so the diff surfaces the failure
+        // rather than silently falling back to the stale original preview (#1235).
+        var proposalId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Create card",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString());
+        proposal.SetDiffPreview("0. Create card \"Original card\"");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Non-empty payload that satisfies the entity ctor but carries no operations
+        // array — TryParseOperations rejects it (mirrors the executor's behavior).
+        var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), "{}", "Reviewer edit");
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default))
+            .ReturnsAsync(revision);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
     }
 
     #endregion

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -80,8 +80,12 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
       saving.value = true
       const revision = await proposalRevisionsApi.createRevision(proposalId, payload)
       if (gen !== saveGeneration || activeProposal.value?.id !== proposalId) return
+      // Invalidate any in-flight revision load so a pre-save (stale, empty) list
+      // can't overwrite this save's state when it resolves after the save.
+      loadGeneration += 1
       latestRevision.value = revision
       revisionCount.value += 1
+      revisionsLoaded.value = true
       editing.value = false
       toast.success('Revision saved')
     } catch (e: unknown) {

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -15,9 +15,10 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
   const saving = ref(false)
   const revisionCount = ref(0)
   const latestRevision = ref<ProposalRevision | null>(null)
-  // False until the revision list for the active proposal has settled (success or
-  // failure). Consumers must not treat a still-loading revisionCount of 0 as
-  // "no revision" — a proposal with a saved edit renders a revision-aware diff (#1235).
+  // False until the revision list for the active proposal has been authoritatively
+  // loaded. Stays false while loading AND if the load fails, so consumers never
+  // treat a not-yet-known revisionCount of 0 as "no revision" — a proposal with a
+  // saved edit renders a revision-aware diff (#1235).
   const revisionsLoaded = ref(false)
   let loadGeneration = 0
   let saveGeneration = 0
@@ -37,7 +38,8 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
       if (gen !== loadGeneration || activeProposal.value?.id !== proposalId) return
       revisionCount.value = 0
       latestRevision.value = null
-      revisionsLoaded.value = true
+      // Leave revisionsLoaded false: the count is not authoritative, so callers
+      // must fetch (let the backend decide) rather than short-circuit to a no-op.
       toast.error(getErrorDisplay(e, 'Failed to load revision history').message)
     }
   }

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -15,6 +15,10 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
   const saving = ref(false)
   const revisionCount = ref(0)
   const latestRevision = ref<ProposalRevision | null>(null)
+  // False until the revision list for the active proposal has settled (success or
+  // failure). Consumers must not treat a still-loading revisionCount of 0 as
+  // "no revision" — a proposal with a saved edit renders a revision-aware diff (#1235).
+  const revisionsLoaded = ref(false)
   let loadGeneration = 0
   let saveGeneration = 0
 
@@ -28,10 +32,12 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
         revisions.length > 0
           ? revisions.reduce((a, b) => (a.revisionNumber > b.revisionNumber ? a : b))
           : null
+      revisionsLoaded.value = true
     } catch (e: unknown) {
       if (gen !== loadGeneration || activeProposal.value?.id !== proposalId) return
       revisionCount.value = 0
       latestRevision.value = null
+      revisionsLoaded.value = true
       toast.error(getErrorDisplay(e, 'Failed to load revision history').message)
     }
   }
@@ -45,6 +51,7 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
       saving.value = false
       revisionCount.value = 0
       latestRevision.value = null
+      revisionsLoaded.value = false
       if (id) {
         void loadRevisionState(id)
       }
@@ -89,6 +96,7 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
     editing,
     saving,
     revisionCount,
+    revisionsLoaded,
     latestRevision,
     startEditing,
     cancelEditing,

--- a/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
@@ -136,6 +136,37 @@ describe('useProposalRevisions', () => {
     expect(latestRevision.value).toEqual(newRevision)
   })
 
+  it('ignores a pre-save revision load that resolves after the save (no stale overwrite)', async () => {
+    // Codex review: a getRevisions request in flight when a save lands must not
+    // overwrite the save's state when it resolves with the pre-save (empty) list.
+    let resolveLoad: (v: ProposalRevision[]) => void = () => {}
+    const loadPromise = new Promise<ProposalRevision[]>((r) => {
+      resolveLoad = r
+    })
+    vi.mocked(proposalRevisionsApi.getRevisions).mockReturnValueOnce(loadPromise)
+    const saved = makeRevision({ revisionNumber: 1 })
+    vi.mocked(proposalRevisionsApi.createRevision).mockResolvedValue(saved)
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { revisionCount, latestRevision, revisionsLoaded, saveRevision } =
+      useProposalRevisions(proposal)
+    await nextTick()
+
+    // Save lands while the initial load is still pending.
+    await saveRevision({ revisedPayload: '{"title":"Edited"}', reason: 'Fix' })
+    expect(revisionCount.value).toBe(1)
+    expect(revisionsLoaded.value).toBe(true)
+
+    // The stale load now resolves with the OLD (empty) list — must be ignored.
+    resolveLoad([])
+    await nextTick()
+    await nextTick()
+
+    expect(revisionCount.value).toBe(1)
+    expect(latestRevision.value).toEqual(saved)
+    expect(revisionsLoaded.value).toBe(true)
+  })
+
   it('resets editing when proposal changes', async () => {
     vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([])
     const proposal = ref<ApiProposal | null>(makeProposal())

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -970,7 +970,7 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
-  it('shows a revision caveat in the diff preview when a saved revision exists', async () => {
+  it('notes that the diff reflects the saved revision when one exists', async () => {
     const now = new Date().toISOString()
     mocks.getRevisions.mockResolvedValue([
       {
@@ -991,11 +991,12 @@ describe('PaperReviewView', () => {
     await flushPromises()
 
     expect(wrapper.find('[data-testid="paper-review-diff-pre"]').exists()).toBe(true)
-    // The preview reflects the ORIGINAL proposal, so a pending saved revision must
-    // be flagged (the diff does not reflect the revision that Apply will run).
+    // The backend now returns the revision-aware diff (#1235), so the note confirms
+    // the preview reflects the saved edit and equals what Apply will execute.
     const caveat = wrapper.find('[data-testid="paper-review-diff-revision-caveat"]')
     expect(caveat.exists()).toBe(true)
-    expect(caveat.text()).toContain('original')
+    expect(caveat.text()).toContain('saved edit')
+    expect(caveat.text()).toContain('Apply will execute')
 
     wrapper.unmount()
   })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -970,6 +970,40 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
+  it('fetches the revision-aware diff for a 0-operation proposal that has a saved revision', async () => {
+    // Regression for the #1235 review: the no-op short-circuit must not fire when a
+    // saved revision exists. The backend renders a revision-aware diff, so Apply
+    // would execute the revised operations even when the ORIGINAL ops are empty —
+    // the view must fetch, not silently show the empty surface (preview == apply).
+    const now = new Date().toISOString()
+    mocks.getRevisions.mockResolvedValue([
+      {
+        id: 'rev-1',
+        proposalId: 'diff-noop-rev',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload:
+          '{"operations":[{"sequence":0,"actionType":"create","targetType":"card","parameters":"{}","idempotencyKey":"k"}]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    mocks.getProposalDiff.mockResolvedValueOnce('0. Create card')
+    const wrapper = await mountView([
+      makeProposal({ id: 'diff-noop-rev', diffPreview: null, operations: [] }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-noop-rev')
+    expect(wrapper.find('[data-testid="paper-review-diff-empty"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
   it('notes that the diff reflects the saved revision when one exists', async () => {
     const now = new Date().toISOString()
     mocks.getRevisions.mockResolvedValue([

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1031,7 +1031,7 @@ describe('PaperReviewView', () => {
     const caveat = wrapper.find('[data-testid="paper-review-diff-revision-caveat"]')
     expect(caveat.exists()).toBe(true)
     expect(caveat.text()).toContain('saved edit')
-    expect(caveat.text()).toContain('Apply will execute')
+    expect(caveat.text()).toContain('not the original')
 
     wrapper.unmount()
   })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -3,6 +3,7 @@ import { mount, flushPromises, enableAutoUnmount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import type { Proposal } from '../../../../types/automation'
 import PaperReviewView from '../../../../views/paper/PaperReviewView.vue'
+import ReviewRevisionEditor from '../../../../views/paper/review/ReviewRevisionEditor.vue'
 
 const mocks = vi.hoisted(() => ({
   getProposals: vi.fn(),
@@ -1031,6 +1032,48 @@ describe('PaperReviewView', () => {
     expect(caveat.exists()).toBe(true)
     expect(caveat.text()).toContain('saved edit')
     expect(caveat.text()).toContain('Apply will execute')
+
+    wrapper.unmount()
+  })
+
+  it('clears an open diff after a revision is saved so the note cannot certify stale content', async () => {
+    // #1235 review (Codex P2): if the diff is open and the reviewer then saves an
+    // edit, the visible previewDiff is pre-revision content; the "reflects your
+    // saved edit" note must never certify it. Saving clears the diff so re-opening
+    // fetches the fresh revision-aware one.
+    const now = new Date().toISOString()
+    mocks.getProposalDiff.mockResolvedValueOnce('0. Create card "Original"')
+    mocks.createRevision.mockResolvedValue({
+      id: 'rev-1',
+      proposalId: 'proposal-001',
+      revisionNumber: 1,
+      editorUserId: 'u-1',
+      revisedPayload:
+        '{"operations":[{"sequence":0,"actionType":"create","targetType":"card","parameters":"{}","idempotencyKey":"k"}]}',
+      revisedAt: now,
+      reason: 'edit',
+      createdAt: now,
+    })
+    const wrapper = await mountView([makeProposal({ id: 'proposal-001' })])
+
+    // Open the diff.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+    expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(true)
+
+    // Enter edit mode and save a revision.
+    await wrapper.find('[data-testid="decision-edit"]').trigger('click')
+    await flushPromises()
+    wrapper.findComponent(ReviewRevisionEditor).vm.$emit('save', {
+      revisedPayload:
+        '{"operations":[{"sequence":0,"actionType":"create","targetType":"card","parameters":"{}","idempotencyKey":"k"}]}',
+      reason: 'edit',
+    })
+    await flushPromises()
+
+    // The stale diff is gone; re-opening would fetch the revision-aware one.
+    expect(mocks.createRevision).toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(false)
 
     wrapper.unmount()
   })

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -682,10 +682,16 @@ async function onPreviewDiff() {
   // No-op proposals: the backend `/diff` (GetProposalDiffAsync) returns 404 when
   // there is no stored DiffPreview AND no operations. The view already renders a
   // "No operation preview" change section for that state, so show the empty-diff
-  // surface directly rather than firing a request that 404s. A saved revision
-  // always carries operations and the backend renders it revision-aware (#1235),
-  // so never short-circuit when one exists.
-  if (!p.diffPreview && (p.operations?.length ?? 0) === 0 && revisionCount.value === 0) {
+  // surface directly rather than firing a request that 404s. Only take this path
+  // when the revision list is authoritatively loaded and empty — a saved revision
+  // carries operations the backend renders revision-aware (#1235), and if the
+  // revision load failed we fetch so the backend, not a stale count, decides.
+  if (
+    !p.diffPreview &&
+    (p.operations?.length ?? 0) === 0 &&
+    revisionsLoaded.value &&
+    revisionCount.value === 0
+  ) {
     latestDiffRequestId += 1
     previewDiffProposalId.value = p.id
     previewDiff.value = ''
@@ -721,6 +727,19 @@ async function onPreviewDiff() {
     if (requestId === latestDiffRequestId) {
       previewDiffLoading.value = false
     }
+  }
+}
+
+async function onSaveRevision(payload: Parameters<typeof saveRevision>[0]) {
+  await saveRevision(payload)
+  // Saving an edit changes what Apply will execute, so a diff already on screen is
+  // now stale — drop it so the "reflects your saved edit" note cannot certify a
+  // pre-revision preview (#1235). Re-opening the diff fetches the revision-aware one.
+  if (previewDiffProposalId.value) {
+    latestDiffRequestId += 1
+    previewDiffProposalId.value = null
+    previewDiff.value = null
+    previewDiffLoading.value = false
   }
 }
 
@@ -875,7 +894,7 @@ function onQueueFilterChange(filter: QueueFilter) {
         v-if="revisionEditing"
         :operations-payload="editablePayload"
         :saving="revisionSaving"
-        @save="saveRevision"
+        @save="onSaveRevision"
         @cancel="cancelRevisionEditing"
       />
     </div>

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -219,10 +219,12 @@ const {
   editing: revisionEditing,
   saving: revisionSaving,
   revisionCount,
+  revisionsLoaded,
   latestRevision,
   startEditing: startRevisionEditing,
   cancelEditing: cancelRevisionEditing,
   saveRevision,
+  loadRevisionState,
 } = useProposalRevisions(activeProposal)
 
 const editablePayload = computed(() => {
@@ -666,6 +668,15 @@ async function onPreviewDiff() {
     previewDiff.value = null
     previewDiffLoading.value = false
     return
+  }
+
+  // A saved revision is rendered revision-aware by the backend (#1235), so a
+  // proposal with a revision must fetch even when its ORIGINAL operations are
+  // empty. Settle the revision list first so a still-loading revisionCount of 0
+  // can't short-circuit a revised proposal to the empty surface.
+  if (!revisionsLoaded.value) {
+    await loadRevisionState(p.id)
+    if (activeProposal.value?.id !== p.id) return
   }
 
   // No-op proposals: the backend `/diff` (GetProposalDiffAsync) returns 404 when

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -671,8 +671,10 @@ async function onPreviewDiff() {
   // No-op proposals: the backend `/diff` (GetProposalDiffAsync) returns 404 when
   // there is no stored DiffPreview AND no operations. The view already renders a
   // "No operation preview" change section for that state, so show the empty-diff
-  // surface directly rather than firing a request that 404s.
-  if (!p.diffPreview && (p.operations?.length ?? 0) === 0) {
+  // surface directly rather than firing a request that 404s. A saved revision
+  // always carries operations and the backend renders it revision-aware (#1235),
+  // so never short-circuit when one exists.
+  if (!p.diffPreview && (p.operations?.length ?? 0) === 0 && revisionCount.value === 0) {
     latestDiffRequestId += 1
     previewDiffProposalId.value = p.id
     previewDiff.value = ''
@@ -831,9 +833,8 @@ function onQueueFilterChange(filter: QueueFilter) {
           class="paper-review-deep__diff-caveat tk-meta"
           data-testid="paper-review-diff-revision-caveat"
         >
-          ⚠ This preview shows the <strong>original</strong> proposal. A saved edit
-          (revision) will be applied instead, so the diff below may not reflect your
-          pending change (revision-aware diff tracked in #1235).
+          ✎ This preview reflects your <strong>saved edit</strong> — it is exactly
+          what Apply will execute.
         </p>
         <div class="card paper-review-deep__diff-card">
           <p

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -863,8 +863,8 @@ function onQueueFilterChange(filter: QueueFilter) {
           class="paper-review-deep__diff-caveat tk-meta"
           data-testid="paper-review-diff-revision-caveat"
         >
-          ✎ This preview reflects your <strong>saved edit</strong> — it is exactly
-          what Apply will execute.
+          ✎ This preview reflects your latest <strong>saved edit</strong> — the
+          revised operations, not the original proposal.
         </p>
         <div class="card paper-review-deep__diff-card">
           <p


### PR DESCRIPTION
## What & why

Closes #1235 — the tracker's named **top engineering priority** and archive exit-criterion **(b)**.

`AutomationProposalService.GetProposalDiffAsync` built the approval-gate diff from the **original** proposal's `DiffPreview`/`Operations`. But **Apply** materializes the latest `ProposalRevision` via `AutomationExecutorService.MaterializeEffectiveProposalAsync`. So once a reviewer saved an edit, the preview showed the *original* operations, not what Apply would actually execute — a review-first trust defect (only the interim #1234 UI caveat kept it disclosed-stale rather than silent).

## The fix (issue's option 1)

`GetProposalDiffAsync` now loads the latest revision and, when one exists, builds the diff from the **revised payload** using the **same parser Apply uses** (`ProposalRevisionPayload.TryParseOperations`) — so **preview == apply**. When no revision exists, behavior is unchanged (stored `DiffPreview`, else generated from original ops).

- Extracted `BuildReadableDiffAsync` + a source-agnostic `DiffOperationView` so the entity path and the revised-payload path render **identically**.
- An unmaterializable revision surfaces the same `ValidationError` Apply would return — not a stale original diff.
- **Frontend:** the #1234 caveat ("preview shows the *original*; saved edit applies instead") is now false, so it's narrowed to an accurate note ("this preview reflects your saved edit — exactly what Apply will execute"). The `onPreviewDiff` no-op guard no longer short-circuits to an empty diff when a revision exists. Legacy ReviewView inherits the backend fix (same endpoint).

## Tests

- **Unit** (`AutomationProposalServiceTests`): diff reflects the revised op — not the original op or the stale stored preview; invalid revision payload → `ValidationError`.
- **API** (`ProposalRevisionApiTests.GetProposalDiff_AfterSavingRevision_ShouldReflectRevisedOperations`): after saving a revision, `/diff` shows the revised card, not the original — **paired with the existing `ExecuteProposal_WithLatestRevision_ShouldApplyRevisedOperations`** to prove preview == apply end-to-end.
- **Frontend** (`PaperReviewView.spec.ts`): the revision note asserts the new copy.

## Verification (local, this box)

- `dotnet build` Application project: clean (0 warn / 0 err).
- Application.Tests `GetProposalDiffAsync` 7/7; `AutomationProposalServiceTests`+`AutomationExecutorServiceTests` 53/53.
- Api.Tests `ProposalRevisionApiTests` 12/12.
- Frontend `PaperReviewView.spec.ts` 44/44; `typecheck` + `eslint` clean.

Docs-neutral (no STATUS/masterplan change until merge). Full suites run in CI.