### PR TITLE
Gate proposal diff on expiry and structure to match apply (#1376)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -483,7 +483,7 @@ public class AutomationProposalService : IAutomationProposalService
     /// so preview rejects exactly what Apply would reject (#1376 preview == apply).
     /// </summary>
     private static Result ValidateProposalNotExpired(AutomationProposal proposal)
-        => DateTime.UtcNow > proposal.ExpiresAt
+        => proposal.IsExpired
             ? Result.Failure(ErrorCodes.ValidationError, "Proposal has expired")
             : Result.Success();
 

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -402,6 +402,18 @@ public class AutomationProposalService : IAutomationProposalService
                 return Result.Failure<string>(ErrorCodes.ValidationError, errorMessage);
             }
 
+            // Apply materializes this same revised payload and runs it through
+            // AutomationPolicyEngine.ValidatePolicy (structure gate, then expiry) before
+            // executing. Mirror both gates here in the same order so a revised proposal that
+            // Apply would reject cannot preview a clean diff first (#1376 preview == apply).
+            var revisedStructureValidation = ProposalOperationStructureValidator.Validate(revisedOperations);
+            if (!revisedStructureValidation.IsSuccess)
+                return Result.Failure<string>(revisedStructureValidation.ErrorCode, revisedStructureValidation.ErrorMessage);
+
+            var revisedExpiryValidation = ValidateProposalNotExpired(proposal);
+            if (!revisedExpiryValidation.IsSuccess)
+                return Result.Failure<string>(revisedExpiryValidation.ErrorCode, revisedExpiryValidation.ErrorMessage);
+
             var revisedValidation = await ProposalOperationContractValidator.ValidateAsync(
                 _unitOfWork,
                 proposal.BoardId,
@@ -419,13 +431,6 @@ public class AutomationProposalService : IAutomationProposalService
             return Result.Success(revisedDiff);
         }
 
-        if (proposal.Operations.Count == 0)
-        {
-            return !string.IsNullOrWhiteSpace(proposal.DiffPreview)
-                ? Result.Success(proposal.DiffPreview)
-                : Result.Failure<string>(ErrorCodes.NotFound, "Diff preview not available for this proposal");
-        }
-
         var originalOperations = proposal.Operations
             .OrderBy(o => o.Sequence)
             .Select(MapOperationToDto)
@@ -435,9 +440,21 @@ public class AutomationProposalService : IAutomationProposalService
         // sequences, parameter size) before building the diff, so a proposal that would be
         // rejected at Apply cannot preview cleanly first (#1370 preview == apply). Apply runs
         // this via AutomationPolicyEngine.ValidatePolicy; mirror it here on the original path.
+        // A zero-operation proposal fails here with the same "Proposal must contain at least
+        // one operation" ValidationError Apply returns — previously this path returned the
+        // cached DiffPreview (200) or a 404, previewing a proposal Apply always rejects
+        // (#1376 preview == apply). Structure runs before expiry to match ValidatePolicy's
+        // order, so a proposal that is both empty and expired reports the empty error on both.
         var structureValidation = ProposalOperationStructureValidator.Validate(originalOperations);
         if (!structureValidation.IsSuccess)
             return Result.Failure<string>(structureValidation.ErrorCode, structureValidation.ErrorMessage);
+
+        // Apply re-checks expiry in ValidatePolicy after the structure gate; mirror it here —
+        // including ahead of the cached-DiffPreview fast path below — so an expired proposal
+        // cannot preview a clean diff and then fail Apply after approval (#1376).
+        var expiryValidation = ValidateProposalNotExpired(proposal);
+        if (!expiryValidation.IsSuccess)
+            return Result.Failure<string>(expiryValidation.ErrorCode, expiryValidation.ErrorMessage);
 
         var originalValidation = await ProposalOperationContractValidator.ValidateAsync(
             _unitOfWork,
@@ -457,6 +474,18 @@ public class AutomationProposalService : IAutomationProposalService
         var generatedDiff = await BuildReadableDiffAsync(proposal.BoardId, orderedViews, cancellationToken);
         return Result.Success(generatedDiff);
     }
+
+    /// <summary>
+    /// Enforces the same expiry gate Apply runs via
+    /// <see cref="AutomationPolicyEngine.ValidatePolicy"/>: an expired proposal is rejected
+    /// with the identical <see cref="ErrorCodes.ValidationError"/> / "Proposal has expired"
+    /// shape. Diff callers run this after the structure gate (matching ValidatePolicy's order)
+    /// so preview rejects exactly what Apply would reject (#1376 preview == apply).
+    /// </summary>
+    private static Result ValidateProposalNotExpired(AutomationProposal proposal)
+        => DateTime.UtcNow > proposal.ExpiresAt
+            ? Result.Failure(ErrorCodes.ValidationError, "Proposal has expired")
+            : Result.Success();
 
     /// <summary>
     /// Builds the human-readable multi-line diff for an ordered operation set,

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -45,6 +45,17 @@ public class AutomationProposalServiceTests
             _provenanceRepoMock.Object);
     }
 
+    // ExpiresAt is private-set on the AutomationProposal aggregate; force it into the past
+    // to simulate a proposal that expired before its diff was requested (mirrors the
+    // reflection seam used in AutomationProposalServiceEdgeCaseTests).
+    private static void SetExpiresAt(AutomationProposal proposal, DateTime expiresAt)
+    {
+        typeof(AutomationProposal).GetProperty(
+            nameof(AutomationProposal.ExpiresAt),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(proposal, expiresAt);
+    }
+
     #region CreateProposalAsync Tests
 
     [Fact]
@@ -913,17 +924,26 @@ public class AutomationProposalServiceTests
     #region GetProposalDiffAsync Tests
 
     [Fact]
-    public async Task GetProposalDiffAsync_ShouldReturnDiff_WhenAvailable()
+    public async Task GetProposalDiffAsync_ShouldReturnStoredPreview_ForWellFormedNonEmptyProposal()
     {
-        // Arrange
+        // Back-compat regression (#1376): a non-expired, well-formed proposal with a
+        // stored DiffPreview still returns that preview byte-for-byte through the cached
+        // fast path — the new expiry/structure gates run ahead of it but pass cleanly, so
+        // behavior is unchanged for the healthy case.
         var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
             Guid.NewGuid(),
             "Test proposal",
             RiskLevel.Low,
-            Guid.NewGuid().ToString());
+            Guid.NewGuid().ToString(),
+            boardId);
 
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { name = "Renamed board", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
         proposal.SetDiffPreview("+ New card created\n- Old card removed");
 
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
@@ -932,15 +952,18 @@ public class AutomationProposalServiceTests
         // Act
         var result = await _service.GetProposalDiffAsync(proposalId);
 
-        // Assert
-        result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Contain("New card created");
+        // Assert: the stored preview is returned unchanged.
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Be("+ New card created\n- Old card removed");
     }
 
     [Fact]
-    public async Task GetProposalDiffAsync_ShouldReturnNotFound_WhenDiffNotAvailable()
+    public async Task GetProposalDiffAsync_ShouldRejectZeroOperationProposal_WhenNoStoredPreview()
     {
-        // Arrange
+        // #1376 asymmetry (2): a zero-operation proposal previously returned 404
+        // "Diff preview not available for this proposal" here, while Apply's structure
+        // gate rejects it with 400 "Proposal must contain at least one operation". Preview
+        // now runs the same structure gate and returns the identical ValidationError.
         var proposalId = Guid.NewGuid();
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
@@ -948,6 +971,35 @@ public class AutomationProposalServiceTests
             "Test proposal",
             RiskLevel.Low,
             Guid.NewGuid().ToString());
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: same failure Apply's structure validation produces.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("Proposal must contain at least one operation");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectZeroOperationProposal_EvenWithStoredPreview()
+    {
+        // #1376 asymmetry (2), cached-preview fast path: a zero-operation proposal that
+        // carries a stored DiffPreview previously previewed 200 with that stale preview,
+        // yet Apply always rejects it. The structure gate now rejects it BEFORE the cached
+        // preview is consulted, so preview == apply (400 "must contain at least one
+        // operation") whether or not a DiffPreview is stored.
+        var proposalId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Test proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString());
+        proposal.SetDiffPreview("0. Create card \"Stale preview\"");
 
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
             .ReturnsAsync(proposal);
@@ -957,7 +1009,112 @@ public class AutomationProposalServiceTests
 
         // Assert
         result.IsSuccess.Should().BeFalse();
-        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("Proposal must contain at least one operation");
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectExpiredProposal_MatchingApplyPolicyGate()
+    {
+        // #1376 asymmetry (1): GetProposalDiffAsync never checked ExpiresAt, so an expired
+        // proposal previewed a clean diff and then failed Apply after approval. Preview now
+        // runs the same expiry gate the executor runs via AutomationPolicyEngine.ValidatePolicy.
+        // True parity contract: the SAME expired proposal is fed to both trust boundaries and
+        // the ErrorCode + ErrorMessage must be identical — no drift allowed.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Test proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { name = "Renamed board", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+        // Force the proposal past its expiry without changing status (mirrors a proposal
+        // that expired between preview requests). ExpiresAt is private-set on the entity.
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Act (preview)
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+
+        // Act (apply-side policy gate) on an equivalent DTO — the expiry semantics live here.
+        var applyOperations = new List<ProposalOperationDto>
+        {
+            new ProposalOperationDto(Guid.NewGuid(), proposal.Id, 0, "update", "board", boardId.ToString(), parameters, Guid.NewGuid().ToString(), null)
+        };
+        var applyProposal = new ProposalDto(
+            proposal.Id,
+            ProposalSourceType.Chat,
+            null,
+            boardId,
+            Guid.NewGuid(),
+            ProposalStatus.Approved,
+            RiskLevel.Low,
+            "Test proposal",
+            null,
+            null,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow,
+            proposal.ExpiresAt,
+            null,
+            null,
+            null,
+            null,
+            Guid.NewGuid().ToString(),
+            applyOperations);
+        var applyResult = new AutomationPolicyEngine(_unitOfWorkMock.Object).ValidatePolicy(applyProposal);
+
+        // Assert: preview rejects, and rejects identically to Apply.
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        applyResult.ErrorMessage.Should().Be("Proposal has expired");
+
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        previewResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectExpiredProposal_EvenWithStoredPreview()
+    {
+        // #1376 asymmetry (1), cached-preview fast path: an expired proposal with a stored
+        // DiffPreview previously previewed 200 with that preview and then failed Apply. The
+        // expiry gate now runs ahead of the cached-preview return, so preview == apply.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Test proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { name = "Renamed board", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+        proposal.SetDiffPreview("0. Update board \"Renamed board\"");
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: the cached preview is NOT returned; the expiry rejection is.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("Proposal has expired");
     }
 
     [Theory]
@@ -1729,6 +1886,63 @@ public class AutomationProposalServiceTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectExpiredProposal_OnRevisedPath()
+    {
+        // #1376 asymmetry (1) on the revision-aware path: Apply materializes the latest
+        // revision and runs ValidatePolicy (structure, then expiry) on it, so an expired
+        // proposal with a saved revision is rejected at Apply. The revised diff path now
+        // runs the same expiry gate, so preview == apply (400 "Proposal has expired")
+        // instead of previewing the revised diff cleanly.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var column = new Column(boardId, "To Do", 0);
+        var columnId = column.Id;
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Create card",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        var revisedParams = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            title = "Revised card",
+            columnId,
+            boardId
+        });
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "create",
+                    targetType = "card",
+                    parameters = revisedParams,
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default))
+            .ReturnsAsync(revision);
+
+        // Act
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: the revised diff is not rendered; the expiry rejection surfaces instead.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("Proposal has expired");
     }
 
     #endregion

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -667,13 +667,16 @@ async function onPreviewDiff() {
     if (activeProposal.value?.id !== p.id) return
   }
 
-  // No-op proposals: the backend `/diff` (GetProposalDiffAsync) returns 404 when
-  // there is no stored DiffPreview AND no operations. The view already renders a
-  // "No operation preview" change section for that state, so show the empty-diff
-  // surface directly rather than firing a request that 404s. Only take this path
-  // when the revision list is authoritatively loaded and empty — a saved revision
-  // carries operations the backend renders revision-aware (#1235), and if the
-  // revision load failed we fetch so the backend, not a stale count, decides.
+  // No-op proposals: the backend `/diff` (GetProposalDiffAsync) rejects a
+  // zero-operation proposal with 400 ValidationError "Proposal must contain at
+  // least one operation" — the same rejection Apply gives (#1376 preview == apply;
+  // 404 now only means the proposal itself was not found). The view already
+  // renders a "No operation preview" change section for that state, so show the
+  // empty-diff surface directly rather than firing a request that 400s. Only take
+  // this path when the revision list is authoritatively loaded and empty — a
+  // saved revision carries operations the backend renders revision-aware (#1235),
+  // and if the revision load failed we fetch so the backend, not a stale count,
+  // decides.
   if (
     !p.diffPreview &&
     (p.operations?.length ?? 0) === 0 &&
@@ -705,9 +708,11 @@ async function onPreviewDiff() {
   } catch (e: unknown) {
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
     // The no-op case (no diff to show) is handled by the guard above BEFORE
-    // fetching, so a failure here is a real error — most often a 404 because the
-    // proposal was deleted/dismissed from another session. Surface it rather than
-    // silently rendering an empty diff for a proposal that no longer exists.
+    // fetching, so a failure here is a real error: a 404 because the proposal was
+    // deleted/dismissed from another session, or a 400 ValidationError because the
+    // backend now runs Apply's gates at diff time (#1376) — "Proposal has expired"
+    // or "Proposal must contain at least one operation". Surface it rather than
+    // silently rendering an empty diff for a proposal Apply would reject.
     previewDiffProposalId.value = null
     previewDiff.value = null
     toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)


### PR DESCRIPTION
## Summary

Two pre-existing preview/apply asymmetries remained in the same trust class #1374 (issue #1370) started closing: preview must reject exactly what apply rejects, or a reviewer approves a diff that then fails after approval. `AutomationProposalService.GetProposalDiffAsync` did not run two gates the executor runs via `AutomationPolicyEngine.ValidatePolicy`.

This wires both the **structure** gate and the **expiry** gate into every diff path — the revised-payload path, the original-operations path, and the cached-`DiffPreview` fast paths — in `ValidatePolicy`'s order (structure, then expiry), returning the identical `ValidationError` shapes apply returns.

Closes #1376

## The two asymmetries

### 1. Proposal expiry was not checked at diff time
`GetProposalDiffAsync` never checked `ExpiresAt`, while apply's `ValidatePolicy` rejects expired proposals. An expired proposal previewed a clean diff (or returned its cached `DiffPreview`), then apply failed after approval.

### 2. Zero-operation proposals diverged between diff and apply
The diff path's zero-op branch returned the cached `DiffPreview` (200) when one was stored, or 404 "Diff preview not available for this proposal" when none was — while apply's structure validation returns 400 "Proposal must contain at least one operation". A reviewer could preview a proposal apply always rejects, and the failure shapes disagreed.

## Before / after HTTP codes + error shapes

`ErrorCodes.ValidationError` maps to HTTP 400; `ErrorCodes.NotFound` maps to 404 (`ResultExtensions`).

| Defect | Diff before | Diff after | Apply (unchanged) |
|---|---|---|---|
| Expired, well-formed, non-empty (no cache) | 200 rendered diff | **400** `ValidationError` "Proposal has expired" | 400 `ValidationError` "Proposal has expired" |
| Expired, with cached `DiffPreview` | 200 cached preview | **400** `ValidationError` "Proposal has expired" | 400 `ValidationError` "Proposal has expired" |
| Expired, with saved revision | 200 revised diff | **400** `ValidationError` "Proposal has expired" | 400 `ValidationError` "Proposal has expired" |
| Zero-op, no cached preview | 404 `NotFound` "Diff preview not available for this proposal" | **400** `ValidationError` "Proposal must contain at least one operation" | 400 `ValidationError` "Proposal must contain at least one operation" |
| Zero-op, with cached `DiffPreview` | 200 cached preview | **400** `ValidationError` "Proposal must contain at least one operation" | 400 `ValidationError` "Proposal must contain at least one operation" |

Ordering matches `ValidatePolicy`: structure runs before expiry, so a proposal that is both empty and expired reports the empty error on both boundaries.

## Back-compat

A non-expired, well-formed proposal's diff is byte-identical to today — the new gates pass cleanly and the cached-`DiffPreview` fast path still returns the stored preview unchanged (covered by a regression test).

## Implementation

- Added a `ValidateProposalNotExpired` helper mirroring `ValidatePolicy`'s expiry expression (`DateTime.UtcNow > proposal.ExpiresAt` → `ValidationError` / "Proposal has expired"). No apply-side behavior changed.
- Original path: expiry gate added after the existing structure gate (from #1374), ahead of the contract check and cached-preview return.
- Zero-op branch removed — flow now falls through to the structure gate, which returns the apply-shaped 400 regardless of a stored `DiffPreview`.
- Revised path: structure gate + expiry gate added after payload parse, before the contract check (apply re-runs structure+expiry on the materialized revision).

## Verification

Backend build: `dotnet build backend/Taskdeck.sln -c Release` — 0 errors (pre-existing warnings only).

Targeted:
- `AutomationProposalServiceTests` — 57 passed (includes 5 new/retargeted diff-parity tests: expiry parity vs `ValidatePolicy`, expiry with cached preview, expiry on revised path, zero-op with and without stored preview, plus the non-empty cached-preview back-compat regression).
- Parity/policy/executor/validator classes (`ProposalOperationStructureValidatorTests`, `ProposalOperationContractValidatorTests`, `AutomationPolicyEngineTests`, `AutomationPolicyEngineEdgeCaseTests`, `AutomationProposalServiceEdgeCaseTests`, `AutomationExecutorServiceTests`, `ColumnServiceTests`) — 115 passed.
- `McpToolsTests` (Api.Tests, exercises `GetProposalDiffAsync` end-to-end) — 29 passed.

Project-level: `Taskdeck.Application.Tests` — **3488 passed, 0 failed, 0 skipped**.

Full-solution suite intentionally not run here (coordinator owns it serially at gate time).
