### PR TITLE
docs: reconcile subagent-delegation policy (CLAUDE.md ↔ Codex AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Its scope applies to the entire repo unless overridden by more specific `AGENTS.
   - if MCP is unavailable, failing, or lacks required capability, use shell/CLI fallback and state that fallback briefly in handoff notes.
 
 ## Multi-Agent / Parallel Execution (required)
-- When the Codex runtime exposes spawned subagents, use them without asking for extra permission when they are efficient or effective for safely parallelizable work.
+- When the Codex runtime exposes spawned subagents, use them without asking for extra permission when they are efficient for safely parallelizable work — but right-size the fan-out (start inline; a few agents, not a reflexive fleet), and keep one coordinator for synthesis and final verification.
 - Split only when work can be separated by clear ownership and can proceed without blocking the coordinator's immediate next step.
 - If spawned agents are unavailable, use explicit git worktrees plus separate Codex/Claude sessions or GitHub coding-agent tasks; do not claim subagent execution unless it actually happened.
 - Split ownership by file/module/concern so concurrent work does not overlap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Mock provider is default. OpenAI and Gemini supported behind config gates. See `
 - Use `.claude/skills/README.md` to pick a local Claude skill for broad, issue, PR-review, CI-recovery, backend, frontend, capture/review, demo, or verification work.
 - Use `docs/agentic/QUESTION_PROTOCOL.md` before asking; batch true blockers and proceed with explicit assumptions for reversible choices.
 - Use `docs/agentic/FAILURE_LEDGER.md` for unresolved command/tool/test/CI failures and promote recurring lessons through `docs/agentic/GUIDE_UPDATE_PROTOCOL.md`.
-- Use spawned subagents or Claude worktree agents only when the user explicitly asks for delegation/parallel work or the task prompt grants that authority. Keep one coordinator responsible for final synthesis and verification.
+- Use spawned subagents or Claude worktree agents when the situation warrants it (genuinely disjoint work, an independent review lens, or context beyond one window) — you don't need to be asked, but right-size the fan-out (start inline; a few agents, not a reflexive fleet) and never delegate final synthesis or verification: one coordinator owns those. Sizing rules: the global `model-effort-routing` skill.
 
 ## Review Policy
 


### PR DESCRIPTION
Resolves an internal canon contradiction surfaced during the harness-workflow update:

- `CLAUDE.md` said use subagents **only when the user explicitly asks**.
- `AGENTS.md` (Codex) said use them **without asking when efficient**.

Both now state the same warrant-based rule: delegate when the situation genuinely warrants it (disjoint work / independent review lens / context beyond one window) without needing to be asked, **right-sized** (start inline; a few agents, not a reflexive fleet), with one coordinator always owning synthesis and final verification. Matches the new global `model-effort-routing` skill.

Docs-only; no code or behavior change. Opened for the T3 merge gate — merge at your discretion (Taskdeck is archive-bound).