### PR TITLE
Make proposal preview match apply for reorder, create-card ids, and structure limits

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
@@ -10,8 +10,6 @@ namespace Taskdeck.Application.Services;
 public class AutomationPolicyEngine : IAutomationPolicyEngine
 {
     private readonly IUnitOfWork _unitOfWork;
-    private const int MaxOperationCount = 50;
-    private const int MaxParametersLength = 10000;
 
     public AutomationPolicyEngine(IUnitOfWork unitOfWork)
     {
@@ -89,31 +87,10 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
             cancellationToken);
     }
 
+    // Delegates to the shared structure validator so Apply, revision-save, and the
+    // original-proposal diff all enforce the same operation-shape invariants (#1370).
     public Result ValidateOperationStructure(IReadOnlyCollection<ProposalOperationDto> operations)
-    {
-        if (operations == null || operations.Count == 0)
-            return Result.Failure(ErrorCodes.ValidationError, "Proposal must contain at least one operation");
-
-        if (operations.Count > MaxOperationCount)
-            return Result.Failure(ErrorCodes.ValidationError, $"Proposal exceeds maximum operation count of {MaxOperationCount}");
-
-        // Validate operation sequences are unique and non-negative
-        var sequences = operations.Select(o => o.Sequence).ToList();
-        if (sequences.Distinct().Count() != sequences.Count)
-            return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be unique");
-
-        if (sequences.Any(s => s < 0))
-            return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be non-negative");
-
-        // Validate parameters size
-        foreach (var operation in operations)
-        {
-            if (operation.Parameters.Length > MaxParametersLength)
-                return Result.Failure(ErrorCodes.ValidationError, $"Operation parameters exceed maximum length of {MaxParametersLength}");
-        }
-
-        return Result.Success();
-    }
+        => ProposalOperationStructureValidator.Validate(operations);
 
     public Result ValidatePolicy(ProposalDto proposal)
     {

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -780,8 +780,12 @@ public class AutomationProposalService : IAutomationProposalService
             return $"{operation.Sequence}. {verb} label {labelDisplay} {preposition} card {cardDisplay}";
         }
 
-        // Column reorder: surface the requested destination position so the approval
+        // Column reorder: surface the CLAMPED effective destination so the approval
         // preview shows what Apply will do (the position is the whole point of the op).
+        // ColumnService.ReorderColumnAsync inserts at Math.Min(position, columnCount - 1),
+        // so an overshooting target silently lands at the end. Mirror that clamp against
+        // the current board columns so preview == apply (#1370); when the board columns
+        // are unknown (best-effort lookup failed) fall back to the requested value.
         if (string.Equals(operation.TargetType, "column", StringComparison.OrdinalIgnoreCase) &&
             string.Equals(operation.ActionType, "reorder", StringComparison.OrdinalIgnoreCase))
         {
@@ -791,9 +795,13 @@ public class AutomationProposalService : IAutomationProposalService
                 ? $"\"{reorderColumnName}\""
                 : reorderColumnId?.ToString() ?? "(unspecified)";
             var reorderPosition = ExtractInt32Parameter(operation.Parameters, "position");
-            return reorderPosition.HasValue
-                ? $"{operation.Sequence}. {verb} column {reorderColumnDisplay} to position {reorderPosition.Value}"
-                : $"{operation.Sequence}. {verb} column {reorderColumnDisplay}";
+            if (!reorderPosition.HasValue)
+                return $"{operation.Sequence}. {verb} column {reorderColumnDisplay}";
+
+            var effectivePosition = columnNames.Count > 0
+                ? Math.Min(reorderPosition.Value, columnNames.Count - 1)
+                : reorderPosition.Value;
+            return $"{operation.Sequence}. {verb} column {reorderColumnDisplay} to position {effectivePosition}";
         }
 
         // Build description, falling back to raw TargetId when no name is available

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -430,6 +430,15 @@ public class AutomationProposalService : IAutomationProposalService
             .OrderBy(o => o.Sequence)
             .Select(MapOperationToDto)
             .ToList();
+
+        // Run the same structure invariants Apply enforces (op count, unique/non-negative
+        // sequences, parameter size) before building the diff, so a proposal that would be
+        // rejected at Apply cannot preview cleanly first (#1370 preview == apply). Apply runs
+        // this via AutomationPolicyEngine.ValidatePolicy; mirror it here on the original path.
+        var structureValidation = ProposalOperationStructureValidator.Validate(originalOperations);
+        if (!structureValidation.IsSuccess)
+            return Result.Failure<string>(structureValidation.ErrorCode, structureValidation.ErrorMessage);
+
         var originalValidation = await ProposalOperationContractValidator.ValidateAsync(
             _unitOfWork,
             proposal.BoardId,

--- a/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationContractValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationContractValidator.cs
@@ -127,17 +127,17 @@ public static class ProposalOperationContractValidator
 
         if (isCardCreate)
         {
-            // The card being created is identified by its TargetId (a cardId parameter,
-            // if present, must equal it — enforced by the equality check above). Validate
-            // it as a NEW card id so a collision with an existing card fails at preview
-            // instead of during Apply. A create op that also carries a cardId parameter
-            // must never be routed through the existing-card branch, which would treat the
-            // colliding id as a valid reference and let Apply blow up on the duplicate
-            // (#1370 preview == apply).
-            var newCardId = targetId ?? cardId;
-            if (newCardId.HasValue)
+            // Apply sources the created card's id exclusively from operation.TargetId
+            // (OperationHandlerRegistry.CreateCardAsync ignores a cardId parameter; a
+            // cardId parameter that disagrees with targetId is already rejected above).
+            // Validate exactly that id as a NEW card id, so a collision with an existing
+            // card fails at preview instead of during Apply, and never route a create op
+            // through the existing-card branch, which would treat the colliding id as a
+            // valid reference (#1370 preview == apply). When TargetId is absent Apply
+            // generates a fresh id, so there is nothing to collision-check.
+            if (targetId.HasValue)
             {
-                var cardResult = await validationContext.ValidateNewCardIdAsync(newCardId.Value, cancellationToken);
+                var cardResult = await validationContext.ValidateNewCardIdAsync(targetId.Value, cancellationToken);
                 if (!cardResult.IsSuccess)
                     return cardResult;
             }
@@ -467,10 +467,10 @@ public static class ProposalOperationContractValidator
             // aggregate rejects it at Apply. Reject it before preview so the approval
             // gate never registers an unusable planned card (#1319 preview == apply).
             if (cardId == Guid.Empty)
-                return Result.Failure(ErrorCodes.ValidationError, "Create card targetId must be a non-empty identifier");
+                return Result.Failure(ErrorCodes.ValidationError, "Create card id must be a non-empty identifier");
 
             if (_plannedCardIds.Contains(cardId))
-                return Result.Failure(ErrorCodes.Conflict, "Create card targetId is duplicated within the proposal");
+                return Result.Failure(ErrorCodes.Conflict, "Create card id is duplicated within the proposal");
 
             if (!_cardBoardIds.TryGetValue(cardId, out var existingCardBoardId))
             {
@@ -479,7 +479,7 @@ public static class ProposalOperationContractValidator
             }
 
             return existingCardBoardId.HasValue
-                ? Result.Failure(ErrorCodes.Conflict, "Create card targetId already exists")
+                ? Result.Failure(ErrorCodes.Conflict, "Create card id already exists")
                 : Result.Success();
         }
 

--- a/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationContractValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationContractValidator.cs
@@ -122,17 +122,29 @@ public static class ProposalOperationContractValidator
             return Result.Failure(ErrorCodes.ValidationError, "Operation targetId must match parameter 'cardId'");
         }
 
-        if (cardId.HasValue)
+        var isCardCreate = operation.TargetType.Equals("card", StringComparison.OrdinalIgnoreCase) &&
+                           operation.ActionType.Equals("create", StringComparison.OrdinalIgnoreCase);
+
+        if (isCardCreate)
+        {
+            // The card being created is identified by its TargetId (a cardId parameter,
+            // if present, must equal it — enforced by the equality check above). Validate
+            // it as a NEW card id so a collision with an existing card fails at preview
+            // instead of during Apply. A create op that also carries a cardId parameter
+            // must never be routed through the existing-card branch, which would treat the
+            // colliding id as a valid reference and let Apply blow up on the duplicate
+            // (#1370 preview == apply).
+            var newCardId = targetId ?? cardId;
+            if (newCardId.HasValue)
+            {
+                var cardResult = await validationContext.ValidateNewCardIdAsync(newCardId.Value, cancellationToken);
+                if (!cardResult.IsSuccess)
+                    return cardResult;
+            }
+        }
+        else if (cardId.HasValue)
         {
             var cardResult = await validationContext.ValidateCardBoardAsync(cardId.Value, cancellationToken);
-            if (!cardResult.IsSuccess)
-                return cardResult;
-        }
-        else if (targetId.HasValue &&
-                 operation.TargetType.Equals("card", StringComparison.OrdinalIgnoreCase) &&
-                 operation.ActionType.Equals("create", StringComparison.OrdinalIgnoreCase))
-        {
-            var cardResult = await validationContext.ValidateNewCardIdAsync(targetId.Value, cancellationToken);
             if (!cardResult.IsSuccess)
                 return cardResult;
         }

--- a/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationStructureValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationStructureValidator.cs
@@ -1,0 +1,46 @@
+using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Application.Services.Pipeline;
+
+/// <summary>
+/// Validates the structural invariants Apply enforces on a proposal's operation set:
+/// operation count, unique non-negative sequences, and per-operation parameter size.
+/// Extracted so preview and apply share one source of truth — the executor runs it via
+/// <c>AutomationPolicyEngine.ValidateOperationStructure</c>, the revision-save path runs
+/// it directly, and the original-proposal diff runs it before rendering (#1370 preview ==
+/// apply). Deliberately dependency-free (pure shape checks) so it can be called anywhere
+/// the effective operation set is materialized.
+/// </summary>
+public static class ProposalOperationStructureValidator
+{
+    public const int MaxOperationCount = 50;
+    public const int MaxParametersLength = 10000;
+
+    public static Result Validate(IReadOnlyCollection<ProposalOperationDto> operations)
+    {
+        if (operations == null || operations.Count == 0)
+            return Result.Failure(ErrorCodes.ValidationError, "Proposal must contain at least one operation");
+
+        if (operations.Count > MaxOperationCount)
+            return Result.Failure(ErrorCodes.ValidationError, $"Proposal exceeds maximum operation count of {MaxOperationCount}");
+
+        // Validate operation sequences are unique and non-negative
+        var sequences = operations.Select(o => o.Sequence).ToList();
+        if (sequences.Distinct().Count() != sequences.Count)
+            return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be unique");
+
+        if (sequences.Any(s => s < 0))
+            return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be non-negative");
+
+        // Validate parameters size
+        foreach (var operation in operations)
+        {
+            if (operation.Parameters.Length > MaxParametersLength)
+                return Result.Failure(ErrorCodes.ValidationError, $"Operation parameters exceed maximum length of {MaxParametersLength}");
+        }
+
+        return Result.Success();
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationStructureValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationStructureValidator.cs
@@ -34,9 +34,15 @@ public static class ProposalOperationStructureValidator
         if (sequences.Any(s => s < 0))
             return Result.Failure(ErrorCodes.ValidationError, "Operation sequences must be non-negative");
 
-        // Validate parameters size
+        // Validate parameters presence and size. The DTO declares Parameters non-nullable,
+        // but legacy rows / nullable DB data can surface null at runtime; fail closed with
+        // the same ValidationError on preview and apply (both share this validator) rather
+        // than throw.
         foreach (var operation in operations)
         {
+            if (operation.Parameters is null)
+                return Result.Failure(ErrorCodes.ValidationError, "Operation parameters must be provided");
+
             if (operation.Parameters.Length > MaxParametersLength)
                 return Result.Failure(ErrorCodes.ValidationError, $"Operation parameters exceed maximum length of {MaxParametersLength}");
         }

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -1104,10 +1104,16 @@ public class AutomationProposalServiceTests
     [Fact]
     public async Task GetProposalDiffAsync_ShouldSurfaceDestinationPosition_ForColumnReorderOperations()
     {
-        // Arrange
+        // Arrange: a 3-column board so the requested destination (position 2) is in range.
+        // An in-range reorder previews the exact position Apply lands on. (Previously this
+        // test used a single-column board with position 2 — an out-of-range target that
+        // Apply clamps to the end — and asserted the raw requested value, locking in the
+        // preview != apply divergence this issue fixes. See the clamp-specific test below.)
         var proposalId = Guid.NewGuid();
         var boardId = Guid.NewGuid();
+        var todo = new Column(boardId, "To Do", 0);
         var column = new Column(boardId, "In Progress", 1);
+        var done = new Column(boardId, "Done", 2);
         var columnId = column.Id;
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
@@ -1127,7 +1133,7 @@ public class AutomationProposalServiceTests
 
         var columnRepoMock = new Mock<IColumnRepository>();
         columnRepoMock.Setup(r => r.GetByIdAsync(columnId, default)).ReturnsAsync(column);
-        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { column });
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { todo, column, done });
         _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
 
         var cardRepoMock = new Mock<ICardRepository>();
@@ -1147,6 +1153,58 @@ public class AutomationProposalServiceTests
         result.Value.Should().Contain("In Progress");
         result.Value.Should().Contain("to position 2");
         result.Value.Should().NotContain(columnId.ToString());
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldSurfaceClampedEffectivePosition_WhenColumnReorderOvershoots()
+    {
+        // Arrange: a 3-column board with a reorder targeting position 99. ColumnService
+        // clamps an overshooting target to the end (Math.Min(position, columnCount - 1) = 2),
+        // so the preview must show the clamped effective destination — not the raw 99 — to
+        // stay equal to what Apply does (#1370 preview == apply).
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var todo = new Column(boardId, "To Do", 0);
+        var column = new Column(boardId, "In Progress", 1);
+        var done = new Column(boardId, "Done", 2);
+        var columnId = column.Id;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Reorder column",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { columnId, position = 99 });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "reorder", "column", parameters, Guid.NewGuid().ToString(),
+            targetId: columnId.ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByIdAsync(columnId, default)).ReturnsAsync(column);
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(new[] { todo, column, done });
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Card>());
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var labelRepoMock = new Mock<ILabelRepository>();
+        labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default)).ReturnsAsync(Array.Empty<Label>());
+        _unitOfWorkMock.Setup(u => u.Labels).Returns(labelRepoMock.Object);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: preview shows the clamped effective destination (2), never the raw 99.
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Contain("In Progress");
+        result.Value.Should().Contain("to position 2");
+        result.Value.Should().NotContain("position 99");
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -1208,6 +1208,43 @@ public class AutomationProposalServiceTests
     }
 
     [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectOriginalProposalViolatingStructureLimits()
+    {
+        // Arrange: an original proposal with duplicate operation sequences violates the
+        // structure invariants Apply enforces (ValidatePolicy -> ValidateOperationStructure).
+        // Preview must fail with the same ValidationError instead of rendering cleanly and
+        // failing only at Apply (#1370 preview == apply).
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Malformed structure",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { name = "Renamed", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: same failure Apply's structure validation produces.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("sequences must be unique");
+    }
+
+    [Fact]
     public async Task GetProposalDiffAsync_ShouldDescribeDueDateExactlyAsApplyNormalizesIt()
     {
         var proposalId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -1104,11 +1104,13 @@ public class AutomationProposalServiceTests
     [Fact]
     public async Task GetProposalDiffAsync_ShouldSurfaceDestinationPosition_ForColumnReorderOperations()
     {
-        // Arrange: a 3-column board so the requested destination (position 2) is in range.
-        // An in-range reorder previews the exact position Apply lands on. (Previously this
-        // test used a single-column board with position 2 — an out-of-range target that
-        // Apply clamps to the end — and asserted the raw requested value, locking in the
-        // preview != apply divergence this issue fixes. See the clamp-specific test below.)
+        // Arrange: a 3-column board with a STRICTLY INTERIOR destination (position 1;
+        // the clamp ceiling is 2). Interior beats the ceiling here: a degenerate bug that
+        // always rendered the ceiling would still pass at position 2, but fails at 1.
+        // (Previously this test used a single-column board with position 2 — an
+        // out-of-range target that Apply clamps to the end — and asserted the raw
+        // requested value, locking in the preview != apply divergence this issue fixes.
+        // See the clamp-specific test below.)
         var proposalId = Guid.NewGuid();
         var boardId = Guid.NewGuid();
         var todo = new Column(boardId, "To Do", 0);
@@ -1123,7 +1125,7 @@ public class AutomationProposalServiceTests
             Guid.NewGuid().ToString(),
             boardId);
 
-        var parameters = System.Text.Json.JsonSerializer.Serialize(new { columnId, position = 2 });
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { columnId, position = 1 });
         proposal.AddOperation(new AutomationProposalOperation(
             proposal.Id, 0, "reorder", "column", parameters, Guid.NewGuid().ToString(),
             targetId: columnId.ToString()));
@@ -1147,11 +1149,13 @@ public class AutomationProposalServiceTests
         // Act
         var result = await _service.GetProposalDiffAsync(proposalId);
 
-        // Assert: the approval preview names the column and its destination position.
+        // Assert: the approval preview names the column and its requested interior
+        // destination — not the clamp ceiling (2).
         result.IsSuccess.Should().BeTrue(result.ErrorMessage);
         result.Value.Should().Contain("Reorder");
         result.Value.Should().Contain("In Progress");
-        result.Value.Should().Contain("to position 2");
+        result.Value.Should().Contain("to position 1");
+        result.Value.Should().NotContain("to position 2");
         result.Value.Should().NotContain(columnId.ToString());
     }
 
@@ -1242,6 +1246,213 @@ public class AutomationProposalServiceTests
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
         result.ErrorMessage.Should().Contain("sequences must be unique");
+    }
+
+    [Fact]
+    public async Task ProposalReorderPreview_ShouldMatchApplyOutcome_ForOvershootingPosition()
+    {
+        // True parity contract for #1370: the destination rendered in the preview is
+        // parsed back out of the diff text and compared against the position
+        // ColumnService actually applies on the same board state. There is no shared
+        // hardcoded expected value — if the preview clamp and the apply clamp ever
+        // drift apart, this test fails regardless of which side moved.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var todo = new Column(boardId, "To Do", 0);
+        var column = new Column(boardId, "In Progress", 1);
+        var done = new Column(boardId, "Done", 2);
+        var columnId = column.Id;
+        const int requestedPosition = 99;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Reorder column",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { columnId, position = requestedPosition });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "reorder", "column", parameters, Guid.NewGuid().ToString(),
+            targetId: columnId.ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByIdAsync(columnId, It.IsAny<CancellationToken>())).ReturnsAsync(column);
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { todo, column, done });
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Card>());
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var labelRepoMock = new Mock<ILabelRepository>();
+        labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Label>());
+        _unitOfWorkMock.Setup(u => u.Labels).Returns(labelRepoMock.Object);
+
+        // Act 1: preview — extract the rendered destination position from the diff text.
+        var diffResult = await _service.GetProposalDiffAsync(proposalId);
+        diffResult.IsSuccess.Should().BeTrue(diffResult.ErrorMessage);
+        var match = System.Text.RegularExpressions.Regex.Match(diffResult.Value, @"to position (\d+)");
+        match.Success.Should().BeTrue($"the preview should surface a destination position, but was: {diffResult.Value}");
+        var previewedPosition = int.Parse(match.Groups[1].Value);
+
+        // Act 2: apply — execute the same reorder via ColumnService on the same board.
+        var columnService = new ColumnService(_unitOfWorkMock.Object);
+        var applyResult = await columnService.ReorderColumnAsync(columnId, requestedPosition);
+
+        // Assert: what the reviewer approved is exactly what Apply executed.
+        applyResult.IsSuccess.Should().BeTrue(applyResult.ErrorMessage);
+        column.Position.Should().Be(previewedPosition,
+            "the destination position shown in the approval preview must equal the position Apply lands on");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldPreviewPositionZero_ForReorderOnSingleColumnBoard()
+    {
+        // Single-column board: the only valid slot is 0, so any requested destination
+        // previews as the clamped "to position 0" — exactly where Apply leaves the column.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var column = new Column(boardId, "Only", 0);
+        var columnId = column.Id;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Reorder column",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { columnId, position = 5 });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "reorder", "column", parameters, Guid.NewGuid().ToString(),
+            targetId: columnId.ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByIdAsync(columnId, It.IsAny<CancellationToken>())).ReturnsAsync(column);
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { column });
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Card>());
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var labelRepoMock = new Mock<ILabelRepository>();
+        labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Label>());
+        _unitOfWorkMock.Setup(u => u.Labels).Returns(labelRepoMock.Object);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Contain("to position 0");
+        result.Value.Should().NotContain("position 5");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldFallBackToRawPosition_WhenBoardColumnLookupFails()
+    {
+        // Pins the documented degraded path: when the best-effort board-column lookup
+        // fails (BuildReadableDiffAsync swallows the exception and renders with empty
+        // lookups), the preview cannot compute the clamp and renders the RAW requested
+        // position — strictly no worse than the pre-#1370 behavior, which always
+        // rendered raw. Contract validation still passes because it resolves the column
+        // via GetByIdAsync, which succeeds here; only GetByBoardIdAsync (the diff's
+        // name/clamp lookup) fails.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var column = new Column(boardId, "In Progress", 1);
+        var columnId = column.Id;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Reorder column",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { columnId, position = 99 });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "reorder", "column", parameters, Guid.NewGuid().ToString(),
+            targetId: columnId.ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByIdAsync(columnId, It.IsAny<CancellationToken>())).ReturnsAsync(column);
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("column lookup unavailable"));
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: degraded preview still renders, with the raw requested position.
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Contain("to position 99");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldPreviewProposalAtMaxOperationCount()
+    {
+        // Boundary-PASS through the new structure gate: exactly 50 operations (the
+        // MaxOperationCount ceiling) must preview cleanly — the gate rejects only >50.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Bulk board renames",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        for (var i = 0; i < 50; i++)
+        {
+            var parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId, name = $"Rename {i}" });
+            proposal.AddOperation(new AutomationProposalOperation(
+                proposal.Id, i, "update", "board", parameters, Guid.NewGuid().ToString(),
+                targetId: boardId.ToString()));
+        }
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(proposal);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Column>());
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Card>());
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var labelRepoMock = new Mock<ILabelRepository>();
+        labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Label>());
+        _unitOfWorkMock.Setup(u => u.Labels).Returns(labelRepoMock.Object);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: previews cleanly with one line per operation.
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Split(Environment.NewLine).Should().HaveCount(50);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/ColumnServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ColumnServiceTests.cs
@@ -528,5 +528,31 @@ public class ColumnServiceTests
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
+    [Fact]
+    public async Task ReorderColumnAsync_ShouldClampOvershootingTargetToEnd()
+    {
+        // Arrange: three columns; request an out-of-range destination (99).
+        var boardId = Guid.NewGuid();
+        var columnA = new Column(boardId, "A", 0);
+        var columnB = new Column(boardId, "B", 1);
+        var columnC = new Column(boardId, "C", 2);
+        var all = new List<Column> { columnA, columnB, columnC };
+        _columnRepoMock.Setup(r => r.GetByIdAsync(columnA.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(columnA);
+        _columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(all);
+
+        // Act: overshoot the last index by a wide margin.
+        var result = await _service.ReorderColumnAsync(columnA.Id, 99);
+
+        // Assert: Apply clamps to the end (columnCount - 1 == 2). This is the exact
+        // effective position the proposal diff/preview now surfaces, so preview == apply
+        // for an overshooting reorder (#1370).
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        columnA.Position.Should().Be(2);
+        columnB.Position.Should().Be(0);
+        columnC.Position.Should().Be(1);
+    }
+
     #endregion
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationContractValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationContractValidatorTests.cs
@@ -282,6 +282,34 @@ public class ProposalOperationContractValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_ShouldRejectNegativePositionForColumnReorder()
+    {
+        // Mirrors the apply-side guard (ColumnService.ReorderColumnAsync and the
+        // operation handler both reject negative positions) so an impossible
+        // destination fails at preview, not after approval.
+        var boardId = Guid.NewGuid();
+        var column = new Column(boardId, "Backlog", 0);
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var columns = new Mock<IColumnRepository>();
+        unitOfWork.Setup(instance => instance.Columns).Returns(columns.Object);
+        columns.Setup(repository => repository.GetByIdAsync(column.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(column);
+        var operation = CreateOperation(
+            0,
+            "reorder",
+            column.Id,
+            new { columnId = column.Id, position = -1 },
+            targetType: "column");
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object, boardId, new[] { operation });
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("Invalid position: must be non-negative");
+    }
+
+    [Fact]
     public async Task ValidateAsync_ShouldRequireAnUpdateFieldForBoardUpdate()
     {
         var boardId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationContractValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationContractValidatorTests.cs
@@ -161,6 +161,39 @@ public class ProposalOperationContractValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_ShouldRejectCreateCardWhoseIdCollidesWithExistingCard_EvenWhenCardIdParameterMatchesTargetId()
+    {
+        // A create-card op that also carries a cardId parameter equal to its targetId must
+        // NOT be routed through the existing-card branch. Before #1370 that branch treated
+        // the colliding id as a valid reference (the card exists on the board), the op
+        // previewed OK and was registered as planned, then Apply blew up creating a card
+        // with a duplicate id. Preview must reject the collision up front.
+        var boardId = Guid.NewGuid();
+        var column = new Column(boardId, "Backlog", 0);
+        var existingCard = new Card(boardId, column.Id, "Existing");
+        var (unitOfWork, cards, columns, _) = CreateMocks();
+        cards.Setup(repository => repository.GetByIdAsync(existingCard.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingCard);
+        columns.Setup(repository => repository.GetByIdAsync(column.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(column);
+        var operations = new[]
+        {
+            CreateOperation(
+                0,
+                "create",
+                existingCard.Id,
+                new { boardId, columnId = column.Id, title = "New card", cardId = existingCard.Id })
+        };
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object, boardId, operations);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("already exists");
+    }
+
+    [Fact]
     public async Task ValidateAsync_ShouldRejectCardReferenceBeforeItsCreateSequence()
     {
         var boardId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationStructureValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationStructureValidatorTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Services.Pipeline;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services.Pipeline;
+
+public class ProposalOperationStructureValidatorTests
+{
+    [Fact]
+    public void Validate_ShouldRejectNullOperationParameters()
+    {
+        // The DTO declares Parameters non-nullable, but legacy rows / nullable DB data
+        // can surface null at runtime. The shared validator must fail closed with a
+        // ValidationError (identically on preview and apply) instead of throwing.
+        var operation = CreateOperation(0, parameters: null!);
+
+        var result = ProposalOperationStructureValidator.Validate(new[] { operation });
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("parameters must be provided");
+    }
+
+    [Fact]
+    public void Validate_ShouldAcceptExactlyMaxOperationCount()
+    {
+        // Boundary-PASS: the ceiling itself is valid; only count > MaxOperationCount fails.
+        var operations = Enumerable.Range(0, ProposalOperationStructureValidator.MaxOperationCount)
+            .Select(i => CreateOperation(i, "{}"))
+            .ToList();
+
+        var result = ProposalOperationStructureValidator.Validate(operations);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+    }
+
+    private static ProposalOperationDto CreateOperation(int sequence, string parameters)
+    {
+        return new ProposalOperationDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            sequence,
+            "update",
+            "card",
+            null,
+            parameters,
+            Guid.NewGuid().ToString(),
+            null);
+    }
+}


### PR DESCRIPTION
Closes #1370

Restores the review-first `preview == apply` guarantee for three post-merge defects found on PR #1339 (confirmed on `main` @ `d46adf48`). Each fix makes what a reviewer approves in a proposal preview equal what Apply executes; three focused commits, one per defect.

## Defect A — reorder clamp divergence
`ColumnService.ReorderColumnAsync` clamps an overshooting target to the end (`Math.Min(position, columnCount - 1)`), but the proposal diff surfaced the **raw** requested position — a reorder-to-99 on a 3-column board previewed *"to position 99"* and applied *"move to end"*.

Per the coordinator decision, apply-side clamping is **unchanged** (manual UI callers rely on it); instead the diff now computes the same clamp against the current board columns. `AutomationProposalService.DescribeOperationReadable` (reorder branch) now renders `Math.Min(requestedPosition, columnCount - 1)` (falling back to the raw value only when the best-effort board lookup returns no columns).

**Updated test (locked in the divergence):** `GetProposalDiffAsync_ShouldSurfaceDestinationPosition_ForColumnReorderOperations` previously used a **single-column** board with an out-of-range `position = 2` and asserted the raw *"to position 2"* — encoding preview ≠ apply. It now uses a 3-column board so the destination is in range (preview == apply). Added `GetProposalDiffAsync_ShouldSurfaceClampedEffectivePosition_WhenColumnReorderOvershoots` (position 99 → preview *"to position 2"*) and `ColumnServiceTests.ReorderColumnAsync_ShouldClampOvershootingTargetToEnd` (position 99 → applied position 2); together they assert preview == apply == 2.

## Defect B — create-card id collision
A create-card op whose `cardId` parameter equalled its `targetId` took the **existing-card** validation branch (`ValidateCardBoardAsync`), previewed OK, was registered as planned, then Apply failed on the duplicate id.

`ProposalOperationContractValidator.ValidateEntityScopeAsync` now routes **every** create-card op through `ValidateNewCardIdAsync` (never the existing-card branch), so a collision with an existing card fails at preview with a stable **409 Conflict** — consistent with the neighbouring duplicate-within-proposal / empty-id validators.

Added `ValidateAsync_ShouldRejectCreateCardWhoseIdCollidesWithExistingCard_EvenWhenCardIdParameterMatchesTargetId`.

## Defect C — structure checks after preview
The policy structure checks (op count ≤ 50, unique/non-negative sequences, params ≤ 10000 chars — PR #1288) ran before **revised-payload** diffs and at Apply (`ValidatePolicy`), but not before **original-proposal** diffs, so Apply could fail structure validation after a clean preview.

Extracted the checks into a shared `ProposalOperationStructureValidator` (`AutomationPolicyEngine.ValidateOperationStructure` now delegates to it — one source of truth), and `GetProposalDiffAsync` runs it before building an original-proposal diff, returning the same `ValidationError` Apply returns.

Added `GetProposalDiffAsync_ShouldRejectOriginalProposalViolatingStructureLimits`.

## Scope / constraints
No new endpoints, no EF/model changes, no migrations. Clean Architecture boundaries preserved (Application-only, delegates to Domain `Result`/`ErrorCodes`). Stable HTTP codes preserved (409 for id collisions, 400 for structure/validation).

## Verification (local, Release)
- `dotnet build backend/Taskdeck.sln -c Release -m:1` — **0 errors** (pre-existing warnings only).
- Targeted `Taskdeck.Application.Tests` (`ColumnService | AutomationProposalService | ProposalOperationContractValidator | AutomationPolicyEngine | AutomationExecutorService | ProposalRevision`) — **168 passed, 0 failed**.
- Full `Taskdeck.Application.Tests` — **3459 passed, 0 failed**.
- `Taskdeck.Api.Tests` (`Proposal | Mcp | Automation`) — **359 passed, 0 failed**.
- CI runs the full matrix.
