### PR TITLE
Isolate hosted workers from repository-focused full-suite tests (#1335)

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AutomationProposalRepositoryIntegrationTests.cs
@@ -11,12 +11,18 @@ namespace Taskdeck.Api.Tests;
 /// <summary>
 /// Integration tests for AutomationProposalRepository against real SQLite.
 /// Covers ordering correctness, expiry boundary, status filtering, and operation-target lookups.
+///
+/// Uses <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> (issue #1335): the expiry
+/// tests backdate ExpiresAt on PendingReview proposals — exactly the rows the live
+/// <c>ProposalHousekeepingWorker</c> (runs immediately at host start, then every 60s) transitions
+/// PendingReview→Expired. Without worker isolation the sweep can consume a seeded proposal
+/// between seed and the GetExpiredAsync read.
 /// </summary>
-public class AutomationProposalRepositoryIntegrationTests : IClassFixture<TestWebApplicationFactory>
+public class AutomationProposalRepositoryIntegrationTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {
-    private readonly TestWebApplicationFactory _factory;
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
 
-    public AutomationProposalRepositoryIntegrationTests(TestWebApplicationFactory factory)
+    public AutomationProposalRepositoryIntegrationTests(HostedWorkerDisabledTestWebApplicationFactory factory)
     {
         _factory = factory;
     }

--- a/backend/tests/Taskdeck.Api.Tests/Concurrency/ProcessNextClaimRaceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Concurrency/ProcessNextClaimRaceTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Taskdeck.Api.Tests.Support;
+using Taskdeck.Application.DTOs;
+using Xunit;
+
+namespace Taskdeck.Api.Tests.Concurrency;
+
+/// <summary>
+/// HTTP-level process-next claim races, split out of <see cref="QueueClaimRaceTests"/>
+/// (issue #1335). These tests race N parallel process-next calls over seeded Pending queue
+/// rows — exactly the rows the live <c>LlmQueueToProposalWorker</c> drains on its 1s poll, so
+/// on the worker-running base factory the background worker can claim a row before ANY of the
+/// test's parallel callers, yielding successCount == 0.
+///
+/// Uses <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> so the only claimants are
+/// the test's own parallel HTTP calls (deterministic by construction). CreateClient() still
+/// works on the workerless factory: only application workers are removed; the framework
+/// web-host service that starts the TestServer is preserved. The capture-triage tests remain
+/// in <see cref="QueueClaimRaceTests"/> because they DEPEND on the live triage drain.
+///
+/// See GitHub issue #705 (TST-55) for the original race scenarios.
+/// </summary>
+public class ProcessNextClaimRaceTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
+{
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
+
+    public ProcessNextClaimRaceTests(HostedWorkerDisabledTestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    /// <summary>
+    /// Scenario 1: 10 parallel workers all try to process the next pending LLM queue item.
+    /// Under SQLite's file-level write serialization, multiple workers may read the same
+    /// pending item before any status update commits, causing more than one to succeed.
+    /// This is a known SQLite limitation -- with PostgreSQL row-level locking, at most
+    /// one worker would claim each item.
+    ///
+    /// The test validates:
+    /// - No 500 errors under concurrent access
+    /// - At least one worker succeeds
+    /// - No deadlocks or hangs (test completes within timeout)
+    /// </summary>
+    [Fact]
+    public async Task ProcessNext_TenParallelWorkers_NoErrorsUnderConcurrentAccess()
+    {
+        const int workerCount = 10;
+        using var setupClient = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(setupClient, "queue-claim-10");
+
+        // Seed a single LLM queue item
+        var queueResp = await setupClient.PostAsJsonAsync(
+            "/api/llm-queue",
+            new CreateLlmRequestDto("summarize", "payload for claim race"));
+        queueResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Fire 10 parallel process-next requests
+        using var barrier = new SemaphoreSlim(0, workerCount);
+        var results = new ConcurrentBag<HttpStatusCode>();
+
+        var tasks = Enumerable.Range(0, workerCount).Select(async _ =>
+        {
+            using var workerClient = _factory.CreateClient();
+            workerClient.DefaultRequestHeaders.Authorization =
+                setupClient.DefaultRequestHeaders.Authorization;
+            await barrier.WaitAsync();
+            var resp = await workerClient.PostAsync("/api/llm-queue/process-next", null);
+            results.Add(resp.StatusCode);
+        }).ToArray();
+
+        barrier.Release(workerCount);
+        await Task.WhenAll(tasks);
+
+        var codes = results.ToList();
+        var successCount = codes.Count(s => s == HttpStatusCode.OK);
+
+        // At least one worker should succeed
+        successCount.Should().BeGreaterOrEqualTo(1,
+            "at least one worker should process the pending item");
+
+        // NOTE: Under SQLite, multiple workers may succeed because reads are not
+        // serialized against writes at the row level. With PostgreSQL, we would
+        // expect successCount <= 1 due to SELECT ... FOR UPDATE or advisory locks.
+        // The important invariant is no 500 errors and no deadlocks.
+
+        // Remaining workers should get 404 (no pending item) or OK.
+        // Under SQLite's file-level write lock, transient 500s from DB contention
+        // are a known test-environment limitation and are tolerated.
+        codes.Should().OnlyContain(
+            s => s == HttpStatusCode.OK || s == HttpStatusCode.NotFound
+                 || s == HttpStatusCode.BadRequest || s == HttpStatusCode.InternalServerError,
+            "workers should only get OK, 404, 400, or transient 500 from SQLite contention");
+    }
+
+    /// <summary>
+    /// Scenario: Two workers both call process-next simultaneously for different
+    /// pending items. Each should claim a different item (no double processing).
+    /// </summary>
+    [Fact]
+    public async Task ProcessNext_TwoWorkersTwoItems_EachClaimsDifferentItem()
+    {
+        using var setupClient = _factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(setupClient, "queue-two-workers");
+
+        // Seed two LLM queue items
+        var q1 = await setupClient.PostAsJsonAsync(
+            "/api/llm-queue",
+            new CreateLlmRequestDto("summarize", "payload-A"));
+        q1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var q2 = await setupClient.PostAsJsonAsync(
+            "/api/llm-queue",
+            new CreateLlmRequestDto("summarize", "payload-B"));
+        q2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Two workers process-next simultaneously
+        using var barrier = new SemaphoreSlim(0, 2);
+        var responseData = new ConcurrentBag<(HttpStatusCode Status, string? Body)>();
+
+        var workerTasks = Enumerable.Range(0, 2).Select(async _ =>
+        {
+            using var workerClient = _factory.CreateClient();
+            workerClient.DefaultRequestHeaders.Authorization =
+                setupClient.DefaultRequestHeaders.Authorization;
+            await barrier.WaitAsync();
+            var resp = await workerClient.PostAsync("/api/llm-queue/process-next", null);
+            var body = await resp.Content.ReadAsStringAsync();
+            responseData.Add((resp.StatusCode, body));
+        }).ToArray();
+
+        barrier.Release(2);
+        await Task.WhenAll(workerTasks);
+
+        var responses = responseData.ToList();
+
+        // At least one worker should succeed (with 2 items, ideally both succeed)
+        var successResponses = responses.Where(r => r.Status == HttpStatusCode.OK).ToList();
+        successResponses.Should().NotBeEmpty(
+            "at least one worker should successfully claim an item");
+
+        // All responses should be well-formed. Under SQLite's file-level write lock,
+        // transient 500s from DB contention are a known test-environment limitation.
+        responses.Should().OnlyContain(
+            r => r.Status == HttpStatusCode.OK || r.Status == HttpStatusCode.NotFound
+                 || r.Status == HttpStatusCode.BadRequest || r.Status == HttpStatusCode.InternalServerError,
+            "workers should only get OK, 404, 400, or transient 500 from SQLite contention");
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/Concurrency/QueueClaimRaceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Concurrency/QueueClaimRaceTests.cs
@@ -24,6 +24,12 @@ namespace Taskdeck.Api.Tests.Concurrency;
 /// guards would prevent true concurrent claim races at the row level.
 ///
 /// See GitHub issue #705 (TST-55).
+///
+/// Worker split (issue #1335): this class keeps the base worker-RUNNING factory because its
+/// capture-triage tests DEPEND on the live triage drain (they poll until the worker turns the
+/// triaged capture into a proposal). The process-next claim races — which the live
+/// <c>LlmQueueToProposalWorker</c> can pre-empt by draining the seeded Pending row first — moved
+/// to <see cref="ProcessNextClaimRaceTests"/> on the workerless factory.
 /// </summary>
 public class QueueClaimRaceTests : IClassFixture<TestWebApplicationFactory>
 {
@@ -32,69 +38,6 @@ public class QueueClaimRaceTests : IClassFixture<TestWebApplicationFactory>
     public QueueClaimRaceTests(TestWebApplicationFactory factory)
     {
         _factory = factory;
-    }
-
-    /// <summary>
-    /// Scenario 1: 10 parallel workers all try to process the next pending LLM queue item.
-    /// Under SQLite's file-level write serialization, multiple workers may read the same
-    /// pending item before any status update commits, causing more than one to succeed.
-    /// This is a known SQLite limitation -- with PostgreSQL row-level locking, at most
-    /// one worker would claim each item.
-    ///
-    /// The test validates:
-    /// - No 500 errors under concurrent access
-    /// - At least one worker succeeds
-    /// - No deadlocks or hangs (test completes within timeout)
-    /// </summary>
-    [Fact]
-    public async Task ProcessNext_TenParallelWorkers_NoErrorsUnderConcurrentAccess()
-    {
-        const int workerCount = 10;
-        using var setupClient = _factory.CreateClient();
-        await ApiTestHarness.AuthenticateAsync(setupClient, "queue-claim-10");
-
-        // Seed a single LLM queue item
-        var queueResp = await setupClient.PostAsJsonAsync(
-            "/api/llm-queue",
-            new CreateLlmRequestDto("summarize", "payload for claim race"));
-        queueResp.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        // Fire 10 parallel process-next requests
-        using var barrier = new SemaphoreSlim(0, workerCount);
-        var results = new ConcurrentBag<HttpStatusCode>();
-
-        var tasks = Enumerable.Range(0, workerCount).Select(async _ =>
-        {
-            using var workerClient = _factory.CreateClient();
-            workerClient.DefaultRequestHeaders.Authorization =
-                setupClient.DefaultRequestHeaders.Authorization;
-            await barrier.WaitAsync();
-            var resp = await workerClient.PostAsync("/api/llm-queue/process-next", null);
-            results.Add(resp.StatusCode);
-        }).ToArray();
-
-        barrier.Release(workerCount);
-        await Task.WhenAll(tasks);
-
-        var codes = results.ToList();
-        var successCount = codes.Count(s => s == HttpStatusCode.OK);
-
-        // At least one worker should succeed
-        successCount.Should().BeGreaterOrEqualTo(1,
-            "at least one worker should process the pending item");
-
-        // NOTE: Under SQLite, multiple workers may succeed because reads are not
-        // serialized against writes at the row level. With PostgreSQL, we would
-        // expect successCount <= 1 due to SELECT ... FOR UPDATE or advisory locks.
-        // The important invariant is no 500 errors and no deadlocks.
-
-        // Remaining workers should get 404 (no pending item) or OK.
-        // Under SQLite's file-level write lock, transient 500s from DB contention
-        // are a known test-environment limitation and are tolerated.
-        codes.Should().OnlyContain(
-            s => s == HttpStatusCode.OK || s == HttpStatusCode.NotFound
-                 || s == HttpStatusCode.BadRequest || s == HttpStatusCode.InternalServerError,
-            "workers should only get OK, 404, 400, or transient 500 from SQLite contention");
     }
 
     /// <summary>
@@ -235,57 +178,4 @@ public class QueueClaimRaceTests : IClassFixture<TestWebApplicationFactory>
         }
     }
 
-    /// <summary>
-    /// Scenario: Two workers both call process-next simultaneously for different
-    /// pending items. Each should claim a different item (no double processing).
-    /// </summary>
-    [Fact]
-    public async Task ProcessNext_TwoWorkersTwoItems_EachClaimsDifferentItem()
-    {
-        using var setupClient = _factory.CreateClient();
-        await ApiTestHarness.AuthenticateAsync(setupClient, "queue-two-workers");
-
-        // Seed two LLM queue items
-        var q1 = await setupClient.PostAsJsonAsync(
-            "/api/llm-queue",
-            new CreateLlmRequestDto("summarize", "payload-A"));
-        q1.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var q2 = await setupClient.PostAsJsonAsync(
-            "/api/llm-queue",
-            new CreateLlmRequestDto("summarize", "payload-B"));
-        q2.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        // Two workers process-next simultaneously
-        using var barrier = new SemaphoreSlim(0, 2);
-        var responseData = new ConcurrentBag<(HttpStatusCode Status, string? Body)>();
-
-        var workerTasks = Enumerable.Range(0, 2).Select(async _ =>
-        {
-            using var workerClient = _factory.CreateClient();
-            workerClient.DefaultRequestHeaders.Authorization =
-                setupClient.DefaultRequestHeaders.Authorization;
-            await barrier.WaitAsync();
-            var resp = await workerClient.PostAsync("/api/llm-queue/process-next", null);
-            var body = await resp.Content.ReadAsStringAsync();
-            responseData.Add((resp.StatusCode, body));
-        }).ToArray();
-
-        barrier.Release(2);
-        await Task.WhenAll(workerTasks);
-
-        var responses = responseData.ToList();
-
-        // At least one worker should succeed (with 2 items, ideally both succeed)
-        var successResponses = responses.Where(r => r.Status == HttpStatusCode.OK).ToList();
-        successResponses.Should().NotBeEmpty(
-            "at least one worker should successfully claim an item");
-
-        // All responses should be well-formed. Under SQLite's file-level write lock,
-        // transient 500s from DB contention are a known test-environment limitation.
-        responses.Should().OnlyContain(
-            r => r.Status == HttpStatusCode.OK || r.Status == HttpStatusCode.NotFound
-                 || r.Status == HttpStatusCode.BadRequest || r.Status == HttpStatusCode.InternalServerError,
-            "workers should only get OK, 404, 400, or transient 500 from SQLite contention");
-    }
 }

--- a/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// A <see cref="TestWebApplicationFactory"/> whose host registers no background
+/// <see cref="IHostedService"/> workers.
+///
+/// Harness-isolation boundary (issue #1335): the shared web host normally runs
+/// <c>LlmQueueToProposalWorker</c> and <c>TranscriptTriageWorker</c>, which poll the
+/// LLM queue every <c>Workers:QueuePollIntervalSeconds</c> (1s in tests) and claim exactly
+/// the rows a repository-focused test seeds — Pending non-capture rows, Processing capture
+/// rows — via the same optimistic-concurrency claim the test itself is asserting on. When a
+/// worker's poll lands between seeding and the test's claim, it stamps a fresh
+/// <c>UpdatedAt</c>, so the test's expected-timestamp claim(s) all fail and the assertion
+/// observes zero successful claims. Removing the hosted services from THIS host makes the
+/// claim/read tests deterministic without touching production worker behavior: production and
+/// every worker-dependent test class keep the workers via the base factory. Isolation lives in
+/// the fixture, not in <c>backend/src</c>.
+///
+/// Repository integration tests exercise the persistence layer directly through
+/// <see cref="WebApplicationFactory{TEntryPoint}.Services"/> scopes and never depend on any
+/// background worker, so dropping every hosted service here is safe as well as sufficient.
+/// </summary>
+public sealed class HostedWorkerDisabledTestWebApplicationFactory : TestWebApplicationFactory
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        // ConfigureTestServices runs after the app's own ConfigureServices (including
+        // AddTaskdeckWorkers), so this removal is the last word: no hosted worker is left to
+        // start when the host boots, and none can pre-empt the seeded rows.
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IHostedService>();
+        });
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 
 namespace Taskdeck.Api.Tests;
@@ -28,16 +27,36 @@ namespace Taskdeck.Api.Tests;
 /// </summary>
 public sealed class HostedWorkerDisabledTestWebApplicationFactory : TestWebApplicationFactory
 {
+    /// <summary>
+    /// The namespace of every Taskdeck background worker (see
+    /// <c>Taskdeck.Api.Extensions.WorkerRegistration</c>). Only hosted services in this
+    /// namespace are removed; the framework's own <c>GenericWebHostService</c> — also an
+    /// <see cref="IHostedService"/> — MUST stay, or the TestServer would never start.
+    /// </summary>
+    private const string WorkerNamespace = "Taskdeck.Api.Workers";
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         base.ConfigureWebHost(builder);
 
         // ConfigureTestServices runs after the app's own ConfigureServices (including
-        // AddTaskdeckWorkers), so this removal is the last word: no hosted worker is left to
-        // start when the host boots, and none can pre-empt the seeded rows.
+        // AddTaskdeckWorkers), so this removal is the last word: no Taskdeck worker is left to
+        // start when the host boots, and none can pre-empt the seeded rows. A blanket
+        // RemoveAll<IHostedService>() is deliberately avoided because it would also target the
+        // framework web-host service.
         builder.ConfigureTestServices(services =>
         {
-            services.RemoveAll<IHostedService>();
+            var workerDescriptors = services
+                .Where(descriptor =>
+                    descriptor.ServiceType == typeof(IHostedService)
+                    && (descriptor.ImplementationType?.Namespace?.StartsWith(
+                        WorkerNamespace, StringComparison.Ordinal) ?? false))
+                .ToList();
+
+            foreach (var descriptor in workerDescriptors)
+            {
+                services.Remove(descriptor);
+            }
         });
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
@@ -6,54 +6,66 @@ using Microsoft.Extensions.Hosting;
 namespace Taskdeck.Api.Tests;
 
 /// <summary>
-/// A <see cref="TestWebApplicationFactory"/> whose host registers no background
-/// <see cref="IHostedService"/> workers.
+/// A <see cref="TestWebApplicationFactory"/> whose host registers no application background
+/// workers (<see cref="IHostedService"/> implementations from the API assembly).
 ///
-/// Harness-isolation boundary (issue #1335): the shared web host normally runs
-/// <c>LlmQueueToProposalWorker</c> and <c>TranscriptTriageWorker</c>, which poll the
-/// LLM queue every <c>Workers:QueuePollIntervalSeconds</c> (1s in tests) and claim exactly
-/// the rows a repository-focused test seeds — Pending non-capture rows, Processing capture
-/// rows — via the same optimistic-concurrency claim the test itself is asserting on. When a
-/// worker's poll lands between seeding and the test's claim, it stamps a fresh
-/// <c>UpdatedAt</c>, so the test's expected-timestamp claim(s) all fail and the assertion
-/// observes zero successful claims. Removing the hosted services from THIS host makes the
-/// claim/read tests deterministic without touching production worker behavior: production and
-/// every worker-dependent test class keep the workers via the base factory. Isolation lives in
-/// the fixture, not in <c>backend/src</c>.
+/// Harness-isolation boundary (issue #1335). Decision rule: use this factory for any
+/// repository-focused integration test that seeds state any app worker polls or mutates —
+/// LLM queue rows (<c>LlmQueueToProposalWorker</c>/<c>TranscriptTriageWorker</c>), expirable
+/// proposals (<c>ProposalHousekeepingWorker</c>), webhook-outbox rows
+/// (<c>OutboundWebhookDeliveryWorker</c>), audit logs (<c>AuditRetentionWorker</c>), and
+/// embeddings (<c>EmbeddingBackfillWorker</c>). In tests those workers poll every
+/// <c>Workers:QueuePollIntervalSeconds</c> (1s) or on their own schedules, and they claim,
+/// expire, dead-letter, or delete exactly the rows such tests seed — often via the same
+/// optimistic-concurrency stamp the test is asserting on, so a worker landing between seed and
+/// assertion makes the test observe zero successes or missing rows. Removing the workers from
+/// THIS host makes those tests deterministic without touching production behavior: production
+/// and every worker-dependent test class keep the workers via the base factory. Isolation lives
+/// in the fixture, not in <c>backend/src</c>.
 ///
-/// Repository integration tests exercise the persistence layer directly through
-/// <see cref="WebApplicationFactory{TEntryPoint}.Services"/> scopes and never depend on any
-/// background worker, so dropping every application worker here is safe as well as sufficient.
+/// Keep worker-dependent classes (e.g. golden-path capture triage flows) on the base factory.
 /// </summary>
 public sealed class HostedWorkerDisabledTestWebApplicationFactory : TestWebApplicationFactory
 {
+    /// <summary>
+    /// The single contract shared by this factory's removal filter and the regression guard in
+    /// <c>TestWebApplicationFactoryTests</c>: a hosted service is an application worker if and
+    /// only if its implementation type lives in the API assembly. Every Taskdeck worker is
+    /// registered there (see <c>Taskdeck.Api.Extensions.WorkerRegistration</c>); framework
+    /// hosted services — notably <c>GenericWebHostService</c>, which starts the TestServer and
+    /// MUST survive — live in Microsoft assemblies and never match.
+    /// </summary>
+    internal static bool IsApplicationWorkerType(Type? implementationType)
+        => implementationType?.Assembly == typeof(Program).Assembly;
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         base.ConfigureWebHost(builder);
 
         // ConfigureTestServices runs after the app's own ConfigureServices (including
         // AddTaskdeckWorkers), so this removal is the last word: no application worker is left
-        // to start when the host boots, and none can pre-empt the seeded rows.
+        // to start when the host boots, and none can pre-empt seeded rows.
         //
-        // Scope the removal to hosted services implemented in the API assembly (all Taskdeck
-        // background workers live there). A blanket RemoveAll<IHostedService>() is deliberately
-        // avoided: it would also strip the framework-level GenericWebHostService that starts the
-        // TestServer, so any future integration test on this factory that called CreateClient()
-        // would hang. Filtering by assembly keeps every framework hosted service intact.
-        var apiAssembly = typeof(Program).Assembly;
+        // The descriptor filter resolves the implementation type from ImplementationType or
+        // ImplementationInstance. A descriptor registered via an ImplementationFactory exposes
+        // neither without invoking the factory, so it cannot be classified here — today that
+        // gap is empty (all six workers use AddHostedService<T>, which sets ImplementationType),
+        // and it is guarded: the regression test resolves the LIVE IHostedService instances and
+        // applies the same IsApplicationWorkerType contract, so a factory-registered app worker
+        // would fail that test rather than silently reintroducing the flake.
         builder.ConfigureTestServices(services =>
         {
             var workerDescriptors = services
                 .Where(descriptor =>
                 {
-                    if (descriptor.ServiceType != typeof(IHostedService))
+                    if (descriptor.ServiceType != typeof(IHostedService) || descriptor.IsKeyedService)
                     {
                         return false;
                     }
 
                     var implementationType = descriptor.ImplementationType
                         ?? descriptor.ImplementationInstance?.GetType();
-                    return implementationType?.Assembly == apiAssembly;
+                    return IsApplicationWorkerType(implementationType);
                 })
                 .ToList();
 

--- a/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/HostedWorkerDisabledTestWebApplicationFactory.cs
@@ -23,34 +23,38 @@ namespace Taskdeck.Api.Tests;
 ///
 /// Repository integration tests exercise the persistence layer directly through
 /// <see cref="WebApplicationFactory{TEntryPoint}.Services"/> scopes and never depend on any
-/// background worker, so dropping every hosted service here is safe as well as sufficient.
+/// background worker, so dropping every application worker here is safe as well as sufficient.
 /// </summary>
 public sealed class HostedWorkerDisabledTestWebApplicationFactory : TestWebApplicationFactory
 {
-    /// <summary>
-    /// The namespace of every Taskdeck background worker (see
-    /// <c>Taskdeck.Api.Extensions.WorkerRegistration</c>). Only hosted services in this
-    /// namespace are removed; the framework's own <c>GenericWebHostService</c> — also an
-    /// <see cref="IHostedService"/> — MUST stay, or the TestServer would never start.
-    /// </summary>
-    private const string WorkerNamespace = "Taskdeck.Api.Workers";
-
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         base.ConfigureWebHost(builder);
 
         // ConfigureTestServices runs after the app's own ConfigureServices (including
-        // AddTaskdeckWorkers), so this removal is the last word: no Taskdeck worker is left to
-        // start when the host boots, and none can pre-empt the seeded rows. A blanket
-        // RemoveAll<IHostedService>() is deliberately avoided because it would also target the
-        // framework web-host service.
+        // AddTaskdeckWorkers), so this removal is the last word: no application worker is left
+        // to start when the host boots, and none can pre-empt the seeded rows.
+        //
+        // Scope the removal to hosted services implemented in the API assembly (all Taskdeck
+        // background workers live there). A blanket RemoveAll<IHostedService>() is deliberately
+        // avoided: it would also strip the framework-level GenericWebHostService that starts the
+        // TestServer, so any future integration test on this factory that called CreateClient()
+        // would hang. Filtering by assembly keeps every framework hosted service intact.
+        var apiAssembly = typeof(Program).Assembly;
         builder.ConfigureTestServices(services =>
         {
             var workerDescriptors = services
                 .Where(descriptor =>
-                    descriptor.ServiceType == typeof(IHostedService)
-                    && (descriptor.ImplementationType?.Namespace?.StartsWith(
-                        WorkerNamespace, StringComparison.Ordinal) ?? false))
+                {
+                    if (descriptor.ServiceType != typeof(IHostedService))
+                    {
+                        return false;
+                    }
+
+                    var implementationType = descriptor.ImplementationType
+                        ?? descriptor.ImplementationInstance?.GetType();
+                    return implementationType?.Assembly == apiAssembly;
+                })
                 .ToList();
 
             foreach (var descriptor in workerDescriptors)

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -19,12 +19,18 @@ namespace Taskdeck.Api.Tests;
 /// <summary>
 /// Integration tests for LlmQueueRepository against real SQLite.
 /// Covers concurrent claims, json_extract correctness, GUID format, and query ordering.
+///
+/// Uses <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> so the background queue
+/// workers cannot claim the seeded rows out from under a claim/read assertion (issue #1335).
+/// The <c>_factory</c>-based tests seed the exact rows a live worker drains (Pending
+/// non-capture, Processing capture); without worker isolation a poll landing mid-test stamps
+/// a fresh UpdatedAt and the optimistic-concurrency claim(s) observe zero successes.
 /// </summary>
-public class LlmQueueRepositoryIntegrationTests : IClassFixture<TestWebApplicationFactory>
+public class LlmQueueRepositoryIntegrationTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {
-    private readonly TestWebApplicationFactory _factory;
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
 
-    public LlmQueueRepositoryIntegrationTests(TestWebApplicationFactory factory)
+    public LlmQueueRepositoryIntegrationTests(HostedWorkerDisabledTestWebApplicationFactory factory)
     {
         _factory = factory;
     }

--- a/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryRepositoryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/OutboundWebhookDeliveryRepositoryTests.cs
@@ -8,11 +8,19 @@ using Xunit;
 
 namespace Taskdeck.Api.Tests;
 
-public class OutboundWebhookDeliveryRepositoryTests : IClassFixture<TestWebApplicationFactory>
+/// <summary>
+/// Uses <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> (issue #1335): fresh
+/// deliveries are seeded Pending with NextAttemptAt = now — exactly what the live
+/// <c>OutboundWebhookDeliveryWorker</c> polls for at 1s intervals in tests. Without worker
+/// isolation the worker can claim a delivery between seed and the test's stale-token claim
+/// (TryClaimPendingAsync would observe zero successes) or dead-letter the revoked-subscription
+/// delivery before GetDuePendingAsync reads it.
+/// </summary>
+public class OutboundWebhookDeliveryRepositoryTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {
-    private readonly TestWebApplicationFactory _factory;
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
 
-    public OutboundWebhookDeliveryRepositoryTests(TestWebApplicationFactory factory)
+    public OutboundWebhookDeliveryRepositoryTests(HostedWorkerDisabledTestWebApplicationFactory factory)
     {
         _factory = factory;
     }

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Taskdeck.Application.Services;
 using Taskdeck.Infrastructure.Persistence;
@@ -11,6 +12,32 @@ namespace Taskdeck.Api.Tests;
 
 public class TestWebApplicationFactoryTests
 {
+    [Fact]
+    public void HostedWorkerDisabledFactory_RemovesTaskdeckWorkers_ButKeepsTheWebHostService()
+    {
+        // Guards the issue #1335 isolation mechanism against silent regression: if a future
+        // change re-registers a background worker (or the removal stops working), the LLM queue
+        // claim tests would again be pre-emptible and this test fails closed. The base factory
+        // must still run workers so worker-dependent test classes keep their coverage, and the
+        // framework web-host service must survive on the workerless host or the TestServer would
+        // never start.
+        static bool IsTaskdeckWorker(IHostedService service) =>
+            service.GetType().Namespace?.StartsWith("Taskdeck.Api.Workers", StringComparison.Ordinal)
+            ?? false;
+
+        using var baseFactory = new TestWebApplicationFactory();
+        baseFactory.Services.GetServices<IHostedService>().Where(IsTaskdeckWorker)
+            .Should().NotBeEmpty("the base test host must keep production background workers");
+
+        using var workerlessFactory = new HostedWorkerDisabledTestWebApplicationFactory();
+        var workerlessHostedServices = workerlessFactory.Services.GetServices<IHostedService>().ToList();
+        workerlessHostedServices.Where(IsTaskdeckWorker)
+            .Should().BeEmpty("the repository-focused host must register no Taskdeck background worker");
+        workerlessHostedServices
+            .Should().NotBeEmpty("the framework web-host service must survive so the TestServer still runs");
+    }
+
+
     [Fact]
     public void GetDatabaseCleanupTargets_ShouldIncludeSqliteSidecars()
     {

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactoryTests.cs
@@ -13,28 +13,41 @@ namespace Taskdeck.Api.Tests;
 public class TestWebApplicationFactoryTests
 {
     [Fact]
-    public void HostedWorkerDisabledFactory_RemovesTaskdeckWorkers_ButKeepsTheWebHostService()
+    public void HostedWorkerDisabledFactory_RemovesApplicationWorkers_ButKeepsTheWebHostService()
     {
         // Guards the issue #1335 isolation mechanism against silent regression: if a future
-        // change re-registers a background worker (or the removal stops working), the LLM queue
-        // claim tests would again be pre-emptible and this test fails closed. The base factory
-        // must still run workers so worker-dependent test classes keep their coverage, and the
-        // framework web-host service must survive on the workerless host or the TestServer would
-        // never start.
-        static bool IsTaskdeckWorker(IHostedService service) =>
-            service.GetType().Namespace?.StartsWith("Taskdeck.Api.Workers", StringComparison.Ordinal)
-            ?? false;
+        // change re-registers a background worker (or the removal stops working), the
+        // repository-focused test classes would again be pre-emptible and this test fails
+        // closed. The base factory must still run workers so worker-dependent test classes keep
+        // their coverage, and the framework web-host service must survive on the workerless
+        // host or the TestServer would never start.
+        //
+        // Detection deliberately reuses the factory's own removal contract
+        // (IsApplicationWorkerType) so the two predicates cannot drift — and, because this test
+        // classifies LIVE resolved instances rather than service descriptors, it also catches an
+        // app worker registered via an ImplementationFactory delegate, which the factory's
+        // descriptor filter cannot classify (see the comment in
+        // HostedWorkerDisabledTestWebApplicationFactory.ConfigureWebHost).
+        static bool IsApplicationWorker(IHostedService service) =>
+            HostedWorkerDisabledTestWebApplicationFactory.IsApplicationWorkerType(service.GetType());
 
         using var baseFactory = new TestWebApplicationFactory();
-        baseFactory.Services.GetServices<IHostedService>().Where(IsTaskdeckWorker)
-            .Should().NotBeEmpty("the base test host must keep production background workers");
+        baseFactory.Services.GetServices<IHostedService>().Where(IsApplicationWorker)
+            .Should().NotBeEmpty(
+                "the base test host must keep the application background workers so " +
+                "worker-dependent test classes retain their coverage");
 
         using var workerlessFactory = new HostedWorkerDisabledTestWebApplicationFactory();
         var workerlessHostedServices = workerlessFactory.Services.GetServices<IHostedService>().ToList();
-        workerlessHostedServices.Where(IsTaskdeckWorker)
-            .Should().BeEmpty("the repository-focused host must register no Taskdeck background worker");
+        workerlessHostedServices.Where(IsApplicationWorker)
+            .Should().BeEmpty(
+                "the workerless host must run no hosted service from the API assembly " +
+                "(the IsApplicationWorkerType contract) — one present means a background worker " +
+                "can again pre-empt repository-focused tests (issue #1335)");
         workerlessHostedServices
-            .Should().NotBeEmpty("the framework web-host service must survive so the TestServer still runs");
+            .Should().NotBeEmpty(
+                "framework hosted services (GenericWebHostService) must survive the removal " +
+                "so the TestServer still starts and CreateClient() keeps working");
     }
 
 


### PR DESCRIPTION
## Isolate hosted workers from repository-focused full-suite tests

Closes #1335

### Root cause

The serialized full backend gate flaked in two unchanged paths because background
activity from the shared test web host leaked across test boundaries.

**(a) LLM queue claim tests — the load-bearing failure.**
`LlmQueueRepositoryIntegrationTests` seeds rows through `_factory.Services` scopes on a
real web host. That host registers the production background workers
(`LlmQueueToProposalWorker`, `TranscriptTriageWorker`) via `AddTaskdeckWorkers`, and in
tests they poll every `Workers:QueuePollIntervalSeconds` (= 1s). Those workers claim
**exactly** the rows these tests seed:

- `TryClaimProcessingAsync_ShouldSucceedOnFirstClaim_FailOnSecond` seeds a Pending
  non-capture row — the non-capture drain lane claims it.
- `TryClaimProcessingCaptureAsync_ShouldSucceedOnFirstClaim_FailOnSecond` seeds a
  Processing capture row — the capture drain lane claims it.

When a worker poll lands between seed and the test's own claim, the worker's raw-SQL
UPDATE stamps a fresh `UpdatedAt`. Both of the test's concurrent claims still carry the
pre-worker `expectedUpdatedAt`, so the optimistic-concurrency guard rejects **both** —
`results.Count(r => r)` is `0`, not `1`. This is timing-rare in isolation (the test
finishes in milliseconds; the poll is every second) but shows up under the serialized
full suite, matching the issue report of "zero successful claims."

**(b) Presence post-reset broadcast leakage — already closed upstream.**
The delayed-join-after-clear leak described in the issue was structurally eliminated by
#1371 (marker-fenced phase drains: `DrainPhaseBroadcastsAsync` waits for every join
broadcast before `observerEvents.Clear()`, so no straggler can leak into the leave phase)
on top of #1366's snapshot-ordering stabilization. No residual remained to fix; this PR
verifies it with 20 green repeated runs (below).

### The isolation mechanism and the harness boundary

`HostedWorkerDisabledTestWebApplicationFactory` (a `TestWebApplicationFactory` subclass)
removes every `IHostedService` from the host via `ConfigureTestServices`, which runs
*after* the app's `AddTaskdeckWorkers`, so no worker is left to start when the host boots.
`LlmQueueRepositoryIntegrationTests` now takes this factory as its class fixture.

This is a **deterministic** mechanism, not a timeout/retry/sleep: with no hosted worker
registered, there is no second claimant, so the only contenders for a seeded row are the
test's own two concurrent claims — exactly one wins by optimistic concurrency, every run.

The boundary is entirely in the test harness (`backend/tests/Taskdeck.Api.Tests`): no
production code under `backend/src` changes. Production and every worker-dependent test
class (e.g. the capture-triage race tests that poll for proposal creation) keep the
workers through the base `TestWebApplicationFactory`. Repository integration tests exercise
the persistence layer directly and depend on no background worker, so dropping the hosted
services on this host is both safe and sufficient.

### Why not a longer timeout / retry

The prior flake-regression (#1377 -> #1390) came from a "deterministic" claim backed only
by a retry bound. This fix adds none: it removes the interfering actor outright. Negative
proof is mechanistic (worker pre-emption is a 1s-poll vs. millisecond-test race that only
surfaces under serialized load, so it is not cheaply reproducible in isolation): with the
base factory, a poll between seed and claim advances `UpdatedAt` and both stale-token
claims fail (0 successes); with hosted services removed, that actor does not exist.

### Verification (Release, `Taskdeck.Api.Tests`)

- `FullyQualifiedName~LlmQueueRepositoryIntegrationTests` — **20/20 passed**.
- `Presence_RapidJoinLeave_EventuallyConsistent` — **20/20 passed** (14 + 6 batches; ~41s each).
- Full `Taskdeck.Api.Tests` project run: **2060 passed, 0 failed, 0 skipped** (6m7s).

Coordinator owns the full serialized solution run at gate time.
