### PR TITLE
Make Redis dispose-vs-connect guard reach the seam deterministically (#1332)

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
@@ -94,8 +94,8 @@ public sealed class RedisCacheServiceTests : IDisposable
         //   - Pre-#1189 code: lock held across connect -> probe times out -> lockWasFree == false.
         var probeAcquiredLock = false;
         var probeElapsed = TimeSpan.MaxValue;
-        var probeCompleted = new ManualResetEventSlim(false);
-        var seamFired = new ManualResetEventSlim(false);
+        using var probeCompleted = new ManualResetEventSlim(false);
+        using var seamFired = new ManualResetEventSlim(false);
 
         _cache.OnBeforeConnect = () =>
         {
@@ -156,8 +156,8 @@ public sealed class RedisCacheServiceTests : IDisposable
         //                    Dispose acquires it immediately.
         //   - Pre-#1189 code: the connecting thread holds _connectionLock across the multi-second
         //                    connect, so Dispose blocks behind it for the whole connect.
-        var releaseConnect = new ManualResetEventSlim(false);
-        var connectEntered = new ManualResetEventSlim(false);
+        using var releaseConnect = new ManualResetEventSlim(false);
+        using var connectEntered = new ManualResetEventSlim(false);
 
         _cache.OnBeforeConnect = () =>
         {

--- a/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/RedisCacheServiceTests.cs
@@ -168,7 +168,31 @@ public sealed class RedisCacheServiceTests : IDisposable
         };
 
         // Park a connecting thread inside the seam (simulated mid-connect).
-        var connectingCall = Task.Run(() => _cache.GetAsync<TestData>("connector").GetAwaiter().GetResult());
+        //
+        // Mechanism note (#1332): use a DEDICATED, named background Thread — NOT Task.Run. A
+        // Task.Run work item is queued to the thread pool, and under full-API-suite load the pool
+        // is saturated; its injection throttle then delays running the item, so the connecting
+        // worker could fail to reach OnBeforeConnect before the wait window elapsed (the observed
+        // flake: "connectEntered.Wait(5s) ... found False"). A dedicated Thread is created and
+        // scheduled by the OS immediately, independent of thread-pool saturation, so the connect
+        // seam is reached deterministically. This is a synchronization guarantee, not a bigger
+        // timeout — GetConnection invokes OnBeforeConnect synchronously on this thread before any
+        // await, so the handshake below is a real rendezvous.
+        TestData? connectorResult = null;
+        Exception? connectorError = null;
+        var connectingThread = new Thread(() =>
+        {
+            try
+            {
+                connectorResult = _cache.GetAsync<TestData>("connector").GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                connectorError = ex;
+            }
+        })
+        { IsBackground = true, Name = "redis-connector" };
+        connectingThread.Start();
 
         connectEntered.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
             "the connect seam must be reached so Dispose is timed against a real mid-connect window");
@@ -181,7 +205,9 @@ public sealed class RedisCacheServiceTests : IDisposable
 
         // Let the parked connecting thread proceed and finish (it must not throw post-dispose).
         releaseConnect.Set();
-        var connectorResult = connectingCall.GetAwaiter().GetResult();
+        connectingThread.Join(TimeSpan.FromSeconds(5)).Should().BeTrue(
+            "the connecting thread must complete once the simulated connect is released");
+        connectorError.Should().BeNull("the parked connector must degrade cleanly post-dispose, not throw");
         connectorResult.Should().BeNull("an unreachable Redis degrades the connector to a miss");
 
         // On the fixed path Dispose acquires the free lock in microseconds. On the old path it would


### PR DESCRIPTION
## Summary

`RedisCacheServiceTests.Dispose_IsNotSerialized_BehindAnInFlightConnect` flaked under full-API-suite load on Windows with `Expected connectEntered.Wait(TimeSpan.FromSeconds(5)) to be True ... but found False`. The connecting actor was launched with `Task.Run(...)`, which queues a thread-pool work item. Under a saturated pool the injection throttle delayed running that item, so the worker never reached `OnBeforeConnect` before the wait window elapsed — a scheduling artifact, not a real regression.

This is a **test-only** change. No production `RedisCacheService` behavior is touched (the production file has an empty diff).

## Mechanism (deterministic, not a bigger timeout)

Replaced `Task.Run(...)` with a **dedicated, named background `Thread`** (`redis-connector`, `IsBackground = true`) that is created and scheduled by the OS immediately, independent of thread-pool saturation. Coordination is unchanged and explicit:

- `GetConnection` invokes `OnBeforeConnect` synchronously on the connecting thread before any `await`, so the existing `connectEntered` / `releaseConnect` handshake is a real rendezvous.
- The connecting thread is now `Join`ed (bounded, 5s) instead of awaited, and its result/exception are captured on fields so the post-dispose degrade assertions still hold.

The 5s wait was **not** increased; determinism comes from the dedicated OS thread, not from a wider margin. The `disposeElapsed < 500ms` concurrency assertion is preserved verbatim.

## Negative proof (still fails against pre-#1189 semantics)

Temporarily reverted the production `GetConnection` to hold `_connectionLock` across the blocking connect (the pre-#1189 lock-around-connect bug), rebuilt, and ran the test:

```
Expected disposeElapsed to be less than 500ms because Dispose must not be serialized
behind another thread's in-flight connect (#1189), but found 7s, 75ms and 86.9µs.
Failed!  - Failed: 1, Passed: 0
```

With the fixed production code the dedicated connecting thread releases `_connectionLock` before the connect, so `Dispose()` acquires it in microseconds. The revert was restored before committing (production diff is empty); the new mechanism did not weaken the guard.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release` — clean (0 errors).
- Targeted repeat: 20/20 runs green of `--filter "FullyQualifiedName~RedisCacheServiceTests"` (8/8 tests each run).
- Negative proof: pre-#1189 revert → Dispose test fails (disposeElapsed ~7s), as required.
- Full project run: `Taskdeck.Api.Tests` — **2060 passed, 0 failed, 0 skipped**.

Closes #1332
