### PR TITLE
Format SQLite timestamp comparison strings with InvariantCulture (#1393)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
@@ -262,8 +263,8 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
             // SQLite stores DateTimeOffset as a string; use SUBSTR to extract the date portion
             // and push the GROUP BY into SQL. The IX_AuditLogs_UserId_Timestamp index covers
             // the WHERE clause so this avoids a full table scan.
-            var fromStr = from.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff") + "+00:00";
-            var toStr = to.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff") + "+00:00";
+            var fromStr = from.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
+            var toStr = to.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
 
             var rows = await _context.Database
                 .SqlQueryRaw<DateCountRow>(
@@ -313,7 +314,7 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
                 // its UTC-equivalent time before the "+00:00" suffix is appended; without this the time
                 // component would be wrong and entries in the wrong window could be kept or deleted.
                 var utcCutoff = olderThan.UtcDateTime;
-                var olderThanStr = utcCutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff") + "+00:00";
+                var olderThanStr = utcCutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
                 deleted = await _context.Database.ExecuteSqlRawAsync(
                     "DELETE FROM AuditLogs WHERE Id IN (SELECT Id FROM AuditLogs WHERE Timestamp < {0} ORDER BY Timestamp ASC LIMIT {1})",
                     new object[] { olderThanStr, batchSize },

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
@@ -276,7 +276,7 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
                 .ToListAsync(cancellationToken);
 
             return rows
-                .Select(r => new DailyAuditCount(DateOnly.Parse(r.DateStr), r.Count))
+                .Select(r => new DailyAuditCount(DateOnly.Parse(r.DateStr, CultureInfo.InvariantCulture), r.Count))
                 .ToList();
         }
 

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -28,8 +28,11 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         //
         // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm" format.
         // We must use the same format for string comparison to work correctly.
+        // Normalize via .UtcDateTime before appending the "+00:00" suffix, mirroring
+        // AuditLogRepository.DeleteOldEntriesAsync. Self-defending: `now` is UtcNow (zero offset)
+        // so normalization is a no-op today, but the site stays correct if its source ever changes.
         var now = DateTimeOffset.UtcNow;
-        var nowStr = now.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00", CultureInfo.InvariantCulture);
+        var nowStr = now.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
         var affected = await _context.Database.ExecuteSqlRawAsync(
             "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0 AND ExpiresAt > {3}",
             [nowStr, nowStr, code, nowStr],
@@ -43,7 +46,11 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         // Use raw SQL to avoid loading all rows into memory (DoS risk with large tables).
         // Deletes both expired codes AND consumed codes to prevent unbounded table growth.
         // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm".
-        var cutoffStr = cutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00", CultureInfo.InvariantCulture);
+        // Normalize to UTC first so that a non-UTC DateTimeOffset (e.g. -05:00) is converted to
+        // its UTC-equivalent time before the "+00:00" suffix is appended; without this the time
+        // component would be wrong and codes in the wrong window could be kept or deleted
+        // (mirrors AuditLogRepository.DeleteOldEntriesAsync).
+        var cutoffStr = cutoff.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
         var affected = await _context.Database.ExecuteSqlRawAsync(
             "DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {0} OR IsConsumed = 1",
             [cutoffStr],

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Domain.Entities;
@@ -28,7 +29,7 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm" format.
         // We must use the same format for string comparison to work correctly.
         var now = DateTimeOffset.UtcNow;
-        var nowStr = now.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00");
+        var nowStr = now.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00", CultureInfo.InvariantCulture);
         var affected = await _context.Database.ExecuteSqlRawAsync(
             "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0 AND ExpiresAt > {3}",
             [nowStr, nowStr, code, nowStr],
@@ -42,7 +43,7 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         // Use raw SQL to avoid loading all rows into memory (DoS risk with large tables).
         // Deletes both expired codes AND consumed codes to prevent unbounded table growth.
         // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm".
-        var cutoffStr = cutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00");
+        var cutoffStr = cutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff+00:00", CultureInfo.InvariantCulture);
         var affected = await _context.Database.ExecuteSqlRawAsync(
             "DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {0} OR IsConsumed = 1",
             [cutoffStr],

--- a/backend/src/Taskdeck.Infrastructure/Services/KnowledgeFtsSearchService.cs
+++ b/backend/src/Taskdeck.Infrastructure/Services/KnowledgeFtsSearchService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.EntityFrameworkCore;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
@@ -117,7 +118,9 @@ public class KnowledgeFtsSearchService : IFtsKnowledgeSearchService
         return string.Join(" ", words);
     }
 
-    private static KnowledgeSearchResultDto MapRowToDto(KnowledgeSearchRow row)
+    // Internal (not private) so the culture-regression test can call it directly via
+    // InternalsVisibleTo("Taskdeck.Api.Tests") — see KnowledgeFtsSearchServiceCultureTests.
+    internal static KnowledgeSearchResultDto MapRowToDto(KnowledgeSearchRow row)
     {
         Guid? boardId = null;
         if (!string.IsNullOrEmpty(row.BoardId) && Guid.TryParse(row.BoardId, out var parsedBoardId))
@@ -131,7 +134,12 @@ public class KnowledgeFtsSearchService : IFtsKnowledgeSearchService
             ? parsedDocId
             : Guid.Empty;
 
-        var createdAt = DateTimeOffset.TryParse(row.CreatedAt, out var parsedDate)
+        // InvariantCulture: EF Core stores DateTimeOffset in SQLite as invariant TEXT
+        // ("yyyy-MM-dd HH:mm:ss.FFFFFFFzzz"). A culture-sensitive TryParse would fail on hosts
+        // whose culture uses a non-':' time separator and silently yield DateTimeOffset.MinValue
+        // (issue #1393 bug class, read side).
+        var createdAt = DateTimeOffset.TryParse(
+            row.CreatedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate)
             ? parsedDate
             : DateTimeOffset.MinValue;
 

--- a/backend/tests/Taskdeck.Api.Tests/AuditCultureInvariantRepositoryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuditCultureInvariantRepositoryTests.cs
@@ -22,15 +22,22 @@ namespace Taskdeck.Api.Tests;
 ///
 /// Each test seeds rows with LITERAL invariant timestamp strings (culture-immune), then invokes the
 /// repository under a hostile culture — a clone of the invariant culture whose only difference is
-/// <c>TimeSeparator = "."</c>. The seeded rows share the hour+minute of the comparison bound so the
+/// <c>TimeSeparator = "."</c>. The literals use the REAL EF Core SQLite storage shape:
+/// <c>yyyy-MM-dd HH:mm:ss.FFFFFFFzzz</c> — trailing fraction zeros are TRIMMED and the dot is
+/// dropped entirely at a zero fraction (empirically verified on PR #1391), so whole-second seeds
+/// must be written as e.g. <c>2020-06-15 12:00:00+00:00</c> for the tests to exercise the shapes
+/// production string comparisons actually run against (the fixed-vs-trimmed boundary residual is
+/// tracked as issue #1403). The seeded rows share the hour+minute of the comparison bound so the
 /// divergence is forced into the seconds separator, making the assertion fail on the unfixed code.
 /// The culture is set before the await chain starts (it flows across awaits via ExecutionContext)
 /// and restored in a finally.
 ///
 /// Uses <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> because these tests seed audit
 /// rows that <c>AuditRetentionWorker</c> polls and deletes — see that factory's decision rule.
-/// Each test uses a distinct year so the table-wide retention delete in one test cannot touch the
-/// rows seeded by another (the class shares one database across its methods).
+/// Each backdated test uses a distinct year so the table-wide retention delete in one test cannot
+/// touch the rows seeded by another (the class shares one database across its methods). The consume
+/// test seeds at real current time with a unique code and completes all assertions within itself
+/// (a consumed row may later be swept by DeleteExpiredAsync's IsConsumed=1 clause — that is fine).
 /// </summary>
 public class AuditCultureInvariantRepositoryTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {
@@ -74,9 +81,10 @@ public class AuditCultureInvariantRepositoryTests : IClassFixture<HostedWorkerDi
         await db.SaveChangesAsync();
 
         // Literal invariant timestamps sharing 2020-06-15 12:00 with the cutoff (12:00:05) so the
-        // string divergence lands in the seconds separator, not an earlier digit.
-        await SetTimestampAsync(db, oldEntry.Id, "2020-06-15 12:00:00.0000000+00:00");
-        await SetTimestampAsync(db, recentEntry.Id, "2020-06-15 12:00:10.0000000+00:00");
+        // string divergence lands in the seconds separator, not an earlier digit. EF-realistic
+        // trimmed shape: whole-second values carry NO fraction (see class doc).
+        await SetTimestampAsync(db, oldEntry.Id, "2020-06-15 12:00:00+00:00");
+        await SetTimestampAsync(db, recentEntry.Id, "2020-06-15 12:00:10+00:00");
 
         var cutoff = new DateTimeOffset(2020, 6, 15, 12, 0, 5, TimeSpan.Zero);
 
@@ -115,7 +123,8 @@ public class AuditCultureInvariantRepositoryTests : IClassFixture<HostedWorkerDi
 
         // Row at 2021-06-15 12:00:05; range bounds share the hour+minute (12:00:00..12:00:10) so a
         // corrupted time separator on either bound would wrongly exclude the row at the range edge.
-        await SetTimestampAsync(db, entry.Id, "2021-06-15 12:00:05.0000000+00:00");
+        // EF-realistic trimmed shape: no fraction on a whole-second value (see class doc).
+        await SetTimestampAsync(db, entry.Id, "2021-06-15 12:00:05+00:00");
 
         var from = new DateTimeOffset(2021, 6, 15, 12, 0, 0, TimeSpan.Zero);
         var to = new DateTimeOffset(2021, 6, 15, 12, 0, 10, TimeSpan.Zero);
@@ -145,9 +154,10 @@ public class AuditCultureInvariantRepositoryTests : IClassFixture<HostedWorkerDi
         await db.SaveChangesAsync();
 
         // Both codes share 2022-06-15 12:00 with the cutoff (12:00:05); the expired one precedes it,
-        // the live one follows it, forcing the divergence into the seconds separator.
-        await SetExpiresAtAsync(db, expiredCode.Id, "2022-06-15 12:00:00.0000000+00:00");
-        await SetExpiresAtAsync(db, liveCode.Id, "2022-06-15 12:00:10.0000000+00:00");
+        // the live one follows it, forcing the divergence into the seconds separator. EF-realistic
+        // trimmed shape: no fraction on whole-second values (see class doc).
+        await SetExpiresAtAsync(db, expiredCode.Id, "2022-06-15 12:00:00+00:00");
+        await SetExpiresAtAsync(db, liveCode.Id, "2022-06-15 12:00:10+00:00");
 
         var cutoff = new DateTimeOffset(2022, 6, 15, 12, 0, 5, TimeSpan.Zero);
 
@@ -163,6 +173,48 @@ public class AuditCultureInvariantRepositoryTests : IClassFixture<HostedWorkerDi
             .ToListAsync();
         remaining.Should().NotContain(expiredCode.Id, "the pre-cutoff code must be deleted");
         remaining.Should().Contain(liveCode.Id, "the post-cutoff code must survive");
+    }
+
+    [Fact]
+    public async Task TryConsumeAtomicAsync_UnderNonInvariantTimeSeparator_ConsumesAndPersistsInvariantTimestamps()
+    {
+        // MED-B1 (PR #1400 round 2): TryConsumeAtomicAsync is the live OAuth code-exchange path.
+        // Its hand-built nowStr feeds BOTH the ExpiresAt > {now} comparison AND the persisted
+        // ConsumedAt/UpdatedAt values — pre-fix, a hostile culture WROTE the malformed string
+        // (with '.' time separators) into those columns. This runs the real SQL path.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IOAuthAuthCodeRepository>();
+
+        // Seed THROUGH EF so ExpiresAt is stored in the real trimmed invariant shape.
+        var code = $"consume-{Guid.NewGuid():N}";
+        var authCode = new OAuthAuthCode(code, Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddMinutes(5));
+        db.Set<OAuthAuthCode>().Add(authCode);
+        await db.SaveChangesAsync();
+
+        var consumed = await UnderHostileTimeSeparatorCultureAsync(
+            () => repo.TryConsumeAtomicAsync(code));
+
+        consumed.Should().BeTrue(
+            "an unexpired, unconsumed code must consume successfully under a non-':' culture");
+
+        var reloaded = await db.Set<OAuthAuthCode>().AsNoTracking()
+            .SingleAsync(c => c.Id == authCode.Id);
+        reloaded.IsConsumed.Should().BeTrue();
+
+        // Assert the raw persisted TEXT, not the materialized DateTimeOffset: a malformed write
+        // is only visible at the string level (EF materialization may still parse or throw later).
+        var consumedAtRaw = (await db.Database
+            .SqlQueryRaw<string>("SELECT ConsumedAt AS Value FROM OAuthAuthCodes WHERE Id = {0}", authCode.Id)
+            .ToListAsync()).Single();
+        consumedAtRaw.Should().MatchRegex(@"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{7}\+00:00$",
+            "ConsumedAt must be persisted in the invariant SQLite timestamp shape with ':' time separators");
+
+        var updatedAtRaw = (await db.Database
+            .SqlQueryRaw<string>("SELECT UpdatedAt AS Value FROM OAuthAuthCodes WHERE Id = {0}", authCode.Id)
+            .ToListAsync()).Single();
+        updatedAtRaw.Should().MatchRegex(@"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{7}\+00:00$",
+            "UpdatedAt must be persisted in the invariant SQLite timestamp shape with ':' time separators");
     }
 
     private static Task SetTimestampAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)

--- a/backend/tests/Taskdeck.Api.Tests/AuditCultureInvariantRepositoryTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuditCultureInvariantRepositoryTests.cs
@@ -1,0 +1,175 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Persistence;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Regression tests for issue #1393: production repositories that hand-build SQLite
+/// DateTimeOffset comparison strings must format with <see cref="CultureInfo.InvariantCulture"/>.
+///
+/// The <c>:</c> in a .NET custom date/time format string is the culture-sensitive time separator
+/// (<see cref="DateTimeFormatInfo.TimeSeparator"/>). EF Core stores <see cref="DateTimeOffset"/> in
+/// SQLite using the invariant <c>yyyy-MM-dd HH:mm:ss.fffffff+HH:mm</c> shape. On a host whose culture
+/// uses a non-<c>:</c> time separator the hand-built string diverges from the stored rows and the
+/// string-based comparison silently returns the wrong rows.
+///
+/// Each test seeds rows with LITERAL invariant timestamp strings (culture-immune), then invokes the
+/// repository under a hostile culture — a clone of the invariant culture whose only difference is
+/// <c>TimeSeparator = "."</c>. The seeded rows share the hour+minute of the comparison bound so the
+/// divergence is forced into the seconds separator, making the assertion fail on the unfixed code.
+/// The culture is set before the await chain starts (it flows across awaits via ExecutionContext)
+/// and restored in a finally.
+///
+/// Uses <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> because these tests seed audit
+/// rows that <c>AuditRetentionWorker</c> polls and deletes — see that factory's decision rule.
+/// Each test uses a distinct year so the table-wide retention delete in one test cannot touch the
+/// rows seeded by another (the class shares one database across its methods).
+/// </summary>
+public class AuditCultureInvariantRepositoryTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
+{
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
+
+    public AuditCultureInvariantRepositoryTests(HostedWorkerDisabledTestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    private static async Task<T> UnderHostileTimeSeparatorCultureAsync<T>(Func<Task<T>> action)
+    {
+        // Clone the invariant culture and change ONLY the time separator, isolating the exact bug:
+        // everything else (date separator '-', digit grouping) stays invariant.
+        var hostile = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        hostile.DateTimeFormat.TimeSeparator = ".";
+
+        var original = CultureInfo.CurrentCulture;
+        // Set before the await chain starts; CurrentCulture flows across awaits via ExecutionContext.
+        CultureInfo.CurrentCulture = hostile;
+        try
+        {
+            return await action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public async Task DeleteOldEntriesAsync_UnderNonInvariantTimeSeparator_DeletesCorrectEntries()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuditLogRepository>();
+
+        var oldEntry = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        var recentEntry = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        db.AuditLogs.AddRange(oldEntry, recentEntry);
+        await db.SaveChangesAsync();
+
+        // Literal invariant timestamps sharing 2020-06-15 12:00 with the cutoff (12:00:05) so the
+        // string divergence lands in the seconds separator, not an earlier digit.
+        await SetTimestampAsync(db, oldEntry.Id, "2020-06-15 12:00:00.0000000+00:00");
+        await SetTimestampAsync(db, recentEntry.Id, "2020-06-15 12:00:10.0000000+00:00");
+
+        var cutoff = new DateTimeOffset(2020, 6, 15, 12, 0, 5, TimeSpan.Zero);
+
+        var deleted = await UnderHostileTimeSeparatorCultureAsync(
+            () => repo.DeleteOldEntriesAsync(cutoff, batchSize: 1000));
+
+        deleted.Should().BeGreaterThanOrEqualTo(1,
+            "the entry older than the cutoff must be deleted even under a non-':' time-separator culture");
+
+        // Verify against the database (AsNoTracking) rather than GetByIdAsync: the raw-SQL DELETE
+        // bypasses the change tracker, so a Find-based read would return the still-tracked instance.
+        var survivors = await db.AuditLogs.AsNoTracking()
+            .Where(a => a.Id == oldEntry.Id || a.Id == recentEntry.Id)
+            .Select(a => a.Id)
+            .ToListAsync();
+        survivors.Should().NotContain(oldEntry.Id,
+            "the pre-cutoff entry must be deleted regardless of host culture");
+        survivors.Should().Contain(recentEntry.Id,
+            "the post-cutoff entry must survive regardless of host culture");
+    }
+
+    [Fact]
+    public async Task CountByDateAsync_UnderNonInvariantTimeSeparator_CountsBoundaryRow()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuditLogRepository>();
+
+        // AuditLog.UserId is a real FK to Users, so seed a user to own the row.
+        var user = new User("audit-culture-count", "audit-culture-count@example.com", "hash");
+        db.Users.Add(user);
+
+        var entry = new AuditLog("Card", Guid.NewGuid(), AuditAction.Updated, user.Id);
+        db.AuditLogs.Add(entry);
+        await db.SaveChangesAsync();
+
+        // Row at 2021-06-15 12:00:05; range bounds share the hour+minute (12:00:00..12:00:10) so a
+        // corrupted time separator on either bound would wrongly exclude the row at the range edge.
+        await SetTimestampAsync(db, entry.Id, "2021-06-15 12:00:05.0000000+00:00");
+
+        var from = new DateTimeOffset(2021, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        var to = new DateTimeOffset(2021, 6, 15, 12, 0, 10, TimeSpan.Zero);
+
+        var counts = await UnderHostileTimeSeparatorCultureAsync(
+            () => repo.CountByDateAsync(from, to, user.Id));
+
+        counts.Should().ContainSingle(
+            "the seeded row lies inside the range and must be counted under a non-':' culture");
+        counts[0].Date.Should().Be(new DateOnly(2021, 6, 15));
+        counts[0].Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeleteExpiredAsync_UnderNonInvariantTimeSeparator_DeletesExpiredCode()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IOAuthAuthCodeRepository>();
+
+        // Construct with a valid future expiry (entity invariant), then backdate via raw SQL.
+        var expiredCode = new OAuthAuthCode(
+            $"expired-{Guid.NewGuid():N}", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddMinutes(5));
+        var liveCode = new OAuthAuthCode(
+            $"live-{Guid.NewGuid():N}", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddMinutes(5));
+        db.Set<OAuthAuthCode>().AddRange(expiredCode, liveCode);
+        await db.SaveChangesAsync();
+
+        // Both codes share 2022-06-15 12:00 with the cutoff (12:00:05); the expired one precedes it,
+        // the live one follows it, forcing the divergence into the seconds separator.
+        await SetExpiresAtAsync(db, expiredCode.Id, "2022-06-15 12:00:00.0000000+00:00");
+        await SetExpiresAtAsync(db, liveCode.Id, "2022-06-15 12:00:10.0000000+00:00");
+
+        var cutoff = new DateTimeOffset(2022, 6, 15, 12, 0, 5, TimeSpan.Zero);
+
+        var deleted = await UnderHostileTimeSeparatorCultureAsync(
+            () => repo.DeleteExpiredAsync(cutoff));
+
+        deleted.Should().BeGreaterThanOrEqualTo(1,
+            "the code expiring before the cutoff must be deleted even under a non-':' culture");
+
+        var remaining = await db.Set<OAuthAuthCode>().AsNoTracking()
+            .Where(c => c.Id == expiredCode.Id || c.Id == liveCode.Id)
+            .Select(c => c.Id)
+            .ToListAsync();
+        remaining.Should().NotContain(expiredCode.Id, "the pre-cutoff code must be deleted");
+        remaining.Should().Contain(liveCode.Id, "the post-cutoff code must survive");
+    }
+
+    private static Task SetTimestampAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)
+        => db.Database.ExecuteSqlRawAsync(
+            "UPDATE AuditLogs SET Timestamp = {0} WHERE Id = {1}", invariantTimestamp, id);
+
+    private static Task SetExpiresAtAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)
+        => db.Database.ExecuteSqlRawAsync(
+            "UPDATE OAuthAuthCodes SET ExpiresAt = {0} WHERE Id = {1}", invariantTimestamp, id);
+}

--- a/backend/tests/Taskdeck.Api.Tests/KnowledgeFtsSearchServiceCultureTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/KnowledgeFtsSearchServiceCultureTests.cs
@@ -1,0 +1,98 @@
+using System.Globalization;
+using FluentAssertions;
+using Taskdeck.Infrastructure.Services;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Regression tests for the read-side of the issue #1393 bug class (PR #1400 round 2, MED-A1):
+/// <c>KnowledgeFtsSearchService.MapRowToDto</c> parses the EF-stored invariant SQLite TEXT
+/// (<c>yyyy-MM-dd HH:mm:ss.FFFFFFFzzz</c>) for <c>CreatedAt</c>. A culture-sensitive
+/// <c>DateTimeOffset.TryParse</c> fails on hosts whose culture cannot parse that shape and
+/// silently yields <c>DateTimeOffset.MinValue</c> (wrong ordering/display in FTS results).
+///
+/// Hostile cultures used:
+/// - an invariant clone with <c>TimeSeparator = "."</c> (same probe as
+///   <see cref="AuditCultureInvariantRepositoryTests"/>). Empirical note (red/green run on the
+///   unfixed code): .NET's parser still accepts ':' on the READ side regardless of the culture's
+///   TimeSeparator, so these cases pass either way — kept as documentation of parse robustness,
+///   not as the regression carrier.
+/// - <c>ar-SA</c> (real-world: its default Um Al-Qura calendar interprets "2026" as a Hijri year
+///   outside the supported range, so a culture-sensitive parse of a Gregorian string FAILS).
+///   These cases are the proven red/green regression carrier: they fail (MinValue) on the
+///   culture-sensitive TryParse and pass with InvariantCulture.
+/// Unit-level test via InternalsVisibleTo("Taskdeck.Api.Tests"); the culture is saved and
+/// restored in a finally around the call.
+/// </summary>
+public class KnowledgeFtsSearchServiceCultureTests
+{
+    private static readonly DateTimeOffset ExpectedFractional =
+        new DateTimeOffset(2026, 7, 17, 12, 34, 56, TimeSpan.Zero).AddTicks(1234567);
+
+    private static readonly DateTimeOffset ExpectedWholeSecond =
+        new DateTimeOffset(2026, 7, 17, 12, 34, 56, TimeSpan.Zero);
+
+    private static T UnderCulture<T>(CultureInfo culture, Func<T> action)
+    {
+        var original = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = culture;
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    private static CultureInfo HostileTimeSeparatorClone()
+    {
+        var hostile = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        hostile.DateTimeFormat.TimeSeparator = ".";
+        return hostile;
+    }
+
+    private static KnowledgeSearchRow Row(string createdAt) => new()
+    {
+        DocumentId = Guid.NewGuid().ToString(),
+        Title = "title",
+        Snippet = "snippet",
+        Rank = -1.5,
+        CreatedAt = createdAt
+    };
+
+    [Theory]
+    [InlineData("2026-07-17 12:34:56.1234567+00:00", true)]  // fixed-width fraction (write-path shape)
+    [InlineData("2026-07-17 12:34:56+00:00", false)]         // EF-trimmed whole-second shape (PR #1391 evidence)
+    public void MapRowToDto_UnderNonInvariantTimeSeparator_ParsesEfStoredCreatedAt(
+        string createdAt, bool fractional)
+    {
+        var dto = UnderCulture(
+            HostileTimeSeparatorClone(),
+            () => KnowledgeFtsSearchService.MapRowToDto(Row(createdAt)));
+
+        dto.CreatedAt.Should().Be(
+            fractional ? ExpectedFractional : ExpectedWholeSecond,
+            "CreatedAt must parse the invariant stored shape under a non-':' time-separator culture");
+        dto.CreatedAt.Should().NotBe(DateTimeOffset.MinValue,
+            "a failed parse silently yields MinValue — the exact regression this guards against");
+    }
+
+    [Theory]
+    [InlineData("2026-07-17 12:34:56.1234567+00:00", true)]
+    [InlineData("2026-07-17 12:34:56+00:00", false)]
+    public void MapRowToDto_UnderNonGregorianCalendarCulture_ParsesEfStoredCreatedAt(
+        string createdAt, bool fractional)
+    {
+        var dto = UnderCulture(
+            new CultureInfo("ar-SA"),
+            () => KnowledgeFtsSearchService.MapRowToDto(Row(createdAt)));
+
+        dto.CreatedAt.Should().Be(
+            fractional ? ExpectedFractional : ExpectedWholeSecond,
+            "CreatedAt must parse the invariant stored shape under a non-Gregorian-calendar culture");
+        dto.CreatedAt.Should().NotBe(DateTimeOffset.MinValue);
+    }
+}


### PR DESCRIPTION
## Summary

Production repositories that hand-build SQLite `DateTimeOffset` comparison strings were using culture-sensitive `.ToString(...)` calls. The `:` in a .NET custom date/time format string is the **time separator** and resolves to `DateTimeFormatInfo.TimeSeparator` of the current culture. EF Core stores `DateTimeOffset` in SQLite with the invariant `yyyy-MM-dd HH:mm:ss.fffffff+HH:mm` shape, so on a host whose culture uses a non-`:` time separator the built string diverges from stored rows and the string comparison silently returns the wrong rows.

This passes `CultureInfo.InvariantCulture` to every such call.

Closes #1393

## Sites fixed (bug class: hand-built datetime strings fed to SQLite string comparisons)

| File | Method | Line | Called from issue? |
|---|---|---|---|
| `AuditLogRepository.cs` | `CountByDateAsync` (`fromStr`) | 266 | Yes |
| `AuditLogRepository.cs` | `CountByDateAsync` (`toStr`) | 267 | Yes |
| `AuditLogRepository.cs` | `DeleteOldEntriesAsync` (`olderThanStr`) | 317 | Yes |
| `OAuthAuthCodeRepository.cs` | `DeleteExpiredAsync` (`cutoffStr`) | 46 | Yes (named to audit) |
| `OAuthAuthCodeRepository.cs` | `TryConsumeAtomicAsync` (`nowStr`) | 32 | **No — additional find** |

`TryConsumeAtomicAsync` was not named in the issue but has the identical bug class: it builds `nowStr` (used for both the `ConsumedAt`/`UpdatedAt` written values and the `ExpiresAt > {now}` comparison) with a culture-sensitive format. Under a hostile culture the `ExpiresAt > now` guard could misfire and the persisted `ConsumedAt`/`UpdatedAt` strings would be malformed. Fixed and covered indirectly by the existing green `OAuthTokenLifecycleTests` (28 tests).

## Bug-class sweep (backend/src) — sites checked and cleared

Swept `backend/src` for datetime `.ToString(format)` calls whose output feeds a SQLite string comparison:

- **All 5 sites above** were the complete set of format-string datetime `ToString` calls in `backend/src` (`grep` for `fffffff` / `+00:00` / date-format tokens).
- **`LlmQueueRepository.GetStuckProcessingNonCaptureAsync` (L379-381)** — CLEARED. It passes the `DateTimeOffset staleBefore` **directly as an EF `FromSqlInterpolated` parameter**; EF serializes it invariantly. No hand-built `.ToString`, not the bug class.
- **`AuditLogRepository.BuildSqliteQueryAsync` / `QueryAsync`** — CLEARED. `from`/`to` are passed as raw-SQL parameters, not formatted into strings.
- Note (out of scope, not the bug class): `CountByDateAsync` parses SQL output via `DateOnly.Parse(r.DateStr)` without an explicit culture. It reads the DB `SUBSTR(...,1,10)` date (separator `-`, invariant) rather than building a SQL comparison string, so it is unaffected by the time-separator bug. Left unchanged to keep this slice tight.

## Tests

New file `backend/tests/Taskdeck.Api.Tests/AuditCultureInvariantRepositoryTests.cs` (3 tests). Each seeds rows with **literal invariant** timestamp strings (culture-immune), then invokes the repository under a **hostile culture** — a clone of the invariant culture whose only difference is `TimeSeparator = "."`. Seeded rows share the hour+minute of the comparison bound so the divergence is forced into the seconds separator (making the assertion fail on unfixed code). Culture is set before the await chain starts (it flows across awaits via `ExecutionContext`) and restored in a `finally`.

- `DeleteOldEntriesAsync_UnderNonInvariantTimeSeparator_DeletesCorrectEntries`
- `CountByDateAsync_UnderNonInvariantTimeSeparator_CountsBoundaryRow`
- `DeleteExpiredAsync_UnderNonInvariantTimeSeparator_DeletesExpiredCode`

Uses `HostedWorkerDisabledTestWebApplicationFactory` (its decision rule: the test seeds audit rows `AuditRetentionWorker` polls/deletes). Does **not** touch the PR #1391-reserved `AuditRetentionRepositoryIntegrationTests.cs`.

**Red/green proof:** with the production fix reverted (`git stash` on the two src files), all 3 new tests **fail**; with the fix restored they **pass** — confirming genuine regressions that catch the exact bug.

## Verification

All in the isolated worktree, `-c Release`:

- Build: `dotnet build backend/Taskdeck.sln -c Release` → **succeeded, 0 errors**
- New test class **10× repeated** → **10/10 green** (3 passed each run)
- `AuditRetentionRepositoryIntegrationTests` → 6 passed
- `AuditRetentionWorkerTests` → 4 passed
- `OAuthTokenLifecycleTests` → 28 passed
- `OAuthAuthCode` domain tests → 16 passed
- Full `Taskdeck.Api.Tests` project → **2070 passed, 0 failed**

Not run (coordinator owns): full solution suite; frontend.
