### PR TITLE
Batch buffered account-export artefact blob loads (#1355)

### DIFF
--- a/backend/src/Taskdeck.Application/Interfaces/ISourceArtefactRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ISourceArtefactRepository.cs
@@ -50,6 +50,7 @@ public interface ISourceArtefactRepository : IRepository<SourceArtefact>
     /// user, or have no blob are simply absent from the result (never surfaced across users).
     /// Callers must bound <paramref name="ids"/> so the IN-clause stays within SQLite's parameter
     /// limit (SQLITE_MAX_VARIABLE_NUMBER = 999); the buffered export path pages ids in chunks of 500.
+    /// Passing more than the implementation's batch cap throws <see cref="ArgumentException"/>.
     /// </summary>
     Task<IReadOnlyDictionary<Guid, byte[]>> GetContentsForUserAsync(
         IReadOnlyCollection<Guid> ids,

--- a/backend/src/Taskdeck.Application/Interfaces/ISourceArtefactRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/ISourceArtefactRepository.cs
@@ -44,6 +44,18 @@ public interface ISourceArtefactRepository : IRepository<SourceArtefact>
         Guid userId,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Batch-loads blob content for the requested artefacts owned by <paramref name="userId"/>,
+    /// keyed by artefact id, in a single query. Artefacts that do not exist, are not owned by the
+    /// user, or have no blob are simply absent from the result (never surfaced across users).
+    /// Callers must bound <paramref name="ids"/> so the IN-clause stays within SQLite's parameter
+    /// limit (SQLITE_MAX_VARIABLE_NUMBER = 999); the buffered export path pages ids in chunks of 500.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, byte[]>> GetContentsForUserAsync(
+        IReadOnlyCollection<Guid> ids,
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
     Task<bool> CopyContentForUserAsync(
         Guid id,
         Guid userId,

--- a/backend/src/Taskdeck.Application/Services/DataExportService.cs
+++ b/backend/src/Taskdeck.Application/Services/DataExportService.cs
@@ -188,27 +188,21 @@ public class DataExportService : IDataExportService
 
             var exportArtefacts = new List<UserDataExportArtefactDto>(artefactMetadata.Count);
             // #1355: batch the blob loads in bounded chunks instead of one round-trip per artefact.
-            // The chunk size mirrors StreamPageSize so the IN-clause stays within SQLite's parameter
-            // limit and peak memory holds at most one chunk of raw blob bytes at a time (the buffered
-            // total is already capped by MaxBufferedArtefactBytes). Metadata is iterated in its
+            // The chunk size mirrors StreamPageSize so each IN-clause stays well within SQLite's
+            // parameter budget and peak memory holds at most one chunk of raw blob bytes at a time
+            // (the buffered total is already capped by MaxBufferedArtefactBytes). Metadata keeps its
             // original (Id) order, so the exported artefact array is byte-for-byte identical to the
             // former per-item path.
-            for (var offset = 0; offset < artefactMetadata.Count; offset += StreamPageSize)
+            foreach (var chunk in artefactMetadata.Chunk(StreamPageSize))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var end = Math.Min(offset + StreamPageSize, artefactMetadata.Count);
-                var chunkIds = new List<Guid>(end - offset);
-                for (var i = offset; i < end; i++)
-                    chunkIds.Add(artefactMetadata[i].Id);
-
                 var blobs = await _artefacts.GetContentsForUserAsync(
-                    chunkIds,
+                    chunk.Select(a => a.Id).ToList(),
                     userId,
                     cancellationToken);
 
-                for (var i = offset; i < end; i++)
+                foreach (var artefact in chunk)
                 {
-                    var artefact = artefactMetadata[i];
                     if (!blobs.TryGetValue(artefact.Id, out var bytes) || bytes is null)
                         throw new InvalidOperationException($"Artefact {artefact.Id} is missing its blob.");
 

--- a/backend/src/Taskdeck.Application/Services/DataExportService.cs
+++ b/backend/src/Taskdeck.Application/Services/DataExportService.cs
@@ -187,17 +187,36 @@ public class DataExportService : IDataExportService
                 f.ReportedAt)).ToList();
 
             var exportArtefacts = new List<UserDataExportArtefactDto>(artefactMetadata.Count);
-            foreach (var artefact in artefactMetadata)
+            // #1355: batch the blob loads in bounded chunks instead of one round-trip per artefact.
+            // The chunk size mirrors StreamPageSize so the IN-clause stays within SQLite's parameter
+            // limit and peak memory holds at most one chunk of raw blob bytes at a time (the buffered
+            // total is already capped by MaxBufferedArtefactBytes). Metadata is iterated in its
+            // original (Id) order, so the exported artefact array is byte-for-byte identical to the
+            // former per-item path.
+            for (var offset = 0; offset < artefactMetadata.Count; offset += StreamPageSize)
             {
-                var bytes = await _artefacts.GetContentForUserAsync(artefact.Id, userId, cancellationToken);
-                if (bytes is null)
-                    throw new InvalidOperationException($"Artefact {artefact.Id} is missing its blob.");
+                cancellationToken.ThrowIfCancellationRequested();
+                var count = Math.Min(StreamPageSize, artefactMetadata.Count - offset);
+                var chunk = new List<Domain.Entities.SourceArtefact>(count);
+                for (var i = offset; i < offset + count; i++)
+                    chunk.Add(artefactMetadata[i]);
 
-                var extractionHistory = await GetAllExtractionHistoryAsync(
-                    artefact.Id,
+                var blobs = await _artefacts.GetContentsForUserAsync(
+                    chunk.Select(a => a.Id).ToList(),
                     userId,
                     cancellationToken);
-                exportArtefacts.Add(MapArtefactForExport(artefact, bytes, extractionHistory));
+
+                foreach (var artefact in chunk)
+                {
+                    if (!blobs.TryGetValue(artefact.Id, out var bytes) || bytes is null)
+                        throw new InvalidOperationException($"Artefact {artefact.Id} is missing its blob.");
+
+                    var extractionHistory = await GetAllExtractionHistoryAsync(
+                        artefact.Id,
+                        userId,
+                        cancellationToken);
+                    exportArtefacts.Add(MapArtefactForExport(artefact, bytes, extractionHistory));
+                }
             }
 
             var content = new UserDataExportContentDto(

--- a/backend/src/Taskdeck.Application/Services/DataExportService.cs
+++ b/backend/src/Taskdeck.Application/Services/DataExportService.cs
@@ -189,10 +189,12 @@ public class DataExportService : IDataExportService
             var exportArtefacts = new List<UserDataExportArtefactDto>(artefactMetadata.Count);
             // #1355: batch the blob loads in bounded chunks instead of one round-trip per artefact.
             // The chunk size mirrors StreamPageSize so each IN-clause stays well within SQLite's
-            // parameter budget and peak memory holds at most one chunk of raw blob bytes at a time
-            // (the buffered total is already capped by MaxBufferedArtefactBytes). Metadata keeps its
-            // original (Id) order, so the exported artefact array is byte-for-byte identical to the
-            // former per-item path.
+            // parameter budget. Memory: the raw byte[] dictionary holds at most one chunk at a time
+            // (released between chunks), while the mapped DTOs' base64 strings DO accumulate across
+            // chunks — both halves stay bounded because the pre-load MaxBufferedArtefactBytes guard
+            // caps the total artefact bytes this path may buffer. Metadata keeps its original (Id)
+            // order, so the exported artefact array is byte-for-byte identical to the former
+            // per-item path.
             foreach (var chunk in artefactMetadata.Chunk(StreamPageSize))
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/backend/src/Taskdeck.Application/Services/DataExportService.cs
+++ b/backend/src/Taskdeck.Application/Services/DataExportService.cs
@@ -196,18 +196,19 @@ public class DataExportService : IDataExportService
             for (var offset = 0; offset < artefactMetadata.Count; offset += StreamPageSize)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var count = Math.Min(StreamPageSize, artefactMetadata.Count - offset);
-                var chunk = new List<Domain.Entities.SourceArtefact>(count);
-                for (var i = offset; i < offset + count; i++)
-                    chunk.Add(artefactMetadata[i]);
+                var end = Math.Min(offset + StreamPageSize, artefactMetadata.Count);
+                var chunkIds = new List<Guid>(end - offset);
+                for (var i = offset; i < end; i++)
+                    chunkIds.Add(artefactMetadata[i].Id);
 
                 var blobs = await _artefacts.GetContentsForUserAsync(
-                    chunk.Select(a => a.Id).ToList(),
+                    chunkIds,
                     userId,
                     cancellationToken);
 
-                foreach (var artefact in chunk)
+                for (var i = offset; i < end; i++)
                 {
+                    var artefact = artefactMetadata[i];
                     if (!blobs.TryGetValue(artefact.Id, out var bytes) || bytes is null)
                         throw new InvalidOperationException($"Artefact {artefact.Id} is missing its blob.");
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/SourceArtefactRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/SourceArtefactRepository.cs
@@ -16,6 +16,15 @@ public sealed class SourceArtefactRepository : Repository<SourceArtefact>, ISour
     private static readonly IReadOnlyDictionary<Guid, byte[]> EmptyContentMap =
         new Dictionary<Guid, byte[]>();
 
+    /// <summary>
+    /// Upper bound on ids accepted by <see cref="GetContentsForUserAsync"/> in one call. EF Core 8
+    /// parameterises the id set via <c>json_each</c> (a single SQLite parameter), so this is
+    /// defense-in-depth against a future translation/provider change reintroducing per-id
+    /// parameters — it keeps the worst case well under SQLITE_MAX_VARIABLE_NUMBER (999). Callers
+    /// page in chunks of 500, comfortably below this bound.
+    /// </summary>
+    private const int MaxBatchIdCount = 900;
+
     public SourceArtefactRepository(TaskdeckDbContext context) : base(context)
     {
     }
@@ -127,9 +136,14 @@ public sealed class SourceArtefactRepository : Repository<SourceArtefact>, ISour
         if (ids.Count == 0)
             return EmptyContentMap;
 
-        // De-duplicate to keep the IN-clause parameter count minimal; the caller bounds the
-        // set size (<= 500) so it stays under SQLITE_MAX_VARIABLE_NUMBER. Same user-scoped blob
-        // join as GetContentForUserAsync, so a foreign artefact id can never surface content.
+        if (ids.Count > MaxBatchIdCount)
+            throw new ArgumentException(
+                $"Cannot batch more than {MaxBatchIdCount} artefact ids in one query; page the ids.",
+                nameof(ids));
+
+        // De-duplicate to keep the IN-clause parameter footprint minimal; the caller bounds the
+        // set size (<= 500) and the guard above caps it. Same user-scoped blob join as
+        // GetContentForUserAsync, so a foreign artefact id can never surface content.
         var idList = ids.Distinct().ToList();
 
         var rows = await (

--- a/backend/src/Taskdeck.Infrastructure/Repositories/SourceArtefactRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/SourceArtefactRepository.cs
@@ -116,6 +116,36 @@ public sealed class SourceArtefactRepository : Repository<SourceArtefact>, ISour
             .SingleOrDefaultAsync(cancellationToken);
     }
 
+    private static readonly IReadOnlyDictionary<Guid, byte[]> EmptyContentMap =
+        new Dictionary<Guid, byte[]>();
+
+    public async Task<IReadOnlyDictionary<Guid, byte[]>> GetContentsForUserAsync(
+        IReadOnlyCollection<Guid> ids,
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+            return EmptyContentMap;
+
+        // De-duplicate to keep the IN-clause parameter count minimal; the caller bounds the
+        // set size (<= 500) so it stays under SQLITE_MAX_VARIABLE_NUMBER. Same user-scoped blob
+        // join as GetContentForUserAsync, so a foreign artefact id can never surface content.
+        var idList = ids.Distinct().ToList();
+
+        var rows = await (
+            from artefact in _context.SourceArtefacts.AsNoTracking()
+            join blob in _context.ArtefactBlobs.AsNoTracking()
+                on artefact.Id equals blob.SourceArtefactId
+            where artefact.UserId == userId && idList.Contains(artefact.Id)
+            select new { artefact.Id, blob.Content })
+            .ToListAsync(cancellationToken);
+
+        var map = new Dictionary<Guid, byte[]>(rows.Count);
+        foreach (var row in rows)
+            map[row.Id] = row.Content;
+        return map;
+    }
+
     public async Task<bool> CopyContentForUserAsync(
         Guid id,
         Guid userId,

--- a/backend/src/Taskdeck.Infrastructure/Repositories/SourceArtefactRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/SourceArtefactRepository.cs
@@ -13,6 +13,9 @@ namespace Taskdeck.Infrastructure.Repositories;
 /// </summary>
 public sealed class SourceArtefactRepository : Repository<SourceArtefact>, ISourceArtefactRepository
 {
+    private static readonly IReadOnlyDictionary<Guid, byte[]> EmptyContentMap =
+        new Dictionary<Guid, byte[]>();
+
     public SourceArtefactRepository(TaskdeckDbContext context) : base(context)
     {
     }
@@ -115,9 +118,6 @@ public sealed class SourceArtefactRepository : Repository<SourceArtefact>, ISour
             select blob.Content)
             .SingleOrDefaultAsync(cancellationToken);
     }
-
-    private static readonly IReadOnlyDictionary<Guid, byte[]> EmptyContentMap =
-        new Dictionary<Guid, byte[]>();
 
     public async Task<IReadOnlyDictionary<Guid, byte[]>> GetContentsForUserAsync(
         IReadOnlyCollection<Guid> ids,

--- a/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
@@ -1,0 +1,234 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Persistence;
+using Taskdeck.Infrastructure.Repositories;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="SourceArtefactRepository.GetContentsForUserAsync"/> against
+/// real SQLite (#1355). Verifies the batched blob load resolves every requested artefact in a
+/// single round-trip, stays user-scoped, and is valid for the empty-set edge.
+/// </summary>
+public sealed class SourceArtefactRepositoryIntegrationTests
+{
+    private const string Sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Fact]
+    public async Task GetContentsForUserAsync_WithEmptyIdSet_ReturnsEmptyAndIssuesNoQuery()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var user = AddUser(db, "artefact-empty");
+            await db.SaveChangesAsync();
+
+            var repo = new SourceArtefactRepository(db);
+            interceptor.Clear();
+
+            var result = await repo.GetContentsForUserAsync(Array.Empty<Guid>(), user.Id);
+
+            result.Should().BeEmpty();
+            BlobSelects(interceptor).Should().BeEmpty(
+                "an empty id set must short-circuit before touching the database");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetContentsForUserAsync_LoadsAllRequestedBlobs_InASingleRoundTrip()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var user = AddUser(db, "artefact-batch");
+
+            var seeded = new Dictionary<Guid, byte[]>();
+            for (var i = 0; i < 25; i++)
+            {
+                var content = Encoding.UTF8.GetBytes($"blob-content-{i}");
+                var artefact = AddArtefact(db, user.Id, $"a{i}.txt", content);
+                seeded[artefact.Id] = content;
+            }
+            await db.SaveChangesAsync();
+
+            var repo = new SourceArtefactRepository(db);
+            interceptor.Clear();
+
+            var result = await repo.GetContentsForUserAsync(seeded.Keys.ToList(), user.Id);
+
+            result.Should().HaveCount(25);
+            foreach (var (id, content) in seeded)
+                result[id].Should().Equal(content);
+
+            // The whole point of #1355: one SELECT, not one per artefact.
+            BlobSelects(interceptor).Should().HaveCount(1,
+                "batched blob loads must resolve every artefact in a single query");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetContentsForUserAsync_NeverReturnsAnotherUsersBlob()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var owner = AddUser(db, "artefact-owner");
+            var other = AddUser(db, "artefact-other");
+
+            var ownerContent = Encoding.UTF8.GetBytes("owner blob");
+            var ownerArtefact = AddArtefact(db, owner.Id, "owned.txt", ownerContent);
+            var otherArtefact = AddArtefact(db, other.Id, "foreign.txt", Encoding.UTF8.GetBytes("foreign blob"));
+            await db.SaveChangesAsync();
+
+            var repo = new SourceArtefactRepository(db);
+
+            // Request BOTH ids while scoped to the owner — the foreign artefact must be absent.
+            var result = await repo.GetContentsForUserAsync(
+                new[] { ownerArtefact.Id, otherArtefact.Id },
+                owner.Id);
+
+            result.Should().ContainKey(ownerArtefact.Id);
+            result[ownerArtefact.Id].Should().Equal(ownerContent);
+            result.Should().NotContainKey(otherArtefact.Id,
+                "user-scoping must exclude another user's artefact even when its id is requested");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetContentsForUserAsync_OmitsUnknownIds_WithoutError()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var user = AddUser(db, "artefact-unknown");
+            var content = Encoding.UTF8.GetBytes("present");
+            var artefact = AddArtefact(db, user.Id, "present.txt", content);
+            await db.SaveChangesAsync();
+
+            var repo = new SourceArtefactRepository(db);
+            var missing = Guid.NewGuid();
+
+            var result = await repo.GetContentsForUserAsync(new[] { artefact.Id, missing }, user.Id);
+
+            result.Should().ContainKey(artefact.Id);
+            result.Should().NotContainKey(missing);
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    private static (DbContextOptions<TaskdeckDbContext> Options, CapturingCommandInterceptor Interceptor, string DbPath) CreateSqliteOptions()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-artefact-batch-{Guid.NewGuid():N}.db");
+        var interceptor = new CapturingCommandInterceptor();
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(interceptor)
+            .Options;
+        return (options, interceptor, dbPath);
+    }
+
+    private static User AddUser(TaskdeckDbContext db, string handle)
+    {
+        var user = new User(handle, $"{handle}@example.com", "hash");
+        db.Users.Add(user);
+        return user;
+    }
+
+    private static SourceArtefact AddArtefact(TaskdeckDbContext db, Guid userId, string fileName, byte[] content)
+    {
+        var artefact = new SourceArtefact(
+            userId,
+            ArtefactKind.TextFile,
+            "text/plain",
+            fileName,
+            content.Length,
+            Sha,
+            CaptureSource.Import);
+        db.SourceArtefacts.Add(artefact);
+        db.ArtefactBlobs.Add(new ArtefactBlob(artefact.Id, content));
+        return artefact;
+    }
+
+    private static IReadOnlyList<string> BlobSelects(CapturingCommandInterceptor interceptor) =>
+        interceptor.CapturedCommands
+            .Where(sql => sql.Contains("ArtefactBlobs", StringComparison.OrdinalIgnoreCase)
+                          && sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    private static void Cleanup(string dbPath)
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+        {
+            var path = dbPath + suffix;
+            if (!File.Exists(path))
+                continue;
+
+            try { File.Delete(path); }
+            catch (IOException) { /* best-effort temp cleanup */ }
+        }
+    }
+
+    /// <summary>
+    /// Records the text of every reader command EF executes so a test can count the SELECTs that
+    /// actually reached SQLite (proving the batch load is one round-trip, not one per artefact).
+    /// </summary>
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly ConcurrentQueue<string> _commands = new();
+
+        public IReadOnlyCollection<string> CapturedCommands => _commands;
+
+        public void Clear() => _commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
@@ -170,6 +170,30 @@ public sealed class SourceArtefactRepositoryIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task GetContentsForUserAsync_WithExactlyMaxBatchIds_DoesNotThrow()
+    {
+        // Pass-side of the guard boundary: exactly 900 ids (MaxBatchIdCount) must be accepted —
+        // pins the comparison as > rather than >=. No matching rows are seeded, so an empty map
+        // is the expected result; the point is that the query runs instead of throwing.
+        var (options, _, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var repo = new SourceArtefactRepository(db);
+            var exactlyMax = Enumerable.Range(0, 900).Select(_ => Guid.NewGuid()).ToList();
+
+            var result = await repo.GetContentsForUserAsync(exactlyMax, Guid.NewGuid());
+
+            result.Should().BeEmpty("no artefacts were seeded; the call must succeed, not throw");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
     private static (DbContextOptions<TaskdeckDbContext> Options, CapturingCommandInterceptor Interceptor, string DbPath) CreateSqliteOptions()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-artefact-batch-{Guid.NewGuid():N}.db");

--- a/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
@@ -147,6 +147,29 @@ public sealed class SourceArtefactRepositoryIntegrationTests
         }
     }
 
+    [Fact]
+    public async Task GetContentsForUserAsync_WithTooManyIds_ThrowsBeforeTouchingDatabase()
+    {
+        // Defense-in-depth: an oversized id set must fail fast with ArgumentException (before any
+        // query) rather than risk a SQLite parameter-limit error under a future translation change.
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            var repo = new SourceArtefactRepository(db);
+            var tooMany = Enumerable.Range(0, 901).Select(_ => Guid.NewGuid()).ToList();
+
+            var act = async () => await repo.GetContentsForUserAsync(tooMany, Guid.NewGuid());
+
+            await act.Should().ThrowAsync<ArgumentException>();
+            interceptor.CapturedCommands.Should().BeEmpty("the guard must trip before any SQL runs");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
     private static (DbContextOptions<TaskdeckDbContext> Options, CapturingCommandInterceptor Interceptor, string DbPath) CreateSqliteOptions()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-artefact-batch-{Guid.NewGuid():N}.db");

--- a/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
@@ -409,6 +409,174 @@ public class DataExportServiceTests
         result1.Value.Profile.Username.Should().Be(result2.Value.Profile.Username);
     }
 
+    [Fact]
+    public async Task ExportUserDataAsync_WithNoArtefacts_DoesNotQueryAnyBlob()
+    {
+        // #1355: the buffered blob-batch loop must not run when there are no artefacts.
+        SetupUserFound();
+        SetupEmptyRepositories();
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Data.Artefacts.Should().NotBeNull().And.BeEmpty();
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _artefactRepoMock.Verify(
+            r => r.GetContentForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_BatchLoadsArtefactBlobs_InOneCall_NotOnePerArtefact()
+    {
+        // #1355 regression: a single-chunk export must resolve every artefact blob in ONE batch
+        // query, never the former one-round-trip-per-artefact path.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, contentById) = SeedArtefactsWithBlobBatch(3);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        var exported = result.Value.Data.Artefacts!;
+        // Same set, same order as the metadata (byte-for-byte parity with the per-item path).
+        exported.Select(a => a.Id).Should().Equal(artefacts.Select(a => a.Id));
+        for (var i = 0; i < artefacts.Count; i++)
+        {
+            Convert.FromBase64String(exported[i].ContentBase64)
+                .Should().Equal(contentById[artefacts[i].Id]);
+        }
+
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _artefactRepoMock.Verify(
+            r => r.GetContentForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the buffered export must not fall back to the per-artefact blob load");
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_BatchesBlobLoadsAcrossChunks_PreservingOrder()
+    {
+        // #1355: 501 artefacts must page into exactly two batch queries (500 + 1) — proving the
+        // chunk arithmetic at the StreamPageSize boundary — while the exported array stays in the
+        // exact metadata order.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, contentById) = SeedArtefactsWithBlobBatch(501);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        var exported = result.Value.Data.Artefacts!;
+        exported.Should().HaveCount(501);
+        exported.Select(a => a.Id).Should().Equal(artefacts.Select(a => a.Id));
+        for (var i = 0; i < artefacts.Count; i++)
+        {
+            Convert.FromBase64String(exported[i].ContentBase64)
+                .Should().Equal(contentById[artefacts[i].Id]);
+        }
+
+        // ceil(501 / 500) == 2 batch queries, not 501.
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 500), _userId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the first chunk must carry exactly the 500-id StreamPageSize batch");
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1), _userId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the trailing chunk must carry the single remaining id");
+        _artefactRepoMock.Verify(
+            r => r.GetContentForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_BatchBlobLoad_ScopedToRequestingUserOnly()
+    {
+        // #1355 user-scoping: every batch load must pass the requesting user's id and never another.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        SeedArtefactsWithBlobBatch(4);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(),
+                It.Is<Guid>(u => u != _userId),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the buffered export must never batch-load another user's artefact blobs");
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_Fails_WhenBatchOmitsAnArtefactBlob()
+    {
+        // #1355: preserve the missing-blob contract — if the batch does not return content for an
+        // artefact that has metadata, the export must fail rather than emit a partial artefact.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, contentById) = SeedArtefactsWithBlobBatch(2);
+
+        // Drop the second artefact's blob from every batch response.
+        var missingId = artefacts[1].Id;
+        _artefactRepoMock
+            .Setup(r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<Guid> ids, Guid _, CancellationToken _) =>
+                (IReadOnlyDictionary<Guid, byte[]>)ids
+                    .Where(id => id != missingId)
+                    .ToDictionary(id => id, id => contentById[id]));
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.UnexpectedError);
+    }
+
+    /// <summary>
+    /// Seeds <paramref name="count"/> user-owned artefacts (paged via GetByUserAsync) plus a
+    /// batch blob responder keyed by artefact id, and returns the ordered metadata and the
+    /// per-id content so a test can assert order + content parity.
+    /// </summary>
+    private (IReadOnlyList<SourceArtefact> Artefacts, IReadOnlyDictionary<Guid, byte[]> ContentById) SeedArtefactsWithBlobBatch(int count)
+    {
+        var artefacts = Enumerable.Range(0, count)
+            .Select(index => new SourceArtefact(
+                _userId,
+                ArtefactKind.TextFile,
+                "text/plain",
+                $"artefact-{index}.txt",
+                1,
+                new string('a', SourceArtefact.Sha256HexLength),
+                CaptureSource.Import))
+            .ToList();
+        var contentById = artefacts.ToDictionary(
+            a => a.Id,
+            a => System.Text.Encoding.UTF8.GetBytes(a.FileName));
+
+        _artefactRepoMock
+            .Setup(r => r.GetByUserAsync(_userId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid _, int limit, int offset, CancellationToken _) =>
+                artefacts.Skip(offset).Take(limit).ToList());
+        _artefactRepoMock
+            .Setup(r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<Guid> ids, Guid _, CancellationToken _) =>
+                (IReadOnlyDictionary<Guid, byte[]>)ids.ToDictionary(id => id, id => contentById[id]));
+
+        return (artefacts, contentById);
+    }
+
     private void SetupUserFound()
     {
         _userRepoMock.Setup(r => r.GetByIdAsync(_userId, default)).ReturnsAsync(_testUser);

--- a/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
@@ -523,6 +523,9 @@ public class DataExportServiceTests
     public async Task ExportUserDataAsync_BatchBlobLoad_ScopedToRequestingUserOnly()
     {
         // #1355 user-scoping: every batch load must pass the requesting user's id and never another.
+        // NOTE: this is a wiring check only (the service forwards its own parameter); the REAL
+        // scoping enforcement proof lives in SourceArtefactRepositoryIntegrationTests
+        // .GetContentsForUserAsync_NeverReturnsAnotherUsersBlob against real SQLite.
         SetupUserFound();
         SetupEmptyRepositories();
         SeedArtefactsWithBlobBatch(4);
@@ -547,6 +550,9 @@ public class DataExportServiceTests
     {
         // #1355: preserve the missing-blob contract — if the batch does not return content for an
         // artefact that has metadata, the export must fail rather than emit a partial artefact.
+        // Pins BOTH halves: the public UnexpectedError result AND the internal
+        // InvalidOperationException with the same "...is missing its blob." message shape as the
+        // per-item path (observed via the logged exception at the service seam).
         SetupUserFound();
         SetupEmptyRepositories();
         var (artefacts, contentById) = SeedArtefactsWithBlobBatch(2);
@@ -560,10 +566,29 @@ public class DataExportServiceTests
                     .Where(id => id != missingId)
                     .ToDictionary(id => id, id => contentById[id]));
 
-        var result = await _service.ExportUserDataAsync(_userId);
+        var loggerMock = new Mock<ILogger<DataExportService>>();
+        var serviceWithLogger = new DataExportService(
+            _unitOfWorkMock.Object,
+            _historyServiceMock.Object,
+            _artefactRepoMock.Object,
+            _extractionRepoMock.Object,
+            loggerMock.Object);
+
+        var result = await serviceWithLogger.ExportUserDataAsync(_userId);
 
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.UnexpectedError);
+        loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to export user data")),
+                It.Is<Exception>(ex =>
+                    ex is InvalidOperationException &&
+                    ex.Message == $"Artefact {missingId} is missing its blob."),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once,
+            "the batched path must surface the same InvalidOperationException missing-blob contract as the per-item path");
     }
 
     /// <summary>

--- a/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
@@ -498,6 +498,28 @@ public class DataExportServiceTests
     }
 
     [Fact]
+    public async Task ExportUserDataAsync_WithExactlyChunkSizeArtefacts_IssuesSingleBatch()
+    {
+        // #1355 boundary: exactly StreamPageSize (500) artefacts must resolve in ONE batch query,
+        // with no spurious trailing empty-chunk query (off-by-one guard at exactly chunk-size).
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, _) = SeedArtefactsWithBlobBatch(500);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Data.Artefacts!.Select(a => a.Id).Should().Equal(artefacts.Select(a => a.Id));
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "exactly chunk-size artefacts must be one batch, not one plus an empty trailing query");
+        _artefactRepoMock.Verify(
+            r => r.GetContentsForUserAsync(It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 500), _userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ExportUserDataAsync_BatchBlobLoad_ScopedToRequestingUserOnly()
     {
         // #1355 user-scoping: every batch load must pass the requesting user's id and never another.

--- a/backend/tests/Taskdeck.Application.Tests/Services/GdprDataExportRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/GdprDataExportRoundTripTests.cs
@@ -262,6 +262,65 @@ public class GdprDataExportRoundTripTests
     }
 
     [Fact]
+    public async Task ExportUserData_WithBatchedArtefacts_RoundTripsOrderedBase64Content()
+    {
+        // #1355 (review LOW): this suite previously stubbed zero artefacts, so no full
+        // serialize -> parse -> deserialize round-trip ever carried batched blob content through
+        // the buffered path. Seeds two artefacts with distinguishable content and asserts the
+        // parsed JSON carries the correct base64 content in metadata order.
+        var userId = Guid.NewGuid();
+        var user = new User("artefactuser", "artefact@example.com", "hashedpw");
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(user);
+        SetupEmptyRepositories(userId);
+
+        var first = new SourceArtefact(
+            userId, ArtefactKind.TextFile, "text/plain", "first.txt",
+            10, new string('a', SourceArtefact.Sha256HexLength), CaptureSource.Import);
+        var second = new SourceArtefact(
+            userId, ArtefactKind.TextFile, "text/plain", "second.txt",
+            11, new string('b', SourceArtefact.Sha256HexLength), CaptureSource.Import);
+        var artefacts = new[] { first, second };
+        var contentById = new Dictionary<Guid, byte[]>
+        {
+            [first.Id] = System.Text.Encoding.UTF8.GetBytes("first blob content"),
+            [second.Id] = System.Text.Encoding.UTF8.GetBytes("second blob content"),
+        };
+
+        _artefactRepoMock
+            .Setup(r => r.GetByUserAsync(userId, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid _, int limit, int offset, CancellationToken _) =>
+                artefacts.Skip(offset).Take(limit).ToArray());
+        _artefactRepoMock
+            .Setup(r => r.GetContentsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<Guid> ids, Guid _, CancellationToken _) =>
+                (IReadOnlyDictionary<Guid, byte[]>)ids.ToDictionary(id => id, id => contentById[id]));
+
+        var result = await _service.ExportUserDataAsync(userId);
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+
+        // Serialize -> parse: the JSON must carry the batched content, base64-encoded, in order.
+        var json = JsonSerializer.Serialize(result.Value, JsonOptions);
+        using var doc = JsonDocument.Parse(json);
+        var artefactArray = doc.RootElement.GetProperty("data").GetProperty("artefacts")
+            .EnumerateArray().ToList();
+        artefactArray.Should().HaveCount(2);
+        artefactArray[0].GetProperty("id").GetGuid().Should().Be(first.Id);
+        artefactArray[1].GetProperty("id").GetGuid().Should().Be(second.Id);
+        Convert.FromBase64String(artefactArray[0].GetProperty("contentBase64").GetString()!)
+            .Should().Equal(contentById[first.Id]);
+        Convert.FromBase64String(artefactArray[1].GetProperty("contentBase64").GetString()!)
+            .Should().Equal(contentById[second.Id]);
+
+        // Parse -> deserialize: the typed DTO round-trips the same ordered content.
+        var deserialized = JsonSerializer.Deserialize<UserDataExportDto>(json, JsonOptions);
+        deserialized!.Data.Artefacts.Should().HaveCount(2);
+        deserialized.Data.Artefacts![0].ContentBase64
+            .Should().Be(Convert.ToBase64String(contentById[first.Id]));
+        deserialized.Data.Artefacts[1].ContentBase64
+            .Should().Be(Convert.ToBase64String(contentById[second.Id]));
+    }
+
+    [Fact]
     public async Task ExportUserData_VersionIsAlwaysPresent()
     {
         var userId = Guid.NewGuid();


### PR DESCRIPTION
Closes #1355

## What & why
The buffered `/api/account/export` path (`DataExportService.ExportUserDataAsync`) loaded artefact blobs one round-trip per artefact via `ISourceArtefactRepository.GetContentForUserAsync` — up to ~10,000 SELECTs for a heavy export (LOW-2 from the #1341 GEN-01 security review). This batches the blob loads while preserving the export contract byte-for-byte.

## Design
- New repository method `GetContentsForUserAsync(IReadOnlyCollection<Guid> ids, Guid userId, ct)` → `IReadOnlyDictionary<Guid, byte[]>`: a single keyed IN-query using the **same user-scoped artefact→blob join** as `GetContentForUserAsync` (so a foreign artefact id can never surface content). Empty id set short-circuits with no query. Mirrors the existing `ChatMessageRepository.CountBySessionIdsAsync` batching precedent.
- `DataExportService` now pages the artefact metadata (already Id-ordered) in **bounded chunks of `StreamPageSize` (500)**, batch-loading each chunk's blobs and mapping in metadata order.

**Chunk size:** 500. With the 500-id `IN (...)` plus the `userId` parameter that is 501 bound parameters, comfortably under `SQLITE_MAX_VARIABLE_NUMBER = 999`. Matches the `StreamPageSize` constant already used by the streaming export's chat-session batching.

**Memory posture:** deliberately *not* one mega-query. Each chunk's raw blob dictionary is processed then released before the next chunk loads, so peak raw-bytes held is one chunk's worth. Total buffered content remains bounded by the pre-existing `MaxBufferedArtefactBytes` (10 MB) and 10,000-row guards, which run **before** any blob load. Round-trips drop from N to `ceil(N/500)`.

**Contract preserved:** artefacts are emitted in the exact former (Id) order; a missing blob still throws `InvalidOperationException` (→ `UnexpectedError`); user-scoping and the pre-load size guards are unchanged. `GetContentForUserAsync` is retained on the interface (symmetry with `CopyContentForUserAsync`; regression tests assert the buffered path no longer calls it).

## Tests
Service-level (`DataExportServiceTests`, Moq):
- 0 artefacts → no blob query at all (batch and per-item both `Times.Never`).
- 1 chunk (3 artefacts) → exactly one batch call, per-item never called, order + decoded content match.
- **501 artefacts** → exactly two batch calls (`ids.Count == 500` once, `ids.Count == 1` once — the chunk-size and chunk-size+1 boundary), order preserved across chunks, all content correct, per-item never called.
- user-scoping → batch always invoked with the requesting user id, never another.
- missing-blob → export fails (`UnexpectedError`), contract preserved.

Repository integration (`SourceArtefactRepositoryIntegrationTests`, real SQLite + `DbCommandInterceptor`):
- empty id set → empty result, **zero** `ArtefactBlobs` SELECTs (empty-set validity).
- 25 artefacts → all resolved in **exactly one** SELECT (round-trip reduction proven at the SQL level).
- another user's artefact id requested while scoped to the owner → excluded.
- unknown id → omitted without error.

## Verification
- `dotnet restore` + `dotnet build backend/Taskdeck.sln -c Release -m:1` → **0 errors** (pre-existing warnings only).
- `DataExportService*` + `GdprDataExportRoundTrip*` (Application.Tests) → **37 passed**.
- `SourceArtefactRepositoryIntegrationTests` (Api.Tests) → **4 passed**.
- `DataPortabilityApiTests` (end-to-end export through the real repository) → **12 passed**.
- `AccountDeletionServiceTests` + `ArtefactServiceTests` + `ArtefactExtractionServiceTests` → **43 passed**.
- `dotnet ef migrations has-pending-model-changes` → **"No changes"** (no schema impact).
