### PR TITLE
Fix SQLite similar-past history query

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -305,6 +305,55 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
 
         var boundedLimit = limit <= 0 ? DefaultLimit : limit;
 
+        if (_context.Database.IsSqlite())
+        {
+            // EF Core's SQLite provider cannot translate the UpdatedAt DateTimeOffset tiebreaker.
+            // Keep the action/status/scope filters plus ORDER BY and LIMIT in SQLite so the
+            // similar-past lookback remains bounded instead of materializing all history.
+            var sql = new StringBuilder(
+                "SELECT * FROM AutomationProposals AS p " +
+                "WHERE p.Status IN ({0}, {1}) " +
+                "AND EXISTS (" +
+                "SELECT 1 FROM AutomationProposalOperations AS op " +
+                "WHERE op.ProposalId = p.Id AND op.ActionType = {2})");
+            var parameters = new List<object>
+            {
+                (int)ProposalStatus.Applied,
+                (int)ProposalStatus.Rejected,
+                actionType,
+            };
+
+            if (boardId.HasValue)
+            {
+                sql.Append(" AND p.BoardId = {").Append(parameters.Count).Append('}');
+                parameters.Add(boardId.Value);
+            }
+            else
+            {
+                sql.Append(" AND p.RequestedByUserId = {").Append(parameters.Count).Append('}');
+                parameters.Add(userId);
+            }
+
+            sql.Append(" ORDER BY p.DecidedAt DESC, p.UpdatedAt DESC, p.Id LIMIT {")
+                .Append(parameters.Count)
+                .Append('}');
+            parameters.Add(boundedLimit);
+
+            var rows = await _dbSet
+                .FromSqlRaw(sql.ToString(), parameters.ToArray())
+                .AsNoTracking()
+                .Include(p => p.Operations)
+                .ToListAsync(cancellationToken);
+
+            // Include composes over the raw query and does not guarantee the inner order survives.
+            // Re-sort the already bounded result to preserve the repository's newest-first contract.
+            return rows
+                .OrderByDescending(p => p.DecidedAt)
+                .ThenByDescending(p => p.UpdatedAt)
+                .ThenBy(p => p.Id.ToString(), StringComparer.Ordinal)
+                .ToList();
+        }
+
         // Find proposal IDs whose operations match the action type
         var matchingProposalIds = _context.AutomationProposalOperations
             .Where(op => op.ActionType == actionType)
@@ -347,6 +396,7 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
         return proposals
             .OrderByDescending(p => p.DecidedAt)
             .ThenByDescending(p => p.UpdatedAt)
+            .ThenBy(p => p.Id)
             .ToList();
     }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AutomationProposalRepository.cs
@@ -380,6 +380,7 @@ public class AutomationProposalRepository : Repository<AutomationProposal>, IAut
             .AsNoTracking()
             .OrderByDescending(p => p.DecidedAt)
             .ThenByDescending(p => p.UpdatedAt)
+            .ThenBy(p => p.Id)
             .Take(boundedLimit)
             .Select(p => p.Id)
             .ToListAsync(cancellationToken);

--- a/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
@@ -526,6 +526,142 @@ public class AutomationProposalRepositoryIntegrationTests : IClassFixture<TestWe
     }
 
     [Fact]
+    public async Task GetTerminalByActionTypeAsync_OnSqlite_WithNoTerminalHistory_ReturnsEmpty()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAutomationProposalRepository>();
+
+        var user = new User(
+            $"ap-similar-past-{Guid.NewGuid():N}",
+            $"ap-similar-past-{Guid.NewGuid():N}@example.com",
+            "hash");
+        var board = new Board("Similar-past SQLite board", ownerId: user.Id);
+        var pending = new AutomationProposal(
+            ProposalSourceType.Queue,
+            user.Id,
+            "Pending capture proposal",
+            RiskLevel.Low,
+            $"corr-similar-{Guid.NewGuid():N}",
+            boardId: board.Id);
+        pending.AddOperation(new AutomationProposalOperation(
+            pending.Id,
+            0,
+            "create",
+            "card",
+            "{\"title\":\"Captured card\"}",
+            $"key-similar-{Guid.NewGuid():N}"));
+
+        db.Users.Add(user);
+        db.Boards.Add(board);
+        db.AutomationProposals.Add(pending);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var result = await repo.GetTerminalByActionTypeAsync(
+            "create",
+            board.Id,
+            user.Id,
+            limit: 200);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetTerminalByActionTypeAsync_OnSqlite_BoardScope_ReturnsBoundedTerminalHistory()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAutomationProposalRepository>();
+
+        var owner = new User(
+            $"ap-history-owner-{Guid.NewGuid():N}",
+            $"ap-history-owner-{Guid.NewGuid():N}@example.com",
+            "hash");
+        var collaborator = new User(
+            $"ap-history-collab-{Guid.NewGuid():N}",
+            $"ap-history-collab-{Guid.NewGuid():N}@example.com",
+            "hash");
+        var board = new Board("Similar-past scoped board", ownerId: owner.Id);
+        var otherBoard = new Board("Similar-past other board", ownerId: owner.Id);
+        db.Users.AddRange(owner, collaborator);
+        db.Boards.AddRange(board, otherBoard);
+
+        var oldestApplied = CreateTerminalProposal(owner.Id, board.Id, "Old applied", "create", ProposalStatus.Applied);
+        var middleRejected = CreateTerminalProposal(owner.Id, board.Id, "Middle rejected", "create", ProposalStatus.Rejected);
+        var newestCollaboratorApplied = CreateTerminalProposal(collaborator.Id, board.Id, "Newest collaborator applied", "create", ProposalStatus.Applied);
+        var otherBoardApplied = CreateTerminalProposal(owner.Id, otherBoard.Id, "Other board", "create", ProposalStatus.Applied);
+        var wrongActionApplied = CreateTerminalProposal(owner.Id, board.Id, "Wrong action", "move", ProposalStatus.Applied);
+        db.AutomationProposals.AddRange(
+            oldestApplied,
+            middleRejected,
+            newestCollaboratorApplied,
+            otherBoardApplied,
+            wrongActionApplied);
+
+        var now = DateTime.UtcNow;
+        SetDecisionTimestamps(db, oldestApplied, now.AddMinutes(-3));
+        SetDecisionTimestamps(db, middleRejected, now.AddMinutes(-2));
+        SetDecisionTimestamps(db, newestCollaboratorApplied, now.AddMinutes(-1));
+        SetDecisionTimestamps(db, otherBoardApplied, now);
+        SetDecisionTimestamps(db, wrongActionApplied, now);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var result = await repo.GetTerminalByActionTypeAsync(
+            "create",
+            board.Id,
+            owner.Id,
+            limit: 2);
+
+        result.Select(proposal => proposal.Id).Should().Equal(
+            newestCollaboratorApplied.Id,
+            middleRejected.Id);
+        result.Should().OnlyContain(proposal =>
+            proposal.BoardId == board.Id &&
+            proposal.Operations.Any(operation => operation.ActionType == "create"));
+        result.Should().NotContain(proposal => proposal.Id == oldestApplied.Id, "the database-side limit is two");
+        result.Should().NotContain(proposal => proposal.Id == otherBoardApplied.Id);
+        result.Should().NotContain(proposal => proposal.Id == wrongActionApplied.Id);
+    }
+
+    [Fact]
+    public async Task GetTerminalByActionTypeAsync_OnSqlite_WithoutBoard_ScopesToRequestingUser()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAutomationProposalRepository>();
+
+        var caller = new User(
+            $"ap-history-caller-{Guid.NewGuid():N}",
+            $"ap-history-caller-{Guid.NewGuid():N}@example.com",
+            "hash");
+        var otherUser = new User(
+            $"ap-history-other-{Guid.NewGuid():N}",
+            $"ap-history-other-{Guid.NewGuid():N}@example.com",
+            "hash");
+        db.Users.AddRange(caller, otherUser);
+
+        var callerApplied = CreateTerminalProposal(caller.Id, null, "Caller applied", "create", ProposalStatus.Applied);
+        var callerRejected = CreateTerminalProposal(caller.Id, null, "Caller rejected", "create", ProposalStatus.Rejected);
+        var otherApplied = CreateTerminalProposal(otherUser.Id, null, "Other applied", "create", ProposalStatus.Applied);
+        db.AutomationProposals.AddRange(callerApplied, callerRejected, otherApplied);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var result = await repo.GetTerminalByActionTypeAsync(
+            "create",
+            boardId: null,
+            userId: caller.Id,
+            limit: 10);
+
+        result.Select(proposal => proposal.Id).Should().BeEquivalentTo(
+            new[] { callerApplied.Id, callerRejected.Id });
+        result.Should().OnlyContain(proposal => proposal.RequestedByUserId == caller.Id);
+        result.Should().NotContain(proposal => proposal.Id == otherApplied.Id);
+    }
+
+    [Fact]
     public async Task GetExpiredAsync_WithExpiresAtExactlyNow_ShouldNotReturnAsExpired()
     {
         // Locks in that GetExpiredAsync uses strict < (not <=) for ExpiresAt comparison.
@@ -757,5 +893,53 @@ public class AutomationProposalRepositoryIntegrationTests : IClassFixture<TestWe
         typeof(AutomationProposal)
             .GetProperty(nameof(AutomationProposal.DeferredUntil))!
             .SetValue(proposal, deferredUntil);
+    }
+
+    private static AutomationProposal CreateTerminalProposal(
+        Guid userId,
+        Guid? boardId,
+        string summary,
+        string actionType,
+        ProposalStatus status)
+    {
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Queue,
+            userId,
+            summary,
+            RiskLevel.Low,
+            $"corr-history-{Guid.NewGuid():N}",
+            boardId: boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            actionType,
+            "card",
+            "{\"title\":\"History card\"}",
+            $"key-history-{Guid.NewGuid():N}"));
+
+        if (status == ProposalStatus.Applied)
+        {
+            proposal.Approve(userId);
+            proposal.MarkAsApplied();
+        }
+        else if (status == ProposalStatus.Rejected)
+        {
+            proposal.Reject(userId);
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException(nameof(status), status, "Expected Applied or Rejected.");
+        }
+
+        return proposal;
+    }
+
+    private static void SetDecisionTimestamps(
+        TaskdeckDbContext db,
+        AutomationProposal proposal,
+        DateTime decidedAt)
+    {
+        db.Entry(proposal).Property(nameof(AutomationProposal.DecidedAt)).CurrentValue = decidedAt;
+        db.Entry(proposal).Property(nameof(AutomationProposal.UpdatedAt)).CurrentValue = new DateTimeOffset(decidedAt);
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/AutomationProposalsApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AutomationProposalsApiTests.cs
@@ -878,6 +878,27 @@ public class AutomationProposalsApiTests : IClassFixture<TestWebApplicationFacto
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    [Fact]
+    public async Task GetSimilarPast_ForPendingCaptureProposalWithoutHistory_ReturnsEmptyResult()
+    {
+        var userId = await AuthenticateAsync("automation-similar-past-empty");
+        var boardId = await CreateOwnedBoardAsync(userId);
+        var proposal = await CreateTestProposalAsync(
+            _client,
+            userId,
+            boardId,
+            RiskLevel.Low,
+            ProposalSourceType.Queue);
+
+        var response = await _client.GetAsync($"/api/automation/proposals/{proposal.Id}/similar-past");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<SimilarPastResultDto>();
+        result.Should().NotBeNull();
+        result!.Decisions.Should().BeEmpty();
+        result.ApplyRate.Should().Be(0);
+    }
+
     private async Task<List<ProposalDto>> GetBoardProposalsAsync(Guid boardId)
     {
         var response = await _client.GetAsync($"/api/automation/proposals?boardId={boardId}");
@@ -890,10 +911,15 @@ public class AutomationProposalsApiTests : IClassFixture<TestWebApplicationFacto
         return await CreateTestProposalAsync(_client, userId, boardId, riskLevel);
     }
 
-    private static async Task<ProposalDto> CreateTestProposalAsync(HttpClient client, Guid userId, Guid boardId, RiskLevel riskLevel)
+    private static async Task<ProposalDto> CreateTestProposalAsync(
+        HttpClient client,
+        Guid userId,
+        Guid boardId,
+        RiskLevel riskLevel,
+        ProposalSourceType sourceType = ProposalSourceType.Chat)
     {
         var createRequest = new CreateProposalDto(
-            SourceType: ProposalSourceType.Chat,
+            SourceType: sourceType,
             RequestedByUserId: userId,
             Summary: $"Test proposal {Guid.NewGuid()}",
             RiskLevel: riskLevel,

--- a/backend/tests/Taskdeck.Integration.Tests/AutomationProposalRepositoryPostgresIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Integration.Tests/AutomationProposalRepositoryPostgresIntegrationTests.cs
@@ -1,0 +1,83 @@
+using FluentAssertions;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Repositories;
+using Taskdeck.Integration.Tests.Fixtures;
+using Xunit;
+
+namespace Taskdeck.Integration.Tests;
+
+[Collection(PostgresTestCollection.Name)]
+public class AutomationProposalRepositoryPostgresIntegrationTests : PostgresIntegrationTestBase
+{
+    public AutomationProposalRepositoryPostgresIntegrationTests(PostgresContainerFixture fixture) : base(fixture)
+    {
+    }
+
+    [SkippableFact]
+    public async Task GetTerminalByActionTypeAsync_TiedCutoff_UsesIdBeforeTake()
+    {
+        SkipIfDockerUnavailable();
+
+        var user = new User("similar-postgres", "similar-postgres@example.com", "hash");
+        var board = new Board("Similar-past PostgreSQL board", ownerId: user.Id);
+        Db.Users.Add(user);
+        Db.Boards.Add(board);
+        await Db.SaveChangesAsync();
+
+        var firstId = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var secondId = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var thirdId = Guid.Parse("00000000-0000-0000-0000-000000000003");
+        var first = CreateAppliedProposal(firstId, user.Id, board.Id, "First deterministic row");
+        var second = CreateAppliedProposal(secondId, user.Id, board.Id, "Second deterministic row");
+        var third = CreateAppliedProposal(thirdId, user.Id, board.Id, "Third deterministic row");
+
+        var tiedDecision = DateTime.UtcNow.AddMinutes(-1);
+        var tiedUpdate = new DateTimeOffset(tiedDecision);
+        // Persist each row separately in reverse Id order. Without Id in SQL's ORDER BY before
+        // LIMIT, PostgreSQL's tied-row cohort follows this heap arrival order on the regression path.
+        foreach (var proposal in new[] { third, second, first })
+        {
+            Db.Entry(proposal).Property(nameof(AutomationProposal.DecidedAt)).CurrentValue = tiedDecision;
+            Db.Entry(proposal).Property(nameof(AutomationProposal.UpdatedAt)).CurrentValue = tiedUpdate;
+            Db.AutomationProposals.Add(proposal);
+            await Db.SaveChangesAsync();
+        }
+        Db.ChangeTracker.Clear();
+
+        var repository = new AutomationProposalRepository(Db);
+        var result = await repository.GetTerminalByActionTypeAsync(
+            "create",
+            board.Id,
+            user.Id,
+            limit: 2);
+
+        result.Select(proposal => proposal.Id).Should().Equal(firstId, secondId);
+    }
+
+    private static AutomationProposal CreateAppliedProposal(
+        Guid id,
+        Guid userId,
+        Guid boardId,
+        string summary)
+    {
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Queue,
+            userId,
+            summary,
+            RiskLevel.Low,
+            $"corr-postgres-{id:N}",
+            boardId: boardId);
+        typeof(Entity).GetProperty(nameof(Entity.Id))!.SetValue(proposal, id);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            "create",
+            "card",
+            "{\"title\":\"History card\"}",
+            $"key-postgres-{id:N}"));
+        proposal.Approve(userId);
+        proposal.MarkAsApplied();
+        return proposal;
+    }
+}


### PR DESCRIPTION
## Summary

- reproduce the real SQLite `similar-past` failure as `NotSupportedException` from the `UpdatedAt` `DateTimeOffset` ORDER BY
- keep terminal-status, action-type, board/user scope, newest-first ordering, and `LIMIT` inside SQLite via the repository's established parameterized raw-SQL path
- make non-SQLite cutoff membership deterministic by applying the Id tiebreaker before `Take`
- add real SQLite scope/boundary/API regressions and a PostgreSQL tied-cutoff regression

Closes #1348

## Verification

Exact-head local proof at `6e1dbe791583ccce1ce01afd9f4051f606b95a4e`:

- SimilarDecision application tests ? 26 passed
- SQLite repository/API tests ? 27 passed
- PostgreSQL Testcontainer tied-cutoff regression ? 1 passed; temporarily removing the Id-before-`Take` fix made it fail with IDs 2/3 instead of 1/2
- Release solution build ? succeeded, 12 pre-existing warnings / 0 errors
- serialized full backend ? 7,203 passed / 0 failed / 1 known INV-09 skip
- `git diff --check` ? passed

Two independent fresh exact-head re-reviews found no remaining issue. Exact-head CI completed with 24 successful checks, 11 intentional skips, and no pending or failing checks.

## Docs

No canonical status/masterplan update: this restores the already-documented similar-past contract and does not change roadmap sequencing. The durable failure-ledger row stays open until merge.

## Residual

Paper browser coverage remains in parked #1274; this PR proves the server path with real SQLite/API integration and PostgreSQL boundary tests. GitHub Project Priority audit remains blocked until the maintainer grants `project` scope.