### PR TITLE
fix(automation): deterministic-extractor provenance for capture triage (#1273)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/CaptureTriageService.cs
+++ b/backend/src/Taskdeck.Application/Services/CaptureTriageService.cs
@@ -68,6 +68,9 @@ public class CaptureTriageService : ICaptureTriageService
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        if (payload is null)
+            return Result.Failure<CaptureTriageProposalResultDto>(ErrorCodes.ValidationError, "Capture payload cannot be null");
+
         if (captureItemId == Guid.Empty)
             return Result.Failure<CaptureTriageProposalResultDto>(ErrorCodes.ValidationError, "CaptureItemId cannot be empty");
 

--- a/backend/src/Taskdeck.Application/Services/CaptureTriageService.cs
+++ b/backend/src/Taskdeck.Application/Services/CaptureTriageService.cs
@@ -2,7 +2,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.Logging;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Common;
@@ -14,6 +13,17 @@ namespace Taskdeck.Application.Services;
 public class CaptureTriageService : ICaptureTriageService
 {
     private const int MaxExtractedTasks = CaptureTriageOutputContract.MaxTasks;
+
+    /// <summary>
+    /// Provenance actor recorded for capture triage. Triage runs a deterministic, offline text
+    /// extractor (<see cref="ExtractTaskCandidates"/>) that never invokes an LLM, so the recorded
+    /// provider/model must name the extractor itself — not the workspace's configured live LLM
+    /// provider. Recording the live provider here would be false provenance (#1273).
+    /// </summary>
+    public const string TriageProviderName = "deterministic-extractor";
+
+    /// <summary>Model/version identifier for the deterministic capture-triage extractor (#1273).</summary>
+    public const string TriageModelName = "capture-triage-v1";
 
     private static readonly Regex ChecklistPattern = new(
         @"^\s*[-*]\s+\[[xX ]\]\s+(.+?)\s*$",
@@ -38,21 +48,15 @@ public class CaptureTriageService : ICaptureTriageService
     private readonly IUnitOfWork _unitOfWork;
     private readonly IAutomationProposalService _proposalService;
     private readonly IAutomationPolicyEngine _policyEngine;
-    private readonly ILlmProvider _llmProvider;
-    private readonly ILogger<CaptureTriageService>? _logger;
 
     public CaptureTriageService(
         IUnitOfWork unitOfWork,
         IAutomationProposalService proposalService,
-        IAutomationPolicyEngine policyEngine,
-        ILlmProvider llmProvider,
-        ILogger<CaptureTriageService>? logger = null)
+        IAutomationPolicyEngine policyEngine)
     {
         _unitOfWork = unitOfWork;
         _proposalService = proposalService;
         _policyEngine = policyEngine;
-        _llmProvider = llmProvider;
-        _logger = logger;
     }
 
     public async Task<Result<CaptureTriageProposalResultDto>> CreateProposalFromCaptureAsync(
@@ -62,6 +66,8 @@ public class CaptureTriageService : ICaptureTriageService
         CapturePayloadV1 payload,
         CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (captureItemId == Guid.Empty)
             return Result.Failure<CaptureTriageProposalResultDto>(ErrorCodes.ValidationError, "CaptureItemId cannot be empty");
 
@@ -155,15 +161,14 @@ public class CaptureTriageService : ICaptureTriageService
             cancellationToken);
         if (existingProposal != null)
         {
-            var (existingProvider, existingModel) = await GetProviderMetadataAsync(cancellationToken);
             return Result.Success(new CaptureTriageProposalResultDto(
                 captureItemId,
                 ResolveTriageRunId(existingProposal.CorrelationId, triageRunId),
                 existingProposal.Id,
                 existingProposal.Operations.Count == 0 ? operations.Count : existingProposal.Operations.Count,
                 outputValidation.Value.PromptVersion,
-                existingProvider,
-                existingModel));
+                TriageProviderName,
+                TriageModelName));
         }
 
         var createProposalResult = await _proposalService.CreateProposalAsync(
@@ -185,16 +190,14 @@ public class CaptureTriageService : ICaptureTriageService
                 createProposalResult.ErrorMessage);
         }
 
-        var (provider, model) = await GetProviderMetadataAsync(cancellationToken);
-
         return Result.Success(new CaptureTriageProposalResultDto(
             captureItemId,
             triageRunId,
             createProposalResult.Value.Id,
             operations.Count,
             outputValidation.Value.PromptVersion,
-            provider,
-            model));
+            TriageProviderName,
+            TriageModelName));
     }
 
     private static Guid ResolveTriageRunId(string? correlationId, Guid fallback)
@@ -202,33 +205,6 @@ public class CaptureTriageService : ICaptureTriageService
         return Guid.TryParse(correlationId, out var parsed) && parsed != Guid.Empty
             ? parsed
             : fallback;
-    }
-
-    private async Task<(string Provider, string Model)> GetProviderMetadataAsync(CancellationToken ct)
-    {
-        try
-        {
-            ct.ThrowIfCancellationRequested();
-            var health = await _llmProvider.GetHealthAsync(ct);
-            var provider = CaptureRequestContract.SanitizeProvenanceMetadata(
-                health.ProviderName,
-                CaptureRequestContract.MaxProviderLength);
-            var model = CaptureRequestContract.SanitizeProvenanceMetadata(
-                health.Model,
-                CaptureRequestContract.MaxModelLength);
-            return (provider, model);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(
-                "Failed to resolve LLM provider metadata for capture triage provenance. Falling back to unknown values. {ExceptionSummary}",
-                SensitiveDataRedactor.SummarizeException(ex));
-            return ("unknown", "unknown");
-        }
     }
 
     private static (List<string> Tasks, string? ContextHint) ExtractTaskCandidates(string rawText)

--- a/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
@@ -330,8 +330,9 @@ public class CaptureApiTests : IClassFixture<TestWebApplicationFactory>
         finalItem.Provenance.ProposalId.Should().NotBeNull();
         finalItem.Provenance.ProposalId.Should().NotBe(Guid.Empty);
         finalItem.Provenance.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
-        finalItem.Provenance.Provider.Should().Be("Mock");
-        finalItem.Provenance.Model.Should().Be("mock-default");
+        // #1273: triage is deterministic/offline — provenance names the extractor, not the LLM provider.
+        finalItem.Provenance.Provider.Should().Be("deterministic-extractor");
+        finalItem.Provenance.Model.Should().Be("capture-triage-v1");
         finalItem.Provenance.RequestedByUserId.Should().Be(user.UserId);
         finalItem.Provenance.SourceSurface.Should().Be("capture");
         finalItem.Provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();
@@ -353,8 +354,8 @@ public class CaptureApiTests : IClassFixture<TestWebApplicationFactory>
         payload.IsSuccess.Should().BeTrue();
         payload.Value.Provenance.Should().NotBeNull();
         payload.Value.Provenance!.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
-        payload.Value.Provenance.Provider.Should().Be("Mock");
-        payload.Value.Provenance.Model.Should().Be("mock-default");
+        payload.Value.Provenance.Provider.Should().Be("deterministic-extractor");
+        payload.Value.Provenance.Model.Should().Be("capture-triage-v1");
         payload.Value.Provenance.RequestedByUserId.Should().Be(user.UserId);
         payload.Value.Provenance.SourceSurface.Should().Be("capture");
         payload.Value.Provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();

--- a/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
@@ -331,8 +331,8 @@ public class CaptureApiTests : IClassFixture<TestWebApplicationFactory>
         finalItem.Provenance.ProposalId.Should().NotBe(Guid.Empty);
         finalItem.Provenance.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
         // #1273: triage is deterministic/offline — provenance names the extractor, not the LLM provider.
-        finalItem.Provenance.Provider.Should().Be("deterministic-extractor");
-        finalItem.Provenance.Model.Should().Be("capture-triage-v1");
+        finalItem.Provenance.Provider.Should().Be(CaptureTriageService.TriageProviderName);
+        finalItem.Provenance.Model.Should().Be(CaptureTriageService.TriageModelName);
         finalItem.Provenance.RequestedByUserId.Should().Be(user.UserId);
         finalItem.Provenance.SourceSurface.Should().Be("capture");
         finalItem.Provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();
@@ -354,8 +354,8 @@ public class CaptureApiTests : IClassFixture<TestWebApplicationFactory>
         payload.IsSuccess.Should().BeTrue();
         payload.Value.Provenance.Should().NotBeNull();
         payload.Value.Provenance!.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
-        payload.Value.Provenance.Provider.Should().Be("deterministic-extractor");
-        payload.Value.Provenance.Model.Should().Be("capture-triage-v1");
+        payload.Value.Provenance.Provider.Should().Be(CaptureTriageService.TriageProviderName);
+        payload.Value.Provenance.Model.Should().Be(CaptureTriageService.TriageModelName);
         payload.Value.Provenance.RequestedByUserId.Should().Be(user.UserId);
         payload.Value.Provenance.SourceSurface.Should().Be("capture");
         payload.Value.Provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();

--- a/backend/tests/Taskdeck.Api.Tests/CaptureToBoardGoldenPathIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureToBoardGoldenPathIntegrationTests.cs
@@ -110,7 +110,8 @@ public class CaptureToBoardGoldenPathIntegrationTests : IClassFixture<TestWebApp
         // Assert: Provenance chain is intact
         converted.Provenance.CaptureItemId.Should().Be(capture.Id);
         converted.Provenance.BoardId.Should().Be(board.Id);
-        converted.Provenance.Provider.Should().Be("Mock");
+        // #1273: triage is deterministic/offline — provenance names the extractor, not the LLM provider.
+        converted.Provenance.Provider.Should().Be("deterministic-extractor");
         converted.Provenance.SourceSurface.Should().Be("capture");
         converted.Provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();
     }

--- a/backend/tests/Taskdeck.Api.Tests/CaptureToBoardGoldenPathIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureToBoardGoldenPathIntegrationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Enums;
 using Taskdeck.Infrastructure.Persistence;
@@ -111,7 +112,7 @@ public class CaptureToBoardGoldenPathIntegrationTests : IClassFixture<TestWebApp
         converted.Provenance.CaptureItemId.Should().Be(capture.Id);
         converted.Provenance.BoardId.Should().Be(board.Id);
         // #1273: triage is deterministic/offline — provenance names the extractor, not the LLM provider.
-        converted.Provenance.Provider.Should().Be("deterministic-extractor");
+        converted.Provenance.Provider.Should().Be(CaptureTriageService.TriageProviderName);
         converted.Provenance.SourceSurface.Should().Be("capture");
         converted.Provenance.CorrelationId.Should().NotBeNullOrWhiteSpace();
     }

--- a/backend/tests/Taskdeck.Api.Tests/CardsApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CardsApiTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Enums;
 using Xunit;
@@ -290,8 +291,8 @@ public class CardsApiTests : IClassFixture<TestWebApplicationFactory>
         triagedItem.Provenance.Should().NotBeNull();
         triagedItem.Provenance!.ProposalId.Should().NotBeNull();
         // #1273: triage is deterministic/offline — provenance names the extractor, not the LLM provider.
-        triagedItem.Provenance.Provider.Should().Be("deterministic-extractor");
-        triagedItem.Provenance.Model.Should().Be("capture-triage-v1");
+        triagedItem.Provenance.Provider.Should().Be(CaptureTriageService.TriageProviderName);
+        triagedItem.Provenance.Model.Should().Be(CaptureTriageService.TriageModelName);
 
         var proposalId = triagedItem.Provenance.ProposalId!.Value;
         var approveResponse = await _client.PostAsync($"/api/automation/proposals/{proposalId}/approve", null);

--- a/backend/tests/Taskdeck.Api.Tests/CardsApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CardsApiTests.cs
@@ -289,8 +289,9 @@ public class CardsApiTests : IClassFixture<TestWebApplicationFactory>
         var triagedItem = await WaitForCaptureStatusAsync(_client, captureItem.Id, CaptureStatus.ProposalCreated);
         triagedItem.Provenance.Should().NotBeNull();
         triagedItem.Provenance!.ProposalId.Should().NotBeNull();
-        triagedItem.Provenance.Provider.Should().Be("Mock");
-        triagedItem.Provenance.Model.Should().Be("mock-default");
+        // #1273: triage is deterministic/offline — provenance names the extractor, not the LLM provider.
+        triagedItem.Provenance.Provider.Should().Be("deterministic-extractor");
+        triagedItem.Provenance.Model.Should().Be("capture-triage-v1");
 
         var proposalId = triagedItem.Provenance.ProposalId!.Value;
         var approveResponse = await _client.PostAsync($"/api/automation/proposals/{proposalId}/approve", null);

--- a/backend/tests/Taskdeck.Application.Tests/Services/CaptureTriageServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CaptureTriageServiceTests.cs
@@ -19,7 +19,6 @@ public class CaptureTriageServiceTests
     private readonly Mock<IAutomationProposalRepository> _automationProposalsMock;
     private readonly Mock<IAutomationProposalService> _proposalServiceMock;
     private readonly Mock<IAutomationPolicyEngine> _policyEngineMock;
-    private readonly Mock<ILlmProvider> _llmProviderMock;
     private readonly CaptureTriageService _service;
 
     public CaptureTriageServiceTests()
@@ -30,7 +29,6 @@ public class CaptureTriageServiceTests
         _automationProposalsMock = new Mock<IAutomationProposalRepository>();
         _proposalServiceMock = new Mock<IAutomationProposalService>();
         _policyEngineMock = new Mock<IAutomationPolicyEngine>();
-        _llmProviderMock = new Mock<ILlmProvider>();
 
         _unitOfWorkMock.SetupGet(u => u.Boards).Returns(_boardsMock.Object);
         _unitOfWorkMock.SetupGet(u => u.Columns).Returns(_columnsMock.Object);
@@ -49,14 +47,11 @@ public class CaptureTriageServiceTests
                 It.IsAny<IEnumerable<ProposalOperationDto>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
-        _llmProviderMock.Setup(p => p.GetHealthAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new LlmHealthStatus(true, "Mock", Model: "mock-default"));
 
         _service = new CaptureTriageService(
             _unitOfWorkMock.Object,
             _proposalServiceMock.Object,
-            _policyEngineMock.Object,
-            _llmProviderMock.Object);
+            _policyEngineMock.Object);
     }
 
     [Fact]
@@ -158,8 +153,8 @@ public class CaptureTriageServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Value.OperationCount.Should().Be(3);
         result.Value.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
-        result.Value.Provider.Should().Be("Mock");
-        result.Value.Model.Should().Be("mock-default");
+        result.Value.Provider.Should().Be(CaptureTriageService.TriageProviderName);
+        result.Value.Model.Should().Be(CaptureTriageService.TriageModelName);
         createdProposal.Should().NotBeNull();
         var created = createdProposal!;
         created.SourceType.Should().Be(ProposalSourceType.Queue);
@@ -170,6 +165,86 @@ public class CaptureTriageServiceTests
         created.Operations[1].Parameters.Should().Contain("Update docs");
         created.Operations[2].Parameters.Should().Contain("Ship follow-up PR");
         created.Operations.Select(operation => Guid.TryParse(operation.TargetId, out _)).Should().OnlyContain(parsed => parsed);
+    }
+
+    [Fact]
+    public async Task CreateProposalFromCaptureAsync_ShouldRecordDeterministicExtractorProvenance_NotAnLlmProvider()
+    {
+        // #1273: capture triage is a deterministic, offline text extractor and never calls an LLM,
+        // so its provenance must name the extractor itself — not the configured live LLM provider.
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var captureId = Guid.NewGuid();
+        var board = new Board("Capture board", ownerId: userId);
+        var column = new Column(boardId, "Inbox", 0);
+
+        _boardsMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
+        _columnsMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { column });
+        _proposalServiceMock.Setup(s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), default))
+            .ReturnsAsync(Result.Success(BuildProposalDto(userId, boardId, captureId)));
+
+        var result = await _service.CreateProposalFromCaptureAsync(
+            captureId,
+            userId,
+            boardId,
+            new CapturePayloadV1(
+                CaptureRequestContract.CurrentSchemaVersion,
+                CaptureSource.Typed,
+                "- [ ] Deterministic provenance"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Provider.Should().Be("deterministic-extractor");
+        result.Value.Model.Should().Be("capture-triage-v1");
+        result.Value.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
+        // Provenance values must satisfy the capture provenance length contract the worker enforces.
+        result.Value.Provider.Length.Should().BeLessThanOrEqualTo(CaptureRequestContract.MaxProviderLength);
+        result.Value.Model.Length.Should().BeLessThanOrEqualTo(CaptureRequestContract.MaxModelLength);
+    }
+
+    [Fact]
+    public async Task CreateProposalFromCaptureAsync_ShouldReuseExistingProposalProvenance_AsDeterministicExtractor()
+    {
+        // The reuse (already-triaged) branch must record the same deterministic provenance.
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var captureId = Guid.NewGuid();
+        var board = new Board("Capture board", ownerId: userId);
+        var column = new Column(boardId, "Inbox", 0);
+        var existingProposal = new AutomationProposal(
+            ProposalSourceType.Queue,
+            userId,
+            "Capture triage",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId,
+            captureId.ToString());
+        existingProposal.AddOperation(new AutomationProposalOperation(
+            existingProposal.Id,
+            sequence: 0,
+            actionType: "create",
+            targetType: "card",
+            parameters: "{\"title\":\"existing\"}",
+            idempotencyKey: "existing-op-1"));
+
+        _boardsMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
+        _columnsMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { column });
+        _automationProposalsMock
+            .Setup(r => r.GetBySourceReferenceAsync(ProposalSourceType.Queue, captureId.ToString(), default))
+            .ReturnsAsync(existingProposal);
+
+        var result = await _service.CreateProposalFromCaptureAsync(
+            captureId,
+            userId,
+            boardId,
+            new CapturePayloadV1(
+                CaptureRequestContract.CurrentSchemaVersion,
+                CaptureSource.Typed,
+                "- [ ] Reuse existing"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ProposalId.Should().Be(existingProposal.Id);
+        result.Value.Provider.Should().Be("deterministic-extractor");
+        result.Value.Model.Should().Be("capture-triage-v1");
     }
 
     [Fact]
@@ -342,73 +417,10 @@ public class CaptureTriageServiceTests
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
         _proposalServiceMock.Verify(s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), default), Times.Never);
-        _llmProviderMock.Verify(p => p.GetHealthAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task CreateProposalFromCaptureAsync_ShouldUseUnknownProviderMetadata_WhenProviderHealthFails()
-    {
-        var userId = Guid.NewGuid();
-        var boardId = Guid.NewGuid();
-        var captureId = Guid.NewGuid();
-        var board = new Board("Capture board", ownerId: userId);
-        var column = new Column(boardId, "Inbox", 0);
-
-        _boardsMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
-        _columnsMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { column });
-        _proposalServiceMock
-            .Setup(s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), default))
-            .ReturnsAsync(Result.Success(BuildProposalDto(userId, boardId, captureId)));
-        _llmProviderMock.Setup(p => p.GetHealthAsync(It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("health unavailable"));
-
-        var payload = new CapturePayloadV1(
-            CaptureRequestContract.CurrentSchemaVersion,
-            CaptureSource.Typed,
-            "- [ ] provider metadata fallback");
-
-        var result = await _service.CreateProposalFromCaptureAsync(captureId, userId, boardId, payload);
-
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Provider.Should().Be("unknown");
-        result.Value.Model.Should().Be("unknown");
-    }
-
-    [Fact]
-    public async Task CreateProposalFromCaptureAsync_ShouldClampProviderMetadataToContractLimits()
-    {
-        var userId = Guid.NewGuid();
-        var boardId = Guid.NewGuid();
-        var captureId = Guid.NewGuid();
-        var board = new Board("Capture board", ownerId: userId);
-        var column = new Column(boardId, "Inbox", 0);
-        var longProvider = new string('p', CaptureRequestContract.MaxProviderLength + 10);
-        var longModel = new string('m', CaptureRequestContract.MaxModelLength + 10);
-
-        _boardsMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
-        _columnsMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { column });
-        _proposalServiceMock
-            .Setup(s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), default))
-            .ReturnsAsync(Result.Success(BuildProposalDto(userId, boardId, captureId)));
-        _llmProviderMock.Setup(p => p.GetHealthAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new LlmHealthStatus(true, longProvider, Model: longModel));
-
-        var payload = new CapturePayloadV1(
-            CaptureRequestContract.CurrentSchemaVersion,
-            CaptureSource.Typed,
-            "- [ ] metadata clamp");
-
-        var result = await _service.CreateProposalFromCaptureAsync(captureId, userId, boardId, payload);
-
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Provider.Should().HaveLength(CaptureRequestContract.MaxProviderLength);
-        result.Value.Model.Should().HaveLength(CaptureRequestContract.MaxModelLength);
-        result.Value.Provider.Should().Be(longProvider[..CaptureRequestContract.MaxProviderLength]);
-        result.Value.Model.Should().Be(longModel[..CaptureRequestContract.MaxModelLength]);
-    }
-
-    [Fact]
-    public async Task CreateProposalFromCaptureAsync_ShouldNotResolveProviderMetadata_WhenProposalCreationFails()
+    public async Task CreateProposalFromCaptureAsync_ShouldReturnFailure_WhenProposalCreationFails()
     {
         var userId = Guid.NewGuid();
         var boardId = Guid.NewGuid();
@@ -430,11 +442,11 @@ public class CaptureTriageServiceTests
         var result = await _service.CreateProposalFromCaptureAsync(captureId, userId, boardId, payload);
 
         result.IsSuccess.Should().BeFalse();
-        _llmProviderMock.Verify(p => p.GetHealthAsync(It.IsAny<CancellationToken>()), Times.Never);
+        result.ErrorCode.Should().Be(ErrorCodes.UnexpectedError);
     }
 
     [Fact]
-    public async Task CreateProposalFromCaptureAsync_ShouldPropagateCancellation_WhenMetadataLookupTokenIsCancelled()
+    public async Task CreateProposalFromCaptureAsync_ShouldPropagateCancellation_WhenTokenIsAlreadyCancelled()
     {
         var userId = Guid.NewGuid();
         var boardId = Guid.NewGuid();
@@ -458,11 +470,12 @@ public class CaptureTriageServiceTests
             new CapturePayloadV1(
                 CaptureRequestContract.CurrentSchemaVersion,
                 CaptureSource.Typed,
-                "- [ ] cancelled metadata lookup"),
+                "- [ ] cancelled before any work"),
             cts.Token);
 
         await act.Should().ThrowAsync<OperationCanceledException>();
-        _llmProviderMock.Verify(p => p.GetHealthAsync(It.IsAny<CancellationToken>()), Times.Never);
+        // An already-cancelled request must fail fast before creating any proposal.
+        _proposalServiceMock.Verify(s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/CaptureTriageServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CaptureTriageServiceTests.cs
@@ -193,6 +193,9 @@ public class CaptureTriageServiceTests
                 "- [ ] Deterministic provenance"));
 
         result.IsSuccess.Should().BeTrue();
+        // Intentional literals (not the constants): this is the single wire-contract lock that pins the
+        // exact strings persisted onto the capture payload / returned by the capture API. A change to the
+        // TriageProviderName/TriageModelName constants is an observable contract change and must fail here.
         result.Value.Provider.Should().Be("deterministic-extractor");
         result.Value.Model.Should().Be("capture-triage-v1");
         result.Value.PromptVersion.Should().Be(CaptureTriageOutputContract.PromptVersionV1);
@@ -243,8 +246,22 @@ public class CaptureTriageServiceTests
 
         result.IsSuccess.Should().BeTrue();
         result.Value.ProposalId.Should().Be(existingProposal.Id);
-        result.Value.Provider.Should().Be("deterministic-extractor");
-        result.Value.Model.Should().Be("capture-triage-v1");
+        result.Value.Provider.Should().Be(CaptureTriageService.TriageProviderName);
+        result.Value.Model.Should().Be(CaptureTriageService.TriageModelName);
+    }
+
+    [Fact]
+    public async Task CreateProposalFromCaptureAsync_ShouldReturnValidationError_WhenPayloadIsNull()
+    {
+        var result = await _service.CreateProposalFromCaptureAsync(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            payload: null!);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("payload cannot be null");
     }
 
     [Fact]

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -245,6 +245,8 @@ Current review model:
 3. user approves or rejects
 4. user executes explicitly
 
+> Capture triage is deterministic and offline in every mode — it extracts tasks from your text with a fixed rule-based parser and never calls an LLM, even when a live AI provider is configured. Its provenance is recorded as `deterministic-extractor` / `capture-triage-v1`, not the configured provider.
+
 ## Daily Rhythm
 
 Morning:

--- a/docs/api/CAPTURE.md
+++ b/docs/api/CAPTURE.md
@@ -2,7 +2,7 @@
 
 > **Data model:** See [Data Model Reference](../architecture/DATA_MODEL.md) for entity fields, constraints, and relationships.
 
-The capture pipeline is Taskdeck's quick-capture system. Raw text is captured, then triaged by the LLM to generate automation proposals. Proposals must be explicitly approved by the user before any board mutations occur (review-first principle).
+The capture pipeline is Taskdeck's quick-capture system. Raw text is captured, then triaged by a deterministic, offline rule-based extractor (no LLM call) to generate automation proposals. Proposals must be explicitly approved by the user before any board mutations occur (review-first principle).
 
 ## Capture flow
 
@@ -80,7 +80,7 @@ curl -s "http://localhost:5000/api/capture/items/$CAPTURE_ID" \
 
 ## Enqueue for triage
 
-Sends the capture item to the LLM for proposal generation. The response is asynchronous -- the proposal will appear in the review queue when ready.
+Enqueues the capture item for triage by the deterministic offline extractor (no LLM call) into proposal operations. The response is asynchronous -- the proposal will appear in the review queue when ready.
 
 ```bash
 curl -s -X POST "http://localhost:5000/api/capture/items/$CAPTURE_ID/triage" \
@@ -126,7 +126,7 @@ Response: `204 No Content`
 | Status | Description |
 |--------|-------------|
 | `Pending` | Newly created, awaiting user action |
-| `Triaging` | Sent to LLM for proposal generation |
+| `Triaging` | Being triaged by the deterministic extractor into proposal operations |
 | `Processed` | Triage complete, proposal generated |
 | `Ignored` | Dismissed by user |
 | `Cancelled` | Cancelled by user |

--- a/docs/legal/PRIVACY_POLICY.md
+++ b/docs/legal/PRIVACY_POLICY.md
@@ -53,13 +53,16 @@ should decide whether to prohibit specific data categories in `TERMS_OF_SERVICE.
 
 ### 2.3 Capture, proposal, and LLM data
 
-Taskdeck's core flow involves capturing short notes and letting an LLM propose
+Taskdeck's core flow involves capturing short notes, turning them into proposed
 structured changes to a board, which you then review and approve. This means:
 
 - Captures and inbox items you create are stored until you dismiss or process them.
-- If an LLM provider is enabled (see Section 4), the text of your captures and
-  relevant board context (column names, card titles, card IDs) may be sent to
-  that provider to generate proposals. **LLM providers are disabled by default**
+- **Capture triage is deterministic and offline in every mode**: turning a capture
+  into a proposal is performed by a local rule-based extractor that never sends your
+  capture text or board context to an LLM provider.
+- Separately, if you use **Automation Chat** and an LLM provider is enabled (see
+  Section 4), the text you send and relevant board context (column names, card titles,
+  card IDs) may be sent to that provider. **LLM providers are disabled by default**
   (the shipped default is a deterministic local "Mock" provider) and must be
   turned on explicitly in configuration.
 - Proposals, chat sessions, chat messages, tool-call metadata, and the audit

--- a/docs/ops/CLOUD_COST_OBSERVABILITY.md
+++ b/docs/ops/CLOUD_COST_OBSERVABILITY.md
@@ -46,7 +46,7 @@ Cloud costs are tracked across six dimensions. Each dimension maps to a billing 
 | Application metric | Persisted `ILlmQuotaService` usage records and quota summaries |
 | Current baseline | GPT-4o-mini: ~$0.15/1M input tokens, ~$0.60/1M output tokens (reference baseline; verify against current OpenAI pricing). Gemini 2.5 Flash pricing differs and should be verified separately against current Google pricing. |
 | Estimated monthly cost | $5-50 (light usage, 10-50 active users) to $200-500 (heavy usage, 100+ users with tool-calling) |
-| Scaling driver | Chat messages per user, tool-calling rounds per message (max 5), capture triage volume |
+| Scaling driver | Chat messages per user, tool-calling rounds per message (max 5), non-capture LLM queue requests (capture triage is deterministic/offline and adds no LLM cost) |
 
 LLM costs are the highest-variance dimension. See `docs/ops/COST_HOTSPOT_REGISTRY.md` for detailed breakdown.
 

--- a/docs/ops/COST_HOTSPOT_REGISTRY.md
+++ b/docs/ops/COST_HOTSPOT_REGISTRY.md
@@ -36,7 +36,7 @@ Each hotspot follows this structure:
 | Feature | Automation Chat (`ChatService`), capture triage (`LlmQueueToProposalWorker`), tool-calling orchestrator |
 | Cost dimension | LLM API (OpenAI / Gemini) |
 | Estimated cost range | $5-50/month (10-50 users, light chat) to $200-500/month (100+ users, heavy tool-calling) |
-| Scaling behavior | **Superlinear** — each chat message may trigger 1-5 tool-calling rounds, each round is a full API call with growing context window. A single complex conversation can cost 5-10x a simple one. Capture triage adds per-item LLM cost. |
+| Scaling behavior | **Superlinear** — each chat message may trigger 1-5 tool-calling rounds, each round is a full API call with growing context window. A single complex conversation can cost 5-10x a simple one. Capture triage adds **no** LLM cost — it is a deterministic, offline extractor. |
 | Current guardrails | Per-user rate limit: 60 req/60s. Per-user token limit: 100K tokens/day. Global budget ceiling config (`LlmQuota:GlobalBudgetCeilingTokens`). Tool-calling loop cap: 5 rounds, 60s total timeout, 30s per-round timeout. Tool result truncation: 8KB max. Kill-switch (global/surface/per-user). Mock provider default (zero cost). |
 | Mitigation levers | 1. Lower global `LlmQuota:RequestsPerHour` or `LlmQuota:TokensPerDay` defaults. 2. Block abusive users entirely via per-user kill-switch. 3. Switch high-volume users to Mock provider. 4. Activate surface-level kill-switch for Chat or CaptureTriage. 5. Reduce context window size (`BoardContextBuilder` budget). 6. Switch from GPT-4o-mini to a cheaper model. 7. Enable clarification detection to reduce wasted rounds (`ClarificationDetector`). |
 | Action owner | Product/backend lead |

--- a/docs/ops/COST_HOTSPOT_REGISTRY.md
+++ b/docs/ops/COST_HOTSPOT_REGISTRY.md
@@ -29,16 +29,18 @@ Each hotspot follows this structure:
 
 ---
 
-## Hotspot 1: LLM API Usage (Chat and Capture Triage)
+## Hotspot 1: LLM API Usage (Chat and Tool-Calling)
+
+> **Capture triage is not an LLM cost.** Turning a capture into a proposal is a deterministic, offline extractor that never calls a provider, so it contributes $0 to this hotspot in every mode. The LLM cost of `LlmQueueToProposalWorker` comes only from **non-capture** queue requests.
 
 | Attribute | Detail |
 |---|---|
-| Feature | Automation Chat (`ChatService`), capture triage (`LlmQueueToProposalWorker`), tool-calling orchestrator |
+| Feature | Automation Chat (`ChatService`), LLM queue processing (`LlmQueueToProposalWorker`, non-capture requests only), tool-calling orchestrator |
 | Cost dimension | LLM API (OpenAI / Gemini) |
 | Estimated cost range | $5-50/month (10-50 users, light chat) to $200-500/month (100+ users, heavy tool-calling) |
 | Scaling behavior | **Superlinear** — each chat message may trigger 1-5 tool-calling rounds, each round is a full API call with growing context window. A single complex conversation can cost 5-10x a simple one. Capture triage adds **no** LLM cost — it is a deterministic, offline extractor. |
 | Current guardrails | Per-user rate limit: 60 req/60s. Per-user token limit: 100K tokens/day. Global budget ceiling config (`LlmQuota:GlobalBudgetCeilingTokens`). Tool-calling loop cap: 5 rounds, 60s total timeout, 30s per-round timeout. Tool result truncation: 8KB max. Kill-switch (global/surface/per-user). Mock provider default (zero cost). |
-| Mitigation levers | 1. Lower global `LlmQuota:RequestsPerHour` or `LlmQuota:TokensPerDay` defaults. 2. Block abusive users entirely via per-user kill-switch. 3. Switch high-volume users to Mock provider. 4. Activate surface-level kill-switch for Chat or CaptureTriage. 5. Reduce context window size (`BoardContextBuilder` budget). 6. Switch from GPT-4o-mini to a cheaper model. 7. Enable clarification detection to reduce wasted rounds (`ClarificationDetector`). |
+| Mitigation levers | 1. Lower global `LlmQuota:RequestsPerHour` or `LlmQuota:TokensPerDay` defaults. 2. Block abusive users entirely via per-user kill-switch. 3. Switch high-volume users to Mock provider. 4. Activate the surface-level kill-switch for an LLM-consuming surface (Chat, or non-capture queue processing — killing capture triage saves $0). 5. Reduce context window size (`BoardContextBuilder` budget). 6. Switch from GPT-4o-mini to a cheaper model. 7. Enable clarification detection to reduce wasted rounds (`ClarificationDetector`). |
 | Action owner | Product/backend lead |
 | Risk level | **High** — highest variance cost component with no natural ceiling per conversation |
 
@@ -50,7 +52,7 @@ Each hotspot follows this structure:
 | Chat with 1 read tool | ~1,200 | ~400 | ~$0.00042 |
 | Chat with 3 tool rounds | ~3,000 | ~800 | ~$0.00093 |
 | Chat with 5 tool rounds (max) | ~5,500 | ~1,200 | ~$0.00155 |
-| Capture triage (per item) | ~300 | ~150 | ~$0.00014 |
+| Capture triage (per item) | — | — | **$0** (deterministic, no provider call) |
 
 These estimates assume approximate GPT-4o-mini pricing ($0.15/1M input, $0.60/1M output) as a reference baseline. Gemini 2.5 Flash pricing differs and should be checked against current Google pricing. All provider prices should be verified against the current pricing pages at deployment time — LLM pricing changes frequently. Actual costs depend on conversation length, board context size, and tool result sizes.
 
@@ -61,7 +63,8 @@ These estimates assume approximate GPT-4o-mini pricing ($0.15/1M input, $0.60/1M
 | Light | 10 | 5 | 1.5 avg | ~$8 |
 | Moderate | 50 | 10 | 2.0 avg | ~$85 |
 | Heavy | 100 | 15 | 2.5 avg | ~$350 |
-| Peak (with triage) | 100 | 15 + 20 triage | 2.5 avg | ~$430 |
+
+(Capture triage volume is intentionally omitted — it adds no LLM cost regardless of triage throughput.)
 
 ---
 

--- a/docs/platform/LLM_PROVIDER_SETUP_GUIDE.md
+++ b/docs/platform/LLM_PROVIDER_SETUP_GUIDE.md
@@ -157,7 +157,7 @@ This is intentionally separate from the broader demo tooling so an operator can 
 
 ## Behavior Guarantees
 
-- application services remain provider-agnostic (`ChatService`, capture triage paths depend on `ILlmProvider` only)
+- LLM-consuming application services remain provider-agnostic (`ChatService` depends on `ILlmProvider` only). Capture triage does not depend on `ILlmProvider` at all — it is a deterministic, offline extractor.
 - invalid/missing live-provider configuration does not crash requests
 - provider adapters return deterministic fallback responses when upstream calls fail
 - capture triage provenance persists `promptVersion`, `provider`, and `model`

--- a/docs/product/FIRST_RUN_WORKFLOWS.md
+++ b/docs/product/FIRST_RUN_WORKFLOWS.md
@@ -117,4 +117,4 @@ Use the advanced paths when you specifically need diagnostics, collaboration evi
 
 ## Managed-Key LLM Mode Notice
 
-If your Taskdeck instance uses a platform-managed LLM provider key (rather than your own), fair-use limits and privacy disclosures apply to Chat and capture triage features. See `docs/security/MANAGED_KEY_USAGE_POLICY.md` for the full policy.
+If your Taskdeck instance uses a platform-managed LLM provider key (rather than your own), fair-use limits and privacy disclosures apply to Automation Chat and other LLM features. (Capture triage is deterministic and offline — it never calls a provider — so it is exempt.) See `docs/security/MANAGED_KEY_USAGE_POLICY.md` for the full policy.

--- a/docs/security/MANAGED_KEY_USAGE_POLICY.md
+++ b/docs/security/MANAGED_KEY_USAGE_POLICY.md
@@ -52,16 +52,17 @@ When you use managed-key LLM features, Taskdeck transmits information to the con
 
 ### What is sent to the provider
 
-- The text content of your chat messages, capture items, and triage prompts
+- The text content of your Automation Chat messages (and any non-capture LLM queue request you submit)
 - A pseudonymous user token derived from your Taskdeck user ID (not your actual user ID, email, or name)
 - Attribution metadata headers (`x-taskdeck-*`) identifying the request surface and correlation context
 
 ### What is NOT sent to the provider
 
+- **Your capture text or board context during capture triage** — triage is deterministic and offline; it never calls the provider
 - Your Taskdeck password or authentication credentials
 - Your email address or display name
 - Your raw Taskdeck user ID
-- Board content beyond what you explicitly submit for triage or chat
+- Board content beyond what you explicitly submit for Automation Chat
 
 ### What Taskdeck records locally
 

--- a/docs/security/MANAGED_KEY_USAGE_POLICY.md
+++ b/docs/security/MANAGED_KEY_USAGE_POLICY.md
@@ -14,7 +14,7 @@ When Taskdeck operates with a platform-managed LLM provider key (managed-key mod
 - prohibited abuse patterns
 - enforcement consequences (throttle, restrict, block)
 
-This policy applies only when users consume LLM features (Automation Chat, capture triage, queue processing) through a managed key. Users who supply their own provider keys (BYOK) are not subject to these managed-key limits.
+This policy applies only when users consume LLM features (Automation Chat, LLM queue processing) through a managed key. Users who supply their own provider keys (BYOK) are not subject to these managed-key limits. Note: **capture triage is deterministic and offline — it never invokes a provider**, so it is not a managed-key LLM feature and consumes no managed-key quota.
 
 ## Fair-Use Boundaries
 
@@ -37,11 +37,11 @@ These values are operator-configurable and may be adjusted based on deployment s
 ### What counts toward quota
 
 - Each Automation Chat message that triggers a provider completion
-- Each capture triage operation that invokes the LLM provider
-- Each LLM queue processing request
+- Each LLM queue processing request that invokes the provider
 
 ### What does not count
 
+- Capture triage — deterministic and offline; it never invokes a provider
 - Requests served by the Mock provider
 - Read-only operations (viewing chat history, checking quota status, health checks without `?probe=true`)
 - Board operations, card edits, and other non-LLM features

--- a/frontend/taskdeck-web/src/tests/components/review/ProvenanceDrawer.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ProvenanceDrawer.spec.ts
@@ -119,6 +119,32 @@ describe('ProvenanceDrawer', () => {
     wrapper.unmount()
   })
 
+  it('renders deterministic capture-triage provenance verbatim (#1273)', () => {
+    // Capture triage is a deterministic offline extractor, not an LLM — the drawer must
+    // display the extractor identity as-is, without mapping it to an AI provider label.
+    const deterministicMetadata: ProvenanceMetadata = {
+      model: 'capture-triage-v1',
+      provider: 'deterministic-extractor',
+      confidence: 1,
+      latencyMs: 0,
+      promptVersion: 'triage.v1',
+    }
+    const wrapper = mount(ProvenanceDrawer, {
+      props: {
+        open: true,
+        rows: [],
+        metadata: deterministicMetadata,
+        evidenceLinks: [],
+        proposalId: 'test-proposal-triage',
+      },
+      attachTo: document.body,
+    })
+    const text = document.querySelector('.prov-drawer__meta')?.textContent ?? ''
+    expect(text).toContain('deterministic-extractor/capture-triage-v1')
+    expect(text).toContain('triage.v1')
+    wrapper.unmount()
+  })
+
   it('does not render metadata section when metadata is null', () => {
     const wrapper = mount(ProvenanceDrawer, {
       props: {

--- a/frontend/taskdeck-web/src/tests/components/review/ProvenanceDrawer.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ProvenanceDrawer.spec.ts
@@ -122,6 +122,9 @@ describe('ProvenanceDrawer', () => {
   it('renders deterministic capture-triage provenance verbatim (#1273)', () => {
     // Capture triage is a deterministic offline extractor, not an LLM — the drawer must
     // display the extractor identity as-is, without mapping it to an AI provider label.
+    // Note: this is an isolated-component guarantee. The corrected provenance value is
+    // persisted on the capture payload and returned by the capture API today; wiring the
+    // review provenance drawer to actually surface provider/model metadata is tracked separately.
     const deterministicMetadata: ProvenanceMetadata = {
       model: 'capture-triage-v1',
       provider: 'deterministic-extractor',

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewProvenance.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewProvenance.spec.ts
@@ -13,13 +13,17 @@ const rows: ProvenanceRow[] = [
 ]
 
 describe('ReviewProvenance', () => {
-  it('uses neutral provider routing copy instead of claiming local-only processing', () => {
+  it('describes provenance honestly for both deterministic captures and LLM chat automation (#1273)', () => {
     const wrapper = mount(ReviewProvenance, {
       props: { rows },
     })
 
     const text = wrapper.text()
-    expect(text).toContain("Provider routing follows this workspace's AI settings and policy.")
+    // Captures are triaged offline/deterministically; chat automation uses the configured AI provider.
+    expect(text).toContain('deterministic offline extractor for captures')
+    expect(text).toContain('configured AI provider for chat-driven automation')
+    // Must not hardcode a specific LLM model (was "What haiku read"), and must not over-claim local-only for everything.
+    expect(text).not.toContain('haiku')
     expect(text).not.toContain('No data left this device')
     expect(text).not.toContain('ran locally')
   })

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewProvenance.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewProvenance.vue
@@ -39,7 +39,7 @@ function tone(weight: ProvenanceWeight): string {
       <span class="tk-serial paper-review-prov__serial">§ II</span>
       <h3 class="tk-h3 paper-review-prov__title">Provenance</h3>
       <span class="tk-meta paper-review-prov__sub">
-        What haiku read · what it didn't · what it inferred
+        What was read · what wasn't · what was inferred
       </span>
     </header>
     <div class="card paper-review-prov__card">
@@ -57,7 +57,7 @@ function tone(weight: ProvenanceWeight): string {
       </div>
     </div>
     <p class="tk-meta paper-review-prov__footnote">
-      Provider routing follows this workspace's AI settings and policy.
+      Provenance reflects the actor behind this proposal — a deterministic offline extractor for captures, or your configured AI provider for chat-driven automation.
       <a href="#" class="paper-review-prov__more" @click.prevent="drawerOpen = true">View full read-set →</a>
     </p>
 


### PR DESCRIPTION
## What & why

Closes #1273 (ARCHIVE-05, Priority I product-truth).

`CaptureTriageService` runs a **static, deterministic, offline text extractor**
(`ExtractTaskCandidates` — checklist/bullet/numbered/dash/semicolon patterns) and
**never invokes an LLM**. Yet it previously stamped the workspace's *configured live
LLM provider* name/model into the triage proposal provenance (via
`GetProviderMetadataAsync` → `ILlmProvider.GetHealthAsync`). With live providers
enabled, triage provenance falsely claimed e.g. `OpenAi/gpt-4o-mini` for a run the
LLM never saw — false provenance in a product whose pillar is provenance-visible
automation.

## Change

- **Record the real actor**: provider `deterministic-extractor`, model
  `capture-triage-v1` (the existing `PromptVersion` already carries `triage.v1`).
  New documented public constants (`CaptureTriageService.TriageProviderName/TriageModelName`).
- **Remove the now-unused `ILlmProvider` (and logger) dependency** — structurally
  proves triage is LLM-free, and advertises the real strength: the capture loop works
  **offline and deterministically by design**. DI auto-wires the service, so no
  registration change is needed.
- **Preserve the cancellation contract** with an explicit entry-guard
  (`ThrowIfCancellationRequested`), since the removed metadata lookup was its former
  checkpoint.
- The worker already sanitizes provenance to the length contract; the short constants
  pass through unchanged and are persisted onto the capture payload provenance.

## Acceptance criteria

- [x] Triage provenance records the actual actor (`deterministic-extractor` /
  `capture-triage-v1`; `PromptVersion` = `triage.v1`).
- [x] Tests updated; frontend provenance display verified to render the new values
  sensibly (`ProvenanceDrawer` renders `deterministic-extractor/capture-triage-v1` verbatim).
- [x] One-line note in USER_MANUAL that capture triage is deterministic and offline in every mode.

## Tests

- Unit: `CaptureTriageServiceTests` (17) — added focused deterministic-provenance
  assertions for both the create and reuse branches; dropped the obsolete LLM-health
  fallback/clamp tests; cancellation test now asserts fail-fast before any proposal is created.
- Api integration (DI-wired triage path): `CaptureApiTests`, `CardsApiTests`,
  `CaptureToBoardGoldenPathIntegrationTests` now assert the persisted provenance.
- Frontend: `ProvenanceDrawer.spec` renders the deterministic values verbatim (#1273).

## Verification (local, Release)

- `dotnet build` Application + Api: clean, 0 warnings.
- Application capture tests: 127/127. Affected Api integration classes: 86/86.
- Frontend `typecheck` clean; provenance specs 16/16.

Note: the `deterministic-extractor`/`Provider routing follows AI settings` copy in
`ReviewProvenance.vue` is intentionally left generic — that component also renders
genuinely LLM-routed (chat-origin) proposals, so the per-proposal *metadata value*
(now truthful) is the right place to carry provenance, not the shared footnote.