### PR TITLE
Fail closed on separator-only AllowedHosts in standalone MCP host security

### DIFF
--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -115,6 +115,11 @@ if (args.Contains("--mcp"))
 
         var mcpHttpApp = mcpHttpBuilder.Build();
 
+        // Test seam: lets the standalone MCP host-filtering integration test observe the
+        // built app when it drives this real entry point in-process, so it can await
+        // startup and stop the host cleanly. Never set in production.
+        Program.OnStandaloneMcpHttpAppBuilt?.Invoke(mcpHttpApp);
+
         // Apply EF Core migrations before starting, serialized across processes via a
         // cross-process file lock so the MCP HTTP host does not race the API/CLI (#1164).
         using (var scope = mcpHttpApp.Services.CreateScope())
@@ -423,6 +428,13 @@ public partial class Program
     internal const string StandaloneMcpDefaultBindHost = "127.0.0.1";
     internal const string StandaloneMcpLoopbackAllowedHosts = "localhost;127.0.0.1;[::1]";
 
+    /// <summary>
+    /// Test seam for the standalone MCP HTTP integration test (see
+    /// <c>StandaloneMcpHostFilteringTests</c>): invoked with the built app just before it
+    /// runs, so the test can await startup and stop the host. Never set in production.
+    /// </summary>
+    internal static Action<WebApplication>? OnStandaloneMcpHttpAppBuilt;
+
     internal static void ApplyStandaloneMcpHostSecurity(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -430,12 +442,20 @@ public partial class Program
         var configuredHosts = configuration["AllowedHosts"]?
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             ?? Array.Empty<string>();
-        var containsAnyHost = configuredHosts.Any(host => host is "*" or "0.0.0.0" or "[::]");
 
-        // Fail closed to the loopback allowlist whenever the configured value parses to zero
-        // non-empty hosts (blank, or separator-only such as ";" / ";;" / " ; ") -- which
-        // HostFilteringMiddleware would otherwise treat as "no filter" and allow every host --
-        // or when it names an any-host wildcard.
+        // Normalize each token the same way HostFilteringMiddleware does: it parses every
+        // configured entry through HostString (stripping any :port suffix) BEFORE its own
+        // top-level-wildcard test, so a port-suffixed wildcard like "0.0.0.0:5001" or
+        // "*:5000" would disable host filtering despite not being an exact wildcard token.
+        var containsAnyHost = configuredHosts
+            .Any(host => new HostString(host).Host is "*" or "0.0.0.0" or "[::]");
+
+        // Fail closed to the loopback allowlist on any misconfigured value. The middleware
+        // splits with RemoveEmptyEntries only (no TrimEntries): ";" / ";;" parse to zero
+        // entries, which disables filtering entirely (every host allowed), while " ; "
+        // parses to whitespace-only entries, an active filter that rejects every host.
+        // Both are misconfigurations, so any value whose trimmed parse yields no hosts is
+        // replaced -- as is any value naming an any-host wildcard.
         if (configuredHosts.Length == 0 || containsAnyHost)
         {
             configuration["AllowedHosts"] = StandaloneMcpLoopbackAllowedHosts;

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -443,12 +443,18 @@ public partial class Program
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             ?? Array.Empty<string>();
 
-        // Normalize each token the same way HostFilteringMiddleware does: it parses every
-        // configured entry through HostString (stripping any :port suffix) BEFORE its own
-        // top-level-wildcard test, so a port-suffixed wildcard like "0.0.0.0:5001" or
-        // "*:5000" would disable host filtering despite not being an exact wildcard token.
+        // Mirror HostFilteringMiddleware exactly: it normalizes each configured entry via
+        // new HostString(entry).ToUriComponent() -- which RETAINS any :port suffix (and
+        // punycodes unicode hosts) -- before its ordinal IsTopLevelWildcard test for
+        // "*" / "0.0.0.0" / "[::]". A port-suffixed entry like "0.0.0.0:5001" is therefore
+        // NOT a wildcard to the middleware: it becomes a literal pattern that no real Host
+        // header can match (request hosts are compared portless), i.e. it already fails
+        // closed on its own and must be PRESERVED here. Rewriting it to the loopback
+        // allowlist would be strictly weaker -- on a non-loopback bind it would admit
+        // spoofed loopback Host headers that the literal pattern rejects. Do not switch
+        // this to HostString.Host (port-stripping) without re-reading the middleware source.
         var containsAnyHost = configuredHosts
-            .Any(host => new HostString(host).Host is "*" or "0.0.0.0" or "[::]");
+            .Any(host => new HostString(host).ToUriComponent() is "*" or "0.0.0.0" or "[::]");
 
         // Fail closed to the loopback allowlist on any misconfigured value. The middleware
         // splits with RemoveEmptyEntries only (no TrimEntries): ";" / ";;" parse to zero

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -427,11 +427,16 @@ public partial class Program
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
-        var allowedHosts = configuration["AllowedHosts"];
-        var containsAnyHost = allowedHosts?
+        var configuredHosts = configuration["AllowedHosts"]?
             .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Any(host => host is "*" or "0.0.0.0" or "[::]") == true;
-        if (string.IsNullOrWhiteSpace(allowedHosts) || containsAnyHost)
+            ?? Array.Empty<string>();
+        var containsAnyHost = configuredHosts.Any(host => host is "*" or "0.0.0.0" or "[::]");
+
+        // Fail closed to the loopback allowlist whenever the configured value parses to zero
+        // non-empty hosts (blank, or separator-only such as ";" / ";;" / " ; ") -- which
+        // HostFilteringMiddleware would otherwise treat as "no filter" and allow every host --
+        // or when it names an any-host wildcard.
+        if (configuredHosts.Length == 0 || containsAnyHost)
         {
             configuration["AllowedHosts"] = StandaloneMcpLoopbackAllowedHosts;
         }

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -439,29 +439,26 @@ public partial class Program
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
+        // Single rule: rewrite exactly when HostFilteringMiddleware itself would DISABLE
+        // filtering; every other value is preserved because the middleware fails closed on
+        // it. To decide that, mirror the middleware's parse EXACTLY:
+        //   1. Split(';', RemoveEmptyEntries) with NO trimming -- so null/""/";"/";;" parse
+        //      to zero entries (the middleware then falls back to allow-all: the true #1367
+        //      fail-open), while whitespace-bearing values like " ; " or " * " parse to
+        //      literal whitespace entries, an ACTIVE filter that rejects every real host.
+        //   2. Normalize each entry via new HostString(entry).ToUriComponent() -- which
+        //      RETAINS any :port suffix -- before the ordinal top-level-wildcard test for
+        //      "*" / "0.0.0.0" / "[::]". Port-suffixed pseudo-wildcards ("0.0.0.0:5001")
+        //      are therefore literals no real Host header matches, i.e. deny-all.
+        // Rewriting any of those fail-closed literals to the loopback allowlist would be
+        // strictly WEAKER (spoofed loopback Host headers would pass on a non-loopback
+        // bind), so they are preserved. Do not reintroduce TrimEntries or HostString.Host
+        // (port-stripping) here without re-reading the middleware source.
         var configuredHosts = configuration["AllowedHosts"]?
-            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Split(';', StringSplitOptions.RemoveEmptyEntries)
             ?? Array.Empty<string>();
-
-        // Mirror HostFilteringMiddleware exactly: it normalizes each configured entry via
-        // new HostString(entry).ToUriComponent() -- which RETAINS any :port suffix (and
-        // punycodes unicode hosts) -- before its ordinal IsTopLevelWildcard test for
-        // "*" / "0.0.0.0" / "[::]". A port-suffixed entry like "0.0.0.0:5001" is therefore
-        // NOT a wildcard to the middleware: it becomes a literal pattern that no real Host
-        // header can match (request hosts are compared portless), i.e. it already fails
-        // closed on its own and must be PRESERVED here. Rewriting it to the loopback
-        // allowlist would be strictly weaker -- on a non-loopback bind it would admit
-        // spoofed loopback Host headers that the literal pattern rejects. Do not switch
-        // this to HostString.Host (port-stripping) without re-reading the middleware source.
         var containsAnyHost = configuredHosts
             .Any(host => new HostString(host).ToUriComponent() is "*" or "0.0.0.0" or "[::]");
-
-        // Fail closed to the loopback allowlist on any misconfigured value. The middleware
-        // splits with RemoveEmptyEntries only (no TrimEntries): ";" / ";;" parse to zero
-        // entries, which disables filtering entirely (every host allowed), while " ; "
-        // parses to whitespace-only entries, an active filter that rejects every host.
-        // Both are misconfigurations, so any value whose trimmed parse yields no hosts is
-        // replaced -- as is any value naming an any-host wildcard.
         if (configuredHosts.Length == 0 || containsAnyHost)
         {
             configuration["AllowedHosts"] = StandaloneMcpLoopbackAllowedHosts;

--- a/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
@@ -447,6 +447,9 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     [InlineData("0.0.0.0")]
     [InlineData("[::]")]
     [InlineData("mcp.example.test;[::]")]
+    [InlineData(";")]
+    [InlineData(";;")]
+    [InlineData(" ; ")]
     public void StandaloneMcpHostSecurity_ReplacesPermissiveAllowedHosts(string? configuredHosts)
     {
         var configuration = new ConfigurationBuilder()
@@ -461,19 +464,22 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
         configuration["AllowedHosts"].Should().Be(Program.StandaloneMcpLoopbackAllowedHosts);
     }
 
-    [Fact]
-    public void StandaloneMcpHostSecurity_PreservesExplicitAllowedHosts()
+    [Theory]
+    [InlineData("mcp.example.test")]
+    [InlineData("mcp.example.com")]
+    [InlineData("good; ;")]
+    public void StandaloneMcpHostSecurity_PreservesExplicitAllowedHosts(string configuredHosts)
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["AllowedHosts"] = "mcp.example.test"
+                ["AllowedHosts"] = configuredHosts
             })
             .Build();
 
         Program.ApplyStandaloneMcpHostSecurity(configuration);
 
-        configuration["AllowedHosts"].Should().Be("mcp.example.test");
+        configuration["AllowedHosts"].Should().Be(configuredHosts);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
@@ -438,18 +438,20 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
         activity.GetTagItem("http.status_code").Should().Be((int)HttpStatusCode.Unauthorized);
     }
 
+    // Rewritten exactly when HostFilteringMiddleware itself would disable filtering: its
+    // parse (Split(';', RemoveEmptyEntries), no trimming) yields zero entries -- null,
+    // blank, ";" and ";;" -- or contains a top-level wildcard as the middleware would see
+    // it after HostString.ToUriComponent() normalization.
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("*")]
-    [InlineData(" * ")]
     [InlineData("localhost;*")]
     [InlineData("0.0.0.0")]
     [InlineData("[::]")]
     [InlineData("mcp.example.test;[::]")]
     [InlineData(";")]
     [InlineData(";;")]
-    [InlineData(" ; ")]
     public void StandaloneMcpHostSecurity_ReplacesPermissiveAllowedHosts(string? configuredHosts)
     {
         var configuration = new ConfigurationBuilder()
@@ -476,10 +478,18 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     // an operator misconfiguration that already fails closed (deny-all). Rewriting them to
     // the loopback allowlist would WEAKEN that (spoofed loopback Host headers would pass on
     // a non-loopback bind).
+    //
+    // Whitespace-bearing values (" ; ", " * ") are preserved for the same reason: the
+    // middleware splits with RemoveEmptyEntries but does NOT trim, so they parse to
+    // whitespace/padded literal entries -- an ACTIVE deny-all filter, not allow-all. Only
+    // values the middleware parses to zero entries (";", ";;", blank) disable filtering
+    // and are rewritten.
     [Theory]
     [InlineData("mcp.example.test")]
     [InlineData("mcp.example.com")]
     [InlineData("good; ;")]
+    [InlineData(" ; ")]
+    [InlineData(" * ")]
     [InlineData("0.0.0.0:5001")]
     [InlineData("*:5000")]
     [InlineData("[::]:80")]

--- a/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
@@ -450,6 +450,10 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     [InlineData(";")]
     [InlineData(";;")]
     [InlineData(" ; ")]
+    [InlineData("0.0.0.0:5001")]
+    [InlineData("*:5000")]
+    [InlineData("[::]:80")]
+    [InlineData("good.example;0.0.0.0:5001")]
     public void StandaloneMcpHostSecurity_ReplacesPermissiveAllowedHosts(string? configuredHosts)
     {
         var configuration = new ConfigurationBuilder()
@@ -464,6 +468,10 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
         configuration["AllowedHosts"].Should().Be(Program.StandaloneMcpLoopbackAllowedHosts);
     }
 
+    // Contract: a valid operator-supplied allowlist is preserved byte-for-byte -- the guard
+    // never normalizes or rewrites a value that names at least one real host (e.g. "good; ;"
+    // keeps its separator noise; the middleware parses out the real host itself). Making the
+    // guard normalize valid configs would be a deliberate contract change, not a cleanup.
     [Theory]
     [InlineData("mcp.example.test")]
     [InlineData("mcp.example.com")]

--- a/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
@@ -450,10 +450,6 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     [InlineData(";")]
     [InlineData(";;")]
     [InlineData(" ; ")]
-    [InlineData("0.0.0.0:5001")]
-    [InlineData("*:5000")]
-    [InlineData("[::]:80")]
-    [InlineData("good.example;0.0.0.0:5001")]
     public void StandaloneMcpHostSecurity_ReplacesPermissiveAllowedHosts(string? configuredHosts)
     {
         var configuration = new ConfigurationBuilder()
@@ -472,10 +468,22 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     // never normalizes or rewrites a value that names at least one real host (e.g. "good; ;"
     // keeps its separator noise; the middleware parses out the real host itself). Making the
     // guard normalize valid configs would be a deliberate contract change, not a cleanup.
+    //
+    // Port-suffixed wildcard-LOOKING entries ("0.0.0.0:5001", "*:5000", "[::]:80") are also
+    // preserved: HostFilteringMiddleware normalizes entries via HostString.ToUriComponent(),
+    // which retains the port, so its IsTopLevelWildcard test does NOT match them -- they are
+    // literal patterns no real Host header can match (request hosts are compared portless),
+    // an operator misconfiguration that already fails closed (deny-all). Rewriting them to
+    // the loopback allowlist would WEAKEN that (spoofed loopback Host headers would pass on
+    // a non-loopback bind).
     [Theory]
     [InlineData("mcp.example.test")]
     [InlineData("mcp.example.com")]
     [InlineData("good; ;")]
+    [InlineData("0.0.0.0:5001")]
+    [InlineData("*:5000")]
+    [InlineData("[::]:80")]
+    [InlineData("good.example;0.0.0.0:5001")]
     public void StandaloneMcpHostSecurity_PreservesExplicitAllowedHosts(string configuredHosts)
     {
         var configuration = new ConfigurationBuilder()

--- a/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
@@ -1,0 +1,166 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class StandaloneMcpHostCollection
+{
+    public const string Name = "StandaloneMcpHttpHost";
+}
+
+/// <summary>
+/// End-to-end proof for #1367: boots the REAL standalone MCP HTTP entry point
+/// (<c>--mcp --transport http</c>, the only caller of
+/// <see cref="Program.ApplyStandaloneMcpHostSecurity"/>) in-process with the hostile
+/// separator-only <c>AllowedHosts</c> value and verifies that the rewrite actually reaches
+/// HostFilteringMiddleware: a hostile Host header is rejected with 400 while a loopback Host
+/// passes host filtering (401 missing-API-key is the pass signal). Deleting the
+/// Program.cs guard call, or breaking the post-CreateBuilder config-mutation propagation
+/// into HostFilteringOptions, fails this test. Runs in a non-parallelized collection
+/// because it mutates process-wide environment variables and drives the assembly entry
+/// point, which must not race another test's host bootstrapping.
+/// </summary>
+[Collection(StandaloneMcpHostCollection.Name)]
+public class StandaloneMcpHostFilteringTests
+{
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(120);
+    private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task StandaloneMcpHttpHost_SeparatorOnlyAllowedHosts_FailsClosedToLoopbackFiltering()
+    {
+        var port = ReserveFreeLoopbackPort();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-mcp-hostfilter-{Guid.NewGuid():N}.db");
+        var originalEnvironment = new Dictionary<string, string?>
+        {
+            ["ConnectionStrings__DefaultConnection"] =
+                Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection"),
+            ["Connectors__EncryptionKey"] = Environment.GetEnvironmentVariable("Connectors__EncryptionKey"),
+            ["AllowedHosts"] = Environment.GetEnvironmentVariable("AllowedHosts")
+        };
+
+        var appBuilt = new TaskCompletionSource<WebApplication>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Program.OnStandaloneMcpHttpAppBuilt = app => appBuilt.TrySetResult(app);
+
+        WebApplication? runningApp = null;
+        try
+        {
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            Environment.SetEnvironmentVariable(
+                "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
+            // The exact #1367 fail-open trigger: separator-only, so IsNullOrWhiteSpace is
+            // false while the middleware would parse it to zero hosts and allow every host.
+            Environment.SetEnvironmentVariable("AllowedHosts", ";");
+
+            var entryPoint = typeof(Program).Assembly.EntryPoint
+                ?? throw new InvalidOperationException("Taskdeck.Api assembly has no entry point.");
+            var args = new[] { "--mcp", "--transport", "http", "--port", port.ToString() };
+            var hostTask = Task.Run(() => (int)entryPoint.Invoke(null, new object[] { args })!);
+
+            // Surface a startup crash directly instead of masking it behind a timeout.
+            var completed = await Task.WhenAny(appBuilt.Task, hostTask).WaitAsync(StartupTimeout);
+            if (completed == hostTask)
+            {
+                var earlyExit = await hostTask;
+                throw new InvalidOperationException(
+                    $"Standalone MCP host exited during startup with code {earlyExit}.");
+            }
+
+            var app = await appBuilt.Task;
+            runningApp = app;
+
+            // The guard must have rewritten the hostile value before the host was built.
+            app.Configuration["AllowedHosts"].Should().Be(Program.StandaloneMcpLoopbackAllowedHosts);
+
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            app.Lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+            await started.Task.WaitAsync(StartupTimeout);
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") };
+
+            // (a) Hostile Host header: HostFilteringMiddleware must reject it with 400.
+            using (var hostileRequest = new HttpRequestMessage(HttpMethod.Post, "/mcp"))
+            {
+                hostileRequest.Headers.Host = "evil.example";
+                using var hostileResponse = await client.SendAsync(hostileRequest);
+                hostileResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+                    "a Host header outside the loopback allowlist must be rejected by host filtering");
+            }
+
+            // (b) Loopback Host (127.0.0.1:{port}, set by HttpClient from the base address):
+            // must pass host filtering and reach ApiKeyMiddleware, which rejects the missing
+            // API key with 401 -- the expected pass signal, and specifically NOT 400.
+            using (var loopbackRequest = new HttpRequestMessage(HttpMethod.Post, "/mcp"))
+            {
+                using var loopbackResponse = await client.SendAsync(loopbackRequest);
+                loopbackResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+                    "a loopback Host must pass host filtering and reach API key authentication");
+            }
+
+            await app.StopAsync();
+            runningApp = null;
+            var exitCode = await hostTask.WaitAsync(ShutdownTimeout);
+            exitCode.Should().Be(0, "the standalone MCP host must shut down cleanly");
+        }
+        finally
+        {
+            Program.OnStandaloneMcpHttpAppBuilt = null;
+            if (runningApp is not null)
+            {
+                // Best-effort teardown on the failure path only; assertions above already
+                // report the real failure and a secondary stop error must not mask it.
+                try
+                {
+                    await runningApp.StopAsync();
+                }
+                catch
+                {
+                }
+            }
+
+            foreach (var (name, value) in originalEnvironment)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+
+            TryDeleteDatabase(dbPath);
+        }
+    }
+
+    private static int ReserveFreeLoopbackPort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try
+        {
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
+
+    private static void TryDeleteDatabase(string dbPath)
+    {
+        // Release pooled SQLite handles so Windows allows the delete.
+        SqliteConnection.ClearAllPools();
+        foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch (IOException)
+            {
+                // Temp files; leaking one on a locked handle is not a test failure.
+            }
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
@@ -46,7 +46,16 @@ public class StandaloneMcpHostFilteringTests
         };
 
         var appBuilt = new TaskCompletionSource<WebApplication>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Program.OnStandaloneMcpHttpAppBuilt = app => appBuilt.TrySetResult(app);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Program.OnStandaloneMcpHttpAppBuilt = app =>
+        {
+            // Subscribe to ApplicationStarted HERE, inside the seam: it runs synchronously on
+            // the entry-point thread between Build() and RunAsync(), so a fast startup cannot
+            // fire the token before the test is listening. (Register also invokes the callback
+            // immediately if the token were somehow already signaled.)
+            app.Lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+            appBuilt.TrySetResult(app);
+        };
 
         WebApplication? runningApp = null;
         try
@@ -61,7 +70,27 @@ public class StandaloneMcpHostFilteringTests
             var entryPoint = typeof(Program).Assembly.EntryPoint
                 ?? throw new InvalidOperationException("Taskdeck.Api assembly has no entry point.");
             var args = new[] { "--mcp", "--transport", "http", "--port", port.ToString() };
-            var hostTask = Task.Run(() => (int)entryPoint.Invoke(null, new object[] { args })!);
+            // For C# async top-level statements the assembly entry point is the compiler's
+            // synchronous bridge returning int (verified by execution: this test passes with a
+            // plain int result), but handle every shape (int / Task<int> / Task) so the test
+            // never depends on that compiler implementation detail.
+            var hostTask = Task.Run(async () =>
+            {
+                var result = entryPoint.Invoke(null, new object[] { args });
+                switch (result)
+                {
+                    case int exit:
+                        return exit;
+                    case Task<int> asyncExit:
+                        return await asyncExit;
+                    case Task plainTask:
+                        await plainTask;
+                        return 0;
+                    default:
+                        throw new InvalidOperationException(
+                            $"Unexpected entry point return: {result?.GetType().ToString() ?? "null"}.");
+                }
+            });
 
             // Surface a startup crash directly instead of masking it behind a timeout.
             var completed = await Task.WhenAny(appBuilt.Task, hostTask).WaitAsync(StartupTimeout);
@@ -78,8 +107,8 @@ public class StandaloneMcpHostFilteringTests
             // The guard must have rewritten the hostile value before the host was built.
             app.Configuration["AllowedHosts"].Should().Be(Program.StandaloneMcpLoopbackAllowedHosts);
 
-            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            app.Lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+            // The started signal was subscribed inside the seam (before RunAsync), so it
+            // cannot be missed even on a fast startup.
             await started.Task.WaitAsync(StartupTimeout);
 
             using var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") };

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -362,9 +362,12 @@ enabled.
 
 ASP.NET Core built-in. The full API defaults to `*` in `appsettings.json`;
 restrict it to deployed host names for defense-in-depth against host-header
-attacks. Standalone MCP HTTP mode replaces blank or ASP.NET any-host values
-(`*`, `0.0.0.0`, `[::]`, including mixed lists) with
-`localhost;127.0.0.1;[::1]`. An explicit exact allowlist is preserved.
+attacks. Standalone MCP HTTP mode fails closed: values that parse to zero
+hosts (blank or separator-only, e.g. `";"`) and ASP.NET any-host values
+(`*`, `0.0.0.0`, `[::]` — with or without a `:port` suffix, matching the
+host-filtering middleware's own normalization, including mixed lists) are
+replaced with `localhost;127.0.0.1;[::1]`. An explicit exact allowlist is
+preserved verbatim.
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -362,16 +362,18 @@ enabled.
 
 ASP.NET Core built-in. The full API defaults to `*` in `appsettings.json`;
 restrict it to deployed host names for defense-in-depth against host-header
-attacks. Standalone MCP HTTP mode fails closed: values that parse to zero
-hosts (blank or separator-only, e.g. `";"`) and bare ASP.NET any-host values
-(`*`, `0.0.0.0`, `[::]`, including mixed lists) are replaced with
-`localhost;127.0.0.1;[::1]`, matching the host-filtering middleware's own
-entry normalization (`HostString.ToUriComponent()`, which retains any
-`:port` suffix). Port-suffixed entries such as `0.0.0.0:5001` are NOT
-wildcards to the middleware: they are literal patterns that real `Host`
-headers never match (effectively deny-all — a misconfiguration that fails
-safe), so they are preserved rather than rewritten. An explicit exact
-allowlist is preserved verbatim.
+attacks. Standalone MCP HTTP mode applies one rule, mirroring the
+host-filtering middleware's own parse exactly (split on `;` dropping only
+EMPTY entries — no trimming — then `HostString.ToUriComponent()` per entry,
+which retains any `:port` suffix): the value is replaced with
+`localhost;127.0.0.1;[::1]` exactly when the middleware itself would
+disable filtering — zero parsed entries (blank, `";"`, `";;"`) or a
+top-level wildcard entry (`*`, `0.0.0.0`, `[::]`, including mixed lists).
+Every other value is preserved verbatim because the middleware fails closed
+on it: port-suffixed entries such as `0.0.0.0:5001` and whitespace-bearing
+entries such as `" ; "` are literal patterns that real `Host` headers never
+match (effectively deny-all — misconfigurations that fail safe), not
+wildcards.
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -363,11 +363,15 @@ enabled.
 ASP.NET Core built-in. The full API defaults to `*` in `appsettings.json`;
 restrict it to deployed host names for defense-in-depth against host-header
 attacks. Standalone MCP HTTP mode fails closed: values that parse to zero
-hosts (blank or separator-only, e.g. `";"`) and ASP.NET any-host values
-(`*`, `0.0.0.0`, `[::]` — with or without a `:port` suffix, matching the
-host-filtering middleware's own normalization, including mixed lists) are
-replaced with `localhost;127.0.0.1;[::1]`. An explicit exact allowlist is
-preserved verbatim.
+hosts (blank or separator-only, e.g. `";"`) and bare ASP.NET any-host values
+(`*`, `0.0.0.0`, `[::]`, including mixed lists) are replaced with
+`localhost;127.0.0.1;[::1]`, matching the host-filtering middleware's own
+entry normalization (`HostString.ToUriComponent()`, which retains any
+`:port` suffix). Port-suffixed entries such as `0.0.0.0:5001` are NOT
+wildcards to the middleware: they are literal patterns that real `Host`
+headers never match (effectively deny-all — a misconfiguration that fails
+safe), so they are preserved rather than rewritten. An explicit exact
+allowlist is preserved verbatim.
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #1367

## Defect

`Program.ApplyStandaloneMcpHostSecurity` (`backend/src/Taskdeck.Api/Program.cs`) rewrote
`AllowedHosts` to the loopback allowlist only when the raw value was blank **or** contained an
any-host token (`*`, `0.0.0.0`, `[::]`). A separator-only value like `";"`, `";;"`, or `" ; "`
slipped through both guards:

- `string.IsNullOrWhiteSpace(";")` is `false`.
- Splitting with `RemoveEmptyEntries | TrimEntries` yields an empty array, so `.Any(any-host)` is
  `false`.

ASP.NET Core `HostFilteringMiddleware` then parses `";"` as **zero** configured hosts and falls back
to allowing **all** hosts — the exact fail-open this method exists to prevent.

## Fix

Compute the parsed host set once and treat "parses to zero non-empty hosts" as the failure
condition. Fail closed to `StandaloneMcpLoopbackAllowedHosts` whenever the post-split host set is
empty (this subsumes the old blank check) **or** contains an any-host token. Explicit exact
allowlists are unchanged.

```csharp
var configuredHosts = configuration["AllowedHosts"]?
    .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
    ?? Array.Empty<string>();
var containsAnyHost = configuredHosts.Any(host => host is "*" or "0.0.0.0" or "[::]");
if (configuredHosts.Length == 0 || containsAnyHost)
{
    configuration["AllowedHosts"] = StandaloneMcpLoopbackAllowedHosts;
}
```

## Tests

Extended the existing #1364 host-security tests in
`backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs`:

- `StandaloneMcpHostSecurity_ReplacesPermissiveAllowedHosts` gains regression cases `";"`, `";;"`,
  `" ; "` — each proven to be rewritten to the loopback allowlist.
- `StandaloneMcpHostSecurity_PreservesExplicitAllowedHosts` becomes a theory adding
  `"mcp.example.com"` (legitimate explicit allowlist preserved) and `"good; ;"` (a real host mixed
  with separator noise is preserved, not failed closed).

## Verification

- `dotnet build backend/Taskdeck.sln -c Release -m:1` — 0 errors.
- `dotnet test ... --filter "FullyQualifiedName~McpHttpTransportApiKeyTests"` — **43 passed, 0
  failed** (15 host-security cases, including the 5 new ones, all green).

No EF/model changes; no docs gates touched.
