### PR TITLE
Make the concurrent-migrator test assert final schema state instead of no-throw

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs
@@ -219,8 +219,15 @@ public static class SerializedMigrator
     /// backoff while another process holds it. Returns the held stream, or <c>null</c> if the
     /// lock could not be acquired within <paramref name="timeout"/> or the file could not be
     /// created at all (in which case the caller proceeds without the lock).
+    /// <para>
+    /// <c>internal</c> (not <c>private</c>) so the lock-exclusivity contract — while one
+    /// acquisition holds, a second must fail open; after release, it must succeed — stays
+    /// directly regression-tested (#1164): a <see cref="FileShare.None"/> weakening or early
+    /// stream disposal would otherwise pass every state-based migration test unnoticed.
+    /// Exposed via the existing <c>InternalsVisibleTo("Taskdeck.Api.Tests")</c>.
+    /// </para>
     /// </summary>
-    private static FileStream? AcquireLock(string lockPath, TimeSpan timeout, ILogger? logger)
+    internal static FileStream? AcquireLock(string lockPath, TimeSpan timeout, ILogger? logger)
     {
         // Monotonic clock (Stopwatch), not DateTime.UtcNow: a wall-clock step (NTP correction,
         // DST, manual change) must not skew how long we are willing to wait for the lock.

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -82,23 +82,60 @@ public sealed class SerializedMigratorTests : IDisposable
                 var migratorA = RunMigratorAsync(contextA);
                 var migratorB = RunMigratorAsync(contextB);
 
-                var act = async () => await Task.WhenAll(migratorA, migratorB);
-                await act.Should().NotThrowAsync(
-                    "the advisory file lock must serialize concurrent migrators so neither fails");
+                // Deliberately NOT a NotThrow assertion. SerializedMigrator documents a lock-free
+                // fail-open path: when the sidecar lock file is uncreatable or its acquisition
+                // times out under load, a losing migrator races the winner mid-chain and can throw
+                // a "table already exists" / duplicate-__EFMigrationsHistory conflict that its
+                // NoMigrationsPending re-check could not yet swallow (the winner had not finished
+                // the chain). That collision is an EXPECTED outcome of the documented fallback, so
+                // the test asserts the invariant that actually matters — the FINAL schema state —
+                // instead of no-throw. Await both migrators to completion, tolerating ONLY that
+                // documented collision signature; any other throw, or a failure on the LOCKED path
+                // (which never swallows), is a real defect and must surface.
+                var faults = new List<Exception>();
+                foreach (var migrator in new[] { migratorA, migratorB })
+                {
+                    try
+                    {
+                        await migrator;
+                    }
+                    catch (Exception ex)
+                    {
+                        faults.Add(ex);
+                    }
+                }
+
+                foreach (var fault in faults)
+                {
+                    IsDocumentedMidChainCollision(fault).Should().BeTrue(
+                        "the only tolerable concurrent-migrator failure is the documented fail-open " +
+                        "mid-chain collision (\"already exists\" / duplicate __EFMigrationsHistory); " +
+                        $"any other throw is a real defect, but got: {fault}");
+                }
+
+                faults.Count.Should().BeLessThan(2,
+                    "at least one migrator must drive the schema to completion — the winner that " +
+                    "created the conflicting object never throws the collision, so both migrators " +
+                    "failing means no run applied the chain");
 
                 using var verify = NewFileContext(dbPath);
 
-                // Schema applied: a known table exists.
+                // Representative table exists AND is usable: querying Boards through the migrated
+                // schema must succeed. This proves the migration produced a well-formed table, not
+                // merely a name registered in sqlite_master.
                 GetUserTableNames(verify).Should().Contain(
                     "Boards", "the migration chain must have created the Boards table");
+                verify.Set<Board>().Count().Should().Be(0,
+                    "the migrated Boards table must be usable — a real query against it must succeed");
 
-                // Applied exactly once: every defined migration appears exactly once in history.
+                // Applied exactly once: __EFMigrationsHistory holds the COMPLETE migration list
+                // with no duplicates, regardless of which fail-open collisions occurred above.
                 var historyIds = GetMigrationHistoryIds(verify);
                 historyIds.Should().OnlyHaveUniqueItems(
-                    "two migrators must not double-insert __EFMigrationsHistory rows");
+                    "concurrent migrators must not double-insert __EFMigrationsHistory rows");
                 historyIds.Should().BeEquivalentTo(
                     verify.Database.GetMigrations(),
-                    "every defined migration should be applied exactly once across the concurrent run");
+                    "every defined migration must be applied exactly once across the concurrent run");
             }
             finally
             {
@@ -186,6 +223,31 @@ public sealed class SerializedMigratorTests : IDisposable
         logger.Entries.Should().Contain(
             e => e.Level == LogLevel.Warning,
             "failing to acquire the migration lock within the timeout must be logged as a warning");
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> only for the fail-open mid-chain collision SerializedMigrator documents:
+    /// a losing migrator on the lock-free path re-issues DDL the winner already applied and throws
+    /// a <see cref="SqliteException"/> for a duplicate object (<c>"table ... already exists"</c>) or
+    /// a duplicate <c>__EFMigrationsHistory</c> primary-key insert (<c>"UNIQUE constraint failed"</c>),
+    /// possibly wrapped (e.g. in a <see cref="DbUpdateException"/>). The chain is walked so a wrapped
+    /// SqliteException is still recognized. Deliberately narrow: it excludes barrier timeouts, null
+    /// refs, disk errors, and a leaked <c>SQLITE_BUSY</c> (which busy_timeout must already absorb) —
+    /// those are real defects the test must not mask.
+    /// </summary>
+    private static bool IsDocumentedMidChainCollision(Exception exception)
+    {
+        for (Exception? ex = exception; ex is not null; ex = ex.InnerException)
+        {
+            if (ex is SqliteException sqlite &&
+                (sqlite.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase) ||
+                 sqlite.Message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static List<string> GetUserTableNames(TaskdeckDbContext context)

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -107,10 +107,10 @@ public sealed class SerializedMigratorTests : IDisposable
 
                 foreach (var fault in faults)
                 {
-                    IsDocumentedMidChainCollision(fault).Should().BeTrue(
+                    IsSqliteCollisionFault(fault).Should().BeTrue(
                         "the only tolerable concurrent-migrator failure is the documented fail-open " +
-                        "mid-chain collision (\"already exists\" / duplicate __EFMigrationsHistory); " +
-                        $"any other throw is a real defect, but got: {fault}");
+                        "mid-chain SQLite collision (any SqliteException, walked through wrappers); " +
+                        $"any non-SQL throw is a real defect, but got: {fault}");
                 }
 
                 faults.Count.Should().BeLessThan(2,
@@ -226,28 +226,63 @@ public sealed class SerializedMigratorTests : IDisposable
     }
 
     /// <summary>
-    /// Returns <c>true</c> only for the fail-open mid-chain collision SerializedMigrator documents:
-    /// a losing migrator on the lock-free path re-issues DDL the winner already applied and throws
-    /// a <see cref="SqliteException"/> for a duplicate object (<c>"table ... already exists"</c>) or
-    /// a duplicate <c>__EFMigrationsHistory</c> primary-key insert (<c>"UNIQUE constraint failed"</c>),
-    /// possibly wrapped (e.g. in a <see cref="DbUpdateException"/>). The chain is walked so a wrapped
-    /// SqliteException is still recognized. Deliberately narrow: it excludes barrier timeouts, null
-    /// refs, disk errors, and a leaked <c>SQLITE_BUSY</c> (which busy_timeout must already absorb) —
-    /// those are real defects the test must not mask.
+    /// Returns <c>true</c> when <paramref name="exception"/> is (or wraps, anywhere in its
+    /// inner-exception chain) a <see cref="SqliteException"/> — the signature of a losing
+    /// fail-open migrator racing the winner mid-chain. Deliberately NOT message-based: the same
+    /// race lands on whatever DDL the colliding migration issues first — <c>"table ... already
+    /// exists"</c> (CreateTable), <c>"duplicate column name"</c> (AddColumn-first migrations such
+    /// as AddDeferredUntilToAutomationProposal), <c>"no such table"</c> / <c>ef_temp</c> shapes
+    /// (table-rebuild migrations), or <c>"UNIQUE constraint failed"</c> (a duplicate
+    /// <c>__EFMigrationsHistory</c> insert) — so enumerating message strings re-flakes with a
+    /// misleading "real defect" message the next time the chain reshapes. Tolerating ANY
+    /// <see cref="SqliteException"/> cannot mask a real defect because this check never gates
+    /// success alone: the <c>faults.Count &lt; 2</c> gate rejects "no migrator drove the chain"
+    /// (a genuinely broken migration faults BOTH migrators here and also fails the
+    /// single-migrator test), and the exact-state assertions (complete duplicate-free history ==
+    /// <c>GetMigrations()</c>; usable schema) reject any incomplete or corrupted outcome. This
+    /// type check exists ONLY to keep non-SQL faults — barrier timeouts, null refs, IO failures —
+    /// as hard test failures.
     /// </summary>
-    private static bool IsDocumentedMidChainCollision(Exception exception)
+    private static bool IsSqliteCollisionFault(Exception exception)
     {
         for (Exception? ex = exception; ex is not null; ex = ex.InnerException)
         {
-            if (ex is SqliteException sqlite &&
-                (sqlite.Message.Contains("already exists", StringComparison.OrdinalIgnoreCase) ||
-                 sqlite.Message.Contains("UNIQUE constraint failed", StringComparison.OrdinalIgnoreCase)))
+            if (ex is SqliteException)
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    public static TheoryData<Exception, bool> CollisionFaultCases => new()
+    {
+        // Direct SqliteExceptions from every DDL shape the fail-open race can land on.
+        { new SqliteException("SQLite Error 1: 'table \"ProposalProvenances\" already exists'.", 1), true },
+        { new SqliteException("SQLite Error 1: 'duplicate column name: DeferredUntil'.", 1), true },
+        { new SqliteException("SQLite Error 1: 'no such table: ef_temp_Boards'.", 1), true },
+        // Wrapped: EF surfaces the duplicate __EFMigrationsHistory insert as a DbUpdateException.
+        {
+            new DbUpdateException(
+                "An error occurred while saving the entity changes.",
+                new SqliteException(
+                    "SQLite Error 19: 'UNIQUE constraint failed: __EFMigrationsHistory.MigrationId'.", 19)),
+            true
+        },
+        // Non-SQL faults must stay hard failures.
+        { new TimeoutException("Sibling migrator never reached the start barrier."), false },
+        { new InvalidOperationException("outer", new IOException("disk failure")), false },
+    };
+
+    [Theory]
+    [MemberData(nameof(CollisionFaultCases))]
+    public void Collision_signature_accepts_any_sqlite_fault_and_rejects_non_sql_faults(
+        Exception fault, bool expected)
+    {
+        IsSqliteCollisionFault(fault).Should().Be(expected,
+            "the collision signature must tolerate every SQLite shape of the fail-open race " +
+            "(walking wrapped exceptions) while keeping non-SQL faults as hard failures");
     }
 
     private static List<string> GetUserTableNames(TaskdeckDbContext context)

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -225,6 +225,121 @@ public sealed class SerializedMigratorTests : IDisposable
             "failing to acquire the migration lock within the timeout must be logged as a warning");
     }
 
+    [Fact]
+    public async Task Fail_open_collision_is_tolerated_and_schema_still_applies_exactly_once()
+    {
+        // Deterministically exercises the tolerance branch the concurrent test only reaches under
+        // pathological CI load. The sidecar lock file is held EXTERNALLY for the whole race (same
+        // technique as Migrate_proceeds_with_a_warning_when_lock_cannot_be_acquired_within_timeout)
+        // with a short lock timeout, so BOTH migrators are forced onto the documented fail-open
+        // path. Barrier-synced against a cold DB, both compute the full pending chain and race;
+        // the loser collides on early DDL. Whether that collision propagates (winner mid-chain)
+        // or is swallowed as a no-op (winner finished) is scheduling-dependent, so the loop
+        // retries a few fresh databases until collision evidence is observed — every attempt
+        // still asserts the exactly-once end state.
+        const int maxAttempts = 3;
+        var collisionObserved = false;
+
+        for (var attempt = 1; attempt <= maxAttempts && !collisionObserved; attempt++)
+        {
+            var dbPath = Path.Combine(
+                Path.GetTempPath(), $"taskdeck-serialized-migrate-failopen-{Guid.NewGuid():N}.db");
+            try
+            {
+                // Hold the exclusive lock for the entire attempt: neither migrator can acquire it.
+                using var heldLock = new FileStream(
+                    Path.GetFullPath(dbPath) + ".migrate.lock",
+                    FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+
+                using var contextA = NewFileContext(dbPath);
+                using var contextB = NewFileContext(dbPath);
+                var loggerA = new InMemoryLogger<SerializedMigratorTests>();
+                var loggerB = new InMemoryLogger<SerializedMigratorTests>();
+                using var startBarrier = new Barrier(2);
+
+                Task RunMigratorAsync(TaskdeckDbContext context, InMemoryLogger<SerializedMigratorTests> logger)
+                    => Task.Run(() =>
+                    {
+                        if (!startBarrier.SignalAndWait(TimeSpan.FromSeconds(10)))
+                        {
+                            throw new TimeoutException(
+                                "Sibling migrator never reached the start barrier.");
+                        }
+
+                        SerializedMigrator.Migrate(context, TimeSpan.FromMilliseconds(250), logger);
+                    });
+
+                var migratorA = RunMigratorAsync(contextA, loggerA);
+                var migratorB = RunMigratorAsync(contextB, loggerB);
+
+                var faults = new List<Exception>();
+                foreach (var migrator in new[] { migratorA, migratorB })
+                {
+                    try
+                    {
+                        await migrator;
+                    }
+                    catch (Exception ex)
+                    {
+                        faults.Add(ex);
+                    }
+                }
+
+                // Deterministic precondition: the externally held lock must have forced BOTH
+                // migrators onto the fail-open path — otherwise this test proves nothing.
+                foreach (var logger in new[] { loggerA, loggerB })
+                {
+                    logger.Entries.Should().Contain(
+                        e => e.Level == LogLevel.Warning &&
+                             e.Message.Contains("could not acquire migration lock"),
+                        "an externally held sidecar lock must force every migrator onto the " +
+                        "documented fail-open path");
+                }
+
+                faults.Count.Should().BeLessThan(2,
+                    "even with both migrators on the lock-free path, the winner never throws the " +
+                    "collision it caused — both faulting means no run applied the chain");
+                foreach (var fault in faults)
+                {
+                    IsSqliteCollisionFault(fault).Should().BeTrue(
+                        "a fail-open loser may only fault with the SQLite collision signature; " +
+                        $"any non-SQL throw is a real defect, but got: {fault}");
+                }
+
+                // The invariant that matters, identical to the concurrent test: final schema
+                // migrated exactly once and usable, regardless of how the race interleaved.
+                using var verify = NewFileContext(dbPath);
+                GetUserTableNames(verify).Should().Contain(
+                    "Boards", "the migration chain must have created the Boards table");
+                verify.Set<Board>().Count().Should().Be(0,
+                    "the migrated Boards table must be usable — a real query against it must succeed");
+                var historyIds = GetMigrationHistoryIds(verify);
+                historyIds.Should().OnlyHaveUniqueItems(
+                    "racing fail-open migrators must not double-insert __EFMigrationsHistory rows");
+                historyIds.Should().BeEquivalentTo(
+                    verify.Database.GetMigrations(),
+                    "every defined migration must be applied exactly once despite the fail-open race");
+
+                // Collision evidence: either the loser's fault propagated (winner was mid-chain)
+                // or SerializedMigrator swallowed it and logged the documented race warning
+                // (winner had finished). Absent both, the loser happened to no-op — retry.
+                collisionObserved = faults.Count == 1 ||
+                    loggerA.Entries.Concat(loggerB.Entries).Any(e =>
+                        e.Level == LogLevel.Warning &&
+                        e.Message.Contains("raced a concurrent migrator"));
+            }
+            finally
+            {
+                CleanupDbFiles(dbPath);
+            }
+        }
+
+        collisionObserved.Should().BeTrue(
+            "with both migrators forced onto the lock-free path against a cold database, the " +
+            $"loser must collide mid-chain in at least one of {maxAttempts} attempts — never " +
+            "colliding means the tolerance branch was not exercised at all");
+    }
+
     /// <summary>
     /// Returns <c>true</c> when <paramref name="exception"/> is (or wraps, anywhere in its
     /// inner-exception chain) a <see cref="SqliteException"/> — the signature of a losing

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -340,6 +340,47 @@ public sealed class SerializedMigratorTests : IDisposable
             "colliding means the tolerance branch was not exercised at all");
     }
 
+    [Fact]
+    public void AcquireLock_is_exclusive_while_held_and_reacquirable_after_release()
+    {
+        // Direct contract test at the AcquireLock seam (#1164 serialization guarantee). The
+        // state-based migration tests above cannot catch a lock that silently stops excluding
+        // (e.g. FileShare.None weakened to ReadWrite, or the stream disposed early): migrations
+        // would still converge to the correct schema through the fail-open re-check. This test
+        // pins exclusivity itself.
+        var lockPath = Path.GetFullPath(_dbPath) + ".migrate.lock";
+        var logger = new InMemoryLogger<SerializedMigratorTests>();
+
+        var first = SerializedMigrator.AcquireLock(lockPath, TimeSpan.FromSeconds(5), logger);
+        first.Should().NotBeNull("an uncontended migration lock must be acquirable");
+
+        try
+        {
+            // While held, a second acquisition of the SAME path must NOT succeed: it must
+            // degrade to the fail-open outcome (null) after its short timeout, with the
+            // documented warning.
+            using var second = SerializedMigrator.AcquireLock(
+                lockPath, TimeSpan.FromMilliseconds(300), logger);
+            second.Should().BeNull(
+                "a held migration lock must exclude every other acquirer until it is released — " +
+                "a second successful acquisition means FileShare.None exclusivity is broken");
+
+            logger.Entries.Should().Contain(
+                e => e.Level == LogLevel.Warning &&
+                     e.Message.Contains("could not acquire migration lock"),
+                "the excluded acquirer must log the documented fail-open warning");
+        }
+        finally
+        {
+            first!.Dispose();
+        }
+
+        // After release the lock must be acquirable again: the winner releasing is what
+        // unblocks the waiting migrators.
+        using var third = SerializedMigrator.AcquireLock(lockPath, TimeSpan.FromSeconds(5), logger);
+        third.Should().NotBeNull("releasing the migration lock must let the next acquirer take it");
+    }
+
     /// <summary>
     /// Returns <c>true</c> when <paramref name="exception"/> is (or wraps, anywhere in its
     /// inner-exception chain) a <see cref="SqliteException"/> — the signature of a losing


### PR DESCRIPTION
Closes #1357

## Problem

`SerializedMigratorTests.Concurrent_migrators_apply_schema_exactly_once` intermittently failed on `API Integration (windows-latest)` with `SQLite Error 1: 'table "ProposalProvenances" already exists'`. The test asserted `NotThrowAsync` — but that assertion is wrong for what `SerializedMigrator` actually guarantees.

## Root cause (verified against the code)

`SerializedMigrator` has a **documented lock-free fail-open path** (`AcquireLock` returns `null` when the sidecar `.migrate.lock` file is uncreatable or its acquisition times out; `Migrate` then calls `MigrateWithoutLock`). On that path a losing migrator races the winner mid-chain. EF computes the pending set **before** taking SQLite's write lock, so the loser re-issues DDL the winner already applied and throws (or hits a duplicate `__EFMigrationsHistory` insert). `MigrateWithoutLock` swallows that throw **only** when a `NoMigrationsPending` re-check shows nothing remains pending; if the winner has not finished the chain, the re-check still sees pending migrations and **rethrows**.

The 2026-07-13 wave added `AddRegistrationGating` + `AddArtefactExtractions`, lengthening the cold-DB chain (37 migrations) and widening the window where, under Windows CI load, both migrators take the fail-open path and collide mid-chain before the winner finishes. This is **test-harness fragility asserting the wrong thing**, not a product defect — `SerializedMigrator` (WAL + busy_timeout + advisory file lock + pending re-check) is sound, and the fail-open collision is explicitly documented behavior.

## Fix

State-based assertions instead of no-throw, plus adversarial-review hardening (two independent lenses, coordinator-adjudicated — see review comments):

1. **Concurrent test asserts final schema state.** Await both migrators; collect faults. Tolerate **only** the SQLite collision signature — **any** `SqliteException`, walked through the inner-exception chain. Message-matching was rejected in review (HIGH): the same race lands on whatever DDL the colliding migration issues first — `already exists` (CreateTable), `duplicate column name` (AddColumn-first migrations like `AddDeferredUntilToAutomationProposal`), `no such table`/`ef_temp` (table rebuilds), `UNIQUE constraint failed` (history insert) — so string enumeration re-flakes on the next chain reshape. The type check only excludes non-SQL faults (barrier timeouts, null refs, IO), which stay hard failures; the real gates are `faults.Count < 2` (the winner never throws the collision it caused, so both faulting means no run applied the chain) plus the exact-state block: `__EFMigrationsHistory` complete (`BeEquivalentTo(GetMigrations())`), duplicate-free (`OnlyHaveUniqueItems`), and a **usable** representative table (`verify.Set<Board>().Count()` runs a real query). Theory coverage pins the signature helper for every collision shape, a wrapped `DbUpdateException`, and non-SQL rejection.
2. **Deterministic fail-open collision test.** Under normal conditions the loser acquires the lock and no-ops, so green runs prove the lock, not the tolerance. New test holds the sidecar lock externally (same technique as the existing timeout test) with a 250ms lock timeout so BOTH migrators fail open, barrier-syncs them on a cold DB so both compute the full pending chain, and races them: at most 1 fault, SQLite collision signature on any fault, both fail-open warnings asserted, exactly-once final state, and collision evidence (propagated fault or the swallowed-race warning) required within 3 fresh-DB attempts.
3. **AcquireLock exclusivity contract test.** Removing the no-throw assertion deleted the suite's only lock-serialization regression guard — a `FileShare.None → ReadWrite` weakening (or early stream disposal) would have passed every state-based test, silently disabling the #1164 contract. `AcquireLock` goes `private → internal` (visibility only, via the pre-existing `InternalsVisibleTo("Taskdeck.Api.Tests")`), and a direct contract test asserts: held lock excludes a second acquisition (fail-open `null` + warning) and is reacquirable after release.

Files: `backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs`, `backend/src/Taskdeck.Infrastructure/Persistence/SerializedMigrator.cs` (visibility-only, no behavior change).

## What this does and does not claim

The CI flake is **tolerated, not eliminated**: under CI load the advisory lock legitimately degrades to the documented fail-open path, and the test now accepts that outcome while pinning the invariant that matters (final schema migrated exactly once, usable, complete history). The fail-open collision itself is now deterministically covered (fix 2), so the tolerance branch is proven, not just permitted. The 10-second barrier wait is a deliberate fail-fast posture: if a sibling migrator dies before the barrier, the test fails fast instead of hanging CI.

## Verification

- `dotnet restore` once; `dotnet build backend/Taskdeck.sln -c Release -m:1` → **0 errors**.
- `--filter FullyQualifiedName~SerializedMigratorTests` (now 12 tests: 4 original-shape + 6 signature theory cases + fail-open collision + exclusivity contract) run **10 consecutive times → 10/10 green** (evidence in the fix-evidence comment).

## Discrimination proof (state assertion is not false-green)

Temporarily tampered the shipped equivalence assertion to expect one migration the DB does not contain:
`historyIds.Should().BeEquivalentTo(verify.Database.GetMigrations().Append("0000_DISCRIMINATION_PROBE"))`.
The test went **RED**: `Expected historyIds to be a collection with 38 item(s) ... but {...37 real ids...} contains 1 item(s) less than`. This confirms the assertion reads the real migrated history from the DB and fails when the final schema is genuinely wrong. The probe was reverted and **not committed**.

## Adversarial review

Two independent adversarial lenses were run and coordinator-adjudicated: 1 HIGH + 2 MEDIUM + 1 LOW confirmed and fixed in this batch (matcher gap, untested tolerance branch, deleted serialization guard, PR-body wording); 1 finding refuted with evidence (the failure site is this test itself per issue #1357's recorded symptom — "windows API Integration" is the CI job that runs `Taskdeck.Api.Tests`, not a different code path). Full findings and fix-evidence mapping are in the PR comments.

- **Can the tolerance mask a real product regression?** No. If the lock were completely broken and both migrators applied the chain, SQLite still serializes writes — one wins per migration, the loser throws the tolerated collision, and the final-state block still demands a single complete history and usable schema (proven red-able by the discrimination probe). A lock that silently stops excluding is now caught directly by the exclusivity contract test rather than indirectly by no-throw.
- **Locked-path regressions still surface**: the locked `Migrate()` never swallows, so a genuine failure there fails the test regardless of signature tolerance.

## Possible follow-up (deferred, not in this PR)

The issue also suggested making `AcquireLock` retry the uncreatable-lock-file case under Windows contention. `AcquireLock` currently fail-opens immediately on `UnauthorizedAccessException` (which Windows raises transiently for a lock file pending deletion). A bounded retry would reduce fail-open frequency, but it changes production concurrency behavior, is not deterministically testable, and — done naively — would make a genuinely unwritable directory spin for the full 30s timeout before failing open (a startup-stall regression) unless transient vs. permanent `ACCESS_DENIED` are distinguished. Not cheap/clean enough for this scope; the fail-open path is now deterministically covered by tests either way. Recommend a separate tracked issue if the fail-open frequency is worth reducing.
