### PR TITLE
Batch buffered account-export extraction-history loads, avoid N+1 (#1387)

### DIFF
--- a/backend/src/Taskdeck.Application/Interfaces/IArtefactExtractionRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IArtefactExtractionRepository.cs
@@ -40,9 +40,12 @@ public interface IArtefactExtractionRepository
     /// a byte-for-byte identical export. Artefacts with no extractions, or not owned by the user,
     /// are simply absent from the result (never surfaced across users). Mirrors the batching
     /// convention of <see cref="ISourceArtefactRepository.GetContentsForUserAsync"/>: callers must
-    /// bound <paramref name="sourceArtefactIds"/> so the IN-clause stays within SQLite's parameter
-    /// limit (SQLITE_MAX_VARIABLE_NUMBER = 999); the buffered export pages ids in chunks of 500.
-    /// Passing more than the implementation's batch cap throws <see cref="ArgumentException"/>.
+    /// bound <paramref name="sourceArtefactIds"/> so the IN-clause stays within SQLite's bind
+    /// parameter budget (the implementation caps a batch at 900 ids + userId = 901 parameters,
+    /// under the legacy SQLITE_MAX_VARIABLE_NUMBER default of 999; modern bundled SQLite allows
+    /// far more). The buffered export pages ids in chunks of 500. The cap applies to the RAW input
+    /// count, before de-duplication: passing more ids than the cap throws
+    /// <see cref="ArgumentException"/> even when duplicates would dedup below it.
     /// </summary>
     Task<IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>> GetByArtefactsForUserAsync(
         IReadOnlyCollection<Guid> sourceArtefactIds,

--- a/backend/src/Taskdeck.Application/Interfaces/IArtefactExtractionRepository.cs
+++ b/backend/src/Taskdeck.Application/Interfaces/IArtefactExtractionRepository.cs
@@ -32,6 +32,23 @@ public interface IArtefactExtractionRepository
         int offset = 0,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Batch-loads the complete extraction history for the requested artefacts owned by
+    /// <paramref name="userId"/>, keyed by source-artefact id, in a single user-scoped query.
+    /// Each artefact's list is ordered <c>CreatedAt ASC, Id ASC</c> — identical to the per-artefact
+    /// <see cref="GetByArtefactForUserAsync"/> ordering — so a caller may concatenate the groups for
+    /// a byte-for-byte identical export. Artefacts with no extractions, or not owned by the user,
+    /// are simply absent from the result (never surfaced across users). Mirrors the batching
+    /// convention of <see cref="ISourceArtefactRepository.GetContentsForUserAsync"/>: callers must
+    /// bound <paramref name="sourceArtefactIds"/> so the IN-clause stays within SQLite's parameter
+    /// limit (SQLITE_MAX_VARIABLE_NUMBER = 999); the buffered export pages ids in chunks of 500.
+    /// Passing more than the implementation's batch cap throws <see cref="ArgumentException"/>.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>> GetByArtefactsForUserAsync(
+        IReadOnlyCollection<Guid> sourceArtefactIds,
+        Guid userId,
+        CancellationToken cancellationToken = default);
+
     Task<long> GetTotalTextLengthByUserAsync(
         Guid userId,
         CancellationToken cancellationToken = default);

--- a/backend/src/Taskdeck.Application/Services/DataExportService.cs
+++ b/backend/src/Taskdeck.Application/Services/DataExportService.cs
@@ -198,8 +198,21 @@ public class DataExportService : IDataExportService
             foreach (var chunk in artefactMetadata.Chunk(StreamPageSize))
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                var chunkIds = chunk.Select(a => a.Id).ToList();
                 var blobs = await _artefacts.GetContentsForUserAsync(
-                    chunk.Select(a => a.Id).ToList(),
+                    chunkIds,
+                    userId,
+                    cancellationToken);
+
+                // #1387: batch the per-artefact extraction-history loads in the same 500-id chunks
+                // as the blob batch above, replacing the former one-paged-query-per-artefact N+1
+                // (GetAllExtractionHistoryAsync). The batch groups results per artefact in
+                // CreatedAt ASC, Id ASC order — identical to the former sequential paging — so the
+                // exported extractions stay byte-for-byte identical. Peak memory stays bounded: the
+                // pre-load MaxBufferedArtefactBytes guard already caps total extraction bytes across
+                // the whole export, so a single chunk's grouped history can never exceed that cap.
+                var extractionsByArtefact = await _extractions.GetByArtefactsForUserAsync(
+                    chunkIds,
                     userId,
                     cancellationToken);
 
@@ -208,10 +221,9 @@ public class DataExportService : IDataExportService
                     if (!blobs.TryGetValue(artefact.Id, out var bytes) || bytes is null)
                         throw new InvalidOperationException($"Artefact {artefact.Id} is missing its blob.");
 
-                    var extractionHistory = await GetAllExtractionHistoryAsync(
-                        artefact.Id,
-                        userId,
-                        cancellationToken);
+                    var extractionHistory = extractionsByArtefact.TryGetValue(artefact.Id, out var extractions)
+                        ? extractions.Select(MapExtractionForExport).ToList()
+                        : (IReadOnlyList<UserDataExportArtefactExtractionDto>)Array.Empty<UserDataExportArtefactExtractionDto>();
                     exportArtefacts.Add(MapArtefactForExport(artefact, bytes, extractionHistory));
                 }
             }
@@ -620,26 +632,6 @@ public class DataExportService : IDataExportService
             artefact.CreatedAt,
             Convert.ToBase64String(content),
             extractions);
-
-    private async Task<IReadOnlyList<UserDataExportArtefactExtractionDto>> GetAllExtractionHistoryAsync(
-        Guid artefactId,
-        Guid userId,
-        CancellationToken cancellationToken)
-    {
-        var all = new List<UserDataExportArtefactExtractionDto>();
-        while (true)
-        {
-            var page = await _extractions.GetByArtefactForUserAsync(
-                artefactId,
-                userId,
-                limit: 50,
-                offset: all.Count,
-                cancellationToken: cancellationToken);
-            all.AddRange(page.Select(MapExtractionForExport));
-            if (page.Count < 50)
-                return all;
-        }
-    }
 
     private async Task WriteExtractionHistoryAsync(
         Guid artefactId,

--- a/backend/src/Taskdeck.Application/Services/DataExportService.cs
+++ b/backend/src/Taskdeck.Application/Services/DataExportService.cs
@@ -497,6 +497,11 @@ public class DataExportService : IDataExportService
     private static readonly byte[] ArtefactObjectSuffix = "]}"u8.ToArray();
     private static readonly byte[] ExportSuffix = "]}}"u8.ToArray();
 
+    // Coupled constraint (#1387): this is also the buffered export's batch-chunk size for
+    // ISourceArtefactRepository.GetContentsForUserAsync and
+    // IArtefactExtractionRepository.GetByArtefactsForUserAsync, whose implementations cap a batch
+    // at MaxBatchIdCount (900) raw ids. StreamPageSize must stay <= 900 or the buffered export
+    // throws ArgumentException at runtime.
     private const int StreamPageSize = 500;
 
     private async Task WriteArtefactsTailAsync(

--- a/backend/src/Taskdeck.Infrastructure/Repositories/ArtefactExtractionRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/ArtefactExtractionRepository.cs
@@ -11,6 +11,18 @@ public sealed class ArtefactExtractionRepository : IArtefactExtractionRepository
 {
     private const int MaxPageSize = 50;
     private const int EstimatedJsonOverheadCharacters = 512;
+
+    /// <summary>
+    /// Upper bound on artefact ids accepted by <see cref="GetByArtefactsForUserAsync"/> in one call.
+    /// Each id becomes one SQLite bind parameter, so this keeps the worst case well under
+    /// SQLITE_MAX_VARIABLE_NUMBER (999). Mirrors <c>SourceArtefactRepository.MaxBatchIdCount</c>;
+    /// the buffered export pages ids in chunks of 500, comfortably below this bound.
+    /// </summary>
+    private const int MaxBatchIdCount = 900;
+
+    private static readonly IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>> EmptyHistoryMap =
+        new Dictionary<Guid, IReadOnlyList<ArtefactExtraction>>();
+
     private readonly TaskdeckDbContext _context;
 
     public ArtefactExtractionRepository(TaskdeckDbContext context)
@@ -129,6 +141,88 @@ public sealed class ArtefactExtractionRepository : IArtefactExtractionRepository
             .Skip(boundedOffset)
             .Take(boundedLimit)
             .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>> GetByArtefactsForUserAsync(
+        IReadOnlyCollection<Guid> sourceArtefactIds,
+        Guid userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (sourceArtefactIds.Count == 0)
+            return EmptyHistoryMap;
+
+        if (sourceArtefactIds.Count > MaxBatchIdCount)
+            throw new ArgumentException(
+                $"Cannot batch more than {MaxBatchIdCount} artefact ids in one query; page the ids.",
+                nameof(sourceArtefactIds));
+
+        // De-duplicate to keep the IN-clause parameter footprint minimal; the caller bounds the
+        // set size (<= 500) and the guard above caps it.
+        var idList = sourceArtefactIds.Distinct().ToList();
+
+        List<ArtefactExtraction> rows;
+        if (_context.Database.IsSqlite())
+        {
+            // Mirror GetByArtefactForUserAsync's SQLite raw-SQL ordering (CreatedAt ASC, Id ASC over
+            // the stored TEXT) so each artefact's batch group is byte-for-byte identical to the
+            // former per-artefact page reads — including the Guid tiebreak, which orders by TEXT
+            // here (not .NET Guid comparison). The IN-clause is fully parameterised (one param per
+            // id, capped by MaxBatchIdCount well under SQLITE_MAX_VARIABLE_NUMBER). Same user-scoped
+            // join as the per-artefact read, so a foreign artefact id can never surface history.
+            var placeholders = new string[idList.Count];
+            var parameters = new List<object>(idList.Count + 1);
+            for (var i = 0; i < idList.Count; i++)
+            {
+                placeholders[i] = $"@id{i}";
+                parameters.Add(new SqliteParameter($"@id{i}", idList[i]));
+            }
+            parameters.Add(new SqliteParameter("@userId", userId));
+
+            var sql = $"""
+                SELECT extraction.*
+                FROM ArtefactExtractions AS extraction
+                INNER JOIN SourceArtefacts AS artefact
+                    ON artefact.Id = extraction.SourceArtefactId
+                WHERE extraction.SourceArtefactId IN ({string.Join(", ", placeholders)})
+                    AND artefact.UserId = @userId
+                ORDER BY extraction.SourceArtefactId ASC, extraction.CreatedAt ASC, extraction.Id ASC
+                """;
+
+            rows = await _context.ArtefactExtractions
+                .FromSqlRaw(sql, parameters.ToArray())
+                .AsNoTracking()
+                .ToListAsync(cancellationToken);
+        }
+        else
+        {
+            rows = await (
+                    from extraction in _context.ArtefactExtractions.AsNoTracking()
+                    join artefact in _context.SourceArtefacts.AsNoTracking()
+                        on extraction.SourceArtefactId equals artefact.Id
+                    where artefact.UserId == userId && idList.Contains(extraction.SourceArtefactId)
+                    orderby extraction.SourceArtefactId, extraction.CreatedAt, extraction.Id
+                    select extraction)
+                .ToListAsync(cancellationToken);
+        }
+
+        // Rows arrive ordered by (SourceArtefactId, CreatedAt, Id); appending in encounter order
+        // preserves each artefact's CreatedAt/Id ordering within its group.
+        var grouped = new Dictionary<Guid, List<ArtefactExtraction>>();
+        foreach (var extraction in rows)
+        {
+            if (!grouped.TryGetValue(extraction.SourceArtefactId, out var list))
+            {
+                list = new List<ArtefactExtraction>();
+                grouped[extraction.SourceArtefactId] = list;
+            }
+
+            list.Add(extraction);
+        }
+
+        var map = new Dictionary<Guid, IReadOnlyList<ArtefactExtraction>>(grouped.Count);
+        foreach (var entry in grouped)
+            map[entry.Key] = entry.Value;
+        return map;
     }
 
     public async Task<long> GetTotalTextLengthByUserAsync(

--- a/backend/src/Taskdeck.Infrastructure/Repositories/ArtefactExtractionRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/ArtefactExtractionRepository.cs
@@ -13,10 +13,14 @@ public sealed class ArtefactExtractionRepository : IArtefactExtractionRepository
     private const int EstimatedJsonOverheadCharacters = 512;
 
     /// <summary>
-    /// Upper bound on artefact ids accepted by <see cref="GetByArtefactsForUserAsync"/> in one call.
-    /// Each id becomes one SQLite bind parameter, so this keeps the worst case well under
-    /// SQLITE_MAX_VARIABLE_NUMBER (999). Mirrors <c>SourceArtefactRepository.MaxBatchIdCount</c>;
-    /// the buffered export pages ids in chunks of 500, comfortably below this bound.
+    /// Upper bound on artefact ids accepted by <see cref="GetByArtefactsForUserAsync"/> in one
+    /// call, applied to the RAW input count (before de-duplication). Each id becomes one SQLite
+    /// bind parameter, so the worst case is 900 ids + the userId = 901 bind parameters — under the
+    /// legacy SQLITE_MAX_VARIABLE_NUMBER default of 999 (a deliberate ~10% margin; modern bundled
+    /// SQLite defaults to 32766, so this cap is conservative defense-in-depth). Mirrors
+    /// <c>SourceArtefactRepository.MaxBatchIdCount</c>. Coupled constraint:
+    /// <c>DataExportService.StreamPageSize</c> (currently 500) must stay &lt;= this cap — raising
+    /// that chunk size past 900 makes the buffered export throw at runtime.
     /// </summary>
     private const int MaxBatchIdCount = 900;
 
@@ -166,9 +170,10 @@ public sealed class ArtefactExtractionRepository : IArtefactExtractionRepository
             // Mirror GetByArtefactForUserAsync's SQLite raw-SQL ordering (CreatedAt ASC, Id ASC over
             // the stored TEXT) so each artefact's batch group is byte-for-byte identical to the
             // former per-artefact page reads — including the Guid tiebreak, which orders by TEXT
-            // here (not .NET Guid comparison). The IN-clause is fully parameterised (one param per
-            // id, capped by MaxBatchIdCount well under SQLITE_MAX_VARIABLE_NUMBER). Same user-scoped
-            // join as the per-artefact read, so a foreign artefact id can never surface history.
+            // here (not .NET Guid comparison). The IN-clause is fully parameterised: one param per
+            // id plus the userId, at most 901 bind parameters under the MaxBatchIdCount cap (see
+            // its doc for the margin against SQLite's parameter limits). Same user-scoped join as
+            // the per-artefact read, so a foreign artefact id can never surface history.
             var placeholders = new string[idList.Count];
             var parameters = new List<object>(idList.Count + 1);
             for (var i = 0; i < idList.Count; i++)
@@ -195,6 +200,10 @@ public sealed class ArtefactExtractionRepository : IArtefactExtractionRepository
         }
         else
         {
+            // Non-SQLite providers: the Id tiebreak uses the provider's native Guid ordering, which
+            // can differ from SQLite's TEXT ordering above and is deliberately unpinned by tests
+            // (same pre-existing pattern as GetByArtefactForUserAsync's LINQ branch). Byte-for-byte
+            // export parity with the former per-artefact reads is guaranteed only on SQLite.
             rows = await (
                     from extraction in _context.ArtefactExtractions.AsNoTracking()
                     join artefact in _context.SourceArtefacts.AsNoTracking()

--- a/backend/tests/Taskdeck.Api.Tests/ArtefactExtractionRepositoryBatchIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ArtefactExtractionRepositoryBatchIntegrationTests.cs
@@ -1,0 +1,309 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Persistence;
+using Taskdeck.Infrastructure.Repositories;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="ArtefactExtractionRepository.GetByArtefactsForUserAsync"/>
+/// against real SQLite (#1387). Verifies the batched extraction-history load resolves every
+/// requested artefact in a single round-trip, is byte-for-byte order-identical to the former
+/// per-artefact sequential paging (including the CreatedAt/Id-as-TEXT tiebreak across the 50-row
+/// page boundary), stays user-scoped, and honours the empty-set and batch-cap edges.
+/// </summary>
+public sealed class ArtefactExtractionRepositoryBatchIntegrationTests
+{
+    private const string Sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Fact]
+    public async Task GetByArtefactsForUserAsync_MatchesSequentialPaging_InASingleRoundTrip()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var user = AddUser(db, "extraction-batch");
+
+            // Two owned artefacts: one whose history crosses the 50-row page boundary twice, one
+            // small. Some extractions deliberately share a CreatedAt to exercise the Id tiebreak —
+            // a naive in-memory Guid sort would diverge from the raw-SQL TEXT ordering here.
+            var heavy = AddArtefact(db, user.Id, "heavy.txt");
+            var light = AddArtefact(db, user.Id, "light.txt");
+            var baseTime = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero);
+            for (var i = 0; i < 120; i++)
+                AddExtraction(db, heavy.Id, $"heavy-{i}", baseTime.AddMinutes(i / 2)); // pairs share a timestamp
+            for (var i = 0; i < 3; i++)
+                AddExtraction(db, light.Id, $"light-{i}", baseTime.AddMinutes(i));
+            await db.SaveChangesAsync();
+
+            var repo = new ArtefactExtractionRepository(db);
+
+            // Reference: reproduce the former per-artefact path (page limit 50, accumulate all).
+            var sequentialHeavy = await ReadAllSequentiallyAsync(repo, heavy.Id, user.Id);
+            var sequentialLight = await ReadAllSequentiallyAsync(repo, light.Id, user.Id);
+
+            interceptor.Clear();
+            var batch = await repo.GetByArtefactsForUserAsync(new[] { heavy.Id, light.Id }, user.Id);
+
+            // Byte-for-byte ordering parity, id-for-id, including across the page boundary.
+            batch[heavy.Id].Select(e => e.Id).Should().Equal(sequentialHeavy.Select(e => e.Id));
+            batch[light.Id].Select(e => e.Id).Should().Equal(sequentialLight.Select(e => e.Id));
+            batch[heavy.Id].Should().HaveCount(120);
+            batch[light.Id].Should().HaveCount(3);
+
+            // The whole point of #1387: one SELECT, not one per artefact (nor one per page).
+            ExtractionSelects(interceptor).Should().HaveCount(1,
+                "batched extraction-history loads must resolve every artefact in a single query");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetByArtefactsForUserAsync_NeverReturnsAnotherUsersExtractions()
+    {
+        var (options, _, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var owner = AddUser(db, "extraction-owner");
+            var other = AddUser(db, "extraction-other");
+
+            var ownerArtefact = AddArtefact(db, owner.Id, "owned.txt");
+            var otherArtefact = AddArtefact(db, other.Id, "foreign.txt");
+            AddExtraction(db, ownerArtefact.Id, "owned", DateTimeOffset.UtcNow);
+            AddExtraction(db, otherArtefact.Id, "foreign", DateTimeOffset.UtcNow);
+            await db.SaveChangesAsync();
+
+            var repo = new ArtefactExtractionRepository(db);
+
+            // Request BOTH ids while scoped to the owner — the foreign artefact must be absent.
+            var result = await repo.GetByArtefactsForUserAsync(
+                new[] { ownerArtefact.Id, otherArtefact.Id },
+                owner.Id);
+
+            result.Should().ContainKey(ownerArtefact.Id);
+            result[ownerArtefact.Id].Should().ContainSingle().Which.ExtractedText.Should().Be("owned");
+            result.Should().NotContainKey(otherArtefact.Id,
+                "user-scoping must exclude another user's extraction history even when its id is requested");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetByArtefactsForUserAsync_OmitsArtefactsWithNoHistory_WithoutError()
+    {
+        var (options, _, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var user = AddUser(db, "extraction-empty-history");
+            var withHistory = AddArtefact(db, user.Id, "with.txt");
+            var withoutHistory = AddArtefact(db, user.Id, "without.txt");
+            AddExtraction(db, withHistory.Id, "present", DateTimeOffset.UtcNow);
+            await db.SaveChangesAsync();
+
+            var repo = new ArtefactExtractionRepository(db);
+
+            var result = await repo.GetByArtefactsForUserAsync(
+                new[] { withHistory.Id, withoutHistory.Id },
+                user.Id);
+
+            result.Should().ContainKey(withHistory.Id);
+            result.Should().NotContainKey(withoutHistory.Id,
+                "an artefact with no extractions is simply absent from the map");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetByArtefactsForUserAsync_WithEmptyIdSet_ReturnsEmptyAndIssuesNoQuery()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var repo = new ArtefactExtractionRepository(db);
+            interceptor.Clear();
+
+            var result = await repo.GetByArtefactsForUserAsync(Array.Empty<Guid>(), Guid.NewGuid());
+
+            result.Should().BeEmpty();
+            ExtractionSelects(interceptor).Should().BeEmpty(
+                "an empty id set must short-circuit before touching the database");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetByArtefactsForUserAsync_WithTooManyIds_ThrowsBeforeTouchingDatabase()
+    {
+        var (options, interceptor, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            var repo = new ArtefactExtractionRepository(db);
+            var tooMany = Enumerable.Range(0, 901).Select(_ => Guid.NewGuid()).ToList();
+
+            var act = async () => await repo.GetByArtefactsForUserAsync(tooMany, Guid.NewGuid());
+
+            await act.Should().ThrowAsync<ArgumentException>();
+            interceptor.CapturedCommands.Should().BeEmpty("the guard must trip before any SQL runs");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task GetByArtefactsForUserAsync_WithExactlyMaxBatchIds_DoesNotThrow()
+    {
+        var (options, _, dbPath) = CreateSqliteOptions();
+        try
+        {
+            await using var db = new TaskdeckDbContext(options);
+            await db.Database.MigrateAsync();
+            var repo = new ArtefactExtractionRepository(db);
+            var exactlyMax = Enumerable.Range(0, 900).Select(_ => Guid.NewGuid()).ToList();
+
+            var result = await repo.GetByArtefactsForUserAsync(exactlyMax, Guid.NewGuid());
+
+            result.Should().BeEmpty("no extractions were seeded; the call must succeed, not throw");
+        }
+        finally
+        {
+            Cleanup(dbPath);
+        }
+    }
+
+    private static async Task<IReadOnlyList<ArtefactExtraction>> ReadAllSequentiallyAsync(
+        ArtefactExtractionRepository repo,
+        Guid artefactId,
+        Guid userId)
+    {
+        var all = new List<ArtefactExtraction>();
+        while (true)
+        {
+            var page = await repo.GetByArtefactForUserAsync(artefactId, userId, limit: 50, offset: all.Count);
+            all.AddRange(page);
+            if (page.Count < 50)
+                return all;
+        }
+    }
+
+    private static (DbContextOptions<TaskdeckDbContext> Options, CapturingCommandInterceptor Interceptor, string DbPath) CreateSqliteOptions()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-extraction-batch-{Guid.NewGuid():N}.db");
+        var interceptor = new CapturingCommandInterceptor();
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(interceptor)
+            .Options;
+        return (options, interceptor, dbPath);
+    }
+
+    private static User AddUser(TaskdeckDbContext db, string handle)
+    {
+        var user = new User(handle, $"{handle}@example.com", "hash");
+        db.Users.Add(user);
+        return user;
+    }
+
+    private static SourceArtefact AddArtefact(TaskdeckDbContext db, Guid userId, string fileName)
+    {
+        var artefact = new SourceArtefact(
+            userId,
+            ArtefactKind.TextFile,
+            "text/plain",
+            fileName,
+            7,
+            Sha,
+            CaptureSource.Import);
+        db.SourceArtefacts.Add(artefact);
+        return artefact;
+    }
+
+    private static void AddExtraction(TaskdeckDbContext db, Guid artefactId, string text, DateTimeOffset createdAt)
+    {
+        var extraction = new ArtefactExtraction(artefactId, "test-extractor", "1.0", [], text);
+        typeof(Entity).GetProperty(nameof(Entity.CreatedAt))!.SetValue(extraction, createdAt);
+        db.ArtefactExtractions.Add(extraction);
+    }
+
+    private static IReadOnlyList<string> ExtractionSelects(CapturingCommandInterceptor interceptor) =>
+        interceptor.CapturedCommands
+            .Where(sql => sql.Contains("ArtefactExtractions", StringComparison.OrdinalIgnoreCase)
+                          && sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    private static void Cleanup(string dbPath)
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+        {
+            var path = dbPath + suffix;
+            if (!File.Exists(path))
+                continue;
+
+            try { File.Delete(path); }
+            catch (IOException) { /* best-effort temp cleanup */ }
+        }
+    }
+
+    /// <summary>
+    /// Records the text of every reader command EF executes so a test can count the SELECTs that
+    /// actually reached SQLite (proving the batch load is one round-trip, not one per artefact).
+    /// </summary>
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly ConcurrentQueue<string> _commands = new();
+
+        public IReadOnlyCollection<string> CapturedCommands => _commands;
+
+        public void Clear() => _commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/DataExportServiceTests.cs
@@ -75,6 +75,8 @@ public class DataExportServiceTests
             .ReturnsAsync(0L);
         _extractionRepoMock.Setup(r => r.GetByArtefactForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<ArtefactExtraction>());
+        _extractionRepoMock.Setup(r => r.GetByArtefactsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>)new Dictionary<Guid, IReadOnlyList<ArtefactExtraction>>());
 
         _testUser = new User("testuser", "test@example.com", BCrypt.Net.BCrypt.HashPassword("password123"));
 
@@ -589,6 +591,146 @@ public class DataExportServiceTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once,
             "the batched path must surface the same InvalidOperationException missing-blob contract as the per-item path");
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_BatchLoadsExtractionHistory_InOneCall_NotOnePerArtefact()
+    {
+        // #1387 regression: a single-chunk export must resolve every artefact's extraction history
+        // in ONE batch query, never the former one-paged-query-per-artefact N+1
+        // (GetByArtefactForUserAsync). Order + content per artefact must match the batch result.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, _) = SeedArtefactsWithBlobBatch(3);
+        var historyByArtefact = SeedExtractionHistoryBatch(artefacts, extractionsPerArtefact: 2);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        var exported = result.Value.Data.Artefacts!;
+        exported.Select(a => a.Id).Should().Equal(artefacts.Select(a => a.Id));
+        foreach (var artefact in artefacts)
+        {
+            var exportedArtefact = exported.Single(a => a.Id == artefact.Id);
+            exportedArtefact.Extractions!.Select(e => e.Id)
+                .Should().Equal(historyByArtefact[artefact.Id].Select(e => e.Id),
+                    "each artefact's exported extraction order must match the batch group order");
+            exportedArtefact.Extractions!.Select(e => e.ExtractedText)
+                .Should().Equal(historyByArtefact[artefact.Id].Select(e => e.ExtractedText));
+        }
+
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the buffered export must not fall back to the per-artefact extraction-history read");
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_BatchesExtractionHistoryAcrossChunks_TwoQueriesFor501()
+    {
+        // #1387: 501 artefacts must page extraction-history loads into exactly two batch queries
+        // (500 + 1), matching the blob-batch chunk arithmetic — never 501 sequential reads.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        SeedArtefactsWithBlobBatch(501);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactsForUserAsync(It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 500), _userId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the first chunk must carry exactly the 500-id StreamPageSize batch");
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactsForUserAsync(It.Is<IReadOnlyCollection<Guid>>(ids => ids.Count == 1), _userId, It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the trailing chunk must carry the single remaining id");
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_ExtractionHistoryBatch_ScopedToRequestingUserOnly()
+    {
+        // #1387 user-scoping: every extraction-history batch load must pass the requesting user's
+        // id and never another. The REAL scoping enforcement proof lives in
+        // ArtefactExtractionRepositoryBatchIntegrationTests against real SQLite.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, _) = SeedArtefactsWithBlobBatch(4);
+        SeedExtractionHistoryBatch(artefacts, extractionsPerArtefact: 1);
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        _extractionRepoMock.Verify(
+            r => r.GetByArtefactsForUserAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(),
+                It.Is<Guid>(u => u != _userId),
+                It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the buffered export must never batch-load another user's extraction history");
+    }
+
+    [Fact]
+    public async Task ExportUserDataAsync_WithArtefactHavingNoExtractions_ExportsEmptyHistory()
+    {
+        // #1387: an artefact absent from the batch map (no extraction history) must export an empty
+        // extraction array, not throw — parity with the former path where GetAllExtractionHistory
+        // returned an empty list for such an artefact.
+        SetupUserFound();
+        SetupEmptyRepositories();
+        var (artefacts, _) = SeedArtefactsWithBlobBatch(2);
+        // Only seed history for the first artefact; the second is absent from the batch map.
+        _extractionRepoMock
+            .Setup(r => r.GetByArtefactsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>)
+                new Dictionary<Guid, IReadOnlyList<ArtefactExtraction>>
+                {
+                    [artefacts[0].Id] = new[] { NewExtraction(artefacts[0].Id, "only") },
+                });
+
+        var result = await _service.ExportUserDataAsync(_userId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        var exported = result.Value.Data.Artefacts!;
+        exported.Single(a => a.Id == artefacts[0].Id).Extractions.Should().HaveCount(1);
+        exported.Single(a => a.Id == artefacts[1].Id).Extractions.Should().NotBeNull().And.BeEmpty();
+    }
+
+    private static ArtefactExtraction NewExtraction(Guid artefactId, string text)
+        => new(artefactId, "test-extractor", "1.0", [], text);
+
+    /// <summary>
+    /// Sets up the extraction-history batch responder to return <paramref name="extractionsPerArtefact"/>
+    /// ordered extractions for each seeded artefact, keyed by artefact id, and returns that map so a
+    /// test can assert per-artefact order + content parity.
+    /// </summary>
+    private IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>> SeedExtractionHistoryBatch(
+        IReadOnlyList<SourceArtefact> artefacts,
+        int extractionsPerArtefact)
+    {
+        var byArtefact = artefacts.ToDictionary(
+            a => a.Id,
+            a => (IReadOnlyList<ArtefactExtraction>)Enumerable.Range(0, extractionsPerArtefact)
+                .Select(index => NewExtraction(a.Id, $"{a.FileName}-extraction-{index}"))
+                .ToList());
+
+        _extractionRepoMock
+            .Setup(r => r.GetByArtefactsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), _userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<Guid> ids, Guid _, CancellationToken _) =>
+                (IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>)ids
+                    .Where(byArtefact.ContainsKey)
+                    .ToDictionary(id => id, id => byArtefact[id]));
+
+        return byArtefact;
     }
 
     /// <summary>

--- a/backend/tests/Taskdeck.Application.Tests/Services/GdprDataExportRoundTripTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/GdprDataExportRoundTripTests.cs
@@ -84,6 +84,8 @@ public class GdprDataExportRoundTripTests
             .ReturnsAsync(0L);
         _extractionRepoMock.Setup(r => r.GetByArtefactForUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<ArtefactExtraction>());
+        _extractionRepoMock.Setup(r => r.GetByArtefactsForUserAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>)new Dictionary<Guid, IReadOnlyList<ArtefactExtraction>>());
 
         _historyServiceMock
             .Setup(h => h.LogActionAsync(It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<AuditAction>(), It.IsAny<Guid?>(), It.IsAny<string?>()))


### PR DESCRIPTION
## What & why

Closes #1387. Gemini flagged a HIGH N+1 on PR #1385 (tracked out of scope there): PR #1385 batched artefact **blob** loads in the buffered `/api/account/export` path, but a second pre-existing N+1 remained in the same loop — extraction history was still fetched **one artefact at a time**.

### The N+1 shape (before)

`DataExportService.ExportUserDataAsync` chunks artefacts by 500, batch-loads blobs (one query per chunk), then — inside the per-artefact loop — called `GetAllExtractionHistoryAsync(artefact.Id, …)`, which paged `IArtefactExtractionRepository.GetByArtefactForUserAsync` (limit 50) until exhausted. For a 500-artefact chunk that is **≥500 sequential queries** (more when an artefact's history crosses the 50-row page boundary).

## The fix

New batch method mirroring `ISourceArtefactRepository.GetContentsForUserAsync`:

```
Task<IReadOnlyDictionary<Guid, IReadOnlyList<ArtefactExtraction>>> GetByArtefactsForUserAsync(
    IReadOnlyCollection<Guid> sourceArtefactIds, Guid userId, CancellationToken ct = default)
```

- **Interface** in Application (`IArtefactExtractionRepository`), **implementation** in Infrastructure (`ArtefactExtractionRepository`) — no layer violations.
- Fed the **same 500-id chunks** the export already builds for the blob batch: one query per chunk, results grouped per artefact.
- Same user-scoped join (`INNER JOIN SourceArtefacts … WHERE artefact.UserId = @userId`) as the per-artefact read, so a foreign artefact id can never surface another user's history.
- Same `MaxBatchIdCount = 900` defense-in-depth cap as the blob batch (well under `SQLITE_MAX_VARIABLE_NUMBER = 999`); throws `ArgumentException` above it.
- The now-unused `GetAllExtractionHistoryAsync` helper is removed. The streaming export path (`WriteExtractionHistoryAsync`) is untouched — out of scope.

## Byte-for-byte export parity

The critical constraint. Two subtleties handled:

1. **Ordering incl. tiebreak.** The old SQLite path used raw SQL `ORDER BY CreatedAt ASC, Id ASC` over the **stored TEXT**. A naive in-memory sort would diverge because `.NET Guid` comparison differs from lexicographic TEXT ordering. The batch reproduces the exact raw-SQL ordering: SQLite branch uses `FromSqlRaw` with a parameterised `IN (…)` and `ORDER BY SourceArtefactId, CreatedAt ASC, Id ASC`; other providers use the mirrored LINQ branch. Rows arrive ordered, then group in encounter order, so each artefact's list is identical to the former sequential paging.
2. **No truncation.** The old `GetAllExtractionHistoryAsync` looped **all** pages (limit 50 was page size, not a cap) and returned the complete history. Verified — so there is **no truncation bug to reproduce and no truncation-behavior question to flag**; the batch faithfully returns the full set, proven across a 120-extraction (page-boundary-crossing) artefact in the integration test.

### Memory bounding

Extractions carry `ExtractedText` (capped at 100 KB/row by the entity) and this path is **not** covered by a per-row streaming guard. Peak memory stays bounded because `ExportUserDataAsync` already runs the pre-load `MaxBufferedArtefactBytes` (10 MB) guard over **artefact + extraction** bytes before any load; a single 500-id chunk's grouped history can therefore never exceed that cap. The buffered DTOs already accumulated the full extraction set under the same guard, so this is no worse than before and removes 500× round-trips.

## Parity proof (tests)

Real-SQLite integration (`ArtefactExtractionRepositoryBatchIntegrationTests`, exercises the raw-SQL IN path):
- **Ordering parity**: batch output is id-for-id equal to the former per-artefact sequential paging, across a 120-row history crossing the 50-page boundary twice, with pairs sharing a `CreatedAt` to exercise the `Id` TEXT tiebreak.
- **One round-trip**: exactly one `ArtefactExtractions` SELECT (command interceptor), not one per artefact/page.
- User-scoping (foreign history excluded when its id is requested), empty-set short-circuit, too-many-ids guard, exactly-900 boundary.

Service unit tests (`DataExportServiceTests`): one batch call per chunk / two for 501, never falls back to the per-artefact read, per-artefact order+content parity, user-scoping wiring, empty-history artefact exports `[]`.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release` — clean (0 errors; only pre-existing warnings).
- Targeted: `DataExportServiceTests | GdprDataExportRoundTripTests | DataExportServiceStreamingTests` → 43 passed. `ArtefactExtractionRepositoryBatchIntegrationTests | ArtefactExtractionPersistenceTests | SourceArtefactRepositoryIntegrationTests` → 16 passed.
- Full touched projects: **Taskdeck.Application.Tests 3488 passed**, **Taskdeck.Api.Tests 2066 passed**, 0 failed.

## NOT verified

Full-solution suite (coordinator owns it at the gate); frontend unaffected.
