### PR TITLE
Mirror production SQLite settings in the API test factory

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Taskdeck.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -31,19 +30,11 @@ public static class DependencyInjection
             .ValidateDataAnnotations()
             .ValidateOnStart();
 
+        // Command timeout + WAL/busy_timeout interceptor live in UseTaskdeckSqlite —
+        // the single shared helper the API test factory also calls, so the test
+        // registration cannot drift from this one (#1282).
         services.AddDbContext<TaskdeckDbContext>(options =>
-            options
-                .UseSqlite(connectionString, sqliteOptions =>
-                {
-                    // Apply command timeout from configuration (default: 30s).
-                    // This applies to all EF Core commands including Database.Migrate().
-                    sqliteOptions.CommandTimeout(databaseSettings.CommandTimeoutSeconds);
-                })
-                // Enable WAL + busy_timeout on every connection so the local-first
-                // UI + MCP + CLI processes sharing one SQLite file don't hit
-                // SQLITE_BUSY ("database is locked") under normal concurrency.
-                .AddInterceptors(new SqlitePragmaConnectionInterceptor(
-                    databaseSettings.BusyTimeoutMilliseconds)));
+            options.UseTaskdeckSqlite(connectionString, databaseSettings));
 
         services.AddScoped<IBoardRepository, BoardRepository>();
         services.AddScoped<IColumnRepository, ColumnRepository>();

--- a/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckSqliteDbContextOptionsExtensions.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckSqliteDbContextOptionsExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Taskdeck.Application.Services;
+
+namespace Taskdeck.Infrastructure.Persistence;
+
+/// <summary>
+/// Single source of truth for Taskdeck's SQLite <see cref="DbContextOptionsBuilder"/>
+/// configuration. Both the production registration (<c>DependencyInjection.AddInfrastructure</c>)
+/// and the API integration-test factory (<c>TestWebApplicationFactory</c>) MUST build their
+/// options through this helper so the two registrations cannot drift apart — a hand-copied
+/// factory block silently losing the pragma interceptor (and with it the per-connection
+/// <c>busy_timeout</c>) is exactly how the #1282 transient <c>SQLITE_BUSY</c> 500s happened.
+/// </summary>
+public static class TaskdeckSqliteDbContextOptionsExtensions
+{
+    /// <summary>
+    /// Applies Taskdeck's standard SQLite options:
+    /// <list type="bullet">
+    ///   <item>the configured command timeout (<see cref="DatabaseSettings.CommandTimeoutSeconds"/>),
+    ///   which applies to all EF Core commands including <c>Database.Migrate()</c>;</item>
+    ///   <item><see cref="SqlitePragmaConnectionInterceptor"/> (WAL +
+    ///   <see cref="DatabaseSettings.BusyTimeoutMilliseconds"/>) so processes sharing one
+    ///   SQLite file don't hit <c>SQLITE_BUSY</c> ("database is locked") under normal
+    ///   concurrency.</item>
+    /// </list>
+    /// Only the connection string may vary between callers.
+    /// </summary>
+    public static DbContextOptionsBuilder UseTaskdeckSqlite(
+        this DbContextOptionsBuilder options,
+        string connectionString,
+        DatabaseSettings databaseSettings)
+    {
+        return options
+            .UseSqlite(connectionString, sqliteOptions =>
+                sqliteOptions.CommandTimeout(databaseSettings.CommandTimeoutSeconds))
+            .AddInterceptors(new SqlitePragmaConnectionInterceptor(
+                databaseSettings.BusyTimeoutMilliseconds));
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
@@ -63,12 +63,11 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             services.RemoveAll<TaskdeckDbContext>();
             services.RemoveAll<LlmProviderSettings>();
             services.RemoveAll<ArtefactStorageSettings>();
+            // Same shared helper as production DependencyInjection.AddInfrastructure —
+            // only the connection string differs (isolated per-factory temp file), so
+            // the test registration is structurally unable to drift from production (#1282).
             services.AddDbContext<TaskdeckDbContext>(options =>
-                options
-                    .UseSqlite($"Data Source={dbPath}", sqliteOptions =>
-                        sqliteOptions.CommandTimeout(databaseSettings.CommandTimeoutSeconds))
-                    .AddInterceptors(new SqlitePragmaConnectionInterceptor(
-                        databaseSettings.BusyTimeoutMilliseconds)));
+                options.UseTaskdeckSqlite($"Data Source={dbPath}", databaseSettings));
             services.AddSingleton(new LlmProviderSettings
             {
                 EnableLiveProviders = false,
@@ -96,6 +95,12 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
         {
             return;
         }
+
+        // Drop pooled connections so WAL/SHM sidecar file handles release before the
+        // delete loop (mirrors SqlitePragmaInterceptorTests.Dispose). Without this, a
+        // pooled connection can hold -wal/-shm open, the delete throws IOException,
+        // and the catch below silently leaks the temp files.
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
 
         foreach (var dbPath in _dbPaths)
         {

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
@@ -54,14 +54,21 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             configBuilder.AddInMemoryCollection(overrideSettings);
         });
 
-        builder.ConfigureServices(services =>
+        builder.ConfigureServices((context, services) =>
         {
+            var databaseSettings = context.Configuration.GetSection("Database").Get<DatabaseSettings>()
+                ?? new DatabaseSettings();
+
             services.RemoveAll<DbContextOptions<TaskdeckDbContext>>();
             services.RemoveAll<TaskdeckDbContext>();
             services.RemoveAll<LlmProviderSettings>();
             services.RemoveAll<ArtefactStorageSettings>();
             services.AddDbContext<TaskdeckDbContext>(options =>
-                options.UseSqlite($"Data Source={dbPath}"));
+                options
+                    .UseSqlite($"Data Source={dbPath}", sqliteOptions =>
+                        sqliteOptions.CommandTimeout(databaseSettings.CommandTimeoutSeconds))
+                    .AddInterceptors(new SqlitePragmaConnectionInterceptor(
+                        databaseSettings.BusyTimeoutMilliseconds)));
             services.AddSingleton(new LlmProviderSettings
             {
                 EnableLiveProviders = false,

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs
@@ -1,4 +1,10 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Taskdeck.Application.Services;
+using Taskdeck.Infrastructure.Persistence;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -15,5 +21,40 @@ public class TestWebApplicationFactoryTests
             "C:\\temp\\taskdeck-api-tests.db-wal",
             "C:\\temp\\taskdeck-api-tests.db-shm",
             "C:\\temp\\taskdeck-api-tests.db-journal");
+    }
+
+    [Fact]
+    public void DatabaseRegistration_ShouldPreserveProductionSqliteSettings()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var settings = scope.ServiceProvider.GetRequiredService<IOptions<DatabaseSettings>>().Value;
+        var connection = context.Database.GetDbConnection();
+
+        connection.Should().BeOfType<SqliteConnection>();
+        Path.GetFileName(connection.DataSource).Should()
+            .MatchRegex("^taskdeck-api-tests-[0-9a-f]{32}\\.db$");
+        context.Database.GetCommandTimeout().Should().Be(settings.CommandTimeoutSeconds);
+
+        context.Database.OpenConnection();
+        try
+        {
+            ScalarPragma<string>(connection, "journal_mode").Should().BeEquivalentTo("wal");
+            ScalarPragma<long>(connection, "busy_timeout").Should()
+                .Be(settings.BusyTimeoutMilliseconds);
+        }
+        finally
+        {
+            context.Database.CloseConnection();
+        }
+    }
+
+    private static T ScalarPragma<T>(System.Data.Common.DbConnection connection, string pragma)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA {pragma};";
+        var result = command.ExecuteScalar();
+        return (T)Convert.ChangeType(result!, typeof(T));
     }
 }


### PR DESCRIPTION
Closes #1282

## Defect

The API integration test factory (`TestWebApplicationFactory`) replaced the production `TaskdeckDbContext` registration with a bare `UseSqlite($"Data Source={dbPath}")`. That drop lost three pieces of production parity:

- **Busy timeout** — the `SqlitePragmaConnectionInterceptor` (WAL journal mode + `PRAGMA busy_timeout`) was never attached, so the test host ran with `busy_timeout=0`. Under hosted concurrency the write lock returned `SQLITE_BUSY` immediately instead of waiting, surfacing as transient HTTP 500s.
- **Command timeout** — the resolved `DatabaseSettings.CommandTimeoutSeconds` was not applied to the SQLite command timeout, so long-running commands under contention did not get production's grace window.
- **Settings binding** — the factory did not bind the resolved `DatabaseSettings` at all, so any future drift in these values would silently diverge from production.

## Fix

Two layers, per the adjudicated adversarial reviews on this PR:

1. **Shared registration helper (structural drift prevention).** SQLite option-building is extracted into a single helper, `UseTaskdeckSqlite(connectionString, databaseSettings)` (`backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckSqliteDbContextOptionsExtensions.cs`), which applies `CommandTimeout(CommandTimeoutSeconds)` and attaches `SqlitePragmaConnectionInterceptor(BusyTimeoutMilliseconds)`. Production `DependencyInjection.AddInfrastructure` and `TestWebApplicationFactory` BOTH call it — only the connection string differs (the factory keeps its isolated per-factory temp database). Semantics are byte-identical to the previous production registration; hand-copied drift (how #1282 happened) is now structurally impossible.
2. **Contract test (wiring guard).** `DatabaseRegistration_ShouldPreserveProductionSqliteSettings` asserts every load-bearing setting deterministically, so a factory registration that loses the interceptor or timeouts fails the build rather than resurfacing as flaky 500s.

The factory `Dispose` also now calls `SqliteConnection.ClearAllPools()` before deleting the temp database files, so pooled connections cannot hold `-wal`/`-shm` sidecar handles and silently leak temp files through the best-effort delete (review finding; mirrors `SqlitePragmaInterceptorTests.Dispose`).

## Red-before-green contract evidence

Against the **pre-fix** factory, the contract test fails on all three load-bearing assertions independently — each discriminates on its own:

- **First red:** `GetCommandTimeout()` returns `null` (expected `DatabaseSettings.CommandTimeoutSeconds` = 30) — this assertion fires before `busy_timeout` is ever evaluated.
- `PRAGMA busy_timeout` reads `0` (expected `DatabaseSettings.BusyTimeoutMilliseconds` = 5000) — the direct cause of the #1282 transient `SQLITE_BUSY` 500s.
- `PRAGMA journal_mode` is not `wal` (interceptor absent).

The assertions read back through the real EF connection-open path (`context.Database.OpenConnection()`), the same path production relies on for the interceptor to fire, with expected values from the independently-bound `IOptions<DatabaseSettings>`. Post-fix:

- connection is a `SqliteConnection`;
- data-source filename matches the per-factory isolated pattern `taskdeck-api-tests-<32 hex>.db`;
- `GetCommandTimeout()` equals `DatabaseSettings.CommandTimeoutSeconds`;
- `PRAGMA journal_mode` is `wal`;
- `PRAGMA busy_timeout` equals `DatabaseSettings.BusyTimeoutMilliseconds`.

## Local verification (this branch, merged with origin/main)

Initial delivery (factory parity + contract test):

- Build: `dotnet build backend/Taskdeck.sln -c Release -m:1` — 0 errors.
- Factory contract: `--filter FullyQualifiedName~TestWebApplicationFactoryTests` — **2 passed, 0 failed**.
- Failure families: `--filter FullyQualifiedName~ConcurrencyRaceConditionStressTests|FullyQualifiedName~WebhookDeliveryConcurrencyTests` — **19 passed, 0 failed**.
- Full serialized backend suite: `dotnet test backend/Taskdeck.sln -c Release -m:1 --no-build` — **7223 passed, 0 failed, 1 skipped** (the single skip is the expected INV-09 architecture skip).

After the review-fix batch (shared helper touches production `DependencyInjection.cs`), all gates rerun:

- Build — 0 errors.
- Factory contract — **2 passed, 0 failed**.
- Failure families — **19 passed, 0 failed**.
- Full serialized backend suite — **7223 passed, 0 failed, 1 skipped** (identical counts; architecture layer-purity tests included and green).

## Scope

Test-harness fix plus one coordinator-authorized production touch: the extraction of the existing production SQLite option-building into the shared `UseTaskdeckSqlite` helper (no behavior change — same two calls, same values). Files:

- `backend/src/Taskdeck.Infrastructure/Persistence/TaskdeckSqliteDbContextOptionsExtensions.cs` (new)
- `backend/src/Taskdeck.Infrastructure/DependencyInjection.cs` (delegates to the helper)
- `backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs`
- `backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs`

Refs #1332 #1335 — related hosted-concurrency harness issues (Redis dispose, hosted-worker/presence); not closed by this change.
