### PR TITLE
Fix Paper deep-review enum wire contract

### DIFF
--- a/backend/src/Taskdeck.Domain/Entities/ConflictTone.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ConflictTone.cs
@@ -6,7 +6,7 @@ namespace Taskdeck.Domain.Entities;
 /// </summary>
 public enum ConflictTone
 {
-    Warn,
-    Info,
-    Ok
+    Warn = 0,
+    Info = 1,
+    Ok = 2
 }

--- a/backend/tests/Taskdeck.Api.Tests/DeepReviewEnumSerializationContractTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/DeepReviewEnumSerializationContractTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+public sealed class DeepReviewEnumSerializationContractTests : IClassFixture<TestWebApplicationFactory>
+{
+    private readonly TestWebApplicationFactory _factory;
+
+    public DeepReviewEnumSerializationContractTests(TestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public void ApiJsonOptions_ShouldSerializeDeepReviewEnumsAsNumericOrdinals()
+    {
+        var serializerOptions = _factory.Services
+            .GetRequiredService<IOptions<JsonOptions>>()
+            .Value.JsonSerializerOptions;
+        var payload = new
+        {
+            Conflicts = new[]
+            {
+                new ConflictRowDto(ConflictTone.Warn, "warn", "v"),
+                new ConflictRowDto(ConflictTone.Info, "info", "v"),
+                new ConflictRowDto(ConflictTone.Ok, "ok", "v")
+            },
+            History = new[]
+            {
+                new CardHistoryRowDto("#1", "pending", "now", CardHistoryStatus.Pending),
+                new CardHistoryRowDto("#2", "applied", "now", CardHistoryStatus.Applied),
+                new CardHistoryRowDto("#3", "past", "now", CardHistoryStatus.Past)
+            }
+        };
+
+        var json = JsonSerializer.Serialize(payload, serializerOptions);
+        using var document = JsonDocument.Parse(json);
+
+        document.RootElement.GetProperty("conflicts")
+            .EnumerateArray()
+            .Select(row => row.GetProperty("tone").GetInt32())
+            .Should().Equal(0, 1, 2);
+        document.RootElement.GetProperty("history")
+            .EnumerateArray()
+            .Select(row => row.GetProperty("status").GetInt32())
+            .Should().Equal(0, 1, 2);
+    }
+}

--- a/frontend/taskdeck-web/src/api/proposalDeepReviewApi.ts
+++ b/frontend/taskdeck-web/src/api/proposalDeepReviewApi.ts
@@ -37,8 +37,31 @@ export interface ProposalSideEffectsDto {
   reversibility: ReversibilityDto
 }
 
+/**
+ * Numeric System.Text.Json enum values emitted by the deep-review API.
+ * Keep these ordinals aligned with the backend enums; API contract coverage
+ * pins the serialized values so an enum reorder cannot silently break Paper.
+ */
+export const conflictToneWireValues = {
+  Warn: 0,
+  Info: 1,
+  Ok: 2,
+} as const
+
+export type ConflictToneWireValue =
+  (typeof conflictToneWireValues)[keyof typeof conflictToneWireValues]
+
+export const cardHistoryStatusWireValues = {
+  Pending: 0,
+  Applied: 1,
+  Past: 2,
+} as const
+
+export type CardHistoryStatusWireValue =
+  (typeof cardHistoryStatusWireValues)[keyof typeof cardHistoryStatusWireValues]
+
 export interface ConflictRowDto {
-  tone: 'Warn' | 'Info' | 'Ok'
+  tone: ConflictToneWireValue
   key: string
   value: string
 }
@@ -47,7 +70,7 @@ export interface CardHistoryRowDto {
   serial: string
   event: string
   age: string
-  status: 'Pending' | 'Applied' | 'Past'
+  status: CardHistoryStatusWireValue
 }
 
 export interface SimilarPastDecisionDto {

--- a/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
+++ b/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
@@ -58,7 +58,7 @@ export interface HistoryRow {
   serial: string
   event: string
   age: string
-  status: 'pending' | 'applied' | 'past'
+  status: 'pending' | 'applied' | 'past' | 'unknown'
 }
 
 export interface SimilarPastRow {
@@ -124,11 +124,11 @@ function mapConflictTone(tone: ConflictToneWireValue): 'warn' | 'info' | 'ok' {
     case conflictToneWireValues.Ok:
       return 'ok'
     default:
-      return unexpectedWireEnum('ConflictTone', tone, 'info')
+      return unexpectedWireEnum('ConflictTone', tone, 'warn')
   }
 }
 
-function mapHistoryStatus(status: CardHistoryStatusWireValue): 'pending' | 'applied' | 'past' {
+function mapHistoryStatus(status: CardHistoryStatusWireValue): HistoryRow['status'] {
   switch (status) {
     case cardHistoryStatusWireValues.Pending:
       return 'pending'
@@ -137,7 +137,7 @@ function mapHistoryStatus(status: CardHistoryStatusWireValue): 'pending' | 'appl
     case cardHistoryStatusWireValues.Past:
       return 'past'
     default:
-      return unexpectedWireEnum('CardHistoryStatus', status, 'past')
+      return unexpectedWireEnum('CardHistoryStatus', status, 'unknown')
   }
 }
 

--- a/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
+++ b/frontend/taskdeck-web/src/composables/usePaperReviewSelectors.ts
@@ -1,12 +1,18 @@
 import { computed, onScopeDispose, ref, watch, type ComputedRef, type Ref } from 'vue'
 import type { Proposal as ApiProposal } from '../types/automation'
-import { proposalDeepReviewApi } from '../api/proposalDeepReviewApi'
+import {
+  proposalDeepReviewApi,
+  conflictToneWireValues,
+  cardHistoryStatusWireValues,
+} from '../api/proposalDeepReviewApi'
 import type {
   ProvenanceRowDto,
   ConfidenceBreakdownDto,
   ProposalSideEffectsDto,
   ConflictRowDto,
   CardHistoryRowDto,
+  ConflictToneWireValue,
+  CardHistoryStatusWireValue,
   SimilarPastResultDto,
 } from '../api/proposalDeepReviewApi'
 
@@ -104,25 +110,34 @@ function mapProvenanceRow(dto: ProvenanceRowDto): ProvenanceRow {
   }
 }
 
-function mapConflictTone(tone: string): 'warn' | 'info' | 'ok' {
-  switch (tone.toLowerCase()) {
-    case 'warn':
+function unexpectedWireEnum<T>(name: string, value: unknown, fallback: T): T {
+  console.error(`[Paper Review] Unexpected ${name} wire value`, value)
+  return fallback
+}
+
+function mapConflictTone(tone: ConflictToneWireValue): 'warn' | 'info' | 'ok' {
+  switch (tone) {
+    case conflictToneWireValues.Warn:
       return 'warn'
-    case 'ok':
+    case conflictToneWireValues.Info:
+      return 'info'
+    case conflictToneWireValues.Ok:
       return 'ok'
     default:
-      return 'info'
+      return unexpectedWireEnum('ConflictTone', tone, 'info')
   }
 }
 
-function mapHistoryStatus(status: string): 'pending' | 'applied' | 'past' {
-  switch (status.toLowerCase()) {
-    case 'pending':
+function mapHistoryStatus(status: CardHistoryStatusWireValue): 'pending' | 'applied' | 'past' {
+  switch (status) {
+    case cardHistoryStatusWireValues.Pending:
       return 'pending'
-    case 'applied':
+    case cardHistoryStatusWireValues.Applied:
       return 'applied'
-    default:
+    case cardHistoryStatusWireValues.Past:
       return 'past'
+    default:
+      return unexpectedWireEnum('CardHistoryStatus', status, 'past')
   }
 }
 

--- a/frontend/taskdeck-web/src/tests/api/proposalDeepReviewApi.spec.ts
+++ b/frontend/taskdeck-web/src/tests/api/proposalDeepReviewApi.spec.ts
@@ -44,7 +44,7 @@ describe('proposalDeepReviewApi', () => {
   })
 
   it('fetches conflicts for a proposal', async () => {
-    const conflicts = [{ tone: 'Warn', key: 'stale', value: 'desc' }]
+    const conflicts = JSON.parse('[{"tone":0,"key":"stale","value":"desc"}]')
     vi.mocked(http.get).mockResolvedValue({ data: conflicts })
 
     const result = await proposalDeepReviewApi.getConflicts('p-1')
@@ -54,7 +54,7 @@ describe('proposalDeepReviewApi', () => {
   })
 
   it('fetches card history for a proposal', async () => {
-    const history = [{ serial: '#1', event: 'created', age: '2h', status: 'Applied' }]
+    const history = JSON.parse('[{"serial":"#1","event":"created","age":"2h","status":1}]')
     vi.mocked(http.get).mockResolvedValue({ data: history })
 
     const result = await proposalDeepReviewApi.getHistory('p-1')

--- a/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
@@ -168,7 +168,7 @@ describe('usePaperReviewSelectors', () => {
     expect(selectors.history.value[2].status).toBe('past')
   })
 
-  it('keeps unexpected runtime enum values visible while rendering safe defaults', async () => {
+  it('fails closed for unexpected runtime enum values without crashing', async () => {
     mockAllEndpointsEmpty()
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     const conflicts = JSON.parse('[{"tone":99,"key":"unknown","value":"v"}]') as ConflictRowDto[]
@@ -185,8 +185,8 @@ describe('usePaperReviewSelectors', () => {
       expect(selectors.history.value).toHaveLength(1)
     })
 
-    expect(selectors.conflicts.value[0].tone).toBe('info')
-    expect(selectors.history.value[0].status).toBe('past')
+    expect(selectors.conflicts.value[0].tone).toBe('warn')
+    expect(selectors.history.value[0].status).toBe('unknown')
     expect(consoleError).toHaveBeenCalledWith(
       '[Paper Review] Unexpected ConflictTone wire value',
       99,

--- a/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/usePaperReviewSelectors.spec.ts
@@ -1,19 +1,27 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, computed, nextTick, effectScope } from 'vue'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
-import { proposalDeepReviewApi } from '../../api/proposalDeepReviewApi'
+import {
+  proposalDeepReviewApi,
+  type CardHistoryRowDto,
+  type ConflictRowDto,
+} from '../../api/proposalDeepReviewApi'
 import type { Proposal as ApiProposal } from '../../types/automation'
 
-vi.mock('../../api/proposalDeepReviewApi', () => ({
-  proposalDeepReviewApi: {
-    getProvenance: vi.fn(),
-    getConfidence: vi.fn(),
-    getSideEffects: vi.fn(),
-    getConflicts: vi.fn(),
-    getHistory: vi.fn(),
-    getSimilarPast: vi.fn(),
-  },
-}))
+vi.mock('../../api/proposalDeepReviewApi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/proposalDeepReviewApi')>()
+  return {
+    ...actual,
+    proposalDeepReviewApi: {
+      getProvenance: vi.fn(),
+      getConfidence: vi.fn(),
+      getSideEffects: vi.fn(),
+      getConflicts: vi.fn(),
+      getHistory: vi.fn(),
+      getSimilarPast: vi.fn(),
+    },
+  }
+})
 
 function makeProposal(overrides: Partial<ApiProposal> = {}): ApiProposal {
   return {
@@ -58,6 +66,10 @@ function mockAllEndpointsEmpty() {
 describe('usePaperReviewSelectors', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('returns empty state when no proposal is active', async () => {
@@ -112,13 +124,14 @@ describe('usePaperReviewSelectors', () => {
     expect(selectors.provenance.value[1].weight).toBe('excluded')
   })
 
-  it('maps conflict tones to lowercase', async () => {
+  it('maps serialized numeric conflict tones from the API wire contract', async () => {
     mockAllEndpointsEmpty()
-    vi.mocked(proposalDeepReviewApi.getConflicts).mockResolvedValue([
-      { tone: 'Warn', key: 'stale', value: 'v' },
-      { tone: 'Ok', key: 'clear', value: 'v' },
-      { tone: 'Info', key: 'note', value: 'v' },
-    ])
+    const serializedRows = JSON.parse(`[
+      {"tone":0,"key":"stale","value":"v"},
+      {"tone":2,"key":"clear","value":"v"},
+      {"tone":1,"key":"note","value":"v"}
+    ]`) as ConflictRowDto[]
+    vi.mocked(proposalDeepReviewApi.getConflicts).mockResolvedValue(serializedRows)
 
     const proposal = ref<ApiProposal | null>(makeProposal())
     const activeProposal = computed(() => proposal.value)
@@ -133,13 +146,14 @@ describe('usePaperReviewSelectors', () => {
     expect(selectors.conflicts.value[2].tone).toBe('info')
   })
 
-  it('maps history status to lowercase', async () => {
+  it('maps serialized numeric history statuses from the API wire contract', async () => {
     mockAllEndpointsEmpty()
-    vi.mocked(proposalDeepReviewApi.getHistory).mockResolvedValue([
-      { serial: '#1', event: 'created', age: '2h', status: 'Pending' },
-      { serial: '#2', event: 'applied', age: '1d', status: 'Applied' },
-      { serial: '#3', event: 'old', age: '5d', status: 'Past' },
-    ])
+    const serializedRows = JSON.parse(`[
+      {"serial":"#1","event":"created","age":"2h","status":0},
+      {"serial":"#2","event":"applied","age":"1d","status":1},
+      {"serial":"#3","event":"old","age":"5d","status":2}
+    ]`) as CardHistoryRowDto[]
+    vi.mocked(proposalDeepReviewApi.getHistory).mockResolvedValue(serializedRows)
 
     const proposal = ref<ApiProposal | null>(makeProposal())
     const activeProposal = computed(() => proposal.value)
@@ -152,6 +166,37 @@ describe('usePaperReviewSelectors', () => {
     expect(selectors.history.value[0].status).toBe('pending')
     expect(selectors.history.value[1].status).toBe('applied')
     expect(selectors.history.value[2].status).toBe('past')
+  })
+
+  it('keeps unexpected runtime enum values visible while rendering safe defaults', async () => {
+    mockAllEndpointsEmpty()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const conflicts = JSON.parse('[{"tone":99,"key":"unknown","value":"v"}]') as ConflictRowDto[]
+    const history = JSON.parse('[{"serial":"#1","event":"unknown","age":"now","status":99}]') as CardHistoryRowDto[]
+    vi.mocked(proposalDeepReviewApi.getConflicts).mockResolvedValue(conflicts)
+    vi.mocked(proposalDeepReviewApi.getHistory).mockResolvedValue(history)
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const activeProposal = computed(() => proposal.value)
+    const selectors = usePaperReviewSelectors(activeProposal)
+
+    await vi.waitFor(() => {
+      expect(selectors.conflicts.value).toHaveLength(1)
+      expect(selectors.history.value).toHaveLength(1)
+    })
+
+    expect(selectors.conflicts.value[0].tone).toBe('info')
+    expect(selectors.history.value[0].status).toBe('past')
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Paper Review] Unexpected ConflictTone wire value',
+      99,
+    )
+    expect(consoleError).toHaveBeenCalledWith(
+      '[Paper Review] Unexpected CardHistoryStatus wire value',
+      99,
+    )
+
+    consoleError.mockRestore()
   })
 
   it('computes similarPastApplyRate from decisions', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewMain.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewMain.spec.ts
@@ -48,7 +48,10 @@ const sideEffects: SideEffects = {
 const conflicts: ConflictRow[] = []
 const history: HistoryRow[] = []
 
-function mountMain(confidence: Partial<ConfidenceBreakdown> = {}) {
+function mountMain(
+  confidence: Partial<ConfidenceBreakdown> = {},
+  deepReview: { conflicts?: ConflictRow[]; history?: HistoryRow[] } = {},
+) {
   return mount(ReviewMain, {
     props: {
       serial: '#2026-04-25-014',
@@ -74,8 +77,8 @@ function mountMain(confidence: Partial<ConfidenceBreakdown> = {}) {
       provenance,
       proposalId: 'proposal-001',
       sideEffects,
-      conflicts,
-      history,
+      conflicts: deepReview.conflicts ?? conflicts,
+      history: deepReview.history ?? history,
     },
   })
 }
@@ -130,5 +133,16 @@ describe('ReviewMain', () => {
   it('shows "Below your apply threshold" when confidence < threshold', () => {
     const wrapper = mountMain({ overall: 0.4, threshold: 0.7 })
     expect(wrapper.text()).toContain('Below your apply threshold')
+  })
+
+  it('renders malformed enum fallbacks as user-visible attention states', () => {
+    const wrapper = mountMain({}, {
+      conflicts: [{ tone: 'warn', key: 'Unknown conflict', value: 'Review required' }],
+      history: [{ serial: '#1', event: 'Unknown event', age: 'now', status: 'unknown' }],
+    })
+
+    expect(wrapper.text()).toContain('What the system noticed · 1 minor')
+    expect(wrapper.text()).toContain('WARNING')
+    expect(wrapper.get('[data-status="unknown"]').text()).toContain('UNKNOWN')
   })
 })

--- a/frontend/taskdeck-web/src/views/paper/review/ReviewHistory.vue
+++ b/frontend/taskdeck-web/src/views/paper/review/ReviewHistory.vue
@@ -15,8 +15,9 @@ function statusLabel(status: HistoryRow['status']): string {
     case 'applied':
       return 'APPLIED'
     case 'past':
-    default:
       return 'past'
+    case 'unknown':
+      return 'UNKNOWN'
   }
 }
 </script>
@@ -104,5 +105,9 @@ function statusLabel(status: HistoryRow['status']): string {
 }
 .paper-review-history__row[data-status='applied'] .paper-review-history__status {
   color: var(--applied);
+}
+.paper-review-history__row[data-status='unknown'] .paper-review-history__status {
+  color: var(--overdue);
+  font-weight: 700;
 }
 </style>

--- a/frontend/taskdeck-web/tests/e2e/review-proposals.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/review-proposals.spec.ts
@@ -7,7 +7,7 @@
  * - Applied proposal visibility via the Show Completed toggle
  */
 
-import { expect, test } from '@playwright/test'
+import { expect, test, type ConsoleMessage } from '@playwright/test'
 import { registerAndAttachSession, type AuthResult } from './support/authSession'
 import { createBoardWithColumn } from './support/boardHelpers'
 import {
@@ -18,8 +18,101 @@ import {
 
 let auth: AuthResult
 
-test.beforeEach(async ({ page, request }) => {
+const PAPER_ENUM_TEST_TITLE =
+  'Paper Review renders numeric deep-review enums without browser or API errors'
+
+test.beforeEach(async ({ page, request }, testInfo) => {
+  if (testInfo.title === PAPER_ENUM_TEST_TITLE) {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('td.paper.mode.v2', 'paper')
+    })
+  }
   auth = await registerAndAttachSession(page, request, 'review-proposals')
+})
+
+test(PAPER_ENUM_TEST_TITLE, async ({
+  page,
+  request,
+}) => {
+  test.setTimeout(90_000)
+
+  const seed = `${Date.now()}-${Math.floor(Math.random() * 1_000_000)}`
+  const boardId = await createBoardWithColumn(request, auth, seed, {
+    boardNamePrefix: 'Deep Review Enum',
+    description: 'numeric deep-review enum contract regression',
+    columnNamePrefix: 'Backlog',
+  })
+  const cardTitle = `Review numeric enum payload ${seed}`
+  const capture = await createCaptureItem(
+    request,
+    auth,
+    boardId,
+    `- [ ] ${cardTitle}`,
+  )
+  await triageCaptureItem(request, auth, capture.id)
+  const triaged = await waitForProposalCreated(request, auth, capture.id)
+  const proposalId = triaged.provenance?.proposalId
+  expect(proposalId).toBeTruthy()
+
+  const consoleErrors: string[] = []
+  const pageErrors: string[] = []
+  const failedDeepReviewResponses: string[] = []
+  page.on('console', (message: ConsoleMessage) => {
+    if (message.type() === 'error') consoleErrors.push(message.text())
+  })
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+  page.on('response', (response) => {
+    if (
+      response.url().includes(`/automation/proposals/${proposalId}/`) &&
+      response.status() >= 400
+    ) {
+      failedDeepReviewResponses.push(`${response.status()} ${response.url()}`)
+    }
+  })
+
+  // Similar-past has an independent SQLite failure tracked by #1348. Isolate
+  // that endpoint here so this regression proves the real conflict/history
+  // wire payloads without turning a separate known bug into a false signal.
+  await page.route(`**/automation/proposals/${proposalId}/similar-past`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '{"decisions":[],"applyRate":0}',
+    })
+  })
+
+  const conflictsResponsePromise = page.waitForResponse(
+    (response) => response.url().endsWith(`/automation/proposals/${proposalId}/conflicts`),
+  )
+  const historyResponsePromise = page.waitForResponse(
+    (response) => response.url().endsWith(`/automation/proposals/${proposalId}/history`),
+  )
+
+  await page.goto(`/workspace/review?boardId=${boardId}#proposal-${proposalId}`)
+  await expect(
+    page.getByRole('heading', { level: 1, name: `Capture triage: ${cardTitle}` }),
+  ).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByRole('heading', { name: 'Conflicts & warnings' })).toBeVisible()
+  await expect(page.getByRole('heading', { name: /History/ })).toBeVisible()
+
+  const [conflictsResponse, historyResponse] = await Promise.all([
+    conflictsResponsePromise,
+    historyResponsePromise,
+  ])
+  expect(conflictsResponse.status()).toBe(200)
+  expect(historyResponse.status()).toBe(200)
+
+  const conflicts = await conflictsResponse.json() as Array<{ tone: unknown }>
+  const history = await historyResponse.json() as Array<{ status: unknown }>
+  expect(conflicts.length).toBeGreaterThan(0)
+  expect(history.length).toBeGreaterThan(0)
+  expect(conflicts.every((row) => typeof row.tone === 'number')).toBe(true)
+  expect(history.every((row) => typeof row.status === 'number')).toBe(true)
+
+  await expect(page.getByText('Something went wrong', { exact: true })).toHaveCount(0)
+  expect(failedDeepReviewResponses).toEqual([])
+  expect(pageErrors).toEqual([])
+  expect(consoleErrors).toEqual([])
 })
 
 // --- Board-scoped proposal filtering ---

--- a/frontend/taskdeck-web/tests/e2e/review-proposals.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/review-proposals.spec.ts
@@ -43,32 +43,54 @@ test(PAPER_ENUM_TEST_TITLE, async ({
     columnNamePrefix: 'Backlog',
   })
   const cardTitle = `Review numeric enum payload ${seed}`
-  const capture = await createCaptureItem(
-    request,
-    auth,
-    boardId,
-    `- [ ] ${cardTitle}`,
-  )
-  await triageCaptureItem(request, auth, capture.id)
-  const triaged = await waitForProposalCreated(request, auth, capture.id)
-  const proposalId = triaged.provenance?.proposalId
-  expect(proposalId).toBeTruthy()
+  const captureText = `- [ ] ${cardTitle}`
 
   const consoleErrors: string[] = []
   const pageErrors: string[] = []
   const failedDeepReviewResponses: string[] = []
+  let proposalId: string | undefined
   page.on('console', (message: ConsoleMessage) => {
     if (message.type() === 'error') consoleErrors.push(message.text())
   })
   page.on('pageerror', (error) => pageErrors.push(error.message))
   page.on('response', (response) => {
     if (
+      proposalId &&
       response.url().includes(`/automation/proposals/${proposalId}/`) &&
       response.status() >= 400
     ) {
       failedDeepReviewResponses.push(`${response.status()} ${response.url()}`)
     }
   })
+
+  await page.goto(`/workspace/boards/${boardId}`)
+  const captureHereButton = page.getByRole('button', { name: 'Capture here' })
+  await expect(captureHereButton).toBeVisible()
+
+  await captureHereButton.click()
+  await expect(page).toHaveURL(new RegExp(`/workspace/inbox\\?boardId=${boardId}$`))
+  const captureBody = page.getByRole('textbox', { name: 'Capture body' })
+  await expect(captureBody).toBeVisible()
+
+  const createCaptureResponsePromise = page.waitForResponse((response) =>
+    response.request().method() === 'POST'
+    && /\/api\/capture\/items$/i.test(response.url())
+    && response.ok())
+
+  await captureBody.fill(captureText)
+  await page.getByRole('button', { name: 'Capture' }).click()
+  const createCaptureResponse = await createCaptureResponsePromise
+  const capturePayload = await createCaptureResponse.json() as { id?: string }
+  const captureId = capturePayload.id
+  expect(captureId).toBeTruthy()
+
+  const captureRow = page.locator('.paper-triage__row').filter({ hasText: cardTitle }).first()
+  await expect(captureRow).toBeVisible()
+  await captureRow.getByRole('button', { name: 'Accept' }).click()
+
+  const triaged = await waitForProposalCreated(request, auth, captureId!)
+  proposalId = triaged.provenance?.proposalId
+  expect(proposalId).toBeTruthy()
 
   // Similar-past has an independent SQLite failure tracked by #1348. Isolate
   // that endpoint here so this regression proves the real conflict/history
@@ -88,7 +110,8 @@ test(PAPER_ENUM_TEST_TITLE, async ({
     (response) => response.url().endsWith(`/automation/proposals/${proposalId}/history`),
   )
 
-  await page.goto(`/workspace/review?boardId=${boardId}#proposal-${proposalId}`)
+  await page.getByRole('link', { name: /Review$/ }).click()
+  await expect(page).toHaveURL(/\/workspace\/review$/)
   await expect(
     page.getByRole('heading', { level: 1, name: `Capture triage: ${cardTitle}` }),
   ).toBeVisible({ timeout: 15_000 })
@@ -108,6 +131,17 @@ test(PAPER_ENUM_TEST_TITLE, async ({
   expect(history.length).toBeGreaterThan(0)
   expect(conflicts.every((row) => typeof row.tone === 'number')).toBe(true)
   expect(history.every((row) => typeof row.status === 'number')).toBe(true)
+  expect(conflicts.some((row) => row.tone === 2)).toBe(true)
+  expect(history.some((row) => row.status === 0)).toBe(true)
+
+  // These are mapped UI values from the real numeric responses. Waiting for
+  // them proves all selector requests have settled and the enum mapper ran.
+  await expect(
+    page.locator('.paper-review-conflicts__row').filter({ hasText: 'CLEAR' }).first(),
+  ).toBeVisible()
+  await expect(page.locator('.paper-review-history__row[data-status="pending"]').first()).toContainText(
+    'PENDING',
+  )
 
   await expect(page.getByText('Something went wrong', { exact: true })).toHaveCount(0)
   expect(failedDeepReviewResponses).toEqual([])


### PR DESCRIPTION
## Summary

- pin the backend deep-review enum ordinals and declare the frontend wire DTOs as numeric literal contracts
- map valid conflict-tone and card-history status values without string coercion, while failing closed to user-visible warning / unknown states for unexpected values
- add ASP.NET JSON-options serialization coverage, serialized frontend mapping/UI coverage, and a Paper-native capture-to-review browser regression

## Implementation notes

- `ConflictTone` now declares `Warn = 0`, `Info = 1`, and `Ok = 2`; `CardHistoryStatus` already declared `Pending = 0`, `Applied = 1`, and `Past = 2`.
- Paper consumes the numeric wire values directly. Unexpected conflict values emit a targeted console error and render as `warn`; unexpected history values render as an explicit `UNKNOWN` attention state. Malformed data therefore cannot crash the surface or masquerade as benign/settled.
- The focused Playwright test captures and accepts the item through Paper UI, enters Review through Paper navigation, and waits for real numeric responses to render as concrete `CLEAR` / `PENDING` rows.
- The browser test stubs only `similar-past`, whose separate SQLite failure remains tracked by #1348.

## Tests added/updated

- backend API JSON-options contract for serialized conflict/history enum ordinals
- frontend API/composable tests using JSON-parsed numeric payloads for all six enum members plus fail-closed malformed values
- Paper component proof that conservative fallbacks render `WARNING` / `UNKNOWN` rather than clear/past
- Paper-native capture -> triage -> Review Playwright regression with response shape/status, mapped UI rows, ErrorBoundary, page-error, console-error, and failed-API assertions

## Verification

- [x] `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~DeepReviewEnumSerializationContractTests"` — 1 passed
- [x] `npx vitest --run src/tests/api/proposalDeepReviewApi.spec.ts src/tests/composables/usePaperReviewSelectors.spec.ts src/tests/views/paper/review/ReviewMain.spec.ts --maxWorkers=2` — 27 passed
- [x] `dotnet build backend/Taskdeck.sln -c Release -m:1` — succeeded, 0 errors (12 pre-existing warnings)
- [x] `npm run typecheck` — passed
- [x] `npm run build` — passed
- [x] `npm run lint` — passed, 0 errors (6 pre-existing accessibility warnings)
- [x] focused Chromium Paper-native capture-to-review regression — 1 passed in 10.5s

Not run: full backend or frontend unit suites; the change was verified with the focused contract/mapping/UI tests plus solution build and the real browser path.

## Documentation

- Canonical docs not changed: this is a narrow bug repair and does not change roadmap sequencing or user-facing workflow.

## Risk notes

- Security impact: none.
- Behavior/regression risk: low; valid API values are exhaustively pinned and malformed runtime numbers remain visible through logging plus conservative user-facing states.
- Follow-up: #1348 remains the independent SQLite-backed `similar-past` failure.

Closes #1347