### PR TITLE
Stabilize rapid presence snapshot ordering

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -885,6 +885,14 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             $"the {phase} barrier should contain exactly the users whose hub operations succeeded");
     }
 
+    private static async Task InvokePresenceMutationAndRecordSuccessAsync(
+        Func<Task> invoke,
+        Action recordSuccess)
+    {
+        await invoke();
+        recordSuccess();
+    }
+
     [Fact]
     public async Task PresenceBarrier_UsesMarker_WhenTimestampsTieAndDeliveryIsReordered()
     {
@@ -987,6 +995,37 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             .WithMessage("*No presence snapshot contained the requested owner editing marker*Observed 1 total snapshots*");
     }
 
+    [Theory]
+    [InlineData("JoinBoard")]
+    [InlineData("LeaveBoard")]
+    public async Task PresenceMutation_PostMutationFailure_PropagatesWithoutRecordingSuccess(
+        string operation)
+    {
+        var trackerMutationApplied = false;
+        var successRecorded = false;
+        Exception expectedException = operation == "JoinBoard"
+            ? new HubException("broadcast failed after tracker mutation")
+            : new HttpRequestException("transport lost the result after tracker mutation");
+
+        async Task InvokeWithPostMutationFailure()
+        {
+            trackerMutationApplied = true;
+            await Task.Yield();
+            throw expectedException;
+        }
+
+        var act = () => InvokePresenceMutationAndRecordSuccessAsync(
+            InvokeWithPostMutationFailure,
+            () => successRecorded = true);
+
+        var assertion = await act.Should().ThrowAsync<Exception>();
+        assertion.Which.Should().BeSameAs(expectedException,
+            $"the ambiguous {operation} failure must propagate unchanged");
+        trackerMutationApplied.Should().BeTrue("the control simulates a post-mutation failure");
+        successRecorded.Should().BeFalse(
+            "an ambiguous outcome must abort before expected membership is inferred");
+    }
+
     /// <summary>
     /// Scenario 14: Rapid join/leave stress.
     /// Multiple connections rapidly join and leave a board.
@@ -1027,9 +1066,10 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
         // All users join simultaneously via Barrier for true synchronization.
         // Unlike SemaphoreSlim, Barrier ensures all participants reach the
         // barrier point before any of them proceed past it.
-        // Under load, some SignalR invocations may fail with transient 500
-        // errors (e.g., SQLite contention). We track join successes to set
-        // correct expectations for the eventual-consistency assertion.
+        // Every invocation must complete successfully before its identity is
+        // used in the exact barrier expectation. A transport or hub failure can
+        // happen after the server mutates the tracker, so swallowing it would
+        // leave the expected state ambiguous and recreate a false-red assertion.
         var connections = new List<HubConnection>();
         var joinedConnections = new ConcurrentBag<(HubConnection Connection, Guid UserId)>();
         try
@@ -1042,25 +1082,16 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
                 await conn.StartAsync();
                 lock (connections) { connections.Add(conn); }
                 joinBarrier.SignalAndWait(TimeSpan.FromSeconds(10));
-                try
-                {
-                    await conn.InvokeAsync("JoinBoard", board.Id);
-                    joinedConnections.Add((conn, user.UserId));
-                }
-                catch (Exception ex) when (ex is HubException or HttpRequestException)
-                {
-                    // Tolerate transient HubException (e.g., SQLite contention
-                    // under rapid-fire stress). The eventual-consistency check
-                    // below uses the actual success count.
-                }
+                await InvokePresenceMutationAndRecordSuccessAsync(
+                    () => conn.InvokeAsync("JoinBoard", board.Id),
+                    () => joinedConnections.Add((conn, user.UserId)));
             }).ToArray();
 
             joinBarrier.SignalAndWait(TimeSpan.FromSeconds(10));
             await Task.WhenAll(joinTasks);
 
-            var actualJoined = joinedConnections.Count;
-            actualJoined.Should().BeGreaterThanOrEqualTo(1,
-                "at least one concurrent join must succeed to validate rapid join/leave behavior");
+            joinedConnections.Should().HaveCount(connectionCount,
+                "every concurrent join must complete unambiguously before evaluating presence");
 
             // Publish a uniquely identifiable current-state barrier after every
             // join invocation settles. Earlier snapshots cannot contain this
@@ -1088,24 +1119,16 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             var leaveTasks = leavingConns.Select(async leaving =>
             {
                 leaveBarrier.SignalAndWait(TimeSpan.FromSeconds(10));
-                try
-                {
-                    await leaving.Connection.InvokeAsync("LeaveBoard", board.Id);
-                    leftUserIds.Add(leaving.UserId);
-                }
-                catch (Exception ex) when (ex is HubException or HttpRequestException)
-                {
-                    // Tolerate individual transient failures, but require at least
-                    // one successful leave below so this test still covers leave behavior.
-                }
+                await InvokePresenceMutationAndRecordSuccessAsync(
+                    () => leaving.Connection.InvokeAsync("LeaveBoard", board.Id),
+                    () => leftUserIds.Add(leaving.UserId));
             }).ToArray();
 
             leaveBarrier.SignalAndWait(TimeSpan.FromSeconds(10));
             await Task.WhenAll(leaveTasks);
 
-            var actualLeft = leftUserIds.Count;
-            actualLeft.Should().BeGreaterThan(0,
-                "at least one LeaveBoard invocation must succeed to validate rapid leave behavior");
+            leftUserIds.Should().HaveCount(leavingConns.Count,
+                "every concurrent leave must complete unambiguously before evaluating presence");
 
             // A second unique marker identifies the current state after every
             // leave attempt. Exact identities prove each successful leave took

--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -909,6 +909,40 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             .ToList();
 
     /// <summary>
+    /// Drains the observer's phase broadcasts until every expected join/leave
+    /// delta has been received (or a bounded timeout elapses). The owner's marker
+    /// snapshot ends the causal barrier, but the observer's later marker send is
+    /// not a delivery fence for the OTHER connections' join/leave broadcasts, so a
+    /// legitimate delta can land just after the barrier resolves. Waiting for the
+    /// full expected count both (a) prevents a false-red when a delta is merely
+    /// slow, and (b) guarantees every phase broadcast has been consumed before the
+    /// caller clears the collector — so no straggler from this phase can leak into
+    /// the next and masquerade as one of its deltas. If a delta is genuinely
+    /// dropped, the timeout elapses and the delivery assertion fails closed on the
+    /// short count. Extra broadcasts beyond the expected count are impossible here
+    /// (one per successful invocation), so the count is exact on the green path.
+    /// </summary>
+    private static async Task<IReadOnlyList<BoardPresenceSnapshot>> DrainPhaseBroadcastsAsync(
+        EventCollector<BoardPresenceSnapshot> events,
+        Guid ownerUserId,
+        Guid editingMarker,
+        int expectedDeliveryCount,
+        TimeSpan? timeout = null)
+    {
+        var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(15);
+        var deadline = DateTimeOffset.UtcNow + effectiveTimeout;
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(events.ToList(), ownerUserId, editingMarker);
+        while (phaseBroadcasts.Count < expectedDeliveryCount && DateTimeOffset.UtcNow < deadline)
+        {
+            await Task.Delay(50);
+            phaseBroadcasts = SelectPhaseBroadcasts(events.ToList(), ownerUserId, editingMarker);
+        }
+
+        return phaseBroadcasts;
+    }
+
+    /// <summary>
     /// Asserts every successful join was delivered to the observer as its own
     /// presence broadcast, not merely reflected in the marker snapshot. Each
     /// JoinBoard publishes exactly one snapshot, and the owner marker fence keeps
@@ -1441,8 +1475,12 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             // even if every JoinBoard broadcast were dropped, because SetEditingCard
             // republishes full tracker state. Require the join burst to have reached
             // the observer as its own presence deltas, carrying each joined identity.
-            var observedJoinBroadcasts = SelectPhaseBroadcasts(
-                observerEvents.ToList(), owner.UserId, joinEditingMarker);
+            // Drain until every join delta has arrived (the observer's marker send is
+            // not a delivery fence for the other connections' broadcasts), which also
+            // consumes every join broadcast before the clear below so none can leak
+            // into the leave phase.
+            var observedJoinBroadcasts = await DrainPhaseBroadcastsAsync(
+                observerEvents, owner.UserId, joinEditingMarker, joinedConnections.Count);
             AssertJoinBroadcastsObserved(
                 observedJoinBroadcasts,
                 joinedConnections.Select(joined => joined.UserId));
@@ -1485,9 +1523,11 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
 
             // Delivery coverage (issue #1371): prove each leave reached the observer
             // as its own shrink broadcast, not only via the SetEditingCard marker
-            // snapshot which republishes the already-mutated tracker state.
-            var observedLeaveBroadcasts = SelectPhaseBroadcasts(
-                observerEvents.ToList(), owner.UserId, leaveEditingMarker);
+            // snapshot which republishes the already-mutated tracker state. Drain
+            // until every leave delta has arrived; the join phase was fully drained
+            // before the clear above, so these non-marker deltas are leave-only.
+            var observedLeaveBroadcasts = await DrainPhaseBroadcastsAsync(
+                observerEvents, owner.UserId, leaveEditingMarker, leftUserIds.Count);
             AssertLeaveBroadcastsObserved(observedLeaveBroadcasts, leftUserIds);
         }
         finally

--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -885,6 +885,80 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             $"the {phase} barrier should contain exactly the users whose hub operations succeeded");
     }
 
+    private static bool SnapshotCarriesOwnerMarker(
+        BoardPresenceSnapshot snapshot,
+        Guid ownerUserId,
+        Guid editingMarker)
+        => snapshot.Members.Any(member =>
+            member.UserId == ownerUserId && member.EditingCardId == editingMarker);
+
+    /// <summary>
+    /// Presence snapshots observed for a phase that are NOT the causal marker
+    /// snapshot — i.e. the JoinBoard/LeaveBoard-originated deltas. The marker is
+    /// delivered by a separate <c>SetEditingCard</c> broadcast carrying full
+    /// tracker state, so these deltas are the only proof that the join/leave
+    /// events themselves reached the observer rather than merely mutating the
+    /// tracker (issue #1371).
+    /// </summary>
+    private static IReadOnlyList<BoardPresenceSnapshot> SelectPhaseBroadcasts(
+        IEnumerable<BoardPresenceSnapshot> observed,
+        Guid ownerUserId,
+        Guid editingMarker)
+        => observed
+            .Where(snapshot => !SnapshotCarriesOwnerMarker(snapshot, ownerUserId, editingMarker))
+            .ToList();
+
+    /// <summary>
+    /// Asserts every successful join was delivered to the observer as a presence
+    /// broadcast, not merely reflected in the marker snapshot. Fails closed when
+    /// every JoinBoard broadcast is dropped/suppressed (no non-marker delta
+    /// reaches the observer) or when a joined identity never appears in any delta.
+    /// </summary>
+    private static void AssertJoinBroadcastsObserved(
+        IReadOnlyList<BoardPresenceSnapshot> phaseBroadcasts,
+        IEnumerable<Guid> joinedUserIds)
+    {
+        phaseBroadcasts.Should().NotBeEmpty(
+            "the join burst must reach the observer as at least one presence broadcast " +
+            "distinct from the SetEditingCard marker snapshot; otherwise the test proves " +
+            "tracker membership but not join delivery (issue #1371)");
+
+        var deliveredUserIds = phaseBroadcasts
+            .SelectMany(snapshot => snapshot.Members.Select(member => member.UserId))
+            .ToHashSet();
+
+        foreach (var joinedUserId in joinedUserIds.Distinct())
+        {
+            deliveredUserIds.Should().Contain(joinedUserId,
+                "every successful join must be visible in an observed join-originated presence " +
+                "broadcast, not only in the marker snapshot");
+        }
+    }
+
+    /// <summary>
+    /// Asserts every successful leave was delivered to the observer as a shrink
+    /// broadcast (the leaving member absent), not merely reflected in the marker
+    /// snapshot. Fails closed when every LeaveBoard broadcast is dropped, or when
+    /// a supposedly-left identity is still present in every observed delta.
+    /// </summary>
+    private static void AssertLeaveBroadcastsObserved(
+        IReadOnlyList<BoardPresenceSnapshot> phaseBroadcasts,
+        IEnumerable<Guid> leftUserIds)
+    {
+        phaseBroadcasts.Should().NotBeEmpty(
+            "each leave must reach the observer as at least one presence broadcast distinct " +
+            "from the SetEditingCard marker snapshot; otherwise the test proves tracker " +
+            "membership but not leave delivery (issue #1371)");
+
+        foreach (var leftUserId in leftUserIds.Distinct())
+        {
+            phaseBroadcasts.Should().Contain(
+                snapshot => snapshot.Members.All(member => member.UserId != leftUserId),
+                "every successful leave must be visible as a shrink in an observed leave-originated " +
+                "presence broadcast, not only in the marker snapshot");
+        }
+    }
+
     private static async Task InvokePresenceMutationAndRecordSuccessAsync(
         Func<Task> invoke,
         Action recordSuccess)
@@ -998,33 +1072,212 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
     [Theory]
     [InlineData("JoinBoard")]
     [InlineData("LeaveBoard")]
-    public async Task PresenceMutation_PostMutationFailure_PropagatesWithoutRecordingSuccess(
+    public async Task PresenceMutation_PostMutationFailure_DivergesFromCommittedTrackerAndFailsClosed(
         string operation)
     {
-        var trackerMutationApplied = false;
-        var successRecorded = false;
-        Exception expectedException = operation == "JoinBoard"
-            ? new HubException("broadcast failed after tracker mutation")
-            : new HttpRequestException("transport lost the result after tracker mutation");
+        // Production ordering (BoardsHub.cs): JoinBoard mutates the tracker at :37
+        // and then awaits the broadcast at :38; LeaveBoard mutates at :53 then
+        // broadcasts at :54. A broadcast/transport failure therefore lands *after*
+        // the tracker has already committed the membership change, leaving the
+        // invocation outcome ambiguous. This control drives the real production
+        // InMemoryBoardPresenceTracker to that committed post-mutation state, then
+        // proves the fail-closed helper propagates the ambiguity instead of
+        // recording a success that would diverge from committed tracker state.
+        // (The broadcast failure is simulated because the hub exposes no
+        // broadcast-fault seam; the tracker state under assertion is genuine.)
+        var tracker = new InMemoryBoardPresenceTracker();
+        var boardId = Guid.NewGuid();
+        var subjectUserId = Guid.NewGuid();
+        const string subjectConnection = "conn-subject";
 
-        async Task InvokeWithPostMutationFailure()
+        // An owner keeps the board alive so leave snapshots stay non-empty.
+        tracker.Join(boardId, "conn-owner", Guid.NewGuid(), "Owner");
+
+        BoardPresenceSnapshot committedSnapshot;
+        bool subjectCommittedPresent;
+        Exception broadcastFailure;
+        if (operation == "JoinBoard")
         {
-            trackerMutationApplied = true;
+            committedSnapshot = tracker.Join(boardId, subjectConnection, subjectUserId, "Subject");
+            subjectCommittedPresent = true;
+            broadcastFailure = new HubException("broadcast failed after tracker mutation");
+        }
+        else
+        {
+            tracker.Join(boardId, subjectConnection, subjectUserId, "Subject");
+            committedSnapshot = tracker.Leave(boardId, subjectConnection);
+            subjectCommittedPresent = false;
+            broadcastFailure = new HttpRequestException("transport lost the result after tracker mutation");
+        }
+
+        committedSnapshot.Members.Any(member => member.UserId == subjectUserId)
+            .Should().Be(subjectCommittedPresent,
+                "the production tracker commits the membership change before the broadcast await");
+
+        var recordedSuccessUserIds = new HashSet<Guid>();
+        async Task InvokeWithPostMutationBroadcastFailure()
+        {
             await Task.Yield();
-            throw expectedException;
+            throw broadcastFailure;
         }
 
         var act = () => InvokePresenceMutationAndRecordSuccessAsync(
-            InvokeWithPostMutationFailure,
-            () => successRecorded = true);
+            InvokeWithPostMutationBroadcastFailure,
+            () => recordedSuccessUserIds.Add(subjectUserId));
 
-        var assertion = await act.Should().ThrowAsync<Exception>();
-        assertion.Which.Should().BeSameAs(expectedException,
-            $"the ambiguous {operation} failure must propagate unchanged");
-        trackerMutationApplied.Should().BeTrue("the control simulates a post-mutation failure");
-        successRecorded.Should().BeFalse(
-            "an ambiguous outcome must abort before expected membership is inferred");
+        (await act.Should().ThrowAsync<Exception>())
+            .Which.Should().BeSameAs(broadcastFailure,
+                $"the ambiguous {operation} failure must propagate unchanged so the scenario aborts");
+
+        // The exact divergence fail-closed guards against: the committed tracker
+        // reflects the mutation, but the expectation set does not — tolerating the
+        // failure would let the exact-membership assertion drift from server state.
+        recordedSuccessUserIds.Should().NotContain(subjectUserId,
+            "a post-mutation broadcast failure is ambiguous and must never be recorded as a success");
     }
+
+    [Fact]
+    public void JoinBroadcastAssertion_Passes_WhenEveryJoinDeltaObserved()
+    {
+        var ownerUserId = Guid.NewGuid();
+        var firstJoiner = Guid.NewGuid();
+        var secondJoiner = Guid.NewGuid();
+        var marker = Guid.NewGuid();
+        var observed = new[]
+        {
+            SnapshotWith([(ownerUserId, null), (firstJoiner, null)]),
+            SnapshotWith([(ownerUserId, null), (firstJoiner, null), (secondJoiner, null)]),
+            SnapshotWith([(ownerUserId, marker), (firstJoiner, null), (secondJoiner, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(observed, ownerUserId, marker);
+
+        phaseBroadcasts.Should().HaveCount(2, "only the marker snapshot is excluded");
+        var act = () => AssertJoinBroadcastsObserved(phaseBroadcasts, [firstJoiner, secondJoiner]);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void JoinBroadcastAssertion_FailsClosed_WhenAllJoinBroadcastsSuppressed()
+    {
+        // Regression the delivery assertion exists to catch (issue #1371): the
+        // tracker mutated and the SetEditingCard marker snapshot carries full
+        // membership, but every JoinBoard broadcast was dropped, so no
+        // observer-visible join delta ever arrived.
+        var ownerUserId = Guid.NewGuid();
+        var joinedUserId = Guid.NewGuid();
+        var marker = Guid.NewGuid();
+        var markerOnly = new[]
+        {
+            SnapshotWith([(ownerUserId, marker), (joinedUserId, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(markerOnly, ownerUserId, marker);
+
+        phaseBroadcasts.Should().BeEmpty();
+        var act = () => AssertJoinBroadcastsObserved(phaseBroadcasts, [joinedUserId]);
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*at least one presence broadcast*");
+    }
+
+    [Fact]
+    public void JoinBroadcastAssertion_FailsClosed_WhenAJoinedIdentityNeverBroadcast()
+    {
+        // A join delta reached the observer, but one joined identity's broadcast
+        // was dropped; it only appears in the marker snapshot.
+        var ownerUserId = Guid.NewGuid();
+        var deliveredJoiner = Guid.NewGuid();
+        var droppedJoiner = Guid.NewGuid();
+        var marker = Guid.NewGuid();
+        var observed = new[]
+        {
+            SnapshotWith([(ownerUserId, null), (deliveredJoiner, null)]),
+            SnapshotWith([(ownerUserId, marker), (deliveredJoiner, null), (droppedJoiner, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(observed, ownerUserId, marker);
+
+        var act = () => AssertJoinBroadcastsObserved(phaseBroadcasts, [deliveredJoiner, droppedJoiner]);
+        act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    [Fact]
+    public void LeaveBroadcastAssertion_Passes_WhenEveryLeaveShrinkObserved()
+    {
+        var ownerUserId = Guid.NewGuid();
+        var priorMarker = Guid.NewGuid();
+        var leaveMarker = Guid.NewGuid();
+        var stayer = Guid.NewGuid();
+        var firstLeaver = Guid.NewGuid();
+        var secondLeaver = Guid.NewGuid();
+        var observed = new[]
+        {
+            // Leave deltas still carry the previous phase's owner marker, never the
+            // current leave marker, so they classify as phase broadcasts.
+            SnapshotWith([(ownerUserId, priorMarker), (stayer, null), (secondLeaver, null)]),
+            SnapshotWith([(ownerUserId, priorMarker), (stayer, null)]),
+            SnapshotWith([(ownerUserId, leaveMarker), (stayer, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(observed, ownerUserId, leaveMarker);
+
+        phaseBroadcasts.Should().HaveCount(2);
+        var act = () => AssertLeaveBroadcastsObserved(phaseBroadcasts, [firstLeaver, secondLeaver]);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void LeaveBroadcastAssertion_FailsClosed_WhenAllLeaveBroadcastsSuppressed()
+    {
+        var ownerUserId = Guid.NewGuid();
+        var leaveMarker = Guid.NewGuid();
+        var stayer = Guid.NewGuid();
+        var markerOnly = new[]
+        {
+            SnapshotWith([(ownerUserId, leaveMarker), (stayer, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(markerOnly, ownerUserId, leaveMarker);
+
+        phaseBroadcasts.Should().BeEmpty();
+        var act = () => AssertLeaveBroadcastsObserved(phaseBroadcasts, [Guid.NewGuid()]);
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*at least one presence broadcast*");
+    }
+
+    [Fact]
+    public void LeaveBroadcastAssertion_FailsClosed_WhenALeftIdentityStillPresent()
+    {
+        // A shrink delta arrived, but the supposedly-left identity is still a
+        // member of every observed delta — its LeaveBoard broadcast never landed.
+        var ownerUserId = Guid.NewGuid();
+        var priorMarker = Guid.NewGuid();
+        var leaveMarker = Guid.NewGuid();
+        var stayer = Guid.NewGuid();
+        var stillPresentLeaver = Guid.NewGuid();
+        var observed = new[]
+        {
+            SnapshotWith([(ownerUserId, priorMarker), (stayer, null), (stillPresentLeaver, null)]),
+            SnapshotWith([(ownerUserId, leaveMarker), (stayer, null), (stillPresentLeaver, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(observed, ownerUserId, leaveMarker);
+
+        var act = () => AssertLeaveBroadcastsObserved(phaseBroadcasts, [stillPresentLeaver]);
+        act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    private static BoardPresenceSnapshot SnapshotWith(
+        IEnumerable<(Guid UserId, Guid? EditingCardId)> members)
+        => new(
+            Guid.NewGuid(),
+            members
+                .Select(member => new BoardPresenceMember(
+                    member.UserId,
+                    member.UserId.ToString("N")[..8],
+                    member.EditingCardId))
+                .ToList(),
+            DateTimeOffset.UtcNow);
 
     /// <summary>
     /// Scenario 14: Rapid join/leave stress.
@@ -1070,6 +1323,10 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
         // used in the exact barrier expectation. A transport or hub failure can
         // happen after the server mutates the tracker, so swallowing it would
         // leave the expected state ambiguous and recreate a false-red assertion.
+        // Fail-closed is safe here because the test host now mirrors production
+        // SQLite settings (busy_timeout 5000ms / WAL) via UseTaskdeckSqlite (#1373),
+        // so the auth-check reads these invocations make no longer flake under
+        // contention. Repeated-run evidence backs this before merge (issue #1371).
         var connections = new List<HubConnection>();
         var joinedConnections = new ConcurrentBag<(HubConnection Connection, Guid UserId)>();
         try
@@ -1109,6 +1366,16 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
                 .ToHashSet();
             AssertPresenceMembers(afterJoin, expectedAfterJoin, "post-join");
 
+            // Delivery coverage (issue #1371): the marker snapshot alone would pass
+            // even if every JoinBoard broadcast were dropped, because SetEditingCard
+            // republishes full tracker state. Require the join burst to have reached
+            // the observer as its own presence deltas, carrying each joined identity.
+            var observedJoinBroadcasts = SelectPhaseBroadcasts(
+                observerEvents.ToList(), owner.UserId, joinEditingMarker);
+            AssertJoinBroadcastsObserved(
+                observedJoinBroadcasts,
+                joinedConnections.Select(joined => joined.UserId));
+
             // First half of successfully-joined connections leave rapidly.
             observerEvents.Clear();
             var leavingConns = joinedConnections.Take(Math.Max(1, joinedConnections.Count / 2)).ToList();
@@ -1144,6 +1411,13 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
                 .Except(leftUserIds)
                 .ToHashSet();
             AssertPresenceMembers(afterLeave, expectedAfterLeave, "post-leave");
+
+            // Delivery coverage (issue #1371): prove each leave reached the observer
+            // as its own shrink broadcast, not only via the SetEditingCard marker
+            // snapshot which republishes the already-mutated tracker state.
+            var observedLeaveBroadcasts = SelectPhaseBroadcasts(
+                observerEvents.ToList(), owner.UserId, leaveEditingMarker);
+            AssertLeaveBroadcastsObserved(observedLeaveBroadcasts, leftUserIds);
         }
         finally
         {

--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -841,120 +841,150 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
     // ── SignalR Presence Concurrency ────────────────────────────────────────
 
     /// <summary>
-    /// Waits for eligible presence snapshots to stabilize (no new eligible
-    /// events for <paramref name="stableFor"/>) and returns the snapshot with
-    /// the newest server occurrence time. Tracks eligible event count rather
-    /// than member count so that events
-    /// with the same member count (e.g., simultaneous join + leave) still
-    /// reset the stabilization timer. Snapshots older than <paramref name="notBefore"/>
-    /// are ignored so delayed delivery from a previous phase cannot become the
-    /// apparent final state. Throws when no stable window is observed before timeout.
+    /// Waits for the snapshot published by an owner's uniquely identifiable
+    /// editing-state barrier. The marker supplies causal identity that wall-clock
+    /// timestamps cannot: delayed pre-barrier snapshots cannot contain it, even
+    /// when their timestamps tie or callbacks arrive out of order.
     /// </summary>
-    private static async Task<BoardPresenceSnapshot?> WaitForPresenceStabilizationAsync(
+    private static async Task<BoardPresenceSnapshot> WaitForPresenceBarrierAsync(
         EventCollector<BoardPresenceSnapshot> events,
-        TimeSpan? timeout = null,
-        TimeSpan? stableFor = null,
-        DateTimeOffset? notBefore = null)
+        Guid ownerUserId,
+        Guid editingMarker,
+        TimeSpan? timeout = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
-        var effectiveStableFor = stableFor ?? TimeSpan.FromSeconds(2);
         var deadline = DateTimeOffset.UtcNow + effectiveTimeout;
-        var lastEventCount = -1;
-        var lastChangeTime = DateTimeOffset.UtcNow;
 
         while (DateTimeOffset.UtcNow < deadline)
         {
-            var allSnapshots = events.ToList();
-            var eligibleSnapshots = allSnapshots
-                .Where(snapshot => !notBefore.HasValue || snapshot.OccurredAt >= notBefore.Value)
-                .ToList();
-            var currentEventCount = eligibleSnapshots.Count;
+            var barrierSnapshot = events.ToList().LastOrDefault(snapshot =>
+                snapshot.Members.Any(member =>
+                    member.UserId == ownerUserId
+                    && member.EditingCardId == editingMarker));
 
-            if (currentEventCount != lastEventCount)
-            {
-                lastEventCount = currentEventCount;
-                lastChangeTime = DateTimeOffset.UtcNow;
-            }
-            else if (currentEventCount > 0
-                && DateTimeOffset.UtcNow - lastChangeTime >= effectiveStableFor)
-            {
-                // SignalR delivery order can differ from the order in which the
-                // tracker created snapshots. Return the newest server occurrence,
-                // not merely the last event delivered to this observer.
-                return eligibleSnapshots.MaxBy(snapshot => snapshot.OccurredAt);
-            }
+            if (barrierSnapshot is not null)
+                return barrierSnapshot;
 
             await Task.Delay(50);
         }
 
-        var allObservedSnapshots = events.ToList();
-        var eligibleObservedSnapshots = allObservedSnapshots
-            .Where(snapshot => !notBefore.HasValue || snapshot.OccurredAt >= notBefore.Value)
-            .ToList();
-        var last = eligibleObservedSnapshots.MaxBy(snapshot => snapshot.OccurredAt);
+        var observedSnapshots = events.ToList();
         throw new TimeoutException(
-            $"Presence snapshots did not stabilize for {effectiveStableFor.TotalSeconds}s within {effectiveTimeout.TotalSeconds}s. " +
-            $"Observed {eligibleObservedSnapshots.Count} eligible snapshots " +
-            $"({allObservedSnapshots.Count} total); " +
-            $"newest member count was {last?.Members.Count ?? 0}.");
+            $"No presence snapshot contained the requested owner editing marker within {effectiveTimeout.TotalSeconds}s. " +
+            $"Observed {observedSnapshots.Count} total snapshots; " +
+            $"owner={ownerUserId:N}, marker={editingMarker:N}.");
     }
 
-    private static void AssertPresenceDidNotGrowAfterLeaves(
-        int settledJoinCount,
-        BoardPresenceSnapshot afterLeave)
+    private static void AssertPresenceMembers(
+        BoardPresenceSnapshot snapshot,
+        IEnumerable<Guid> expectedUserIds,
+        string phase)
     {
-        afterLeave.Members.Count.Should().BeLessThanOrEqualTo(settledJoinCount,
-            "presence count should not grow after members leave");
-        afterLeave.Members.Count.Should().BeGreaterThanOrEqualTo(1,
-            "the observer owner should always remain in presence");
+        var expected = expectedUserIds.Distinct().ToList();
+        snapshot.Members.Select(member => member.UserId).Should().BeEquivalentTo(expected,
+            $"the {phase} barrier should contain exactly the users whose hub operations succeeded");
     }
 
     [Fact]
-    public async Task PresenceStabilization_UsesServerOccurrenceOrder_WhenDeliveryIsReordered()
+    public async Task PresenceBarrier_UsesMarker_WhenTimestampsTieAndDeliveryIsReordered()
     {
         var boardId = Guid.NewGuid();
-        var phaseStartedAt = DateTimeOffset.UtcNow;
-        var newestSnapshot = new BoardPresenceSnapshot(
-            boardId,
-            [new BoardPresenceMember(Guid.NewGuid(), "Remaining", null)],
-            phaseStartedAt.AddMilliseconds(2));
-        var delayedOlderSnapshot = new BoardPresenceSnapshot(
+        var ownerUserId = Guid.NewGuid();
+        var remainingUserId = Guid.NewGuid();
+        var editingMarker = Guid.NewGuid();
+        var tiedOccurrence = DateTimeOffset.UtcNow;
+        var staleSnapshot = new BoardPresenceSnapshot(
             boardId,
             [
-                new BoardPresenceMember(Guid.NewGuid(), "Late A", null),
-                new BoardPresenceMember(Guid.NewGuid(), "Late B", null)
+                new BoardPresenceMember(ownerUserId, "Owner", null),
+                new BoardPresenceMember(Guid.NewGuid(), "Stale member", null),
+                new BoardPresenceMember(Guid.NewGuid(), "Stale growth", null)
             ],
-            phaseStartedAt.AddMilliseconds(1));
+            tiedOccurrence);
+        var barrierSnapshot = new BoardPresenceSnapshot(
+            boardId,
+            [
+                new BoardPresenceMember(ownerUserId, "Owner", editingMarker),
+                new BoardPresenceMember(remainingUserId, "Remaining", null)
+            ],
+            tiedOccurrence);
         var events = new EventCollector<BoardPresenceSnapshot>();
-        events.Add(newestSnapshot);
-        events.Add(delayedOlderSnapshot);
+        events.Add(staleSnapshot);
+        events.Add(barrierSnapshot);
 
-        var stabilized = await WaitForPresenceStabilizationAsync(
+        var selected = await WaitForPresenceBarrierAsync(
             events,
-            timeout: TimeSpan.FromSeconds(1),
-            stableFor: TimeSpan.FromMilliseconds(50));
+            ownerUserId,
+            editingMarker,
+            timeout: TimeSpan.FromSeconds(1));
 
-        stabilized.Should().BeSameAs(newestSnapshot,
-            "delivery order can differ from the tracker occurrence order");
+        selected.Should().BeSameAs(barrierSnapshot,
+            "the causal marker, not a tied timestamp or callback order, identifies current state");
+        AssertPresenceMembers(selected, [ownerUserId, remainingUserId], "post-leave");
     }
 
     [Fact]
-    public void PresenceStabilization_StillRejectsNewerGrowthAfterLeaves()
+    public async Task PresenceBarrier_StillRejectsGrowthAfterLeaves()
     {
-        var grownSnapshot = new BoardPresenceSnapshot(
-            Guid.NewGuid(),
+        var boardId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
+        var remainingUserId = Guid.NewGuid();
+        var unexpectedUserId = Guid.NewGuid();
+        var editingMarker = Guid.NewGuid();
+        var tiedOccurrence = DateTimeOffset.UtcNow;
+        var grownBarrierSnapshot = new BoardPresenceSnapshot(
+            boardId,
             [
-                new BoardPresenceMember(Guid.NewGuid(), "Owner", null),
-                new BoardPresenceMember(Guid.NewGuid(), "Member A", null),
-                new BoardPresenceMember(Guid.NewGuid(), "Member B", null),
-                new BoardPresenceMember(Guid.NewGuid(), "Unexpected growth", null)
+                new BoardPresenceMember(ownerUserId, "Owner", editingMarker),
+                new BoardPresenceMember(remainingUserId, "Remaining", null),
+                new BoardPresenceMember(unexpectedUserId, "Unexpected growth", null)
             ],
-            DateTimeOffset.UtcNow);
+            tiedOccurrence);
+        var delayedStaleSnapshot = new BoardPresenceSnapshot(
+            boardId,
+            [
+                new BoardPresenceMember(ownerUserId, "Owner", null),
+                new BoardPresenceMember(remainingUserId, "Remaining", null)
+            ],
+            tiedOccurrence);
+        var events = new EventCollector<BoardPresenceSnapshot>();
+        events.Add(grownBarrierSnapshot);
+        events.Add(delayedStaleSnapshot);
 
-        var act = () => AssertPresenceDidNotGrowAfterLeaves(3, grownSnapshot);
+        var selected = await WaitForPresenceBarrierAsync(
+            events,
+            ownerUserId,
+            editingMarker,
+            timeout: TimeSpan.FromSeconds(1));
+
+        var act = () => AssertPresenceMembers(
+            selected,
+            [ownerUserId, remainingUserId],
+            "post-leave");
 
         act.Should().Throw<Xunit.Sdk.XunitException>()
-            .WithMessage("*presence count should not grow after members leave*");
+            .WithMessage("*post-leave barrier should contain exactly*");
+    }
+
+    [Fact]
+    public async Task PresenceBarrier_WithoutMatchingMarker_ThrowsDiagnosticTimeout()
+    {
+        var ownerUserId = Guid.NewGuid();
+        var editingMarker = Guid.NewGuid();
+        var events = new EventCollector<BoardPresenceSnapshot>();
+        events.Add(new BoardPresenceSnapshot(
+            Guid.NewGuid(),
+            [new BoardPresenceMember(ownerUserId, "Owner", null)],
+            DateTimeOffset.UtcNow));
+
+        var act = () => WaitForPresenceBarrierAsync(
+            events,
+            ownerUserId,
+            editingMarker,
+            timeout: TimeSpan.FromMilliseconds(150));
+
+        await act.Should().ThrowAsync<TimeoutException>()
+            .WithMessage("*No presence snapshot contained the requested owner editing marker*Observed 1 total snapshots*");
     }
 
     /// <summary>
@@ -1001,7 +1031,7 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
         // errors (e.g., SQLite contention). We track join successes to set
         // correct expectations for the eventual-consistency assertion.
         var connections = new List<HubConnection>();
-        var joinedConnections = new ConcurrentBag<HubConnection>();
+        var joinedConnections = new ConcurrentBag<(HubConnection Connection, Guid UserId)>();
         try
         {
             using var joinBarrier = new Barrier(connectionCount + 1);
@@ -1015,7 +1045,7 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
                 try
                 {
                     await conn.InvokeAsync("JoinBoard", board.Id);
-                    joinedConnections.Add(conn);
+                    joinedConnections.Add((conn, user.UserId));
                 }
                 catch (Exception ex) when (ex is HubException or HttpRequestException)
                 {
@@ -1032,51 +1062,36 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             actualJoined.Should().BeGreaterThanOrEqualTo(1,
                 "at least one concurrent join must succeed to validate rapid join/leave behavior");
 
-            // Publish a causal snapshot after every join invocation has settled.
-            // Concurrent SignalR broadcasts are not guaranteed to arrive at the
-            // observer in tracker order, and the observer may not receive one
-            // distinct callback per successful invocation. The owner's existing
-            // no-op editing update supplies a current-state barrier snapshot.
-            var joinSnapshotBarrierAt = DateTimeOffset.UtcNow;
-            await observer.InvokeAsync("SetEditingCard", board.Id, (Guid?)null);
-
-            // Wait for presence to stabilize after the burst of joins.
-            // On resource-constrained CI runners, SignalR presence broadcasts
-            // from concurrent joins may take time to propagate. Rather than
-            // asserting an exact count (which is fragile when some joins
-            // succeed at the Hub level but the presence broadcast is delayed
-            // or coalesced), we wait for the snapshot to stop changing and
-            // then verify it settled to a reasonable value.
-            var afterJoin = await WaitForPresenceStabilizationAsync(
+            // Publish a uniquely identifiable current-state barrier after every
+            // join invocation settles. Earlier snapshots cannot contain this
+            // marker, so timestamp ties and callback reordering are irrelevant.
+            var joinEditingMarker = Guid.NewGuid();
+            await observer.InvokeAsync("SetEditingCard", board.Id, joinEditingMarker);
+            var afterJoin = await WaitForPresenceBarrierAsync(
                 observerEvents,
-                TimeSpan.FromSeconds(30),
-                TimeSpan.FromSeconds(2),
-                notBefore: joinSnapshotBarrierAt);
-            afterJoin.Should().NotBeNull("at least one presence snapshot should arrive after joins");
-            var settledJoinCount = afterJoin!.Members.Count;
-            // Must include the owner plus at least one joined user
-            settledJoinCount.Should().BeGreaterThanOrEqualTo(2,
-                "presence should include the owner plus at least one joined user");
-            // Should not exceed theoretical maximum (all joined + owner)
-            settledJoinCount.Should().BeLessThanOrEqualTo(actualJoined + 1,
-                "presence should not exceed the number of successfully joined users plus the owner");
+                owner.UserId,
+                joinEditingMarker,
+                TimeSpan.FromSeconds(30));
+            var expectedAfterJoin = joinedConnections
+                .Select(joined => joined.UserId)
+                .Append(owner.UserId)
+                .ToHashSet();
+            AssertPresenceMembers(afterJoin, expectedAfterJoin, "post-join");
 
             // First half of successfully-joined connections leave rapidly.
-            // Use the settled count from the join phase (not client-side
-            // joinedConnections count) to set realistic leave expectations.
             observerEvents.Clear();
             var leavingConns = joinedConnections.Take(Math.Max(1, joinedConnections.Count / 2)).ToList();
             leavingConns.Should().NotBeEmpty(
                 "rapid join/leave stress must attempt at least one leave");
-            var leaveSuccessCount = 0;
+            var leftUserIds = new ConcurrentBag<Guid>();
             using var leaveBarrier = new Barrier(leavingConns.Count + 1);
-            var leaveTasks = leavingConns.Select(async conn =>
+            var leaveTasks = leavingConns.Select(async leaving =>
             {
                 leaveBarrier.SignalAndWait(TimeSpan.FromSeconds(10));
                 try
                 {
-                    await conn.InvokeAsync("LeaveBoard", board.Id);
-                    Interlocked.Increment(ref leaveSuccessCount);
+                    await leaving.Connection.InvokeAsync("LeaveBoard", board.Id);
+                    leftUserIds.Add(leaving.UserId);
                 }
                 catch (Exception ex) when (ex is HubException or HttpRequestException)
                 {
@@ -1088,24 +1103,24 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             leaveBarrier.SignalAndWait(TimeSpan.FromSeconds(10));
             await Task.WhenAll(leaveTasks);
 
-            var actualLeft = Interlocked.CompareExchange(ref leaveSuccessCount, 0, 0);
+            var actualLeft = leftUserIds.Count;
             actualLeft.Should().BeGreaterThan(0,
                 "at least one LeaveBoard invocation must succeed to validate rapid leave behavior");
 
-            // Publish the same causal barrier after all leaves settle. Delayed
-            // join broadcasts have an earlier OccurredAt and are excluded; a
-            // genuinely newer growth snapshot still wins and fails the invariant.
-            var leaveSnapshotBarrierAt = DateTimeOffset.UtcNow;
-            await observer.InvokeAsync("SetEditingCard", board.Id, (Guid?)null);
-
-            // Wait for presence to stabilize after the burst of leaves.
-            var afterLeave = await WaitForPresenceStabilizationAsync(
+            // A second unique marker identifies the current state after every
+            // leave attempt. Exact identities prove each successful leave took
+            // effect; an unchanged/no-op leave can no longer pass by equality.
+            var leaveEditingMarker = Guid.NewGuid();
+            await observer.InvokeAsync("SetEditingCard", board.Id, leaveEditingMarker);
+            var afterLeave = await WaitForPresenceBarrierAsync(
                 observerEvents,
-                TimeSpan.FromSeconds(30),
-                TimeSpan.FromSeconds(2),
-                notBefore: leaveSnapshotBarrierAt);
-            afterLeave.Should().NotBeNull("at least one presence snapshot should arrive after leaves");
-            AssertPresenceDidNotGrowAfterLeaves(settledJoinCount, afterLeave!);
+                owner.UserId,
+                leaveEditingMarker,
+                TimeSpan.FromSeconds(30));
+            var expectedAfterLeave = expectedAfterJoin
+                .Except(leftUserIds)
+                .ToHashSet();
+            AssertPresenceMembers(afterLeave, expectedAfterLeave, "post-leave");
         }
         finally
         {

--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -841,17 +841,20 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
     // ── SignalR Presence Concurrency ────────────────────────────────────────
 
     /// <summary>
-    /// Waits for the presence snapshot to stabilize (no new events for
-    /// <paramref name="stableFor"/>) and returns the last snapshot.
-    /// Tracks total event count rather than member count so that events
+    /// Waits for eligible presence snapshots to stabilize (no new eligible
+    /// events for <paramref name="stableFor"/>) and returns the snapshot with
+    /// the newest server occurrence time. Tracks eligible event count rather
+    /// than member count so that events
     /// with the same member count (e.g., simultaneous join + leave) still
-    /// reset the stabilization timer. Throws when no stable window is observed
-    /// before timeout.
+    /// reset the stabilization timer. Snapshots older than <paramref name="notBefore"/>
+    /// are ignored so delayed delivery from a previous phase cannot become the
+    /// apparent final state. Throws when no stable window is observed before timeout.
     /// </summary>
     private static async Task<BoardPresenceSnapshot?> WaitForPresenceStabilizationAsync(
         EventCollector<BoardPresenceSnapshot> events,
         TimeSpan? timeout = null,
-        TimeSpan? stableFor = null)
+        TimeSpan? stableFor = null,
+        DateTimeOffset? notBefore = null)
     {
         var effectiveTimeout = timeout ?? TimeSpan.FromSeconds(30);
         var effectiveStableFor = stableFor ?? TimeSpan.FromSeconds(2);
@@ -862,27 +865,96 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
         while (DateTimeOffset.UtcNow < deadline)
         {
             var allSnapshots = events.ToList();
-            var currentEventCount = allSnapshots.Count;
+            var eligibleSnapshots = allSnapshots
+                .Where(snapshot => !notBefore.HasValue || snapshot.OccurredAt >= notBefore.Value)
+                .ToList();
+            var currentEventCount = eligibleSnapshots.Count;
 
             if (currentEventCount != lastEventCount)
             {
                 lastEventCount = currentEventCount;
                 lastChangeTime = DateTimeOffset.UtcNow;
             }
-            else if (currentEventCount > 0 && DateTimeOffset.UtcNow - lastChangeTime >= effectiveStableFor)
+            else if (currentEventCount > 0
+                && DateTimeOffset.UtcNow - lastChangeTime >= effectiveStableFor)
             {
-                // No new events have arrived for the required duration
-                return allSnapshots.Last();
+                // SignalR delivery order can differ from the order in which the
+                // tracker created snapshots. Return the newest server occurrence,
+                // not merely the last event delivered to this observer.
+                return eligibleSnapshots.MaxBy(snapshot => snapshot.OccurredAt);
             }
 
             await Task.Delay(50);
         }
 
-        var last = events.ToList().LastOrDefault();
-        var snapshotCount = events.ToList().Count;
+        var allObservedSnapshots = events.ToList();
+        var eligibleObservedSnapshots = allObservedSnapshots
+            .Where(snapshot => !notBefore.HasValue || snapshot.OccurredAt >= notBefore.Value)
+            .ToList();
+        var last = eligibleObservedSnapshots.MaxBy(snapshot => snapshot.OccurredAt);
         throw new TimeoutException(
             $"Presence snapshots did not stabilize for {effectiveStableFor.TotalSeconds}s within {effectiveTimeout.TotalSeconds}s. " +
-            $"Observed {snapshotCount} snapshots; last member count was {last?.Members.Count ?? 0}.");
+            $"Observed {eligibleObservedSnapshots.Count} eligible snapshots " +
+            $"({allObservedSnapshots.Count} total); " +
+            $"newest member count was {last?.Members.Count ?? 0}.");
+    }
+
+    private static void AssertPresenceDidNotGrowAfterLeaves(
+        int settledJoinCount,
+        BoardPresenceSnapshot afterLeave)
+    {
+        afterLeave.Members.Count.Should().BeLessThanOrEqualTo(settledJoinCount,
+            "presence count should not grow after members leave");
+        afterLeave.Members.Count.Should().BeGreaterThanOrEqualTo(1,
+            "the observer owner should always remain in presence");
+    }
+
+    [Fact]
+    public async Task PresenceStabilization_UsesServerOccurrenceOrder_WhenDeliveryIsReordered()
+    {
+        var boardId = Guid.NewGuid();
+        var phaseStartedAt = DateTimeOffset.UtcNow;
+        var newestSnapshot = new BoardPresenceSnapshot(
+            boardId,
+            [new BoardPresenceMember(Guid.NewGuid(), "Remaining", null)],
+            phaseStartedAt.AddMilliseconds(2));
+        var delayedOlderSnapshot = new BoardPresenceSnapshot(
+            boardId,
+            [
+                new BoardPresenceMember(Guid.NewGuid(), "Late A", null),
+                new BoardPresenceMember(Guid.NewGuid(), "Late B", null)
+            ],
+            phaseStartedAt.AddMilliseconds(1));
+        var events = new EventCollector<BoardPresenceSnapshot>();
+        events.Add(newestSnapshot);
+        events.Add(delayedOlderSnapshot);
+
+        var stabilized = await WaitForPresenceStabilizationAsync(
+            events,
+            timeout: TimeSpan.FromSeconds(1),
+            stableFor: TimeSpan.FromMilliseconds(50));
+
+        stabilized.Should().BeSameAs(newestSnapshot,
+            "delivery order can differ from the tracker occurrence order");
+    }
+
+    [Fact]
+    public void PresenceStabilization_StillRejectsNewerGrowthAfterLeaves()
+    {
+        var grownSnapshot = new BoardPresenceSnapshot(
+            Guid.NewGuid(),
+            [
+                new BoardPresenceMember(Guid.NewGuid(), "Owner", null),
+                new BoardPresenceMember(Guid.NewGuid(), "Member A", null),
+                new BoardPresenceMember(Guid.NewGuid(), "Member B", null),
+                new BoardPresenceMember(Guid.NewGuid(), "Unexpected growth", null)
+            ],
+            DateTimeOffset.UtcNow);
+
+        var act = () => AssertPresenceDidNotGrowAfterLeaves(3, grownSnapshot);
+
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*presence count should not grow after members leave*");
     }
 
     /// <summary>
@@ -960,6 +1032,14 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             actualJoined.Should().BeGreaterThanOrEqualTo(1,
                 "at least one concurrent join must succeed to validate rapid join/leave behavior");
 
+            // Publish a causal snapshot after every join invocation has settled.
+            // Concurrent SignalR broadcasts are not guaranteed to arrive at the
+            // observer in tracker order, and the observer may not receive one
+            // distinct callback per successful invocation. The owner's existing
+            // no-op editing update supplies a current-state barrier snapshot.
+            var joinSnapshotBarrierAt = DateTimeOffset.UtcNow;
+            await observer.InvokeAsync("SetEditingCard", board.Id, (Guid?)null);
+
             // Wait for presence to stabilize after the burst of joins.
             // On resource-constrained CI runners, SignalR presence broadcasts
             // from concurrent joins may take time to propagate. Rather than
@@ -968,7 +1048,10 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             // or coalesced), we wait for the snapshot to stop changing and
             // then verify it settled to a reasonable value.
             var afterJoin = await WaitForPresenceStabilizationAsync(
-                observerEvents, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2));
+                observerEvents,
+                TimeSpan.FromSeconds(30),
+                TimeSpan.FromSeconds(2),
+                notBefore: joinSnapshotBarrierAt);
             afterJoin.Should().NotBeNull("at least one presence snapshot should arrive after joins");
             var settledJoinCount = afterJoin!.Members.Count;
             // Must include the owner plus at least one joined user
@@ -1009,15 +1092,20 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             actualLeft.Should().BeGreaterThan(0,
                 "at least one LeaveBoard invocation must succeed to validate rapid leave behavior");
 
+            // Publish the same causal barrier after all leaves settle. Delayed
+            // join broadcasts have an earlier OccurredAt and are excluded; a
+            // genuinely newer growth snapshot still wins and fails the invariant.
+            var leaveSnapshotBarrierAt = DateTimeOffset.UtcNow;
+            await observer.InvokeAsync("SetEditingCard", board.Id, (Guid?)null);
+
             // Wait for presence to stabilize after the burst of leaves.
             var afterLeave = await WaitForPresenceStabilizationAsync(
-                observerEvents, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(2));
+                observerEvents,
+                TimeSpan.FromSeconds(30),
+                TimeSpan.FromSeconds(2),
+                notBefore: leaveSnapshotBarrierAt);
             afterLeave.Should().NotBeNull("at least one presence snapshot should arrive after leaves");
-            var settledLeaveCount = afterLeave!.Members.Count;
-            settledLeaveCount.Should().BeLessThanOrEqualTo(settledJoinCount,
-                "presence count should not grow after members leave");
-            settledLeaveCount.Should().BeGreaterThanOrEqualTo(1,
-                "the observer owner should always remain in presence");
+            AssertPresenceDidNotGrowAfterLeaves(settledJoinCount, afterLeave!);
         }
         finally
         {

--- a/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConcurrencyRaceConditionStressTests.cs
@@ -909,25 +909,31 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             .ToList();
 
     /// <summary>
-    /// Asserts every successful join was delivered to the observer as a presence
-    /// broadcast, not merely reflected in the marker snapshot. Fails closed when
-    /// every JoinBoard broadcast is dropped/suppressed (no non-marker delta
-    /// reaches the observer) or when a joined identity never appears in any delta.
+    /// Asserts every successful join was delivered to the observer as its own
+    /// presence broadcast, not merely reflected in the marker snapshot. Each
+    /// JoinBoard publishes exactly one snapshot, and the owner marker fence keeps
+    /// stragglers out of the phase window, so a per-phase count floor catches the
+    /// case where some (not all) join broadcasts are dropped — full-state
+    /// snapshots would otherwise let a later cumulative delta mask an earlier
+    /// suppressed one. Fails closed when any join broadcast is suppressed or a
+    /// joined identity never appears in a delta (issue #1371).
     /// </summary>
     private static void AssertJoinBroadcastsObserved(
         IReadOnlyList<BoardPresenceSnapshot> phaseBroadcasts,
         IEnumerable<Guid> joinedUserIds)
     {
-        phaseBroadcasts.Should().NotBeEmpty(
-            "the join burst must reach the observer as at least one presence broadcast " +
+        var expectedIds = joinedUserIds.Distinct().ToList();
+
+        phaseBroadcasts.Count.Should().BeGreaterThanOrEqualTo(expectedIds.Count,
+            "every successful join must reach the observer as its own presence broadcast " +
             "distinct from the SetEditingCard marker snapshot; otherwise the test proves " +
-            "tracker membership but not join delivery (issue #1371)");
+            "tracker membership but not per-join delivery (issue #1371)");
 
         var deliveredUserIds = phaseBroadcasts
             .SelectMany(snapshot => snapshot.Members.Select(member => member.UserId))
             .ToHashSet();
 
-        foreach (var joinedUserId in joinedUserIds.Distinct())
+        foreach (var joinedUserId in expectedIds)
         {
             deliveredUserIds.Should().Contain(joinedUserId,
                 "every successful join must be visible in an observed join-originated presence " +
@@ -936,21 +942,29 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
     }
 
     /// <summary>
-    /// Asserts every successful leave was delivered to the observer as a shrink
-    /// broadcast (the leaving member absent), not merely reflected in the marker
-    /// snapshot. Fails closed when every LeaveBoard broadcast is dropped, or when
-    /// a supposedly-left identity is still present in every observed delta.
+    /// Asserts every successful leave was delivered to the observer as its own
+    /// shrink broadcast, not merely reflected in the marker snapshot. Because hub
+    /// broadcasts are full-state snapshots, a leaver is absent from every later
+    /// snapshot once removed — so a bare "absent from some delta" check would pass
+    /// even if that leaver's own LeaveBoard broadcast was dropped and only a
+    /// co-leaver's arrived. Each LeaveBoard publishes exactly one snapshot and the
+    /// marker fence keeps stragglers out of the phase window, so the per-phase
+    /// count floor requires one delivered broadcast per successful leave. Fails
+    /// closed when any leave broadcast is suppressed, or when a supposedly-left
+    /// identity is still present in every observed delta (issue #1371).
     /// </summary>
     private static void AssertLeaveBroadcastsObserved(
         IReadOnlyList<BoardPresenceSnapshot> phaseBroadcasts,
         IEnumerable<Guid> leftUserIds)
     {
-        phaseBroadcasts.Should().NotBeEmpty(
-            "each leave must reach the observer as at least one presence broadcast distinct " +
-            "from the SetEditingCard marker snapshot; otherwise the test proves tracker " +
-            "membership but not leave delivery (issue #1371)");
+        var expectedIds = leftUserIds.Distinct().ToList();
 
-        foreach (var leftUserId in leftUserIds.Distinct())
+        phaseBroadcasts.Count.Should().BeGreaterThanOrEqualTo(expectedIds.Count,
+            "every successful leave must reach the observer as its own presence broadcast " +
+            "distinct from the SetEditingCard marker snapshot; otherwise a co-leaver's " +
+            "full-state snapshot could mask a suppressed leave broadcast (issue #1371)");
+
+        foreach (var leftUserId in expectedIds)
         {
             phaseBroadcasts.Should().Contain(
                 snapshot => snapshot.Members.All(member => member.UserId != leftUserId),
@@ -1072,7 +1086,7 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
     [Theory]
     [InlineData("JoinBoard")]
     [InlineData("LeaveBoard")]
-    public async Task PresenceMutation_PostMutationFailure_DivergesFromCommittedTrackerAndFailsClosed(
+    public async Task PresenceMutation_PostMutationFailure_CommitsTrackerStateThenFailsClosed(
         string operation)
     {
         // Production ordering (BoardsHub.cs): JoinBoard mutates the tracker at :37
@@ -1129,9 +1143,12 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
             .Which.Should().BeSameAs(broadcastFailure,
                 $"the ambiguous {operation} failure must propagate unchanged so the scenario aborts");
 
-        // The exact divergence fail-closed guards against: the committed tracker
-        // reflects the mutation, but the expectation set does not — tolerating the
-        // failure would let the exact-membership assertion drift from server state.
+        // The committed tracker already reflects the mutation (asserted above), but
+        // the expectation set is never updated because the broadcast failed. For a
+        // JoinBoard this is an outright divergence (tracker has the member, the
+        // expectation set does not); for a LeaveBoard the risk is the mirror image
+        // under different timing. Either way the fail-closed helper must abort
+        // rather than silently record an ambiguous outcome.
         recordedSuccessUserIds.Should().NotContain(subjectUserId,
             "a post-mutation broadcast failure is ambiguous and must never be recorded as a success");
     }
@@ -1177,7 +1194,7 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
         phaseBroadcasts.Should().BeEmpty();
         var act = () => AssertJoinBroadcastsObserved(phaseBroadcasts, [joinedUserId]);
         act.Should().Throw<Xunit.Sdk.XunitException>()
-            .WithMessage("*at least one presence broadcast*");
+            .WithMessage("*its own presence broadcast*");
     }
 
     [Fact]
@@ -1242,7 +1259,7 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
         phaseBroadcasts.Should().BeEmpty();
         var act = () => AssertLeaveBroadcastsObserved(phaseBroadcasts, [Guid.NewGuid()]);
         act.Should().Throw<Xunit.Sdk.XunitException>()
-            .WithMessage("*at least one presence broadcast*");
+            .WithMessage("*its own presence broadcast*");
     }
 
     [Fact]
@@ -1265,6 +1282,60 @@ public class ConcurrencyRaceConditionStressTests : IClassFixture<TestWebApplicat
 
         var act = () => AssertLeaveBroadcastsObserved(phaseBroadcasts, [stillPresentLeaver]);
         act.Should().Throw<Xunit.Sdk.XunitException>();
+    }
+
+    [Fact]
+    public void JoinBroadcastAssertion_FailsClosed_WhenSomeJoinBroadcastsDropped()
+    {
+        // Two joins, but only one cumulative delta reached the observer (the other
+        // JoinBoard broadcast was dropped). Because snapshots are full-state, the
+        // surviving delta carries both identities, so the union check alone would
+        // false-green; the per-join count floor catches the missing broadcast.
+        var ownerUserId = Guid.NewGuid();
+        var firstJoiner = Guid.NewGuid();
+        var secondJoiner = Guid.NewGuid();
+        var marker = Guid.NewGuid();
+        var observed = new[]
+        {
+            SnapshotWith([(ownerUserId, null), (firstJoiner, null), (secondJoiner, null)]),
+            SnapshotWith([(ownerUserId, marker), (firstJoiner, null), (secondJoiner, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(observed, ownerUserId, marker);
+
+        phaseBroadcasts.Should().HaveCount(1, "only one join delta survived");
+        var act = () => AssertJoinBroadcastsObserved(phaseBroadcasts, [firstJoiner, secondJoiner]);
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*per-join delivery*");
+    }
+
+    [Fact]
+    public void LeaveBroadcastAssertion_FailsClosed_WhenSomeLeaveBroadcastsDropped()
+    {
+        // Two leaves, but only the co-leaver's shrink delta reached the observer
+        // (the other LeaveBoard broadcast was dropped). Both leavers are absent
+        // from the surviving full-state delta, so the bare absence check alone
+        // would false-green; the per-leave count floor catches the missing
+        // broadcast. This is the exact partial-suppression gap flagged in review.
+        var ownerUserId = Guid.NewGuid();
+        var priorMarker = Guid.NewGuid();
+        var leaveMarker = Guid.NewGuid();
+        var stayer = Guid.NewGuid();
+        var firstLeaver = Guid.NewGuid();
+        var secondLeaver = Guid.NewGuid();
+        var observed = new[]
+        {
+            // Only the second leave's snapshot survives; both leavers already absent.
+            SnapshotWith([(ownerUserId, priorMarker), (stayer, null)]),
+            SnapshotWith([(ownerUserId, leaveMarker), (stayer, null)])
+        };
+
+        var phaseBroadcasts = SelectPhaseBroadcasts(observed, ownerUserId, leaveMarker);
+
+        phaseBroadcasts.Should().HaveCount(1, "only one leave delta survived");
+        var act = () => AssertLeaveBroadcastsObserved(phaseBroadcasts, [firstLeaver, secondLeaver]);
+        act.Should().Throw<Xunit.Sdk.XunitException>()
+            .WithMessage("*its own presence broadcast*");
     }
 
     private static BoardPresenceSnapshot SnapshotWith(


### PR DESCRIPTION
## Summary

- replace wall-clock snapshot ordering with a uniquely identifiable owner editing-state barrier
- assert the exact owner + successful-join identities after the join phase
- assert the exact joined set minus successful-leave identities after the leave phase
- add tied-timestamp/reordered delivery, integrated growth, and zero-match timeout regressions

## Root cause

Concurrent SignalR broadcasts can reach the observer in a different order than the in-memory tracker created them. The original helper returned the last callback; the first repair selected `MaxBy(OccurredAt)` behind a client wall-clock cutoff. Two independent reviews showed that `DateTimeOffset.UtcNow` ties are routine and cannot establish causal order, while the relaxed count assertions could false-green both lost successful joins and successful no-op leaves.

The repaired test invokes `SetEditingCard` with a fresh marker only after each concurrent phase settles. No pre-barrier snapshot can contain that marker, so callback order and tied timestamps cannot select stale state. The marker snapshot is then checked against exact user identities rather than a count range.

An earlier event-count attempt was also disproved locally: two successful leave invocations produced only one eligible observer callback. The final contract therefore does not assume one broadcast callback per invocation.

## Review resolution

- both independent initial-head reviews found the same three MEDIUM false-green paths; all are fixed in `1f4bfd6d`
- the Codex no-op-leave thread is fixed, directly replied to, and resolved
- the Gemini empty-reference-`MaxBy` report was invalid under .NET 8; the helper no longer uses `MaxBy`, and an explicit diagnostic-timeout regression locks the intended contract
- two fresh independent exact-head re-reviews and fresh Codex automation are in progress

## Verification — exact `1f4bfd6d022d4f883299607ccebe8035b3dd73a9`

- repaired barrier/negative/timeout + real stress: 4/4 passed
- real rapid join/leave repeated serially: 5/5 passed
- presence-focused API slice: 22/22 passed
- Release solution build: 0 errors / 12 pre-existing warnings
- serialized full backend: 7,225 passed / 0 failed / 1 known INV-09 skip
- docs governance, golden principles, base-to-head diff check, and clean worktree: passed

## Scope

Test/harness only. Production hub, tracker, frontend, API contracts, and canonical product docs are unchanged.

Closes #1365