### PR TITLE
Prevent late summaries from overwriting a newer workspace-mode choice

### DIFF
--- a/frontend/taskdeck-web/src/store/workspaceStore.ts
+++ b/frontend/taskdeck-web/src/store/workspaceStore.ts
@@ -40,6 +40,13 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   let preferenceRequestVersion = 0
   let pendingPreferenceRequests = 0
   let todayRequestVersion = 0
+  // Session-scoped unsaved-local-choice flag (issue #1343). Set when an explicit
+  // updateMode save FAILS: the store keeps the local selection (and says so via
+  // the warning toast), so summary responses must not re-apply the server's
+  // stale preference state until a later save succeeds or hydratePreferences
+  // confirms the server matches the local choice. Deliberately not persisted:
+  // a full reload starts a new session, which re-syncs from server truth.
+  let modeDirty = false
 
   const hasHomeSummary = computed(() => homeSummary.value !== null)
   const hasTodaySummary = computed(() => todaySummary.value !== null)
@@ -55,17 +62,36 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     persistLocalMode(nextMode)
   }
 
-  // Ordering guard for summary-derived mode (issue #1343). A Home/Today summary
-  // request can resolve *after* the user makes a newer local mode choice
-  // (updateMode) or a newer preference hydrate. Both of those bump
-  // preferenceRequestVersion at their start, so a summary that captured an
-  // older version must not overwrite the newer explicit choice. When the
-  // version is unchanged the summary is genuinely newer and applies as normal.
-  function applySummaryMode(nextMode: WorkspaceMode, preferenceVersionAtStart: number): boolean {
-    if (preferenceRequestVersion !== preferenceVersionAtStart) {
+  // Ordering guard for summary-derived preference state — mode AND onboarding —
+  // (issue #1343). A Home/Today summary must not overwrite newer explicit
+  // preference actions. Its mode/onboarding are applied only when ALL hold:
+  //   1. No preference action (updateMode / hydratePreferences / updateOnboarding)
+  //      started after the summary request began — those bump
+  //      preferenceRequestVersion at their start, so a summary that captured an
+  //      older version is stale.
+  //   2. No preference request is still in flight at apply time — its outcome is
+  //      unknown, and the summary payload may predate its server-side commit;
+  //      the preference request's own resolution applies the authoritative state.
+  //   3. No unsaved local choice is pending (modeDirty) — after a FAILED save the
+  //      version is stable but the server still holds the old state.
+  // When all three hold the summary is genuinely newer and applies as normal.
+  function canApplySummaryPreferences(preferenceVersionAtStart: number): boolean {
+    return (
+      preferenceRequestVersion === preferenceVersionAtStart &&
+      pendingPreferenceRequests === 0 &&
+      !modeDirty
+    )
+  }
+
+  function applySummaryPreferences(
+    summary: HomeSummary | TodaySummary,
+    preferenceVersionAtStart: number,
+  ): boolean {
+    if (!canApplySummaryPreferences(preferenceVersionAtStart)) {
       return false
     }
-    applyMode(nextMode)
+    applyMode(summary.workspaceMode)
+    syncOnboarding(summary.onboarding)
     return true
   }
 
@@ -126,9 +152,19 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       const preference = await workspaceApi.getPreferences()
 
       if (isCurrentPreferenceRequest(requestVersion)) {
-        applyMode(preference.workspaceMode)
-        syncOnboarding(preference.onboarding)
-        preferencesHydrated.value = true
+        if (modeDirty && preference.workspaceMode !== mode.value) {
+          // The server still holds the pre-failed-save mode. Keep the unsaved
+          // local choice; preferencesHydrated stays false so the unsynced state
+          // remains visible. Onboarding has no unsaved local state, so the
+          // fresh server copy applies.
+          syncOnboarding(preference.onboarding)
+        } else {
+          // Server matches the local choice (or nothing is unsaved): confirmed.
+          modeDirty = false
+          applyMode(preference.workspaceMode)
+          syncOnboarding(preference.onboarding)
+          preferencesHydrated.value = true
+        }
       }
 
       return preference
@@ -164,12 +200,16 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       const preference = await workspaceApi.updatePreferences({ workspaceMode: nextMode })
 
       if (isCurrentPreferenceRequest(requestVersion)) {
+        modeDirty = false
         applyMode(preference.workspaceMode)
         syncOnboarding(preference.onboarding)
         preferencesHydrated.value = true
       }
     } catch (e: unknown) {
       if (isCurrentPreferenceRequest(requestVersion)) {
+        // Keep the local selection AND remember it is unsaved so subsequent
+        // summary fetches cannot silently revert it (issue #1343).
+        modeDirty = true
         preferenceError.value = getErrorMessage(e, "We couldn't save this workspace mode")
         preferencesHydrated.value = false
         toast.warning(`${preferenceError.value}. Keeping the local selection for now.`)
@@ -199,9 +239,13 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       homeError.value = null
       const summary = await workspaceApi.getHomeSummary()
       homeSummary.value = summary
-      syncOnboarding(summary.onboarding)
-      if (applySummaryMode(summary.workspaceMode, preferenceVersionAtStart)) {
+      if (applySummaryPreferences(summary, preferenceVersionAtStart)) {
         preferencesHydrated.value = true
+      } else if (onboarding.value) {
+        // Stale summary: keep the newer known onboarding visible in the stored
+        // summary so views reading summary.onboarding do not diverge from the
+        // guarded onboarding ref.
+        homeSummary.value = { ...summary, onboarding: onboarding.value }
       }
       return summary
     } catch (e: unknown) {
@@ -235,8 +279,10 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       const summary = await workspaceApi.getTodaySummary()
       if (requestVersion === todayRequestVersion) {
         todaySummary.value = summary
-        syncOnboarding(summary.onboarding)
-        applySummaryMode(summary.workspaceMode, preferenceVersionAtStart)
+        if (!applySummaryPreferences(summary, preferenceVersionAtStart) && onboarding.value) {
+          // Stale summary: keep the newer known onboarding visible (see Home).
+          todaySummary.value = { ...summary, onboarding: onboarding.value }
+        }
       }
       return summary
     } catch (e: unknown) {
@@ -262,7 +308,11 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     }
 
     try {
-      beginPreferenceLoading()
+      // Versioned like updateMode/hydratePreferences: an explicit onboarding
+      // action makes in-flight summaries stale so a late summary cannot revert
+      // it (issue #1343). The response itself applies unconditionally — it is
+      // the authoritative result of this explicit action.
+      startVersionedPreferenceRequest()
       preferenceError.value = null
       const nextOnboarding = await workspaceApi.updateOnboarding({ action })
       syncOnboarding(nextOnboarding)
@@ -289,6 +339,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   }
 
   function resetForLogout() {
+    modeDirty = false
     preferencesHydrated.value = false
     preferenceError.value = null
     onboarding.value = null

--- a/frontend/taskdeck-web/src/store/workspaceStore.ts
+++ b/frontend/taskdeck-web/src/store/workspaceStore.ts
@@ -37,15 +37,22 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   const todaySummary = ref<TodaySummary | null>(null)
   const todayLoading = ref(false)
   const todayError = ref<string | null>(null)
-  let preferenceRequestVersion = 0
   let pendingPreferenceRequests = 0
   let todayRequestVersion = 0
+  // Per-field preference version counters (issue #1343). Each explicit writer
+  // bumps only the field(s) it writes — updateMode bumps mode, updateOnboarding
+  // bumps onboarding, hydratePreferences bumps both — so concurrent actions on
+  // DIFFERENT fields cannot suppress each other's response handling. (A shared
+  // counter let an onboarding dismissal that started mid-save skip the failed
+  // save's warning + unsaved flag entirely.)
+  let modeRequestVersion = 0
+  let onboardingRequestVersion = 0
   // Session-scoped unsaved-local-choice flag (issue #1343). Set when an explicit
   // updateMode save FAILS: the store keeps the local selection (and says so via
   // the warning toast), so summary responses must not re-apply the server's
-  // stale preference state until a later save succeeds or hydratePreferences
-  // confirms the server matches the local choice. Deliberately not persisted:
-  // a full reload starts a new session, which re-syncs from server truth.
+  // stale mode until a later save succeeds or hydratePreferences confirms the
+  // server matches the local choice. Deliberately not persisted: a full reload
+  // starts a new session, which re-syncs from server truth.
   let modeDirty = false
 
   const hasHomeSummary = computed(() => homeSummary.value !== null)
@@ -62,37 +69,54 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     persistLocalMode(nextMode)
   }
 
-  // Ordering guard for summary-derived preference state — mode AND onboarding —
-  // (issue #1343). A Home/Today summary must not overwrite newer explicit
-  // preference actions. Its mode/onboarding are applied only when ALL hold:
-  //   1. No preference action (updateMode / hydratePreferences / updateOnboarding)
-  //      started after the summary request began — those bump
-  //      preferenceRequestVersion at their start, so a summary that captured an
-  //      older version is stale.
-  //   2. No preference request is still in flight at apply time — its outcome is
-  //      unknown, and the summary payload may predate its server-side commit;
-  //      the preference request's own resolution applies the authoritative state.
-  //   3. No unsaved local choice is pending (modeDirty) — after a FAILED save the
-  //      version is stable but the server still holds the old state.
-  // When all three hold the summary is genuinely newer and applies as normal.
-  function canApplySummaryPreferences(preferenceVersionAtStart: number): boolean {
-    return (
-      preferenceRequestVersion === preferenceVersionAtStart &&
-      pendingPreferenceRequests === 0 &&
-      !modeDirty
-    )
+  // Ordering guard for summary-derived preference state — mode and onboarding,
+  // each guarded independently (issue #1343). A Home/Today summary must not
+  // overwrite newer explicit preference actions. Per field, it applies only when:
+  //   1. No preference request was already in flight when the summary request
+  //      BEGAN (preferencePending) — the summary's server-side read may predate
+  //      that request's commit even if the request settles first, so its
+  //      preference fields are indistinguishable from stale.
+  //   2. No writer for that field started after the summary began — writers bump
+  //      their field's version at start, so an older captured version is stale.
+  //   3. No preference request is in flight at APPLY time — defense-in-depth;
+  //      provably redundant with 1+2 today (any writer starting after the
+  //      snapshot bumps a version; writers pending at snapshot set
+  //      preferencePending), but it protects against future writers that track
+  //      pending without versioning.
+  //   4. Mode only: no unsaved local choice (modeDirty) — after a FAILED save
+  //      the versions are stable but the server still holds the old mode.
+  type SummaryGuardSnapshot = {
+    modeVersion: number
+    onboardingVersion: number
+    preferencePending: boolean
+  }
+
+  function captureSummaryGuardSnapshot(): SummaryGuardSnapshot {
+    return {
+      modeVersion: modeRequestVersion,
+      onboardingVersion: onboardingRequestVersion,
+      preferencePending: pendingPreferenceRequests > 0,
+    }
   }
 
   function applySummaryPreferences(
     summary: HomeSummary | TodaySummary,
-    preferenceVersionAtStart: number,
-  ): boolean {
-    if (!canApplySummaryPreferences(preferenceVersionAtStart)) {
-      return false
+    snapshot: SummaryGuardSnapshot,
+  ): { modeApplied: boolean; onboardingApplied: boolean } {
+    const guardClear = !snapshot.preferencePending && pendingPreferenceRequests === 0
+    const modeApplied =
+      guardClear && modeRequestVersion === snapshot.modeVersion && !modeDirty
+    const onboardingApplied =
+      guardClear && onboardingRequestVersion === snapshot.onboardingVersion
+
+    if (modeApplied) {
+      applyMode(summary.workspaceMode)
     }
-    applyMode(summary.workspaceMode)
-    syncOnboarding(summary.onboarding)
-    return true
+    if (onboardingApplied) {
+      syncOnboarding(summary.onboarding)
+    }
+
+    return { modeApplied, onboardingApplied }
   }
 
   function syncOnboarding(nextOnboarding: WorkspaceOnboarding | null) {
@@ -123,13 +147,14 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     preferenceLoading.value = pendingPreferenceRequests > 0
   }
 
-  function startVersionedPreferenceRequest(): number {
+  function startModePreferenceRequest(): number {
     beginPreferenceLoading()
-    return ++preferenceRequestVersion
+    return ++modeRequestVersion
   }
 
-  function isCurrentPreferenceRequest(version: number) {
-    return version === preferenceRequestVersion
+  function startOnboardingPreferenceRequest(): number {
+    beginPreferenceLoading()
+    return ++onboardingRequestVersion
   }
 
   async function hydratePreferences(): Promise<WorkspacePreference | null> {
@@ -145,31 +170,37 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return null
     }
 
-    const requestVersion = startVersionedPreferenceRequest()
+    // Hydration writes both preference fields, so it versions both.
+    beginPreferenceLoading()
+    const modeVersion = ++modeRequestVersion
+    const onboardingVersion = ++onboardingRequestVersion
 
     try {
       preferenceError.value = null
       const preference = await workspaceApi.getPreferences()
 
-      if (isCurrentPreferenceRequest(requestVersion)) {
+      if (onboardingRequestVersion === onboardingVersion) {
+        // Onboarding has no unsaved local state, so the fresh server copy
+        // applies unless a newer onboarding writer superseded this hydrate.
+        syncOnboarding(preference.onboarding)
+      }
+
+      if (modeRequestVersion === modeVersion) {
         if (modeDirty && preference.workspaceMode !== mode.value) {
           // The server still holds the pre-failed-save mode. Keep the unsaved
           // local choice; preferencesHydrated stays false so the unsynced state
-          // remains visible. Onboarding has no unsaved local state, so the
-          // fresh server copy applies.
-          syncOnboarding(preference.onboarding)
+          // remains visible.
         } else {
           // Server matches the local choice (or nothing is unsaved): confirmed.
           modeDirty = false
           applyMode(preference.workspaceMode)
-          syncOnboarding(preference.onboarding)
           preferencesHydrated.value = true
         }
       }
 
       return preference
     } catch (e: unknown) {
-      if (isCurrentPreferenceRequest(requestVersion)) {
+      if (modeRequestVersion === modeVersion) {
         preferenceError.value = getErrorMessage(e, "We couldn't load your workspace preferences")
       }
 
@@ -187,7 +218,8 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return
     }
 
-    const requestVersion = startVersionedPreferenceRequest()
+    const requestVersion = startModePreferenceRequest()
+    const onboardingVersionAtStart = onboardingRequestVersion
 
     if (!session.isAuthenticated) {
       preferencesHydrated.value = false
@@ -199,16 +231,23 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       preferenceError.value = null
       const preference = await workspaceApi.updatePreferences({ workspaceMode: nextMode })
 
-      if (isCurrentPreferenceRequest(requestVersion)) {
+      if (modeRequestVersion === requestVersion) {
         modeDirty = false
         applyMode(preference.workspaceMode)
-        syncOnboarding(preference.onboarding)
         preferencesHydrated.value = true
       }
+      // The response's onboarding is an incidental echo (a mode save does not
+      // change onboarding server-side); it must not clobber a newer explicit
+      // onboarding action that started while this save was in flight.
+      if (onboardingRequestVersion === onboardingVersionAtStart) {
+        syncOnboarding(preference.onboarding)
+      }
     } catch (e: unknown) {
-      if (isCurrentPreferenceRequest(requestVersion)) {
+      if (modeRequestVersion === requestVersion) {
         // Keep the local selection AND remember it is unsaved so subsequent
-        // summary fetches cannot silently revert it (issue #1343).
+        // summary fetches cannot silently revert it (issue #1343). Guarded by
+        // the MODE version only: a concurrent onboarding action must not
+        // suppress this failed-save handling.
         modeDirty = true
         preferenceError.value = getErrorMessage(e, "We couldn't save this workspace mode")
         preferencesHydrated.value = false
@@ -232,19 +271,21 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return summary
     }
 
-    const preferenceVersionAtStart = preferenceRequestVersion
+    const guardSnapshot = captureSummaryGuardSnapshot()
 
     try {
       homeLoading.value = true
       homeError.value = null
       const summary = await workspaceApi.getHomeSummary()
       homeSummary.value = summary
-      if (applySummaryPreferences(summary, preferenceVersionAtStart)) {
+      const { modeApplied, onboardingApplied } = applySummaryPreferences(summary, guardSnapshot)
+      if (modeApplied) {
         preferencesHydrated.value = true
-      } else if (onboarding.value) {
-        // Stale summary: keep the newer known onboarding visible in the stored
-        // summary so views reading summary.onboarding do not diverge from the
-        // guarded onboarding ref.
+      }
+      if (!onboardingApplied && onboarding.value) {
+        // Stale-for-onboarding summary: keep the newer known onboarding visible
+        // in the stored summary so views reading summary.onboarding do not
+        // diverge from the guarded onboarding ref.
         homeSummary.value = { ...summary, onboarding: onboarding.value }
       }
       return summary
@@ -258,7 +299,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
 
   async function fetchTodaySummary(): Promise<TodaySummary> {
     const requestVersion = ++todayRequestVersion
-    const preferenceVersionAtStart = preferenceRequestVersion
+    const guardSnapshot = captureSummaryGuardSnapshot()
 
     if (isDemoMode) {
       todayLoading.value = true
@@ -279,8 +320,10 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       const summary = await workspaceApi.getTodaySummary()
       if (requestVersion === todayRequestVersion) {
         todaySummary.value = summary
-        if (!applySummaryPreferences(summary, preferenceVersionAtStart) && onboarding.value) {
-          // Stale summary: keep the newer known onboarding visible (see Home).
+        const { onboardingApplied } = applySummaryPreferences(summary, guardSnapshot)
+        if (!onboardingApplied && onboarding.value) {
+          // Stale-for-onboarding summary: keep the newer known onboarding
+          // visible (see Home).
           todaySummary.value = { ...summary, onboarding: onboarding.value }
         }
       }
@@ -308,14 +351,16 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     }
 
     try {
-      // Versioned like updateMode/hydratePreferences: an explicit onboarding
-      // action makes in-flight summaries stale so a late summary cannot revert
-      // it (issue #1343). The response itself applies unconditionally — it is
-      // the authoritative result of this explicit action.
-      startVersionedPreferenceRequest()
+      // Versioned per-field (issue #1343): an explicit onboarding action makes
+      // in-flight summaries' ONBOARDING stale without touching the mode guard —
+      // a dismissal that starts mid-save must not suppress the save's own
+      // success/failure handling. Latest onboarding writer wins.
+      const requestVersion = startOnboardingPreferenceRequest()
       preferenceError.value = null
       const nextOnboarding = await workspaceApi.updateOnboarding({ action })
-      syncOnboarding(nextOnboarding)
+      if (onboardingRequestVersion === requestVersion) {
+        syncOnboarding(nextOnboarding)
+      }
       return nextOnboarding
     } catch (e: unknown) {
       preferenceError.value = getErrorMessage(e, "We couldn't update the setup guide")

--- a/frontend/taskdeck-web/src/store/workspaceStore.ts
+++ b/frontend/taskdeck-web/src/store/workspaceStore.ts
@@ -39,21 +39,27 @@ export const useWorkspaceStore = defineStore('workspace', () => {
   const todayError = ref<string | null>(null)
   let pendingPreferenceRequests = 0
   let todayRequestVersion = 0
-  // Per-field preference version counters (issue #1343). Each explicit writer
-  // bumps only the field(s) it writes — updateMode bumps mode, updateOnboarding
-  // bumps onboarding, hydratePreferences bumps both — so concurrent actions on
-  // DIFFERENT fields cannot suppress each other's response handling. (A shared
-  // counter let an onboarding dismissal that started mid-save skip the failed
-  // save's warning + unsaved flag entirely.)
+  // ── Preference ordering model (issue #1343) ────────────────────────────────
+  // WRITES CONFIRM, NEVER RE-APPLY: updateMode/updateOnboarding apply the
+  // user's intent locally at start; their HTTP responses never write field
+  // values back into the store, so no response echo can cross fields or revert
+  // newer intent. A write response only settles bookkeeping for its OWN field,
+  // and only if it is still the latest write of that field: success clears the
+  // field's dirty flag, failure sets it (keeping the local intent + warning).
+  // READS (summaries, hydratePreferences) apply server state per field, and
+  // only when that field is clean: no write of that field overlapped the read
+  // and the field has no unsaved local intent. Reads never bump write versions.
   let modeRequestVersion = 0
   let onboardingRequestVersion = 0
-  // Session-scoped unsaved-local-choice flag (issue #1343). Set when an explicit
-  // updateMode save FAILS: the store keeps the local selection (and says so via
-  // the warning toast), so summary responses must not re-apply the server's
-  // stale mode until a later save succeeds or hydratePreferences confirms the
-  // server matches the local choice. Deliberately not persisted: a full reload
-  // starts a new session, which re-syncs from server truth.
+  let pendingModeWrites = 0
+  let pendingOnboardingWrites = 0
+  // Session-scoped unsaved-local-intent flags. Set when the field's write
+  // FAILS while local intent is applied; cleared when a later write of the
+  // field succeeds or hydratePreferences confirms the server matches the local
+  // intent. Deliberately not persisted: a full reload starts a new session,
+  // which re-syncs from server truth.
   let modeDirty = false
+  let onboardingDirty = false
 
   const hasHomeSummary = computed(() => homeSummary.value !== null)
   const hasTodaySummary = computed(() => todaySummary.value !== null)
@@ -69,45 +75,55 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     persistLocalMode(nextMode)
   }
 
-  // Ordering guard for summary-derived preference state — mode and onboarding,
-  // each guarded independently (issue #1343). A Home/Today summary must not
-  // overwrite newer explicit preference actions. Per field, it applies only when:
-  //   1. No preference request was already in flight when the summary request
-  //      BEGAN (preferencePending) — the summary's server-side read may predate
-  //      that request's commit even if the request settles first, so its
-  //      preference fields are indistinguishable from stale.
-  //   2. No writer for that field started after the summary began — writers bump
-  //      their field's version at start, so an older captured version is stale.
-  //   3. No preference request is in flight at APPLY time — defense-in-depth;
-  //      provably redundant with 1+2 today (any writer starting after the
-  //      snapshot bumps a version; writers pending at snapshot set
-  //      preferencePending), but it protects against future writers that track
-  //      pending without versioning.
-  //   4. Mode only: no unsaved local choice (modeDirty) — after a FAILED save
-  //      the versions are stable but the server still holds the old mode.
-  type SummaryGuardSnapshot = {
+  // Read-guard snapshot, captured synchronously when a read (summary or
+  // preferences hydrate) begins. A field from a read applies only when NO write
+  // of that field overlapped the read:
+  //   1. none was pending when the read began — the read's server-side result
+  //      may predate that write's commit even if the write settles first;
+  //   2. none started after the read began (field version unchanged);
+  //   3. none is pending at apply time — defense-in-depth; provably redundant
+  //      with 1+2 today, but protects future writers that track pending
+  //      without versioning.
+  // Summaries additionally require the field to have no unsaved local intent
+  // (dirty flag); hydratePreferences instead RECONCILES dirty state (see there).
+  type PreferenceReadSnapshot = {
     modeVersion: number
     onboardingVersion: number
-    preferencePending: boolean
+    modeWritePending: boolean
+    onboardingWritePending: boolean
   }
 
-  function captureSummaryGuardSnapshot(): SummaryGuardSnapshot {
+  function capturePreferenceReadSnapshot(): PreferenceReadSnapshot {
     return {
       modeVersion: modeRequestVersion,
       onboardingVersion: onboardingRequestVersion,
-      preferencePending: pendingPreferenceRequests > 0,
+      modeWritePending: pendingModeWrites > 0,
+      onboardingWritePending: pendingOnboardingWrites > 0,
     }
+  }
+
+  function isModeReadClear(snapshot: PreferenceReadSnapshot): boolean {
+    return (
+      !snapshot.modeWritePending &&
+      modeRequestVersion === snapshot.modeVersion &&
+      pendingModeWrites === 0
+    )
+  }
+
+  function isOnboardingReadClear(snapshot: PreferenceReadSnapshot): boolean {
+    return (
+      !snapshot.onboardingWritePending &&
+      onboardingRequestVersion === snapshot.onboardingVersion &&
+      pendingOnboardingWrites === 0
+    )
   }
 
   function applySummaryPreferences(
     summary: HomeSummary | TodaySummary,
-    snapshot: SummaryGuardSnapshot,
+    snapshot: PreferenceReadSnapshot,
   ): { modeApplied: boolean; onboardingApplied: boolean } {
-    const guardClear = !snapshot.preferencePending && pendingPreferenceRequests === 0
-    const modeApplied =
-      guardClear && modeRequestVersion === snapshot.modeVersion && !modeDirty
-    const onboardingApplied =
-      guardClear && onboardingRequestVersion === snapshot.onboardingVersion
+    const modeApplied = isModeReadClear(snapshot) && !modeDirty
+    const onboardingApplied = isOnboardingReadClear(snapshot) && !onboardingDirty
 
     if (modeApplied) {
       applyMode(summary.workspaceMode)
@@ -147,16 +163,6 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     preferenceLoading.value = pendingPreferenceRequests > 0
   }
 
-  function startModePreferenceRequest(): number {
-    beginPreferenceLoading()
-    return ++modeRequestVersion
-  }
-
-  function startOnboardingPreferenceRequest(): number {
-    beginPreferenceLoading()
-    return ++onboardingRequestVersion
-  }
-
   async function hydratePreferences(): Promise<WorkspacePreference | null> {
     if (!session.isAuthenticated) {
       preferencesHydrated.value = false
@@ -170,22 +176,30 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return null
     }
 
-    // Hydration writes both preference fields, so it versions both.
+    // Hydration is a READ: it snapshots the guards and applies per field only
+    // when that field is clean; unlike summaries it can RECONCILE dirty state.
     beginPreferenceLoading()
-    const modeVersion = ++modeRequestVersion
-    const onboardingVersion = ++onboardingRequestVersion
+    const snapshot = capturePreferenceReadSnapshot()
 
     try {
       preferenceError.value = null
       const preference = await workspaceApi.getPreferences()
 
-      if (onboardingRequestVersion === onboardingVersion) {
-        // Onboarding has no unsaved local state, so the fresh server copy
-        // applies unless a newer onboarding writer superseded this hydrate.
-        syncOnboarding(preference.onboarding)
+      if (isOnboardingReadClear(snapshot)) {
+        if (
+          onboardingDirty &&
+          onboarding.value &&
+          preference.onboarding?.visibility !== onboarding.value.visibility
+        ) {
+          // The server still holds the pre-failed-action onboarding. Keep the
+          // unsaved local intent.
+        } else {
+          onboardingDirty = false
+          syncOnboarding(preference.onboarding)
+        }
       }
 
-      if (modeRequestVersion === modeVersion) {
+      if (isModeReadClear(snapshot)) {
         if (modeDirty && preference.workspaceMode !== mode.value) {
           // The server still holds the pre-failed-save mode. Keep the unsaved
           // local choice; preferencesHydrated stays false so the unsynced state
@@ -200,7 +214,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
 
       return preference
     } catch (e: unknown) {
-      if (modeRequestVersion === modeVersion) {
+      if (isModeReadClear(snapshot)) {
         preferenceError.value = getErrorMessage(e, "We couldn't load your workspace preferences")
       }
 
@@ -218,42 +232,42 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return
     }
 
-    const requestVersion = startModePreferenceRequest()
-    const onboardingVersionAtStart = onboardingRequestVersion
+    const requestVersion = ++modeRequestVersion
+    pendingModeWrites += 1
+    beginPreferenceLoading()
 
     if (!session.isAuthenticated) {
       preferencesHydrated.value = false
+      pendingModeWrites -= 1
       finishPreferenceLoading()
       return
     }
 
     try {
       preferenceError.value = null
-      const preference = await workspaceApi.updatePreferences({ workspaceMode: nextMode })
+      await workspaceApi.updatePreferences({ workspaceMode: nextMode })
 
       if (modeRequestVersion === requestVersion) {
+        // Confirm-only: the locally-applied mode is authoritative for this
+        // locally-initiated write. The response's field values are never
+        // applied — in particular its onboarding echo is dead by construction
+        // and cannot revert a concurrent explicit onboarding action.
         modeDirty = false
-        applyMode(preference.workspaceMode)
         preferencesHydrated.value = true
-      }
-      // The response's onboarding is an incidental echo (a mode save does not
-      // change onboarding server-side); it must not clobber a newer explicit
-      // onboarding action that started while this save was in flight.
-      if (onboardingRequestVersion === onboardingVersionAtStart) {
-        syncOnboarding(preference.onboarding)
       }
     } catch (e: unknown) {
       if (modeRequestVersion === requestVersion) {
         // Keep the local selection AND remember it is unsaved so subsequent
-        // summary fetches cannot silently revert it (issue #1343). Guarded by
-        // the MODE version only: a concurrent onboarding action must not
-        // suppress this failed-save handling.
+        // reads cannot silently revert it (issue #1343). Guarded by the MODE
+        // version only: a concurrent onboarding action must not suppress this
+        // failed-save handling.
         modeDirty = true
         preferenceError.value = getErrorMessage(e, "We couldn't save this workspace mode")
         preferencesHydrated.value = false
         toast.warning(`${preferenceError.value}. Keeping the local selection for now.`)
       }
     } finally {
+      pendingModeWrites -= 1
       finishPreferenceLoading()
     }
   }
@@ -271,7 +285,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return summary
     }
 
-    const guardSnapshot = captureSummaryGuardSnapshot()
+    const guardSnapshot = capturePreferenceReadSnapshot()
 
     try {
       homeLoading.value = true
@@ -299,7 +313,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
 
   async function fetchTodaySummary(): Promise<TodaySummary> {
     const requestVersion = ++todayRequestVersion
-    const guardSnapshot = captureSummaryGuardSnapshot()
+    const guardSnapshot = capturePreferenceReadSnapshot()
 
     if (isDemoMode) {
       todayLoading.value = true
@@ -350,23 +364,52 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return next
     }
 
+    // Optimistic local intent (mirrors updateMode): the visibility change the
+    // action requests is applied immediately from the best-known onboarding
+    // state; the write response then confirms rather than re-applies. The full
+    // server-computed object (steps, timestamps) arrives via the next clean
+    // read (summary/hydrate) once the write has settled.
+    const optimisticBase =
+      onboarding.value ?? homeSummary.value?.onboarding ?? todaySummary.value?.onboarding ?? null
+    const appliedOptimistic = optimisticBase !== null
+    if (optimisticBase) {
+      syncOnboarding({
+        ...optimisticBase,
+        visibility: action === 'dismiss' ? 'dismissed' : 'active',
+      })
+    }
+
+    const requestVersion = ++onboardingRequestVersion
+    pendingOnboardingWrites += 1
+    beginPreferenceLoading()
+
     try {
-      // Versioned per-field (issue #1343): an explicit onboarding action makes
-      // in-flight summaries' ONBOARDING stale without touching the mode guard —
-      // a dismissal that starts mid-save must not suppress the save's own
-      // success/failure handling. Latest onboarding writer wins.
-      const requestVersion = startOnboardingPreferenceRequest()
       preferenceError.value = null
       const nextOnboarding = await workspaceApi.updateOnboarding({ action })
       if (onboardingRequestVersion === requestVersion) {
-        syncOnboarding(nextOnboarding)
+        onboardingDirty = false
+        if (!appliedOptimistic) {
+          // Bootstrap: no local onboarding existed to patch, so adopt this
+          // action's authoritative result as initial state. Not an echo
+          // overwrite — this is still the latest onboarding write, so no newer
+          // local intent can exist.
+          syncOnboarding(nextOnboarding)
+        }
       }
       return nextOnboarding
     } catch (e: unknown) {
-      preferenceError.value = getErrorMessage(e, "We couldn't update the setup guide")
-      toast.warning(preferenceError.value)
+      if (onboardingRequestVersion === requestVersion) {
+        if (appliedOptimistic) {
+          // Local intent stays applied; flag it unsaved so reads cannot
+          // silently revert it (mirrors the failed-mode-save semantics).
+          onboardingDirty = true
+        }
+        preferenceError.value = getErrorMessage(e, "We couldn't update the setup guide")
+        toast.warning(preferenceError.value)
+      }
       throw e
     } finally {
+      pendingOnboardingWrites -= 1
       finishPreferenceLoading()
     }
   }
@@ -385,6 +428,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
 
   function resetForLogout() {
     modeDirty = false
+    onboardingDirty = false
     preferencesHydrated.value = false
     preferenceError.value = null
     onboarding.value = null

--- a/frontend/taskdeck-web/src/store/workspaceStore.ts
+++ b/frontend/taskdeck-web/src/store/workspaceStore.ts
@@ -55,6 +55,20 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     persistLocalMode(nextMode)
   }
 
+  // Ordering guard for summary-derived mode (issue #1343). A Home/Today summary
+  // request can resolve *after* the user makes a newer local mode choice
+  // (updateMode) or a newer preference hydrate. Both of those bump
+  // preferenceRequestVersion at their start, so a summary that captured an
+  // older version must not overwrite the newer explicit choice. When the
+  // version is unchanged the summary is genuinely newer and applies as normal.
+  function applySummaryMode(nextMode: WorkspaceMode, preferenceVersionAtStart: number): boolean {
+    if (preferenceRequestVersion !== preferenceVersionAtStart) {
+      return false
+    }
+    applyMode(nextMode)
+    return true
+  }
+
   function syncOnboarding(nextOnboarding: WorkspaceOnboarding | null) {
     onboarding.value = nextOnboarding
 
@@ -178,14 +192,17 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       return summary
     }
 
+    const preferenceVersionAtStart = preferenceRequestVersion
+
     try {
       homeLoading.value = true
       homeError.value = null
       const summary = await workspaceApi.getHomeSummary()
       homeSummary.value = summary
-      applyMode(summary.workspaceMode)
       syncOnboarding(summary.onboarding)
-      preferencesHydrated.value = true
+      if (applySummaryMode(summary.workspaceMode, preferenceVersionAtStart)) {
+        preferencesHydrated.value = true
+      }
       return summary
     } catch (e: unknown) {
       homeError.value = getErrorMessage(e, "We couldn't load your workspace overview")
@@ -197,6 +214,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
 
   async function fetchTodaySummary(): Promise<TodaySummary> {
     const requestVersion = ++todayRequestVersion
+    const preferenceVersionAtStart = preferenceRequestVersion
 
     if (isDemoMode) {
       todayLoading.value = true
@@ -217,8 +235,8 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       const summary = await workspaceApi.getTodaySummary()
       if (requestVersion === todayRequestVersion) {
         todaySummary.value = summary
-        applyMode(summary.workspaceMode)
         syncOnboarding(summary.onboarding)
+        applySummaryMode(summary.workspaceMode, preferenceVersionAtStart)
       }
       return summary
     } catch (e: unknown) {

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
@@ -421,8 +421,9 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
       // The newer local choice survives; the late summary does not overwrite it.
       expect(store.mode).toBe('workbench')
       expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
-      // Summary data still applied (only mode is ordering-guarded), but the failed
-      // save's hydration state is not clobbered back to true by the late summary.
+      // Summary data still applied (mode AND onboarding are ordering-guarded),
+      // but the failed save's hydration state is not clobbered back to true by
+      // the late summary.
       expect(store.homeSummary).not.toBeNull()
       expect(store.preferencesHydrated).toBe(false)
     })
@@ -501,6 +502,224 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
 
       expect(store.mode).toBe('workbench')
       expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+    })
+  })
+
+  // ── unsaved local choice survives SUBSEQUENT summaries (issue #1343, FIX A) ─
+  // After a FAILED save, the preference version is stable while the server still
+  // holds the old mode. Summaries fetched AFTER the failure capture the current
+  // version, so the version guard alone cannot block them — the session-scoped
+  // unsaved-choice flag must.
+
+  describe('failed save keeps the local choice against subsequent summaries', () => {
+    it('keeps the unsaved mode when summaries fetched AFTER the failed save resolve', async () => {
+      vi.mocked(http.put).mockRejectedValue(new Error('save failed'))
+
+      const store = useWorkspaceStore()
+      await store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+
+      // Fresh fetches after the failure: version is current, server still 'guided'.
+      vi.mocked(http.get)
+        .mockResolvedValueOnce({ data: makeHomeSummary({ workspaceMode: 'guided' }) })
+        .mockResolvedValueOnce({ data: makeTodaySummary({ workspaceMode: 'guided' }) })
+
+      await store.fetchHomeSummary()
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(false)
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+
+      await store.fetchTodaySummary()
+      expect(store.mode).toBe('workbench')
+      // Summary data itself still lands (only preference state is guarded).
+      expect(store.homeSummary).not.toBeNull()
+      expect(store.todaySummary).not.toBeNull()
+    })
+
+    it('clears the unsaved flag when a later save succeeds so newer summaries apply again', async () => {
+      vi.mocked(http.put).mockRejectedValueOnce(new Error('save failed'))
+
+      const store = useWorkspaceStore()
+      await store.updateMode('workbench')
+
+      vi.mocked(http.put).mockResolvedValueOnce({ data: makePreferencePayload('workbench') })
+      await store.updateMode('workbench')
+
+      vi.mocked(http.get).mockResolvedValue({ data: makeHomeSummary({ workspaceMode: 'agent' }) })
+      await store.fetchHomeSummary()
+
+      expect(store.mode).toBe('agent')
+      expect(store.preferencesHydrated).toBe(true)
+    })
+
+    it('hydratePreferences keeps the unsaved local mode while the server still disagrees', async () => {
+      vi.mocked(http.put).mockRejectedValue(new Error('save failed'))
+
+      const store = useWorkspaceStore()
+      await store.updateMode('workbench')
+
+      vi.mocked(http.get).mockResolvedValueOnce({ data: makePreferencePayload('guided') })
+      await store.hydratePreferences()
+
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(false)
+      // Onboarding has no unsaved local state, so the fresh server copy applies.
+      expect(store.onboarding).not.toBeNull()
+    })
+
+    it('hydratePreferences confirming the local mode clears the unsaved flag', async () => {
+      vi.mocked(http.put).mockRejectedValue(new Error('save failed'))
+
+      const store = useWorkspaceStore()
+      await store.updateMode('workbench')
+
+      // Server now matches the local choice (e.g. the save actually committed
+      // despite the error response, or another client saved the same mode).
+      vi.mocked(http.get).mockResolvedValueOnce({ data: makePreferencePayload('workbench') })
+      await store.hydratePreferences()
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(true)
+
+      // Flag cleared: a genuinely newer summary applies server truth again.
+      vi.mocked(http.get).mockResolvedValueOnce({ data: makeHomeSummary({ workspaceMode: 'agent' }) })
+      await store.fetchHomeSummary()
+      expect(store.mode).toBe('agent')
+    })
+
+    it('rejects a summary resolving while the preference save is still in flight', async () => {
+      // The summary starts AFTER the save began, so its captured version is
+      // current — but its payload may predate the save's server-side commit.
+      // The pending-preference-request check at apply time must reject it; the
+      // save's own resolution applies the authoritative state.
+      let resolveSave!: (value: unknown) => void
+      vi.mocked(http.put).mockReturnValueOnce(
+        new Promise<unknown>((resolve) => { resolveSave = resolve }),
+      )
+      vi.mocked(http.get).mockResolvedValue({ data: makeHomeSummary({ workspaceMode: 'guided' }) })
+
+      const store = useWorkspaceStore()
+      const saveRequest = store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+
+      await store.fetchHomeSummary()
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(false)
+
+      resolveSave({ data: makePreferencePayload('workbench') })
+      await saveRequest
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(true)
+    })
+  })
+
+  // ── stale summaries cannot revert onboarding either (issue #1343, FIX B) ───
+  // Guarding only the mode would let a stale summary revert a newer onboarding
+  // change (a dismissed setup guide reappearing) and make mode/onboarding
+  // diverge. Explicit onboarding actions version the same guard.
+
+  describe('late summary cannot overwrite newer onboarding state', () => {
+    it('stale summary cannot revert a newer onboarding dismissal', async () => {
+      let resolveHome!: (value: { data: HomeSummary }) => void
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: HomeSummary }>((resolve) => { resolveHome = resolve }),
+      )
+      vi.mocked(http.put).mockResolvedValue({ data: makeOnboarding({ visibility: 'dismissed' }) })
+
+      const store = useWorkspaceStore()
+      const homeRequest = store.fetchHomeSummary()
+
+      // User dismisses the setup guide while the Home request is in flight.
+      await store.updateOnboarding('dismiss')
+      expect(store.onboarding?.visibility).toBe('dismissed')
+
+      resolveHome({
+        data: makeHomeSummary({ onboarding: makeOnboarding({ visibility: 'active' }) }),
+      })
+      await homeRequest
+
+      // The dismissal survives, and the stored summary is patched to match the
+      // guarded onboarding rather than carrying the stale 'active' copy.
+      expect(store.onboarding?.visibility).toBe('dismissed')
+      expect(store.homeSummary?.onboarding.visibility).toBe('dismissed')
+    })
+
+    it('a failed save blocks both mode and onboarding from a later summary (no divergence)', async () => {
+      // Seed a dismissed guide via a successful explicit action first.
+      vi.mocked(http.put).mockResolvedValueOnce({ data: makeOnboarding({ visibility: 'dismissed' }) })
+      const store = useWorkspaceStore()
+      await store.updateOnboarding('dismiss')
+
+      vi.mocked(http.put).mockRejectedValue(new Error('save failed'))
+      await store.updateMode('workbench')
+
+      vi.mocked(http.get).mockResolvedValue({
+        data: makeHomeSummary({
+          workspaceMode: 'guided',
+          onboarding: makeOnboarding({ visibility: 'active' }),
+        }),
+      })
+      await store.fetchHomeSummary()
+
+      // Neither half of the preference state reverts: no mode/onboarding divergence.
+      expect(store.mode).toBe('workbench')
+      expect(store.onboarding?.visibility).toBe('dismissed')
+      expect(store.homeSummary?.onboarding.visibility).toBe('dismissed')
+    })
+  })
+
+  // ── Today dual-guard combinations (issue #1343, FIX C) ─────────────────────
+  // fetchTodaySummary carries two guards: todayRequestVersion (Today-vs-Today
+  // ordering, #1333) and the preference guard. Pin each combination.
+
+  describe('Today dual-guard combinations', () => {
+    it('applies nothing when todayRequestVersion is stale even though the preference version is current', async () => {
+      let resolveOld!: (value: { data: TodaySummary }) => void
+      vi.mocked(http.get).mockImplementationOnce(
+        () => new Promise((resolve) => { resolveOld = resolve }),
+      )
+
+      const store = useWorkspaceStore()
+      const oldRequest = store.fetchTodaySummary()
+      // Bumps todayRequestVersion; the preference version is untouched.
+      store.clearTodaySummary()
+
+      resolveOld({
+        data: makeTodaySummary({
+          workspaceMode: 'agent',
+          onboarding: makeOnboarding({ visibility: 'dismissed' }),
+        }),
+      })
+      await oldRequest
+
+      expect(store.mode).toBe('guided')
+      expect(store.todaySummary).toBeNull()
+      expect(store.onboarding).toBeNull()
+    })
+
+    it('applies nothing when both todayRequestVersion and the preference version are stale', async () => {
+      let resolveOld!: (value: { data: TodaySummary }) => void
+      vi.mocked(http.get).mockImplementationOnce(
+        () => new Promise((resolve) => { resolveOld = resolve }),
+      )
+      vi.mocked(http.put).mockResolvedValue({ data: makePreferencePayload('workbench') })
+
+      const store = useWorkspaceStore()
+      const oldRequest = store.fetchTodaySummary()
+      store.clearTodaySummary()
+      await store.updateMode('workbench')
+
+      resolveOld({
+        data: makeTodaySummary({
+          workspaceMode: 'agent',
+          onboarding: makeOnboarding({ visibility: 'dismissed' }),
+        }),
+      })
+      await oldRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(store.todaySummary).toBeNull()
+      // Onboarding stays what the successful save confirmed, not the stale summary's.
+      expect(store.onboarding?.visibility).toBe('active')
     })
   })
 })

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
@@ -385,4 +385,122 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
       expect(store.todaySummary?.onboarding.currentStepId).toBe('step-2')
     })
   })
+
+  // ── late summary vs. newer local mode choice (issue #1343) ────────────────
+  // A Home/Today summary request that started before a newer local mode choice
+  // (updateMode) must not overwrite that choice when it resolves afterward.
+  // Genuinely newer summaries — those that start after the local action has
+  // settled — must still apply server truth. Ordering is made deterministic by
+  // controlling exactly when each request resolves, so these are not timing
+  // races: they exercise the store's version guard directly.
+
+  describe('late summary cannot overwrite a newer local mode choice', () => {
+    it('keeps a failed-save mode choice when a late Home summary resolves afterward', async () => {
+      // Home request begins first (carries the stale server mode 'guided').
+      let resolveHome!: (value: { data: HomeSummary }) => void
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: HomeSummary }>((resolve) => { resolveHome = resolve }),
+      )
+      // The user's preference save then fails, so the local selection is kept.
+      vi.mocked(http.put).mockRejectedValue(new Error('Failed to save workspace preferences'))
+
+      const store = useWorkspaceStore()
+      const homeRequest = store.fetchHomeSummary()
+
+      // User picks 'workbench' while the Home request is still in flight.
+      await store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+      // Failed save keeps the local selection and records the error (drives the warning).
+      expect(store.preferenceError).toBe('Failed to save workspace preferences')
+      expect(store.preferencesHydrated).toBe(false)
+
+      // The older Home response finally resolves carrying the stale 'guided' mode.
+      resolveHome({ data: makeHomeSummary({ workspaceMode: 'guided' }) })
+      await homeRequest
+
+      // The newer local choice survives; the late summary does not overwrite it.
+      expect(store.mode).toBe('workbench')
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+      // Summary data still applied (only mode is ordering-guarded), but the failed
+      // save's hydration state is not clobbered back to true by the late summary.
+      expect(store.homeSummary).not.toBeNull()
+      expect(store.preferencesHydrated).toBe(false)
+    })
+
+    it('keeps a newer mode choice when a late Today summary resolves afterward', async () => {
+      let resolveToday!: (value: { data: TodaySummary }) => void
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: TodaySummary }>((resolve) => { resolveToday = resolve }),
+      )
+      vi.mocked(http.put).mockResolvedValue({ data: makePreferencePayload('workbench') })
+
+      const store = useWorkspaceStore()
+      const todayRequest = store.fetchTodaySummary()
+
+      await store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+
+      resolveToday({ data: makeTodaySummary({ workspaceMode: 'guided' }) })
+      await todayRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+      // Today summary data is still populated even though its stale mode was dropped.
+      expect(store.todaySummary).not.toBeNull()
+    })
+
+    it('applies a Home summary mode that starts after the local choice has settled', async () => {
+      // Opposite interleaving: the local choice is fully settled first, then a
+      // Home summary begins — it is genuinely newer, so server truth applies.
+      vi.mocked(http.put).mockResolvedValue({ data: makePreferencePayload('workbench') })
+
+      const store = useWorkspaceStore()
+      await store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+
+      vi.mocked(http.get).mockResolvedValue({ data: makeHomeSummary({ workspaceMode: 'agent' }) })
+      await store.fetchHomeSummary()
+
+      expect(store.mode).toBe('agent')
+      expect(store.preferencesHydrated).toBe(true)
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('agent')
+    })
+
+    it('applies a Today summary mode that starts after the local choice has settled', async () => {
+      vi.mocked(http.put).mockResolvedValue({ data: makePreferencePayload('workbench') })
+
+      const store = useWorkspaceStore()
+      await store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+
+      vi.mocked(http.get).mockResolvedValue({ data: makeTodaySummary({ workspaceMode: 'agent' }) })
+      await store.fetchTodaySummary()
+
+      expect(store.mode).toBe('agent')
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('agent')
+    })
+
+    it('drops a late Home mode even when the newer preference save succeeds', async () => {
+      // Ordering guard must fire regardless of whether the concurrent save
+      // succeeds or fails — it is the ordering, not the save outcome, that wins.
+      let resolveHome!: (value: { data: HomeSummary }) => void
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: HomeSummary }>((resolve) => { resolveHome = resolve }),
+      )
+      vi.mocked(http.put).mockResolvedValue({ data: makePreferencePayload('workbench') })
+
+      const store = useWorkspaceStore()
+      const homeRequest = store.fetchHomeSummary()
+
+      await store.updateMode('workbench')
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(true)
+
+      resolveHome({ data: makeHomeSummary({ workspaceMode: 'guided' }) })
+      await homeRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+    })
+  })
 })

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
@@ -381,8 +381,19 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
 
       await store.updateOnboarding('replay')
 
+      // Writes confirm, never re-apply (issue #1343): the action's visibility
+      // intent applies optimistically from the known local base; the response's
+      // server-computed detail (currentStepId) does NOT re-apply. Server truth
+      // arrives via the next clean read.
+      expect(store.onboarding?.visibility).toBe('active')
+      expect(store.onboarding?.currentStepId).toBe('create-first-board')
+      expect(store.todaySummary?.onboarding.visibility).toBe('active')
+
+      vi.mocked(http.get).mockResolvedValue({
+        data: makeTodaySummary({ onboarding: replayed }),
+      })
+      await store.fetchTodaySummary()
       expect(store.onboarding?.currentStepId).toBe('step-2')
-      expect(store.todaySummary?.onboarding.currentStepId).toBe('step-2')
     })
   })
 
@@ -743,6 +754,110 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
     })
   })
 
+  // ── writes confirm, never re-apply (issue #1343, round 4) ──────────────────
+  // Write responses never write field values back into the store, so no echo
+  // can cross fields or revert newer intent; each field's read guard is fully
+  // independent of the other field's in-flight writes.
+
+  describe('write responses confirm without re-applying', () => {
+    it('a mode save echo cannot revert an onboarding action that was already in flight', async () => {
+      // The onboarding action starts BEFORE the mode save, so the save's echo
+      // reflects pre-dismissal server state. Once the dismissal settles, the
+      // later-resolving save must not resurrect the old onboarding.
+      let resolveDismiss!: (value: unknown) => void
+      let resolveSave!: (value: unknown) => void
+      vi.mocked(http.put)
+        .mockReturnValueOnce(
+          new Promise<unknown>((resolve) => { resolveDismiss = resolve }),
+        )
+        .mockReturnValueOnce(
+          new Promise<unknown>((resolve) => { resolveSave = resolve }),
+        )
+
+      const store = useWorkspaceStore()
+      store.homeSummary = makeHomeSummary() // local onboarding base ('active')
+
+      const dismissRequest = store.updateOnboarding('dismiss')
+      const saveRequest = store.updateMode('workbench')
+
+      resolveDismiss({ data: makeOnboarding({ visibility: 'dismissed' }) })
+      await dismissRequest
+      expect(store.onboarding?.visibility).toBe('dismissed')
+
+      // The save resolves LAST; its payload carries pre-dismissal onboarding.
+      resolveSave({ data: makePreferencePayload('workbench') })
+      await saveRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(true)
+      expect(store.onboarding?.visibility).toBe('dismissed')
+      expect(store.homeSummary?.onboarding.visibility).toBe('dismissed')
+    })
+
+    it('a later failed onboarding action is not clobbered by an earlier overlapping success', async () => {
+      let resolveFirst!: (value: unknown) => void
+      let rejectSecond!: (reason: unknown) => void
+      vi.mocked(http.put)
+        .mockReturnValueOnce(
+          new Promise<unknown>((resolve) => { resolveFirst = resolve }),
+        )
+        .mockReturnValueOnce(
+          new Promise<unknown>((_resolve, reject) => { rejectSecond = reject }),
+        )
+
+      const store = useWorkspaceStore()
+      store.homeSummary = makeHomeSummary() // local onboarding base ('active')
+
+      const dismiss = store.updateOnboarding('dismiss') // intent: dismissed
+      const replay = store.updateOnboarding('replay')   // latest intent: active
+
+      resolveFirst({ data: makeOnboarding({ visibility: 'dismissed' }) })
+      await dismiss
+      // The earlier success must not re-apply its result over the later intent.
+      expect(store.onboarding?.visibility).toBe('active')
+
+      rejectSecond(new Error('replay failed'))
+      await expect(replay).rejects.toThrow('replay failed')
+      expect(store.preferenceError).toBe('replay failed')
+      // The latest local intent stands (kept + flagged unsaved).
+      expect(store.onboarding?.visibility).toBe('active')
+
+      // And the unsaved intent survives a subsequent summary carrying the
+      // server's actual state (dismissed — the first action committed).
+      vi.mocked(http.get).mockResolvedValue({
+        data: makeHomeSummary({ onboarding: makeOnboarding({ visibility: 'dismissed' }) }),
+      })
+      await store.fetchHomeSummary()
+      expect(store.onboarding?.visibility).toBe('active')
+    })
+
+    it('a pending onboarding action does not block a summary from hydrating mode', async () => {
+      let resolveDismiss!: (value: unknown) => void
+      vi.mocked(http.put).mockReturnValueOnce(
+        new Promise<unknown>((resolve) => { resolveDismiss = resolve }),
+      )
+      vi.mocked(http.get).mockResolvedValue({ data: makeHomeSummary({ workspaceMode: 'agent' }) })
+
+      const store = useWorkspaceStore()
+      store.todaySummary = makeTodaySummary() // local onboarding base
+      const dismiss = store.updateOnboarding('dismiss') // onboarding write pending
+
+      // The summary starts and resolves entirely during the onboarding write.
+      await store.fetchHomeSummary()
+
+      // Per-field guard: the pending ONBOARDING write must not block MODE.
+      expect(store.mode).toBe('agent')
+      expect(store.preferencesHydrated).toBe(true)
+      // The summary's onboarding overlapped the write and is blocked; the
+      // local dismissal intent stays visible.
+      expect(store.onboarding?.visibility).toBe('dismissed')
+
+      resolveDismiss({ data: makeOnboarding({ visibility: 'dismissed' }) })
+      await dismiss
+      expect(store.onboarding?.visibility).toBe('dismissed')
+    })
+  })
+
   // ── stale summaries cannot revert onboarding either (issue #1343, FIX B) ───
   // Guarding only the mode would let a stale summary revert a newer onboarding
   // change (a dismissed setup guide reappearing) and make mode/onboarding
@@ -884,8 +999,9 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
 
       expect(store.mode).toBe('workbench')
       expect(store.todaySummary).toBeNull()
-      // Onboarding stays what the successful save confirmed, not the stale summary's.
-      expect(store.onboarding?.visibility).toBe('active')
+      // Nothing has synced onboarding: the stale summary is discarded wholesale
+      // and (round 4) the save's response echo never applies field values.
+      expect(store.onboarding).toBeNull()
     })
   })
 })

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.modePersistence.spec.ts
@@ -612,6 +612,137 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
     })
   })
 
+  // ── summaries that STARTED during a pending save (issue #1343, Codex P2#1) ──
+  // A summary GET that begins after a save bumped the version but before the
+  // PUT commits can read the OLD server mode. If the save then settles before
+  // the summary resolves, version/pending/dirty are all clean at apply time —
+  // only the pending-at-start capture can identify the summary as suspect.
+
+  describe('summaries that started during a pending save', () => {
+    it('rejects a Home summary that started during a save even when the save settles first', async () => {
+      let resolveSave!: (value: unknown) => void
+      let resolveHome!: (value: { data: HomeSummary }) => void
+      vi.mocked(http.put).mockReturnValueOnce(
+        new Promise<unknown>((resolve) => { resolveSave = resolve }),
+      )
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: HomeSummary }>((resolve) => { resolveHome = resolve }),
+      )
+
+      const store = useWorkspaceStore()
+      const saveRequest = store.updateMode('workbench')
+      // Summary begins while the save is in flight: its server-side read may
+      // predate the save's commit, so its payload carries 'guided'.
+      const homeRequest = store.fetchHomeSummary()
+
+      // The save settles FIRST: version stable, nothing pending, flag clean.
+      resolveSave({ data: makePreferencePayload('workbench') })
+      await saveRequest
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(true)
+
+      // The overlapped summary resolves LAST with the stale mode.
+      resolveHome({ data: makeHomeSummary({ workspaceMode: 'guided' }) })
+      await homeRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+      expect(store.homeSummary).not.toBeNull()
+    })
+
+    it('rejects a Today summary that started during a save even when the save settles first', async () => {
+      let resolveSave!: (value: unknown) => void
+      let resolveToday!: (value: { data: TodaySummary }) => void
+      vi.mocked(http.put).mockReturnValueOnce(
+        new Promise<unknown>((resolve) => { resolveSave = resolve }),
+      )
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: TodaySummary }>((resolve) => { resolveToday = resolve }),
+      )
+
+      const store = useWorkspaceStore()
+      const saveRequest = store.updateMode('workbench')
+      const todayRequest = store.fetchTodaySummary()
+
+      resolveSave({ data: makePreferencePayload('workbench') })
+      await saveRequest
+      expect(store.mode).toBe('workbench')
+
+      resolveToday({ data: makeTodaySummary({ workspaceMode: 'guided' }) })
+      await todayRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('workbench')
+      expect(store.todaySummary).not.toBeNull()
+    })
+  })
+
+  // ── onboarding actions must not supersede mode saves (Codex P2#2) ──────────
+  // The mode and onboarding guards are versioned per field: an onboarding
+  // dismiss/replay that starts while a mode save is in flight must neither
+  // suppress the save's success/failure handling nor be reverted by the save's
+  // incidental onboarding echo.
+
+  describe('onboarding actions do not supersede mode saves', () => {
+    it('an onboarding action during a pending save does not suppress the failed-save handling', async () => {
+      let rejectSave!: (reason: unknown) => void
+      vi.mocked(http.put)
+        .mockReturnValueOnce(
+          new Promise<unknown>((_resolve, reject) => { rejectSave = reject }),
+        )
+        .mockResolvedValueOnce({ data: makeOnboarding({ visibility: 'dismissed' }) })
+
+      const store = useWorkspaceStore()
+      const saveRequest = store.updateMode('workbench')
+
+      // User dismisses the setup guide while the save is still in flight
+      // (reachable: the topbar fires updateMode un-awaited and Home setup
+      // actions stay clickable during the retry window).
+      await store.updateOnboarding('dismiss')
+      expect(store.onboarding?.visibility).toBe('dismissed')
+
+      // The save now fails. Its handling must still run: error + unsaved flag.
+      rejectSave(new Error('save failed'))
+      await saveRequest
+      expect(store.preferenceError).toBe('save failed')
+      expect(store.preferencesHydrated).toBe(false)
+
+      // Because the flag was set, a subsequent stale-mode summary cannot revert.
+      vi.mocked(http.get).mockResolvedValue({
+        data: makeHomeSummary({
+          workspaceMode: 'guided',
+          onboarding: makeOnboarding({ visibility: 'dismissed' }),
+        }),
+      })
+      await store.fetchHomeSummary()
+      expect(store.mode).toBe('workbench')
+      expect(store.onboarding?.visibility).toBe('dismissed')
+    })
+
+    it('a mode save settling after an onboarding dismissal keeps both results', async () => {
+      let resolveSave!: (value: unknown) => void
+      vi.mocked(http.put)
+        .mockReturnValueOnce(
+          new Promise<unknown>((resolve) => { resolveSave = resolve }),
+        )
+        .mockResolvedValueOnce({ data: makeOnboarding({ visibility: 'dismissed' }) })
+
+      const store = useWorkspaceStore()
+      const saveRequest = store.updateMode('workbench')
+      await store.updateOnboarding('dismiss')
+
+      // The save's response echoes onboarding as of ITS commit — before the
+      // dismissal. The echo must not revert the newer explicit dismissal, but
+      // the save's own mode confirmation must still land.
+      resolveSave({ data: makePreferencePayload('workbench') })
+      await saveRequest
+
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(true)
+      expect(store.onboarding?.visibility).toBe('dismissed')
+    })
+  })
+
   // ── stale summaries cannot revert onboarding either (issue #1343, FIX B) ───
   // Guarding only the mode would let a stale summary revert a newer onboarding
   // change (a dismissed setup guide reappearing) and make mode/onboarding
@@ -643,27 +774,62 @@ describe('workspaceStore — mode persistence and extended scenarios', () => {
       expect(store.homeSummary?.onboarding.visibility).toBe('dismissed')
     })
 
-    it('a failed save blocks both mode and onboarding from a later summary (no divergence)', async () => {
-      // Seed a dismissed guide via a successful explicit action first.
-      vi.mocked(http.put).mockResolvedValueOnce({ data: makeOnboarding({ visibility: 'dismissed' }) })
-      const store = useWorkspaceStore()
-      await store.updateOnboarding('dismiss')
+    it('a stale summary blocks both mode and onboarding after a dismissal and a failed save (no divergence)', async () => {
+      // The summary starts FIRST, so its payload legitimately predates both the
+      // dismissal and the (failed) mode save: it carries 'active' + 'guided'.
+      let resolveHome!: (value: { data: HomeSummary }) => void
+      vi.mocked(http.get).mockReturnValueOnce(
+        new Promise<{ data: HomeSummary }>((resolve) => { resolveHome = resolve }),
+      )
+      vi.mocked(http.put)
+        .mockResolvedValueOnce({ data: makeOnboarding({ visibility: 'dismissed' }) })
+        .mockRejectedValueOnce(new Error('save failed'))
 
-      vi.mocked(http.put).mockRejectedValue(new Error('save failed'))
+      const store = useWorkspaceStore()
+      const homeRequest = store.fetchHomeSummary()
+
+      await store.updateOnboarding('dismiss')
       await store.updateMode('workbench')
 
-      vi.mocked(http.get).mockResolvedValue({
+      resolveHome({
         data: makeHomeSummary({
           workspaceMode: 'guided',
           onboarding: makeOnboarding({ visibility: 'active' }),
         }),
       })
-      await store.fetchHomeSummary()
+      await homeRequest
 
       // Neither half of the preference state reverts: no mode/onboarding divergence.
       expect(store.mode).toBe('workbench')
       expect(store.onboarding?.visibility).toBe('dismissed')
       expect(store.homeSummary?.onboarding.visibility).toBe('dismissed')
+    })
+
+    it('a fresh summary after a failed save applies current onboarding while the unsaved mode survives', async () => {
+      // Per-field independence: the failed MODE save must not freeze onboarding
+      // sync. A summary fetched after the failure carries the server's CURRENT
+      // onboarding (the dismissal committed) — it applies — while its stale
+      // mode is still blocked by the unsaved-choice flag.
+      vi.mocked(http.put)
+        .mockResolvedValueOnce({ data: makeOnboarding({ visibility: 'dismissed' }) })
+        .mockRejectedValueOnce(new Error('save failed'))
+
+      const store = useWorkspaceStore()
+      await store.updateOnboarding('dismiss')
+      await store.updateMode('workbench')
+
+      vi.mocked(http.get).mockResolvedValue({
+        data: makeHomeSummary({
+          workspaceMode: 'guided',
+          onboarding: makeOnboarding({ visibility: 'dismissed', currentStepId: 'step-3' }),
+        }),
+      })
+      await store.fetchHomeSummary()
+
+      expect(store.mode).toBe('workbench')
+      expect(store.preferencesHydrated).toBe(false)
+      // The genuinely-newer onboarding copy applied.
+      expect(store.onboarding?.currentStepId).toBe('step-3')
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/store/workspaceStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/workspaceStore.spec.ts
@@ -108,9 +108,13 @@ describe('workspaceStore', () => {
     await store.updateMode('agent')
 
     expect(store.mode).toBe('agent')
-    expect(store.onboarding?.visibility).toBe('dismissed')
     expect(localStorage.getItem(WORKSPACE_MODE_STORAGE_KEY)).toBe('agent')
+    expect(store.preferencesHydrated).toBe(true)
     expect(workspaceApi.updatePreferences).toHaveBeenCalledWith({ workspaceMode: 'agent' })
+    // Writes confirm, never re-apply (issue #1343): the save's response is an
+    // echo and must not write field values back — its onboarding payload does
+    // NOT apply. Onboarding state arrives via reads (summary/hydrate) instead.
+    expect(store.onboarding).toBeNull()
   })
 
   it('keeps the latest mode when an older hydration request resolves after an update', async () => {

--- a/frontend/taskdeck-web/tests/e2e/error-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/error-recovery.spec.ts
@@ -326,10 +326,35 @@ test('boards list API failure should show error in boards workspace', async ({ p
 // mode", exercised by smoke.spec.ts). On a failed PUT the workspace store
 // keeps the local selection and raises a warning toast (role="status"):
 // "<message>. Keeping the local selection for now."
+//
+// This scenario also pins the ordering guard from issue #1343: a Home summary
+// response that started BEFORE the user's newer mode choice must not overwrite
+// it when it resolves afterward. Rather than depend on CI timing (the original
+// flake source), we hold the first Home summary GET until after the user has
+// switched to `workbench`, and rewrite that held response to carry the stale
+// `guided` mode. With the guard the newer local choice survives; without it the
+// late summary silently overwrites the selection.
 
 test('workspace preferences save failure should show error and not silently discard input', async ({ page }) => {
-  await page.goto('/workspace/home')
-  await expect(page.getByRole('heading', { name: 'Home', exact: true })).toBeVisible()
+  let releaseHome!: () => void
+  const homeReleased = new Promise<void>((resolve) => { releaseHome = resolve })
+  let homeHeld = false
+
+  // Hold the FIRST Home summary GET (topbar select stays reachable while it is
+  // pending) and force its payload to the stale `guided` mode. Later GETs pass
+  // through untouched.
+  await page.route('**/api/workspace/home', async (route) => {
+    if (route.request().method() !== 'GET' || homeHeld) {
+      await route.continue()
+      return
+    }
+    homeHeld = true
+    const response = await route.fetch()
+    const payload = await response.json()
+    payload.workspaceMode = 'guided'
+    await homeReleased
+    await route.fulfill({ response, json: payload })
+  })
 
   // Intercept the preferences PUT and simulate a server error
   await page.route('**/api/workspace/preferences', async (route) => {
@@ -347,8 +372,13 @@ test('workspace preferences save failure should show error and not silently disc
     await route.continue()
   })
 
+  await page.goto('/workspace/home')
+
+  // The mode selector lives in the always-mounted top bar, so it is reachable
+  // while the Home summary is still held. It starts at the local default.
   const workspaceModeSelect = page.getByLabel('Workspace mode')
   await expect(workspaceModeSelect).toBeVisible({ timeout: 5_000 })
+  await expect(workspaceModeSelect).toHaveValue('guided')
 
   const failedSave = page.waitForResponse((response) =>
     response.url().includes('/api/workspace/preferences') &&
@@ -356,6 +386,17 @@ test('workspace preferences save failure should show error and not silently disc
     response.status() === 500)
   await workspaceModeSelect.selectOption('workbench')
   await failedSave
+
+  // Optimistic local selection is applied immediately, before the save settles.
+  await expect(workspaceModeSelect).toHaveValue('workbench')
+
+  // Release the stale Home summary now — it began before the mode change, so the
+  // #1343 ordering guard must drop its mode rather than restore `guided`.
+  const lateHome = page.waitForResponse((response) =>
+    response.url().includes('/api/workspace/home') &&
+    response.request().method() === 'GET')
+  releaseHome()
+  await lateHome
 
   // The save attempt surfaces a warning toast naming the failure.
   // The preferences PUT is idempotent, so httpRetry.ts retries it 3 times
@@ -368,6 +409,7 @@ test('workspace preferences save failure should show error and not silently disc
     page.getByText(/failed to save workspace/i).first(),
   ).toBeVisible({ timeout: 20_000 })
 
-  // The user's selection is kept locally rather than silently discarded
+  // The user's selection is kept locally rather than silently discarded, even
+  // after the late `guided` summary landed.
   await expect(workspaceModeSelect).toHaveValue('workbench')
 })

--- a/frontend/taskdeck-web/tests/e2e/error-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/error-recovery.spec.ts
@@ -412,4 +412,20 @@ test('workspace preferences save failure should show error and not silently disc
   // The user's selection is kept locally rather than silently discarded, even
   // after the late `guided` summary landed.
   await expect(workspaceModeSelect).toHaveValue('workbench')
+
+  // Post-failed-save re-navigation (issue #1343 unsaved-choice seam): a FRESH
+  // summary fetched after the failed save still carries the server's stale
+  // mode — the intercepted PUT never reached the server, so it truly holds
+  // `guided`. The session-scoped unsaved-choice flag must keep `workbench`.
+  // Navigate client-side only: a full reload starts a new session, which
+  // legitimately re-syncs from server truth.
+  const todaySummaryFetch = page.waitForResponse((response) =>
+    response.url().includes('/api/workspace/today') &&
+    response.request().method() === 'GET')
+  await page.getByRole('link', { name: 'Today' }).click()
+  await todaySummaryFetch
+
+  // The fresh Today summary (server mode `guided`) must not revert the
+  // unsaved local choice.
+  await expect(workspaceModeSelect).toHaveValue('workbench')
 })


### PR DESCRIPTION
Closes #1343

## Current-reality verdict (verified before editing)

The core defect was **NOT** fully fixed by prior work. Verified against `origin/main` (`40b7bb2f`):

- `fetchHomeSummary()` applied `summary.workspaceMode` **unconditionally** — no ordering guard of any kind. A Home summary that started before a newer local mode choice would overwrite it on resolve.
- `fetchTodaySummary()` had a `todayRequestVersion` "latest-request-wins" guard (added by #1333, commit `0dcecac6` "Discard stale Today summary responses"). That guard only orders **Today-vs-Today** requests. It does **not** compare against preference actions, so a late Today summary could still overwrite a newer `updateMode()` choice.
- `updateMode()` / `hydratePreferences()` version only preference requests via `preferenceRequestVersion`; **no summary path compared against it** — exactly the root cause the issue describes.

So #1333 addressed a sibling ordering problem (Today request races) but left the #1343 preference-vs-summary overwrite live on **both** Home and Today.

## What this PR adds

- **One consolidated ordering guard** (`applySummaryMode`) in `workspaceStore.ts`. Each summary fetch captures `preferenceRequestVersion` at request start; on resolve it applies the summary's mode only if that version is unchanged (i.e. no newer `updateMode`/hydrate started while the summary was in flight). A genuinely newer summary (one that begins after the local choice settles) still applies server truth.
  - Home: guards `applyMode` + `preferencesHydrated` so a failed-save hydration state is not clobbered back to `true` by a late summary.
  - Today: keeps the existing `todayRequestVersion` guard and adds the preference-ordering guard on the mode apply.
  - Summary payload data (workload, badges, onboarding) is still applied unconditionally — only the contested **mode** is ordering-guarded.

## Evidence

- **Deterministic store tests** (`workspaceStore.modePersistence.spec.ts`, +5 tests): late Home summary after a failed save keeps the local choice; late Today summary after a newer choice keeps the local choice; both "settled-first" interleavings still apply server truth; late Home dropped even when the concurrent save succeeds. Full targeted store suite **52/52 pass** (`--maxWorkers=2`).
- **Regression proof**: temporarily disabling the guard makes exactly the 3 stale-summary tests fail (the 2 settled-interleaving tests still pass), confirming the tests pin the defect.
- **Deterministic E2E** (`error-recovery.spec.ts`, Scenario 8 rewritten): the initial Home GET is held until after the user switches to `workbench`, and the held response is rewritten to carry the stale `guided` mode — reproducing the exact CI flake every run instead of depending on timing. Ran **`--repeat-each=10 --workers=1`, isolated DB → 10/10 passed**; full file **8/8 passed**.
- `npm run typecheck` clean; `npm run lint` 0 errors (6 pre-existing warnings in unrelated `Agent*` views).

No backend changes.
