### PR TITLE
Bound artefact extraction with a wall-clock budget

### DIFF
--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
@@ -17,17 +17,20 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
     private readonly ISourceArtefactRepository _artefacts;
     private readonly IArtefactExtractionRepository _extractions;
     private readonly IReadOnlyList<IArtefactTextExtractor> _extractors;
+    private readonly ArtefactStorageSettings _settings;
     private readonly ILogger<ArtefactExtractionService>? _logger;
 
     public ArtefactExtractionService(
         ISourceArtefactRepository artefacts,
         IArtefactExtractionRepository extractions,
         IEnumerable<IArtefactTextExtractor> extractors,
+        ArtefactStorageSettings? settings = null,
         ILogger<ArtefactExtractionService>? logger = null)
     {
         _artefacts = artefacts;
         _extractions = extractions;
         _extractors = extractors.ToArray();
+        _settings = settings ?? new ArtefactStorageSettings();
         _logger = logger;
     }
 
@@ -111,12 +114,52 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                 }
 
                 stream.Position = 0;
+
+                // Bound the parser's wall-clock, not just its input size. PdfPig's
+                // PdfDocument.Open(...) runs synchronously and does not honour a
+                // CancellationToken, so a parser-bomb PDF that stays under the
+                // byte/page/character caps can still spin the parse thread for an
+                // unbounded time. Enforce a budget with a CancelAfter linked to the
+                // caller's token and run the parse on a worker so a runaway parse can
+                // be abandoned while the request returns. The budget token is also
+                // passed into the extractor, which observes it cooperatively between
+                // pages/words — the clean path for bombs that reach the page loop.
+                using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var budget = _settings.ExtractionTimeout;
+                if (budget > TimeSpan.Zero)
+                    budgetCts.CancelAfter(budget);
+
+                var extractTask = Task.Run(
+                    () => extractor.ExtractAsync(stream, budgetCts.Token),
+                    CancellationToken.None);
                 try
                 {
-                    extractorResult = await extractor.ExtractAsync(stream, cancellationToken);
+                    extractorResult = await extractTask.WaitAsync(budgetCts.Token);
+                }
+                catch (OperationCanceledException)
+                    when (budgetCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                {
+                    // Budget exhausted (not caller cancellation). Abandon the parse:
+                    // it may run to completion on a background thread, but it holds no
+                    // file or DB handle — the blob was copied into the in-memory stream
+                    // and the connection closed before extraction began — so the only
+                    // resource in flight is managed memory the GC reclaims once the
+                    // worker unwinds. Record a single content-free timeout outcome.
+                    ObserveAbandonedExtraction(extractTask);
+                    _logger?.LogWarning(
+                        "Local extraction exceeded the {BudgetSeconds}s wall-clock budget for artefact {ArtefactId} with extractor {ExtractorName}; recording a timeout outcome",
+                        budget.TotalSeconds,
+                        sourceArtefactId,
+                        extractor.ExtractorName);
+                    extractorResult = WarningResult(
+                        extractor,
+                        ArtefactExtractionWarningCodes.ExtractionTimeout);
                 }
                 catch (OperationCanceledException)
                 {
+                    // Caller-driven cancellation (request aborted): abandon the worker
+                    // and propagate without recording an extraction outcome.
+                    ObserveAbandonedExtraction(extractTask);
                     throw;
                 }
                 catch (Exception ex)
@@ -250,6 +293,19 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
             warnings,
             extractor.ExtractorName,
             extractor.ExtractorVersion);
+    }
+
+    private static void ObserveAbandonedExtraction(Task extractTask)
+    {
+        // The request returns before this worker necessarily finishes, and the
+        // request-scoped input stream is disposed on return, so an abandoned parse
+        // typically faults (e.g. ObjectDisposedException) on its next read. Observe
+        // that fault so it is not surfaced as an UnobservedTaskException.
+        _ = extractTask.ContinueWith(
+            static task => _ = task.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private static bool HasValidIdentity(string value, int maxLength)

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
@@ -124,58 +124,88 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                 // be abandoned while the request returns. The budget token is also
                 // passed into the extractor, which observes it cooperatively between
                 // pages/words — the clean path for bombs that reach the page loop.
-                using var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                var budget = _settings.ExtractionTimeout;
-                if (budget > TimeSpan.Zero)
-                    budgetCts.CancelAfter(budget);
-
-                var extractTask = Task.Run(
-                    () => extractor.ExtractAsync(stream, budgetCts.Token),
-                    CancellationToken.None);
+                // Classification note: an extractor that swallowed the budget OCE and
+                // rethrew a non-OCE fault at the instant the budget fires would race
+                // the recorded code between extraction-timeout and extractor-error —
+                // both are warning-bearing rows and exactly one is written, so either
+                // outcome is safe; the shipped extractors propagate OCE, so this
+                // cannot occur today.
+                // The CTS is disposed inline only on paths where the worker has
+                // provably completed; abandonment paths defer disposal to a
+                // worker-completion continuation so the abandoned parse can never
+                // touch a disposed token source.
+                var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var workerAbandoned = false;
                 try
                 {
-                    extractorResult = await extractTask.WaitAsync(budgetCts.Token);
+                    var budget = _settings.ExtractionTimeout;
+                    if (budget > TimeSpan.Zero)
+                        budgetCts.CancelAfter(budget);
+
+                    var extractTask = Task.Run(
+                        () => extractor.ExtractAsync(stream, budgetCts.Token),
+                        CancellationToken.None);
+                    try
+                    {
+                        extractorResult = await extractTask.WaitAsync(budgetCts.Token);
+                    }
+                    catch (OperationCanceledException)
+                        when (budgetCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        // Budget exhausted (not caller cancellation). Abandon the
+                        // parse. Honest cost: .NET cannot stop a thread that never
+                        // observes cancellation, so the abandoned worker keeps holding
+                        // one thread-pool thread at full CPU until PdfPig's synchronous
+                        // parse runs to completion — only the REQUEST is bounded, not
+                        // the parser's resource consumption, and nothing here caps how
+                        // many abandoned parses can accumulate under concurrent
+                        // parser-bomb submissions (tracked: #1379; must land before
+                        // this service is wired to a request or worker path). The
+                        // abandoned worker holds no file or DB handle — the blob was
+                        // copied into the in-memory stream and the connection closed
+                        // before extraction began. Record a single content-free
+                        // timeout outcome.
+                        workerAbandoned = true;
+                        AbandonExtraction(extractTask, budgetCts);
+                        _logger?.LogWarning(
+                            "Local extraction exceeded the {BudgetSeconds}s wall-clock budget for artefact {ArtefactId} with extractor {ExtractorName}; recording a timeout outcome",
+                            budget.TotalSeconds,
+                            sourceArtefactId,
+                            extractor.ExtractorName);
+                        extractorResult = WarningResult(
+                            extractor,
+                            ArtefactExtractionWarningCodes.ExtractionTimeout);
+                    }
+                    catch (OperationCanceledException)
+                        when (cancellationToken.IsCancellationRequested)
+                    {
+                        // Caller-driven cancellation (request aborted): abandon the
+                        // worker and propagate without recording an extraction
+                        // outcome. A stray OCE from a future extractor whose own token
+                        // is unrelated to ours falls through to the extractor-error
+                        // handler below instead of masquerading as caller cancellation.
+                        workerAbandoned = true;
+                        AbandonExtraction(extractTask, budgetCts);
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        // WaitAsync only propagates the task's own exception once the
+                        // task has completed, so the worker is finished on this path.
+                        _logger?.LogWarning(
+                            "Local extraction failed for artefact {ArtefactId} with extractor {ExtractorName}; exception type {ExceptionType}",
+                            sourceArtefactId,
+                            extractor.ExtractorName,
+                            ex.GetType().Name);
+                        extractorResult = WarningResult(
+                            extractor,
+                            ArtefactExtractionWarningCodes.ExtractorError);
+                    }
                 }
-                catch (OperationCanceledException)
-                    when (budgetCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                finally
                 {
-                    // Budget exhausted (not caller cancellation). Abandon the parse:
-                    // it may run to completion on a background thread, but it holds no
-                    // file or DB handle — the blob was copied into the in-memory stream
-                    // and the connection closed before extraction began — so the only
-                    // resource in flight is managed memory the GC reclaims once the
-                    // worker unwinds. Record a single content-free timeout outcome.
-                    ObserveAbandonedExtraction(extractTask);
-                    _logger?.LogWarning(
-                        "Local extraction exceeded the {BudgetSeconds}s wall-clock budget for artefact {ArtefactId} with extractor {ExtractorName}; recording a timeout outcome",
-                        budget.TotalSeconds,
-                        sourceArtefactId,
-                        extractor.ExtractorName);
-                    extractorResult = WarningResult(
-                        extractor,
-                        ArtefactExtractionWarningCodes.ExtractionTimeout);
-                }
-                catch (OperationCanceledException)
-                    when (cancellationToken.IsCancellationRequested)
-                {
-                    // Caller-driven cancellation (request aborted): abandon the worker
-                    // and propagate without recording an extraction outcome. A stray
-                    // OCE from a future extractor whose own token is unrelated to ours
-                    // falls through to the extractor-error handler below instead of
-                    // masquerading as caller cancellation.
-                    ObserveAbandonedExtraction(extractTask);
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    _logger?.LogWarning(
-                        "Local extraction failed for artefact {ArtefactId} with extractor {ExtractorName}; exception type {ExceptionType}",
-                        sourceArtefactId,
-                        extractor.ExtractorName,
-                        ex.GetType().Name);
-                    extractorResult = WarningResult(
-                        extractor,
-                        ArtefactExtractionWarningCodes.ExtractorError);
+                    if (!workerAbandoned)
+                        budgetCts.Dispose();
                 }
             }
         }
@@ -299,16 +329,30 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
             extractor.ExtractorVersion);
     }
 
-    private static void ObserveAbandonedExtraction(Task extractTask)
+    private void AbandonExtraction(Task extractTask, CancellationTokenSource budgetCts)
     {
         // The request returns before this worker necessarily finishes, and the
         // request-scoped input stream is disposed on return, so an abandoned parse
         // typically faults (e.g. ObjectDisposedException) on its next read. Observe
-        // that fault so it is not surfaced as an UnobservedTaskException.
+        // that fault so it is not surfaced as an UnobservedTaskException, and only
+        // dispose the budget CTS once the worker has fully completed so the
+        // abandoned parse can never touch a disposed token source. (Cancelled
+        // workers need no observation — cancelled tasks do not raise
+        // UnobservedTaskException.)
         _ = extractTask.ContinueWith(
-            static task => _ = task.Exception,
+            task =>
+            {
+                if (task.IsFaulted)
+                {
+                    _logger?.LogDebug(
+                        "Abandoned artefact extraction worker faulted after the request completed; exception type {ExceptionType}",
+                        task.Exception!.GetBaseException().GetType().Name);
+                }
+
+                budgetCts.Dispose();
+            },
             CancellationToken.None,
-            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
     }
 

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
@@ -156,9 +156,13 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                         ArtefactExtractionWarningCodes.ExtractionTimeout);
                 }
                 catch (OperationCanceledException)
+                    when (cancellationToken.IsCancellationRequested)
                 {
                     // Caller-driven cancellation (request aborted): abandon the worker
-                    // and propagate without recording an extraction outcome.
+                    // and propagate without recording an extraction outcome. A stray
+                    // OCE from a future extractor whose own token is unrelated to ours
+                    // falls through to the extractor-error handler below instead of
+                    // masquerading as caller cancellation.
                     ObserveAbandonedExtraction(extractTask);
                     throw;
                 }

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionWarningCodes.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionWarningCodes.cs
@@ -13,4 +13,5 @@ public static class ArtefactExtractionWarningCodes
     public const string InvalidText = "invalid-text";
     public const string ExtractorError = "extractor-error";
     public const string ExtractorContractError = "extractor-contract-error";
+    public const string ExtractionTimeout = "extraction-timeout";
 }

--- a/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
@@ -24,7 +24,11 @@ public sealed class ArtefactStorageSettings
     /// to effectively disable the budget without a zero/negative value that would
     /// abort every extraction.
     /// </summary>
-    [Range(1, 3600)]
+    // Double literals set RangeAttribute.OperandType to double; the int-operand
+    // overload would coerce the value to Int32 (rounding) before comparing, so a
+    // sub-1s value like 0.6 would round up to 1 and slip past the floor while the
+    // service still ran the raw sub-second budget.
+    [Range(1.0, 3600.0)]
     public double ExtractionTimeoutSeconds { get; set; } = DefaultExtractionTimeoutSeconds;
 
     /// <summary>

--- a/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
@@ -6,10 +6,32 @@ public sealed class ArtefactStorageSettings
 {
     public const long DefaultMaxBytesPerArtefact = 10L * 1024 * 1024;
     public const long DefaultMaxBytesPerUser = 200L * 1024 * 1024;
+    public const double DefaultExtractionTimeoutSeconds = 30;
 
     [Range(typeof(long), "1", "2147483647")]
     public long MaxBytesPerArtefact { get; set; } = DefaultMaxBytesPerArtefact;
 
     [Range(typeof(long), "1", "9223372036854775807")]
     public long MaxBytesPerUser { get; set; } = DefaultMaxBytesPerUser;
+
+    /// <summary>
+    /// Wall-clock budget, in seconds, for a single artefact text extraction. The
+    /// byte/page/character caps bound the input and persisted output but not the
+    /// parser's in-memory work: a crafted PDF (deeply nested object streams,
+    /// pathological content streams, decompression bombs) that stays under those
+    /// caps can still spin PdfPig's synchronous parse arbitrarily long. This bounds
+    /// that work. It is constrained to [1, 3600] seconds so an operator can raise it
+    /// to effectively disable the budget without a zero/negative value that would
+    /// abort every extraction.
+    /// </summary>
+    [Range(1, 3600)]
+    public double ExtractionTimeoutSeconds { get; set; } = DefaultExtractionTimeoutSeconds;
+
+    /// <summary>
+    /// The extraction wall-clock budget as a <see cref="TimeSpan"/>. A value of
+    /// zero or less (only reachable when the data-annotation range is bypassed, e.g.
+    /// a hand-constructed settings object) is treated by the extraction service as
+    /// "no budget" rather than an instant timeout.
+    /// </summary>
+    public TimeSpan ExtractionTimeout => TimeSpan.FromSeconds(ExtractionTimeoutSeconds);
 }

--- a/backend/tests/Taskdeck.Api.Tests/ArtefactExtractionServiceRealExtractorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ArtefactExtractionServiceRealExtractorTests.cs
@@ -1,0 +1,133 @@
+using System.Text;
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Services;
+using UglyToad.PdfPig.Content;
+using UglyToad.PdfPig.Core;
+using UglyToad.PdfPig.Fonts.Standard14Fonts;
+using UglyToad.PdfPig.Writer;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Runs REAL extractors (PdfPig, PlainText) through the budget-wrapped
+/// <see cref="ArtefactExtractionService"/> path added for #1369. The budget unit
+/// tests use stubs by design; these tests prove result marshaling and
+/// stream-position behavior through the Task.Run + WaitAsync path against the
+/// real parser libraries, with the default 30s budget never firing for normal
+/// documents.
+/// </summary>
+public sealed class ArtefactExtractionServiceRealExtractorTests
+{
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _artefactId = Guid.NewGuid();
+    private readonly Mock<ISourceArtefactRepository> _artefacts = new();
+    private readonly Mock<IArtefactExtractionRepository> _extractions = new();
+
+    [Fact]
+    public async Task ExtractAsync_ShouldRunRealPdfPigExtractorUnderDefaultBudget()
+    {
+        const string marker = "Real PdfPig parse through the budgeted service path.";
+        var pdf = BuildPdf(marker);
+        ArrangeStoredArtefact("application/pdf", pdf);
+        ArtefactExtraction? stored = null;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback<ArtefactExtraction, Guid, CancellationToken>((value, _, _) => stored = value)
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        var service = new ArtefactExtractionService(
+            _artefacts.Object,
+            _extractions.Object,
+            [new PdfPigArtefactTextExtractor()],
+            new ArtefactStorageSettings());
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedText.Should().Contain(marker);
+        result.Value.Warnings.Should().BeEmpty();
+        result.Value.ExtractorName.Should().Be("PdfPig");
+        stored.Should().NotBeNull();
+        stored!.ExtractedText.Should().Contain(marker);
+        stored.Warnings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ShouldRunRealPlainTextExtractorUnderDefaultBudget()
+    {
+        const string content = "Real plain-text extraction through the budgeted service path.";
+        ArrangeStoredArtefact("text/plain", Encoding.UTF8.GetBytes(content));
+        ArtefactExtraction? stored = null;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback<ArtefactExtraction, Guid, CancellationToken>((value, _, _) => stored = value)
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        var service = new ArtefactExtractionService(
+            _artefacts.Object,
+            _extractions.Object,
+            [new PlainTextArtefactTextExtractor()],
+            new ArtefactStorageSettings());
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedText.Should().Be(content);
+        result.Value.Warnings.Should().BeEmpty();
+        result.Value.ExtractorName.Should().Be("PlainText");
+        stored!.ExtractedText.Should().Be(content);
+    }
+
+    private void ArrangeStoredArtefact(string mimeType, byte[] content)
+    {
+        var kind = mimeType == "application/pdf" ? ArtefactKind.Pdf : ArtefactKind.TextFile;
+        var artefact = new SourceArtefact(
+            _userId,
+            kind,
+            mimeType,
+            kind == ArtefactKind.Pdf ? "source.pdf" : "source.txt",
+            content.LongLength,
+            new string('a', 64),
+            CaptureSource.Import);
+        typeof(Taskdeck.Domain.Common.Entity)
+            .GetProperty(nameof(Taskdeck.Domain.Common.Entity.Id))!
+            .SetValue(artefact, _artefactId);
+
+        _artefacts
+            .Setup(repository => repository.GetByIdForUserAsync(
+                _artefactId,
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artefact);
+        _artefacts
+            .Setup(repository => repository.CopyContentForUserAsync(
+                _artefactId,
+                _userId,
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(async (Guid _, Guid _, Stream destination, CancellationToken cancellationToken) =>
+            {
+                await destination.WriteAsync(content, cancellationToken);
+                return true;
+            });
+    }
+
+    private static byte[] BuildPdf(string pageText)
+    {
+        var builder = new PdfDocumentBuilder();
+        var font = builder.AddStandard14Font(Standard14Font.Helvetica);
+        var page = builder.AddPage(PageSize.A4);
+        page.AddText(pageText, 12, new PdfPoint(40, 780), font);
+        return builder.Build();
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
@@ -59,6 +59,86 @@ public class OptionsValidationTests
         Assert.Contains(results, result => result.MemberNames.Contains(nameof(settings.MaxBytesPerArtefact)));
     }
 
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(0.5)]
+    [InlineData(3601.0)]
+    public void ArtefactStorageSettings_ExtractionTimeoutSeconds_RejectsOutOfRange(double value)
+    {
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = value };
+
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(settings);
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var isValid = System.ComponentModel.DataAnnotations.Validator.TryValidateObject(
+            settings, context, results, validateAllProperties: true);
+
+        Assert.False(isValid);
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(ArtefactStorageSettings.ExtractionTimeoutSeconds)));
+    }
+
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(30.0)]
+    [InlineData(3600.0)]
+    public void ArtefactStorageSettings_ExtractionTimeoutSeconds_AcceptsValidValues(double value)
+    {
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = value };
+
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(settings);
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var isValid = System.ComponentModel.DataAnnotations.Validator.TryValidateObject(
+            settings, context, results, validateAllProperties: true);
+
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public void ArtefactStorageSettings_BindsExtractionTimeoutFromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Artefacts:ExtractionTimeoutSeconds"] = "12.5"
+            })
+            .Build();
+
+        var settings = configuration.GetSection("Artefacts").Get<ArtefactStorageSettings>();
+
+        Assert.NotNull(settings);
+        Assert.Equal(12.5, settings!.ExtractionTimeoutSeconds);
+        Assert.Equal(TimeSpan.FromSeconds(12.5), settings.ExtractionTimeout);
+    }
+
+    [Fact]
+    public void ArtefactStorageSettings_DefaultExtractionTimeout_IsThirtySeconds()
+    {
+        var settings = new ArtefactStorageSettings();
+
+        Assert.Equal(ArtefactStorageSettings.DefaultExtractionTimeoutSeconds, settings.ExtractionTimeoutSeconds);
+        Assert.Equal(TimeSpan.FromSeconds(30), settings.ExtractionTimeout);
+    }
+
+    [Fact]
+    public void AddOptionsValidation_RejectsExtractionTimeoutOutOfRangeAtStartup()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Artefacts:ExtractionTimeoutSeconds"] = "0"
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddOptionsValidation(configuration);
+
+        using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ArtefactStorageSettings>>().Value);
+        Assert.Contains(nameof(ArtefactStorageSettings.ExtractionTimeoutSeconds), exception.Message);
+    }
+
     // ── JwtSettingsValidator ─────────────────────────────────────────────
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
@@ -68,6 +68,13 @@ public class OptionsValidationTests
     [InlineData(0.6)]
     [InlineData(0.9)]
     [InlineData(3601.0)]
+    // Non-finite doubles bind successfully from configuration strings ("NaN",
+    // "Infinity") and would reach TimeSpan.FromSeconds — which throws for NaN.
+    // The double-operand range rejects all three today; pin that so removing or
+    // weakening the attribute cannot silently open the FromSeconds(NaN) throw path.
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
     public void ArtefactStorageSettings_ExtractionTimeoutSeconds_RejectsOutOfRange(double value)
     {
         var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = value };

--- a/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
@@ -63,6 +63,10 @@ public class OptionsValidationTests
     [InlineData(0.0)]
     [InlineData(-1.0)]
     [InlineData(0.5)]
+    // 0.6 and 0.9 round UP to 1 under an int-operand range but are below the real
+    // 1.0 floor — they must be rejected by the double-operand range.
+    [InlineData(0.6)]
+    [InlineData(0.9)]
     [InlineData(3601.0)]
     public void ArtefactStorageSettings_ExtractionTimeoutSeconds_RejectsOutOfRange(double value)
     {

--- a/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionServiceTests.cs
@@ -369,6 +369,36 @@ public sealed class ArtefactExtractionServiceTests
     }
 
     [Fact]
+    public async Task ExtractAsync_ShouldRecordExtractorErrorForUnrelatedCancellation()
+    {
+        // An extractor that throws OperationCanceledException from a token unrelated
+        // to the caller's or the budget's is an extractor fault, not a caller
+        // cancellation: it must be recorded as a content-free extractor-error row
+        // rather than propagated as a spurious cancellation with no history.
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        ArtefactExtraction? stored = null;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback<ArtefactExtraction, Guid, CancellationToken>((value, _, _) => stored = value)
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        var extractor = new StubExtractor(
+            "application/pdf",
+            exception: new OperationCanceledException("unrelated token"));
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 30 };
+        var service = CreateService(settings, extractor);
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedText.Should().BeEmpty();
+        result.Value.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractorError);
+        stored!.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractorError);
+    }
+
+    [Fact]
     public async Task GetLatestAsync_ShouldReturnRepositoryWinner()
     {
         var extraction = new ArtefactExtraction(

--- a/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionServiceTests.cs
@@ -239,6 +239,136 @@ public sealed class ArtefactExtractionServiceTests
     }
 
     [Fact]
+    public async Task ExtractAsync_ShouldRecordTimeoutWarningWhenExtractorIgnoresBudget()
+    {
+        // Models a parser-bomb PDF: the extractor never observes the token (like
+        // PdfPig's synchronous Open), so only the wall-clock budget returns control.
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        ArtefactExtraction? stored = null;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback<ArtefactExtraction, Guid, CancellationToken>((value, _, _) => stored = value)
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        using var release = new ManualResetEventSlim(false);
+        var extractor = new StubExtractor("application/pdf", blockUntil: release);
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 0.05 };
+        var service = CreateService(settings, extractor);
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedText.Should().BeEmpty();
+        result.Value.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractionTimeout);
+        stored.Should().NotBeNull();
+        stored!.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractionTimeout);
+        _extractions.Verify(repository => repository.TryAddForUserAsync(
+            It.IsAny<ArtefactExtraction>(),
+            _userId,
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        release.Set(); // let the abandoned worker unwind
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ShouldNotTimeOutNormalDocumentWithinBudget()
+    {
+        ArrangeStoredArtefact("text/markdown", Encoding.UTF8.GetBytes("ignored"));
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        var extractor = new StubExtractor(
+            "text/",
+            new ArtefactExtractionResult("hello world", [], "First", "1.0"),
+            "First");
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 30 };
+        var service = CreateService(settings, extractor);
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedText.Should().Be("hello world");
+        result.Value.Warnings.Should().NotContain(ArtefactExtractionWarningCodes.ExtractionTimeout);
+        extractor.CallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ShouldPropagateCallerCancellationWithoutRecording()
+    {
+        // Caller cancellation must win over the budget: the request throws and no
+        // extraction-history row is written (distinct from the budget-timeout outcome).
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        using var release = new ManualResetEventSlim(false);
+        using var started = new ManualResetEventSlim(false);
+        var extractor = new StubExtractor(
+            "application/pdf",
+            blockUntil: release,
+            signalStarted: started);
+        using var cts = new CancellationTokenSource();
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 30 };
+        var service = CreateService(settings, extractor);
+
+        var task = service.ExtractAsync(_userId, _artefactId, cts.Token);
+        started.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue();
+        cts.Cancel();
+
+        await FluentActions
+            .Awaiting(() => task)
+            .Should()
+            .ThrowAsync<OperationCanceledException>();
+        _extractions.Verify(repository => repository.TryAddForUserAsync(
+            It.IsAny<ArtefactExtraction>(),
+            It.IsAny<Guid>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+
+        release.Set(); // let the abandoned worker unwind
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ShouldStopCooperativeExtractorBetweenPagesOnBudget()
+    {
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        ArtefactExtraction? stored = null;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback<ArtefactExtraction, Guid, CancellationToken>((value, _, _) => stored = value)
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        var extractor = new CooperativePagedExtractor(
+            "application/pdf",
+            totalPages: 1000,
+            perPageWork: TimeSpan.FromMilliseconds(20));
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 0.05 };
+        var service = CreateService(settings, extractor);
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractionTimeout);
+        stored!.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractionTimeout);
+
+        // Deterministically observe the worker's final state (the request itself does
+        // not wait for it): it stopped between pages via the token, not by finishing.
+        (await Task.WhenAny(extractor.Finished, Task.Delay(TimeSpan.FromSeconds(10))))
+            .Should().Be(extractor.Finished);
+        extractor.CooperativelyCancelled.Should().BeTrue();
+        extractor.PagesProcessed.Should().BeLessThan(1000);
+    }
+
+    [Fact]
     public async Task GetLatestAsync_ShouldReturnRepositoryWinner()
     {
         var extraction = new ArtefactExtraction(
@@ -264,6 +394,11 @@ public sealed class ArtefactExtractionServiceTests
 
     private ArtefactExtractionService CreateService(params IArtefactTextExtractor[] extractors)
         => new(_artefacts.Object, _extractions.Object, extractors);
+
+    private ArtefactExtractionService CreateService(
+        ArtefactStorageSettings settings,
+        params IArtefactTextExtractor[] extractors)
+        => new(_artefacts.Object, _extractions.Object, extractors, settings);
 
     private void ArrangeStoredArtefact(
         string mimeType,
@@ -309,13 +444,17 @@ public sealed class ArtefactExtractionServiceTests
         private readonly string _mimePrefix;
         private readonly ArtefactExtractionResult _result;
         private readonly Exception? _exception;
+        private readonly ManualResetEventSlim? _blockUntil;
+        private readonly ManualResetEventSlim? _signalStarted;
 
         public StubExtractor(
             string mimePrefix,
             ArtefactExtractionResult? result = null,
             string name = "Stub",
             Exception? exception = null,
-            long inputByteLimit = 1024 * 1024)
+            long inputByteLimit = 1024 * 1024,
+            ManualResetEventSlim? blockUntil = null,
+            ManualResetEventSlim? signalStarted = null)
         {
             _mimePrefix = mimePrefix;
             ExtractorName = name;
@@ -323,6 +462,8 @@ public sealed class ArtefactExtractionServiceTests
             _result = result ?? new ArtefactExtractionResult("content", [], name, "1.0");
             _exception = exception;
             InputByteLimit = inputByteLimit;
+            _blockUntil = blockUntil;
+            _signalStarted = signalStarted;
         }
 
         public string ExtractorName { get; }
@@ -340,7 +481,74 @@ public sealed class ArtefactExtractionServiceTests
             CallCount++;
             if (_exception is not null)
                 throw _exception;
+
+            // Deliberately ignore the cancellation token to model PdfPig's synchronous
+            // PdfDocument.Open, which does not honour cancellation; the service must
+            // still return by abandoning this worker when the budget fires.
+            _signalStarted?.Set();
+            _blockUntil?.Wait(TimeSpan.FromSeconds(30));
+
             return Task.FromResult(_result);
+        }
+    }
+
+    /// <summary>
+    /// Models an extractor that observes cancellation cooperatively between pages,
+    /// like PdfPig's page loop. Proves the budget token flows through the service and
+    /// stops further page work rather than running to completion.
+    /// </summary>
+    private sealed class CooperativePagedExtractor : IArtefactTextExtractor
+    {
+        private readonly string _mimePrefix;
+        private readonly int _totalPages;
+        private readonly TimeSpan _perPageWork;
+        private readonly TaskCompletionSource _finished =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public CooperativePagedExtractor(string mimePrefix, int totalPages, TimeSpan perPageWork)
+        {
+            _mimePrefix = mimePrefix;
+            _totalPages = totalPages;
+            _perPageWork = perPageWork;
+        }
+
+        public string ExtractorName => "CooperativePaged";
+        public string ExtractorVersion => "1.0";
+        public long InputByteLimit => 1024 * 1024;
+        public int PagesProcessed { get; private set; }
+        public bool CooperativelyCancelled { get; private set; }
+
+        /// <summary>Completes when the worker unwinds (completion or cancellation).</summary>
+        public Task Finished => _finished.Task;
+
+        public bool CanExtract(string mimeType)
+            => mimeType.StartsWith(_mimePrefix, StringComparison.OrdinalIgnoreCase);
+
+        public Task<ArtefactExtractionResult> ExtractAsync(
+            Stream content,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                for (var page = 1; page <= _totalPages; page++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    Thread.Sleep(_perPageWork);
+                    PagesProcessed++;
+                }
+
+                return Task.FromResult(
+                    new ArtefactExtractionResult("done", [], ExtractorName, ExtractorVersion));
+            }
+            catch (OperationCanceledException)
+            {
+                CooperativelyCancelled = true;
+                throw;
+            }
+            finally
+            {
+                _finished.TrySetResult();
+            }
         }
     }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
@@ -399,6 +400,77 @@ public sealed class ArtefactExtractionServiceTests
     }
 
     [Fact]
+    public async Task ExtractAsync_ShouldTreatZeroBudgetAsNoBudget()
+    {
+        // ExtractionTimeoutSeconds = 0 deliberately bypasses the [Range(1.0, 3600.0)]
+        // floor (hand-constructed settings): the service must treat zero/negative as
+        // "no budget" — a slow extraction completes normally — never as an instant
+        // timeout that would abort every extraction.
+        ArrangeStoredArtefact("text/plain", Encoding.UTF8.GetBytes("ignored"));
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        var extractor = new StubExtractor(
+            "text/plain",
+            new ArtefactExtractionResult("slow but done", [], "First", "1.0"),
+            "First",
+            delay: TimeSpan.FromMilliseconds(250));
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 0 };
+        var service = CreateService(settings, extractor);
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ExtractedText.Should().Be("slow but done");
+        result.Value.Warnings.Should().NotContain(ArtefactExtractionWarningCodes.ExtractionTimeout);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ShouldObserveAbandonedWorkerFaultWithoutSecondRecord()
+    {
+        // After the budget fires and the request returns, the abandoned worker
+        // eventually FAULTS (models the disposed-stream ObjectDisposedException an
+        // abandoned PdfPig parse hits). The fault must be observed — the completion
+        // continuation logs it — and must not write a second history row.
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+        using var release = new ManualResetEventSlim(false);
+        var logger = new CapturingLogger();
+        var extractor = new StubExtractor(
+            "application/pdf",
+            blockUntil: release,
+            throwOnRelease: new InvalidDataException("late parser fault"));
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 0.05 };
+        var service = new ArtefactExtractionService(
+            _artefacts.Object,
+            _extractions.Object,
+            [extractor],
+            settings,
+            logger);
+
+        var result = await service.ExtractAsync(_userId, _artefactId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractionTimeout);
+
+        release.Set(); // the abandoned worker now unwinds and throws
+        var observed = await logger.WaitForDebugEntryAsync(TimeSpan.FromSeconds(10));
+        observed.Should().Contain(nameof(InvalidDataException));
+        _extractions.Verify(repository => repository.TryAddForUserAsync(
+            It.IsAny<ArtefactExtraction>(),
+            _userId,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task GetLatestAsync_ShouldReturnRepositoryWinner()
     {
         var extraction = new ArtefactExtraction(
@@ -476,6 +548,8 @@ public sealed class ArtefactExtractionServiceTests
         private readonly Exception? _exception;
         private readonly ManualResetEventSlim? _blockUntil;
         private readonly ManualResetEventSlim? _signalStarted;
+        private readonly Exception? _throwOnRelease;
+        private readonly TimeSpan? _delay;
 
         public StubExtractor(
             string mimePrefix,
@@ -484,7 +558,9 @@ public sealed class ArtefactExtractionServiceTests
             Exception? exception = null,
             long inputByteLimit = 1024 * 1024,
             ManualResetEventSlim? blockUntil = null,
-            ManualResetEventSlim? signalStarted = null)
+            ManualResetEventSlim? signalStarted = null,
+            Exception? throwOnRelease = null,
+            TimeSpan? delay = null)
         {
             _mimePrefix = mimePrefix;
             ExtractorName = name;
@@ -494,6 +570,8 @@ public sealed class ArtefactExtractionServiceTests
             InputByteLimit = inputByteLimit;
             _blockUntil = blockUntil;
             _signalStarted = signalStarted;
+            _throwOnRelease = throwOnRelease;
+            _delay = delay;
         }
 
         public string ExtractorName { get; }
@@ -517,6 +595,10 @@ public sealed class ArtefactExtractionServiceTests
             // still return by abandoning this worker when the budget fires.
             _signalStarted?.Set();
             _blockUntil?.Wait(TimeSpan.FromSeconds(30));
+            if (_throwOnRelease is not null)
+                throw _throwOnRelease;
+            if (_delay is not null)
+                Thread.Sleep(_delay.Value);
 
             return Task.FromResult(_result);
         }
@@ -579,6 +661,40 @@ public sealed class ArtefactExtractionServiceTests
             {
                 _finished.TrySetResult();
             }
+        }
+    }
+
+    /// <summary>
+    /// Captures the first Debug-level entry (the abandoned-worker fault observation)
+    /// and lets a test await it deterministically instead of polling.
+    /// </summary>
+    private sealed class CapturingLogger : ILogger<ArtefactExtractionService>
+    {
+        private readonly TaskCompletionSource<string> _debugEntry =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Debug)
+                _debugEntry.TrySetResult(formatter(state, exception));
+        }
+
+        public async Task<string> WaitForDebugEntryAsync(TimeSpan timeout)
+        {
+            var winner = await Task.WhenAny(_debugEntry.Task, Task.Delay(timeout));
+            winner.Should().Be(
+                _debugEntry.Task,
+                "the abandoned worker's fault must be observed and logged by the completion continuation");
+            return await _debugEntry.Task;
         }
     }
 }

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -578,13 +578,16 @@ Bound to `ArtefactStorageSettings`
 (`Taskdeck.Application.Services.ArtefactStorageSettings`) and validated at
 startup. Source artefact metadata and blobs stay in the same SQLite database;
 the blob table is queried only for explicit content retrieval and GDPR export.
-Both limits are enforced from server configuration, never from multipart form
-fields. Concurrent uploads serialize the quota check with the SQLite write.
+The storage limits are enforced from server configuration, never from multipart
+form fields. Concurrent uploads serialize the quota check with the SQLite write.
+`ExtractionTimeoutSeconds` additionally bounds the local text-extraction path so
+a crafted parser-bomb artefact cannot spin the parse thread indefinitely.
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |
 | `Artefacts:MaxBytesPerArtefact` | `long` | `10485760` (10 MiB) | Maximum bytes accepted for one PNG, JPEG, WebP, PDF, TXT, or Markdown artefact. The upload stream stops and returns HTTP 413 once this bound is crossed. The API raises Kestrel's request-body ceiling to this value plus 128 KiB of bounded multipart overhead. This setting is capped at `int.MaxValue` because upload validation materializes one accepted artefact as a `byte[]` before the atomic SQLite write. Environment variable: `Artefacts__MaxBytesPerArtefact`. | No |
 | `Artefacts:MaxBytesPerUser` | `long` | `209715200` (200 MiB) | Aggregate source-artefact quota for one user, including blob bytes. Uploads that would cross it return HTTP 413. Environment variable: `Artefacts__MaxBytesPerUser`. | No |
+| `Artefacts:ExtractionTimeoutSeconds` | `double` | `30` | Wall-clock budget for a single local text extraction (PdfPig / plain-text / Markdown). The byte, page, and character caps bound the input and persisted output but not the parser's in-memory work; a crafted PDF (deeply nested object streams, decompression bombs) that stays under those caps can still spin PdfPig's synchronous `PdfDocument.Open(...)` arbitrarily long. When the budget is exceeded the extraction is abandoned and recorded as an immutable extraction-history row carrying the `extraction-timeout` warning (no HTTP 500; the artefact stays stored). Bounded to `[1, 3600]`; raise it toward the ceiling to effectively disable the budget. Environment variable: `Artefacts__ExtractionTimeoutSeconds`. | No |
 
 ### `FirstRun`
 


### PR DESCRIPTION
## Summary

Closes #1369.

Artefact text extraction (GEN-02, #1346) bounded the **input** (10 MiB byte cap, 100-page cap, 51,200-char output cap) but not the parser's **wall-clock**. PdfPig's `PdfDocument.Open(...)` runs synchronously and does not honour a `CancellationToken`, so a crafted parser-bomb PDF (deeply nested object streams, decompression bombs, pathological xref) that stays under every byte/page/char cap can still spin the parse thread arbitrarily long — a latent DoS on the artefact-extraction path (latent-only today because `ArtefactExtractionService` has no caller yet; this lands the fix **before** it is wired to a request path).

## Design

- **Configurable budget.** `Artefacts:ExtractionTimeoutSeconds` (`double`, default `30`, `[Range(1.0, 3600.0)]` — double operands so fractional values are validated unrounded) on the existing `ArtefactStorageSettings` (already bound to the `Artefacts` section and startup-validated). Exposed as `ExtractionTimeout` (`TimeSpan`). Documented in `docs/platform/CONFIGURATION_REFERENCE.md`.
- **Enforcement (Application layer).** `ArtefactExtractionService` wraps the parse in a `CancellationTokenSource.CreateLinkedTokenSource(callerToken)` + `CancelAfter(budget)`. Because the synchronous `Open()` ignores cancellation, the parse is offloaded via `Task.Run` and raced with `Task.WaitAsync(budgetToken)`. The budget token is **also** passed into the extractor, so bombs that reach the page/word loop are cancelled cooperatively between pages (the clean path); bombs that spin inside `Open()` are handled by abandoning the worker.
- **On timeout:** no HTTP 500. The service records the standard immutable, warning-bearing extraction-history row using a new content-free warning code `extraction-timeout`, returning the same stable contract as other extraction failures (`InputTooLarge`, `ExtractorError`). The artefact itself stays stored. Caller-driven cancellation still propagates (`OperationCanceledException`) and records **nothing**, preserving prior behaviour.
- No new endpoints; **no schema change** (`ef migrations has-pending-model-changes` → "No changes").

### Abandoned-task caveat (called out explicitly)

When the budget fires on an `Open()`-bomb, the worker is **abandoned** — the request returns immediately, but the honest cost is that .NET cannot stop a thread that never observes cancellation: the abandoned worker **keeps holding one thread-pool thread at full CPU until PdfPig's synchronous parse runs to completion**, and nothing in this PR caps how many abandoned parses can accumulate under concurrent parser-bomb submissions. The budget therefore bounds **request latency**, not the parser's resource consumption — the resource bound is tracked in #1379 and gates any request-path wiring. What *is* safe: `CopyContentForUserAsync` fully copies the blob into an in-memory `BoundedMemoryStream` and closes the SQLite connection **before** extraction begins, so the abandoned parse holds **no file/DB handle**. Its eventual fault (typically `ObjectDisposedException` when the request-scoped stream is disposed) is observed and logged by a worker-completion continuation so it never surfaces as an `UnobservedTaskException`; the same continuation disposes the budget `CancellationTokenSource` only after the worker has fully completed, so an abandoned parse can never touch a disposed token source. `Thread.Abort` is not used.

## Tests (deterministic — no reliance on a real pathological PDF)

Added to `ArtefactExtractionServiceTests` (Application.Tests) and `OptionsValidationTests` (Api.Tests):

1. `ExtractAsync_ShouldRecordTimeoutWarningWhenExtractorIgnoresBudget` — a stub extractor that blocks and ignores the token (models `Open()`) + a 50 ms budget → produces exactly one `extraction-timeout` history row (`TryAddForUserAsync` `Times.Once`).
2. `ExtractAsync_ShouldNotTimeOutNormalDocumentWithinBudget` — normal doc + 30 s budget completes with no timeout warning.
3. `ExtractAsync_ShouldStopCooperativeExtractorBetweenPagesOnBudget` — a paged extractor that checks the token between pages stops early (`PagesProcessed < 1000`, `CooperativelyCancelled == true`, verified via a completion signal so it is race-free).
4. `ExtractAsync_ShouldPropagateCallerCancellationWithoutRecording` — caller cancel wins over budget: throws `OperationCanceledException`, writes no history row.
5. Config binding + `[Range]` (`RejectsOutOfRange` for `0/-1/0.5/0.6/0.9/3601/NaN/±Infinity`, `AcceptsValidValues`, binds `12.5` from config, default is 30 s, and startup `OptionsValidationException` for `0`).

Added in the review rounds (see the adversarial-review comments):

6. `ExtractAsync_ShouldRecordExtractorErrorForUnrelatedCancellation` — a stray extractor OCE (no token of ours cancelled) records `extractor-error`, never masquerades as caller cancellation.
7. `ExtractAsync_ShouldTreatZeroBudgetAsNoBudget` — hand-constructed `ExtractionTimeoutSeconds = 0` (bypassing validation) means "no budget", never instant timeout.
8. `ExtractAsync_ShouldObserveAbandonedWorkerFaultWithoutSecondRecord` — an abandoned worker that later FAULTS is observed (logged by the completion continuation) with exactly one history row.
9. `ArtefactExtractionServiceRealExtractorTests` (Api.Tests) — the REAL `PdfPigArtefactTextExtractor` and `PlainTextArtefactTextExtractor` run through the budget-wrapped service path with the default budget: under-budget success rows, correct extracted text (proves result marshaling + stream-position behavior through `Task.Run` + `WaitAsync` against the real libraries).

## Caller status (explicit)

**`IArtefactExtractionService` currently has NO production caller** — it is not wired to any upload, HTTP, or worker path (by design, unchanged from GEN-02/#1346). All coverage in this PR is unit/integration-level against the service seam; **HTTP-path behavior is unproven until wiring lands**, and that wiring is gated by #1379 (parser resource bounding: concurrency cap + decompression/allocation ceiling).

## Verification (final, head `9d4ebbf2`)

- `dotnet restore` (once) + `dotnet build backend/Taskdeck.sln -c Release -m:1` → **0 errors** (pre-existing warnings only).
- `ArtefactExtractionServiceTests`: **17 passed**.
- Api `OptionsValidationTests` + `PdfPigArtefactExtractionTests` + `ArtefactExtractionPersistenceTests` + `ArtefactExtractionServiceRealExtractorTests`: **121 passed**.
- `ArtefactsApiTests`: **15 passed**. Domain `ArtefactExtractionTests`: **6 passed**.
- Application `PlainTextArtefactExtractionTests`/`ArtefactContentValidatorTests`/`UntrustedArtefactFixtureContractTests`/`DataExportServiceTests`: **42 passed**.
- `Architecture.Tests` (layer purity): **20 passed, 1 skipped** (pre-existing skip) — Domain stays pure; enforcement/settings live in Application.
- `dotnet ef migrations has-pending-model-changes` → **"No changes"**.

## Residual risk / follow-up

Tracked in **#1379** (hard gate before any request-path or worker wiring):

- **No memory/decompression ceiling** — the *expanded* in-memory size is unbounded (only the compressed input is capped); a fast allocation bomb could exhaust memory before the budget fires.
- **Unbounded abandoned-parse accumulation** — N concurrent parser-bombs leave N pool threads spinning at full CPU long after their `extraction-timeout` rows returned; a concurrency cap / bounded worker queue is required before the timeout can be treated as a DoS boundary.

