### PR TITLE
Fix CI Extended Gitleaks permission boundary

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -174,6 +174,11 @@ jobs:
 
   gitleaks:
     name: Secrets Detection (Gitleaks)
+    # PR scan mode relies on pull-request event context; manual runs have no PR diff to scan.
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-gitleaks.yml
     with:
       scan-mode: pr


### PR DESCRIPTION
## Summary

- grant the CI Extended reusable Gitleaks call the exact `contents: read` and `pull-requests: read` permissions its callee declares
- scope that grant to the single calling job rather than broadening workflow-wide token permissions
- guard the PR-only scan mode from `workflow_dispatch`, which has no pull-request diff context

Closes #1330

## Implementation notes

GitHub reusable workflows cannot elevate the caller's `GITHUB_TOKEN`; the calling job must grant every permission the called workflow needs. The required CI lane already grants `pull-requests: read`; this change applies the least-privilege equivalent only to CI Extended's Gitleaks job.

## Verification

- actionlint 1.7.12 on `.github/workflows/ci-extended.yml` — passed
- `node scripts/check-github-ops-governance.mjs` — passed
- `node scripts/check-docs-governance.mjs` — passed
- `git diff --check` — passed
- PR-triggered CI Extended run `29275721576` created jobs and `Secrets Detection (Gitleaks) / Gitleaks Scan` passed — exact head `66382e6c`
- required CI run `29275721628` — passed on exact head `66382e6c`, including Linux/Windows backend/frontend/API lanes and E2E smoke

## Self-review

MEDIUM finding fixed before opening: CI Extended supports manual dispatch, but the Gitleaks call hard-coded PR scan mode. Once the permission startup failure was removed, manual dispatch could reach an invalid PR-only action path. The final change guards the advisory Gitleaks job to `pull_request`, matching the required workflow's existing behavior.

## Docs impact

No canonical product or testing documentation changed. The workflow topology and check context names are unchanged.

## Risks / merge gate

This modifies GitHub Actions permissions and therefore requires the repository's FULL review and workflow-owner gate. Merge only after two independent reviews, every comment/thread is addressed, required CI and CI Extended are green on the exact head, and the live run proves CI Extended creates jobs instead of `startup_failure`.