### PR TITLE
fix(automation): validate revised operation structure on revision save (#1281)

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/McpApplicationServiceRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/McpApplicationServiceRegistration.cs
@@ -31,6 +31,9 @@ public static class McpApplicationServiceRegistration
         services.AddScoped<AutomationProposalService>();
         services.AddScoped<IAutomationProposalService>(
             sp => sp.GetRequiredService<AutomationProposalService>());
+        // ProposalRevisionService validates revised operation structure via the policy engine (#1281),
+        // so the MCP container must be able to construct it (only dep is IUnitOfWork via AddInfrastructure).
+        services.AddScoped<IAutomationPolicyEngine, AutomationPolicyEngine>();
         services.AddScoped<IProposalRevisionService, ProposalRevisionService>();
         services.AddScoped<CaptureService>();
         services.AddScoped<ICaptureService>(

--- a/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
@@ -98,19 +98,16 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
         return Result.Success();
     }
 
-    public Result ValidatePolicy(ProposalDto proposal)
+    public Result ValidateOperationStructure(IReadOnlyCollection<ProposalOperationDto> operations)
     {
-        if (proposal == null)
-            return Result.Failure(ErrorCodes.ValidationError, "Proposal cannot be null");
-
-        if (proposal.Operations == null || !proposal.Operations.Any())
+        if (operations == null || operations.Count == 0)
             return Result.Failure(ErrorCodes.ValidationError, "Proposal must contain at least one operation");
 
-        if (proposal.Operations.Count > MaxOperationCount)
+        if (operations.Count > MaxOperationCount)
             return Result.Failure(ErrorCodes.ValidationError, $"Proposal exceeds maximum operation count of {MaxOperationCount}");
 
         // Validate operation sequences are unique and non-negative
-        var sequences = proposal.Operations.Select(o => o.Sequence).ToList();
+        var sequences = operations.Select(o => o.Sequence).ToList();
         if (sequences.Distinct().Count() != sequences.Count)
             return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be unique");
 
@@ -118,11 +115,23 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
             return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be non-negative");
 
         // Validate parameters size
-        foreach (var operation in proposal.Operations)
+        foreach (var operation in operations)
         {
             if (operation.Parameters.Length > MaxParametersLength)
                 return Result.Failure(ErrorCodes.ValidationError, $"Operation parameters exceed maximum length of {MaxParametersLength}");
         }
+
+        return Result.Success();
+    }
+
+    public Result ValidatePolicy(ProposalDto proposal)
+    {
+        if (proposal == null)
+            return Result.Failure(ErrorCodes.ValidationError, "Proposal cannot be null");
+
+        var structureValidation = ValidateOperationStructure(proposal.Operations);
+        if (!structureValidation.IsSuccess)
+            return structureValidation;
 
         // Validate proposal hasn't expired
         if (DateTime.UtcNow > proposal.ExpiresAt)

--- a/backend/src/Taskdeck.Application/Services/IAutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/IAutomationPolicyEngine.cs
@@ -8,5 +8,15 @@ public interface IAutomationPolicyEngine
 {
     RiskLevel ClassifyRisk(IEnumerable<ProposalOperationDto> operations);
     Task<Result> ValidatePermissionsAsync(Guid userId, Guid? boardId, IEnumerable<ProposalOperationDto> operations, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Validates the structural invariants of a proposal's operations — at least one operation,
+    /// operation count within <c>MaxOperationCount</c>, unique and non-negative sequences, and
+    /// parameters within <c>MaxParametersLength</c>. Does NOT check expiry (that is proposal-level,
+    /// see <see cref="ValidatePolicy"/>). Reusable by both apply-time policy validation and the
+    /// revision-save path so a saved revision cannot be structurally unexecutable (#1281).
+    /// </summary>
+    Result ValidateOperationStructure(IReadOnlyCollection<ProposalOperationDto> operations);
+
     Result ValidatePolicy(ProposalDto proposal);
 }

--- a/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ProposalRevisionService.cs
@@ -10,10 +10,12 @@ namespace Taskdeck.Application.Services;
 public class ProposalRevisionService : IProposalRevisionService
 {
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IAutomationPolicyEngine _policyEngine;
 
-    public ProposalRevisionService(IUnitOfWork unitOfWork)
+    public ProposalRevisionService(IUnitOfWork unitOfWork, IAutomationPolicyEngine policyEngine)
     {
         _unitOfWork = unitOfWork;
+        _policyEngine = policyEngine;
     }
 
     public async Task<Result<ProposalRevisionDto>> CreateRevisionAsync(
@@ -34,12 +36,21 @@ public class ProposalRevisionService : IProposalRevisionService
             var payloadValidation = ProposalRevisionPayload.TryParseOperations(
                 dto.ProposalId,
                 dto.RevisedPayload,
-                out _,
+                out var revisedOperations,
                 out var validationError);
             if (!payloadValidation)
                 return Result.Failure<ProposalRevisionDto>(
                     ErrorCodes.ValidationError,
                     validationError);
+
+            // #1281: a revision must satisfy the same operation-structure invariants Apply enforces
+            // (unique sequences, MaxOperationCount, MaxParametersLength) so a reviewer cannot save a
+            // revision the executor would reject — closing the preview/apply expectation gap.
+            var structureValidation = _policyEngine.ValidateOperationStructure(revisedOperations);
+            if (!structureValidation.IsSuccess)
+                return Result.Failure<ProposalRevisionDto>(
+                    structureValidation.ErrorCode,
+                    structureValidation.ErrorMessage);
 
             var nextRevisionNumber = await _unitOfWork.ProposalRevisions
                 .GetNextRevisionNumberAsync(dto.ProposalId, cancellationToken);

--- a/backend/tests/Taskdeck.Api.Tests/McpApplicationServiceRegistrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpApplicationServiceRegistrationTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Taskdeck.Api.Extensions;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public class McpApplicationServiceRegistrationTests
+{
+    [Fact]
+    public void AddMcpApplicationServices_CanConstructProposalRevisionService()
+    {
+        // #1281: ProposalRevisionService gained an IAutomationPolicyEngine dependency. The minimal
+        // MCP container registers IProposalRevisionService, so it must also be able to construct it —
+        // otherwise an MCP tool/resource that injects it (or ValidateOnBuild) would fail at resolution.
+        var services = new ServiceCollection();
+        services.AddScoped(_ => new Mock<IUnitOfWork>().Object);
+        services.AddMcpApplicationServices();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var revisionService = scope.ServiceProvider.GetRequiredService<IProposalRevisionService>();
+
+        revisionService.Should().NotBeNull();
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using FluentAssertions;
 using Moq;
@@ -23,7 +24,108 @@ public class ProposalRevisionServiceTests
         _unitOfWork.SetupGet(unitOfWork => unitOfWork.AutomationProposals).Returns(_proposals.Object);
         _unitOfWork.SetupGet(unitOfWork => unitOfWork.ProposalRevisions).Returns(_revisions.Object);
 
-        _service = new ProposalRevisionService(_unitOfWork.Object);
+        // Use the real policy engine so the structure invariants (#1281) are exercised end-to-end
+        // through the save path; ValidateOperationStructure is pure and never touches the unit of work.
+        _service = new ProposalRevisionService(_unitOfWork.Object, new AutomationPolicyEngine(_unitOfWork.Object));
+    }
+
+    [Fact]
+    public async Task CreateRevisionAsync_ReturnsValidationError_WhenSequencesAreDuplicated()
+    {
+        var proposal = CreatePendingProposal();
+        _proposals
+            .Setup(repo => repo.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            BuildPayload((sequence: 0, parameters: "{}"), (sequence: 0, parameters: "{}")),
+            "Duplicate sequences");
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("sequences must be unique");
+        _revisions.Verify(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateRevisionAsync_ReturnsValidationError_WhenOperationCountExceedsMaximum()
+    {
+        var proposal = CreatePendingProposal();
+        _proposals
+            .Setup(repo => repo.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var operations = Enumerable.Range(0, 51)
+            .Select(i => (sequence: i, parameters: "{}"))
+            .ToArray();
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            BuildPayload(operations),
+            "Too many operations");
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("maximum operation count");
+        _revisions.Verify(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateRevisionAsync_ReturnsValidationError_WhenParametersExceedMaximumLength()
+    {
+        var proposal = CreatePendingProposal();
+        _proposals
+            .Setup(repo => repo.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var oversizedParameters = "{\"blob\":\"" + new string('a', 10_001) + "\"}";
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            BuildPayload((sequence: 0, parameters: oversizedParameters)),
+            "Oversized parameters");
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("maximum length");
+        _revisions.Verify(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateRevisionAsync_Succeeds_WhenOperationsAreStructurallyValid()
+    {
+        var proposal = CreatePendingProposal();
+        _proposals
+            .Setup(repo => repo.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _revisions
+            .Setup(repo => repo.GetNextRevisionNumberAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _revisions
+            .Setup(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProposalRevision revision, CancellationToken _) => revision);
+        _unitOfWork
+            .Setup(unitOfWork => unitOfWork.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            BuildPayload((sequence: 0, parameters: "{}"), (sequence: 1, parameters: "{}")),
+            "Valid multi-op revision");
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeTrue();
+        _revisions.Verify(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -89,6 +191,21 @@ public class ProposalRevisionServiceTests
                     idempotencyKey = Guid.NewGuid().ToString()
                 }
             }
+        });
+    }
+
+    private static string BuildPayload(params (int sequence, string parameters)[] operations)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            operations = operations.Select(op => new
+            {
+                sequence = op.sequence,
+                actionType = "create",
+                targetType = "card",
+                parameters = op.parameters,
+                idempotencyKey = Guid.NewGuid().ToString()
+            }).ToArray()
         });
     }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ProposalRevisionServiceTests.cs
@@ -129,6 +129,67 @@ public class ProposalRevisionServiceTests
     }
 
     [Fact]
+    public async Task CreateRevisionAsync_Succeeds_AtExactlyMaxOperationCount()
+    {
+        // Boundary: exactly 50 operations is allowed (only >50 is rejected). Pins the allowed
+        // side of the count guard so a `>` -> `>=` mutation is caught.
+        var proposal = CreatePendingProposal();
+        SetupSuccessfulSave(proposal);
+
+        var operations = Enumerable.Range(0, 50)
+            .Select(i => (sequence: i, parameters: "{}"))
+            .ToArray();
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            BuildPayload(operations),
+            "Exactly max operations");
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeTrue();
+        _revisions.Verify(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateRevisionAsync_Succeeds_AtExactlyMaxParametersLength()
+    {
+        // Boundary: a parameters string of exactly 10000 chars is allowed (only >10000 is rejected).
+        var proposal = CreatePendingProposal();
+        SetupSuccessfulSave(proposal);
+
+        // {"blob":"<a...>"} — the 11-char JSON wrapper + 9989 'a' = exactly 10000 chars.
+        var exactlyMaxParameters = "{\"blob\":\"" + new string('a', 9_989) + "\"}";
+        exactlyMaxParameters.Length.Should().Be(10_000);
+        var dto = new CreateProposalRevisionDto(
+            proposal.Id,
+            Guid.NewGuid(),
+            BuildPayload((sequence: 0, parameters: exactlyMaxParameters)),
+            "Exactly max parameters length");
+
+        var result = await _service.CreateRevisionAsync(dto);
+
+        result.IsSuccess.Should().BeTrue();
+        _revisions.Verify(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private void SetupSuccessfulSave(AutomationProposal proposal)
+    {
+        _proposals
+            .Setup(repo => repo.GetByIdAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+        _revisions
+            .Setup(repo => repo.GetNextRevisionNumberAsync(proposal.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        _revisions
+            .Setup(repo => repo.AddAsync(It.IsAny<ProposalRevision>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProposalRevision revision, CancellationToken _) => revision);
+        _unitOfWork
+            .Setup(unitOfWork => unitOfWork.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+    }
+
+    [Fact]
     public async Task CreateRevisionAsync_ReturnsConflict_WhenSaveChangesDetectsRevisionNumberRace()
     {
         var proposal = CreatePendingProposal();


### PR DESCRIPTION
Closes #1281 (surfaced during #1235 review — Codex round 2 on PR #1280).

## Problem

`ProposalRevisionService.CreateRevisionAsync` validated a revised payload with `ProposalRevisionPayload.TryParseOperations` (structural JSON parse) **only** — it did not run the executor's operation-structure policy. So a reviewer could save a revision whose operations have **duplicate sequences**, exceed **`MaxOperationCount`** (50), or have **oversized `parameters`** (>10,000 chars).

Apply later runs `IAutomationPolicyEngine.ValidatePolicy` on the effective (revised) proposal and **rejects before executing anything** — so nothing corrupts — but a reviewer could approve a revision-aware diff preview (post-#1235) for a revision that **cannot actually execute**. This closes that preview/apply expectation gap at its root (the save path).

## Change

- **Extracted** `ValidateOperationStructure(IReadOnlyCollection<ProposalOperationDto>)` on `IAutomationPolicyEngine` — the structural invariants (≥1 op, `MaxOperationCount`, unique + non-negative sequences, `MaxParametersLength`). `ValidatePolicy` now delegates to it and keeps the **expiry** check separate (expiry must NOT run in the read-only diff path — that was the reason #1235 couldn't just call `ValidatePolicy`).
- `CreateRevisionAsync` runs `ValidateOperationStructure` on the parsed revised operations and returns **`400 ValidationError`** on violation, mirroring original proposal creation.

## Tests

- New: revision with **duplicate sequences** / **>Max ops (51)** / **oversized params** is rejected with `ValidationError` and **not persisted** (`AddAsync` never called); a **valid multi-op** revision still saves.
- Uses the **real** `AutomationPolicyEngine` in `ProposalRevisionServiceTests` so the invariants are exercised end-to-end through the save path (`ValidateOperationStructure` is pure — never touches the unit of work).
- Existing `ValidatePolicy` tests unchanged and green (delegation preserves behavior).

## Verification (local, Release)

- `dotnet build backend/Taskdeck.sln`: 0 errors.
- `ProposalRevisionService` + `AutomationPolicyEngine`: **38/38**. Api `ProposalRevision` + `AutomationExecutor`: **13/13**. Mocked executor/planner (interface-addition regression): **96/96**.

Blast radius: `IAutomationPolicyEngine` gains one method (sole impl `AutomationPolicyEngine`; Moq mocks auto-stub, and no non-revision path calls it). `ProposalRevisionService` gains a constructor param — DI auto-wires; the one direct construction site (its test) is updated.