### PR TITLE
Enforce MCP per-key budget before auth-stage DB work (one budget, checked once)

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/McpEndpointMapping.cs
+++ b/backend/src/Taskdeck.Api/Extensions/McpEndpointMapping.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Cors;
-using Taskdeck.Api.RateLimiting;
 
 namespace Taskdeck.Api.Extensions;
 
@@ -13,9 +12,7 @@ public static class McpEndpointMapping
     /// <summary>The only route on which Taskdeck serves MCP over HTTP.</summary>
     public const string HttpRoute = "/mcp";
 
-    public static void MapTaskdeckMcpEndpoint(
-        this IEndpointRouteBuilder endpoints,
-        bool rateLimitingEnabled)
+    public static void MapTaskdeckMcpEndpoint(this IEndpointRouteBuilder endpoints)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
 
@@ -23,9 +20,11 @@ public static class McpEndpointMapping
         // MCP bearer keys are not a browser credential. The co-hosted API's global
         // credentialed frontend policy must not enable cross-origin MCP requests.
         mcpEndpoint.WithMetadata(new DisableCorsAttribute());
-        if (rateLimitingEnabled)
-        {
-            mcpEndpoint.RequireRateLimiting(RateLimitingPolicyNames.McpPerApiKey);
-        }
+
+        // The per-key request budget (McpPerApiKey) is NOT an endpoint-stage policy: it is enforced in
+        // ApiKeyMiddleware via McpPerApiKeyRateLimiter (#1384), at the earliest point the validated key
+        // ID is known — before the user-account lookup and last-used write — so a valid-but-over-quota
+        // key cannot drive that per-request authentication-stage database work. Charging it here as
+        // well would double-count requests, so this endpoint carries no rate-limiting metadata.
     }
 }

--- a/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/PipelineConfiguration.cs
@@ -152,9 +152,9 @@ public static class PipelineConfiguration
         }).AllowAnonymous();
 
         // MCP Streamable HTTP endpoint for external AI agent integration.
-        // Authenticated via ApiKeyMiddleware (Bearer tdsk_... tokens).
-        // Rate limiting applied per validated opaque API key ID.
-        app.MapTaskdeckMcpEndpoint(rateLimitingSettings.Enabled);
+        // Authenticated via ApiKeyMiddleware (Bearer tdsk_... tokens), which also enforces the
+        // per-key request budget (McpPerApiKey) before the user lookup and last-used write (#1384).
+        app.MapTaskdeckMcpEndpoint();
         // MCP is authenticated by ApiKeyMiddleware (above): it 401s missing/invalid/revoked keys
         // before routing and sets an authenticated principal for valid keys, which satisfies the
         // global FallbackPolicy (#1132 AC4). The MCP SDK endpoint does not honor an

--- a/backend/src/Taskdeck.Api/Extensions/RateLimitingRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/RateLimitingRegistration.cs
@@ -17,7 +17,15 @@ public static class RateLimitingRegistration
         RateLimitingSettings settings)
     {
         services.AddRateLimiter(options => ConfigureRateLimiting(options, settings));
-        services.AddSingleton(new McpAuthenticationAttemptLimiter(
+
+        // Factory registrations (not pre-built instances): the container disposes only singletons it
+        // constructed itself, so `AddSingleton(new ...)` would leak each limiter's background
+        // replenishment timer past host shutdown (one leaked timer per WebApplicationFactory host in
+        // tests). Both limiters are IDisposable; factory registration ties their disposal to the host.
+        // Construction is therefore lazy (first resolution, not registration) — callers that must
+        // fail fast on invalid settings validate BEFORE calling this method (see the standalone host
+        // in Program.cs), so the ordering guarantee is unchanged.
+        services.AddSingleton(_ => new McpAuthenticationAttemptLimiter(
             settings.McpAuthenticationPerIp,
             settings.McpAuthenticationPerIpConcurrency));
 
@@ -28,7 +36,7 @@ public static class RateLimitingRegistration
         // and the standalone MCP host call this method, so both pipelines get the same enforcement.
         if (settings.Enabled)
         {
-            services.AddSingleton(new McpPerApiKeyRateLimiter(settings.McpPerApiKey));
+            services.AddSingleton(_ => new McpPerApiKeyRateLimiter(settings.McpPerApiKey));
         }
 
         return services;

--- a/backend/src/Taskdeck.Api/Extensions/RateLimitingRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/RateLimitingRegistration.cs
@@ -3,7 +3,6 @@ using System.Security.Claims;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.RateLimiting;
 using Taskdeck.Api.Contracts;
-using Taskdeck.Api.Middleware;
 using Taskdeck.Api.RateLimiting;
 using Taskdeck.Application.Services;
 using Taskdeck.Domain.Exceptions;
@@ -21,6 +20,17 @@ public static class RateLimitingRegistration
         services.AddSingleton(new McpAuthenticationAttemptLimiter(
             settings.McpAuthenticationPerIp,
             settings.McpAuthenticationPerIpConcurrency));
+
+        // Per-key MCP budget is enforced inside ApiKeyMiddleware (#1384), not as an endpoint-stage
+        // policy, so it charges once at the earliest point the key ID is known. Registered only when
+        // rate limiting is enabled: ApiKeyMiddleware resolves it optionally and skips the check when
+        // absent, preserving the "no MCP throttling when disabled" behaviour. Both the co-hosted API
+        // and the standalone MCP host call this method, so both pipelines get the same enforcement.
+        if (settings.Enabled)
+        {
+            services.AddSingleton(new McpPerApiKeyRateLimiter(settings.McpPerApiKey));
+        }
+
         return services;
     }
 
@@ -84,14 +94,10 @@ public static class RateLimitingRegistration
             return BuildFixedWindowPartition(partitionKey, settings.NoteImportPerUser);
         });
 
-        options.AddPolicy(RateLimitingPolicyNames.McpPerApiKey, httpContext =>
-        {
-            // ApiKeyMiddleware stores the validated opaque key ID before rate limiting runs.
-            // Partitioning by user ID here would make independent keys owned by the same user
-            // consume one shared budget, contrary to the policy contract.
-            var partitionKey = $"mcp-apikey:{ResolveApiKeyOrClientIdentifier(httpContext)}";
-            return BuildFixedWindowPartition(partitionKey, settings.McpPerApiKey);
-        });
+        // The per-key MCP budget (McpPerApiKey) is no longer an endpoint-stage policy: it is enforced
+        // inside ApiKeyMiddleware via McpPerApiKeyRateLimiter (#1384), before the user lookup and
+        // last-used write, so a valid-but-over-quota key cannot drive that per-request database work.
+        // Registering it here as well would double-charge requests that pass the early check.
 
         options.AddPolicy(RateLimitingPolicyNames.TokenRefreshPerUser, httpContext =>
         {
@@ -129,17 +135,6 @@ public static class RateLimitingRegistration
         // ApiKeyMiddleware sets this after validating the Bearer token.
         if (context.Items.TryGetValue(HttpUserContextProvider.UserIdItemKey, out var apiKeyUserId)
             && apiKeyUserId is Guid apiKeyGuid)
-        {
-            return apiKeyGuid.ToString();
-        }
-
-        return ResolveClientAddress(context);
-    }
-
-    private static string ResolveApiKeyOrClientIdentifier(HttpContext context)
-    {
-        if (context.Items.TryGetValue(ApiKeyMiddleware.ApiKeyIdItemKey, out var apiKeyId)
-            && apiKeyId is Guid apiKeyGuid)
         {
             return apiKeyGuid.ToString();
         }

--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -125,9 +125,13 @@ public sealed class ApiKeyMiddleware
         //
         // Resolved optionally: the limiter is registered only when rate limiting is enabled, so when it
         // is absent the check is skipped (no MCP throttling when disabled), matching prior behaviour.
+        // Deliberately NO null-conditional on RequestServices: ASP.NET Core populates the scoped
+        // provider before application middleware runs, and a ?. here would add a second SILENT skip
+        // path for a security charge (fail-open). The only intended skip is GetService returning null
+        // when rate limiting is disabled; a genuinely missing provider should throw loudly.
         context.Items[ApiKeyIdItemKey] = apiKey.Id;
 
-        var perKeyLimiter = context.RequestServices?.GetService<McpPerApiKeyRateLimiter>();
+        var perKeyLimiter = context.RequestServices.GetService<McpPerApiKeyRateLimiter>();
         if (perKeyLimiter is not null)
         {
             using var perKeyLease = perKeyLimiter.AttemptAcquire(context);

--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -127,7 +127,7 @@ public sealed class ApiKeyMiddleware
         // is absent the check is skipped (no MCP throttling when disabled), matching prior behaviour.
         context.Items[ApiKeyIdItemKey] = apiKey.Id;
 
-        var perKeyLimiter = context.RequestServices.GetService<McpPerApiKeyRateLimiter>();
+        var perKeyLimiter = context.RequestServices?.GetService<McpPerApiKeyRateLimiter>();
         if (perKeyLimiter is not null)
         {
             using var perKeyLease = perKeyLimiter.AttemptAcquire(context);

--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -2,8 +2,10 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Taskdeck.Api.Contracts;
 using Taskdeck.Api.Extensions;
+using Taskdeck.Api.RateLimiting;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Exceptions;
 using Taskdeck.Infrastructure.Mcp;
@@ -112,6 +114,31 @@ public sealed class ApiKeyMiddleware
             return;
         }
 
+        // Enforce the per-key request budget (McpPerApiKey) at the EARLIEST point the key identity is
+        // known — right after the key row is resolved and confirmed active, and BEFORE the user-account
+        // lookup and the last-used write below (#1384). The opaque key ID is the budget partition, so
+        // store it first. This is the SINGLE charge point for the per-key budget: the /mcp endpoint no
+        // longer carries an endpoint-stage McpPerApiKey policy, so a request passing this check is never
+        // charged again downstream. A valid-but-over-quota key is rejected with 429 here without setting
+        // AuthenticationFailedItemKey and without a 401, so the pre-auth IP FAILURE budget is not spent
+        // — valid keys never touch that budget (#1368/#1381), only failed authentications do.
+        //
+        // Resolved optionally: the limiter is registered only when rate limiting is enabled, so when it
+        // is absent the check is skipped (no MCP throttling when disabled), matching prior behaviour.
+        context.Items[ApiKeyIdItemKey] = apiKey.Id;
+
+        var perKeyLimiter = context.RequestServices.GetService<McpPerApiKeyRateLimiter>();
+        if (perKeyLimiter is not null)
+        {
+            using var perKeyLease = perKeyLimiter.AttemptAcquire(context);
+            if (!perKeyLease.IsAcquired)
+            {
+                _logger.LogDebug("MCP per-key rate limit exceeded for key {KeyId}", apiKey.Id);
+                await McpPerApiKeyRateLimiter.WriteRejectedAsync(context, perKeyLease, context.RequestAborted);
+                return;
+            }
+        }
+
         // Verify the user account is active
         var user = await dbContext.Users
             .AsNoTracking()
@@ -125,9 +152,9 @@ public sealed class ApiKeyMiddleware
             return;
         }
 
-        // Set the authenticated user ID for HttpUserContextProvider
+        // Set the authenticated user ID for HttpUserContextProvider. The API key ID item was set
+        // above, before the per-key budget check.
         context.Items[HttpUserContextProvider.UserIdItemKey] = apiKey.UserId;
-        context.Items[ApiKeyIdItemKey] = apiKey.Id;
 
         // Establish an authenticated principal so the global authorization FallbackPolicy
         // (RequireAuthenticatedUser, #1132 AC4) is satisfied for valid-key MCP requests — a valid

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -92,12 +92,13 @@ if (args.Contains("--mcp"))
             .Get<Taskdeck.Application.Services.RateLimitingSettings>()
             ?? new Taskdeck.Application.Services.RateLimitingSettings();
 
-        // Fail fast on invalid RateLimiting configuration BEFORE the pre-auth limiter is
-        // constructed (AddTaskdeckRateLimiting instantiates it eagerly at registration, and its
-        // constructor only lower-clamps, so an over-maximum value would otherwise be silently
-        // accepted). The standalone host does not run the co-hosted AddOptionsValidation /
-        // ValidateOnStart pipeline, so apply the same validator here with the same semantics:
-        // skipped when RateLimiting:Enabled=false, fail-fast with the validation message otherwise.
+        // Fail fast on invalid RateLimiting configuration BEFORE the pre-auth limiter can be
+        // constructed (AddTaskdeckRateLimiting registers it via a lazy factory — constructed on
+        // first resolution — and its constructor only lower-clamps, so an over-maximum value would
+        // otherwise be silently accepted). The standalone host does not run the co-hosted
+        // AddOptionsValidation / ValidateOnStart pipeline, so apply the same validator here with the
+        // same semantics: skipped when RateLimiting:Enabled=false, fail-fast with the validation
+        // message otherwise.
         var mcpRateLimitingValidation = new Taskdeck.Api.Validation.RateLimitingSettingsValidator()
             .Validate(null, mcpRateLimitingSettings);
         if (mcpRateLimitingValidation.Failed)

--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -174,17 +174,17 @@ if (args.Contains("--mcp"))
             mcpHttpApp.UseMiddleware<Taskdeck.Api.Middleware.McpAuthenticationRateLimitingMiddleware>();
         }
 
-        // API key authentication for MCP requests.
+        // API key authentication for MCP requests. ApiKeyMiddleware also enforces the per-key request
+        // budget (McpPerApiKey) via McpPerApiKeyRateLimiter (#1384) before the user lookup and
+        // last-used write. The standalone host serves only the /mcp endpoint, which no longer carries
+        // an endpoint-stage rate-limiting policy, so the UseRateLimiter() middleware (which only
+        // applies endpoint/global policies) is not needed here — the pre-auth failure budget and the
+        // per-key budget are both enforced by dedicated middleware/components above.
         mcpHttpApp.UseMiddleware<Taskdeck.Api.Middleware.ApiKeyMiddleware>();
 
-        // Apply rate limiting before endpoint routing.
-        if (mcpRateLimitingSettings.Enabled)
-        {
-            mcpHttpApp.UseRateLimiter();
-        }
-
-        // Use the same authenticated route mapping as the co-hosted API.
-        mcpHttpApp.MapTaskdeckMcpEndpoint(mcpRateLimitingSettings.Enabled);
+        // Use the same authenticated route mapping as the co-hosted API. Per-key rate limiting is
+        // enforced in ApiKeyMiddleware (#1384), shared identically by both pipelines.
+        mcpHttpApp.MapTaskdeckMcpEndpoint();
 
         var mcpHttpLogger = mcpHttpApp.Services.GetRequiredService<ILogger<Program>>();
         mcpHttpLogger.LogInformation("Taskdeck MCP HTTP server starting on http://{Host}:{Port}", mcpBindHost, mcpPort);

--- a/backend/src/Taskdeck.Api/RateLimiting/McpPerApiKeyRateLimiter.cs
+++ b/backend/src/Taskdeck.Api/RateLimiting/McpPerApiKeyRateLimiter.cs
@@ -111,7 +111,7 @@ public sealed class McpPerApiKeyRateLimiter : IDisposable
             return $"mcp-apikey:{apiKeyGuid}";
         }
 
-        return $"mcp-apikey:{context.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+        return $"mcp-apikey:{context.Connection?.RemoteIpAddress?.ToString() ?? "unknown"}";
     }
 
     public void Dispose() => _limiter.Dispose();

--- a/backend/src/Taskdeck.Api/RateLimiting/McpPerApiKeyRateLimiter.cs
+++ b/backend/src/Taskdeck.Api/RateLimiting/McpPerApiKeyRateLimiter.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using System.Threading.RateLimiting;
+using Taskdeck.Api.Contracts;
+using Taskdeck.Api.Middleware;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Exceptions;
+
+namespace Taskdeck.Api.RateLimiting;
+
+/// <summary>
+/// Enforces the MCP per-API-key request budget (the <c>McpPerApiKey</c> policy — default 60/min per
+/// key) as a single, early check-and-charge inside <see cref="ApiKeyMiddleware"/>, immediately after
+/// the key row is resolved and confirmed active and BEFORE the user-account lookup and the last-used
+/// write (#1384).
+/// <para>
+/// This replaces the former endpoint-stage <c>McpPerApiKey</c> rate-limiting policy, which ran after
+/// <see cref="ApiKeyMiddleware"/> completed all of its authentication-stage database work: a valid
+/// but over-quota key still paid the SHA-256 hash, ApiKeys lookup, Users lookup, and
+/// <c>UpdateLastUsedAsync</c> write on every request before the endpoint limiter returned 429. The
+/// budget is now consumed exactly once, at the earliest point the opaque key ID is known, so an
+/// over-quota key is rejected before that per-request database work — bounding auth-stage cost by the
+/// advertised per-key quota, not just by connection/concurrency limits.
+/// </para>
+/// <para>
+/// The partition key (<c>mcp-apikey:{keyId}</c>) and window settings are identical to the endpoint
+/// policy it replaces, and <see cref="WriteRejectedAsync"/> emits the same 429 contract, so the
+/// externally observable behaviour is unchanged apart from happening earlier and only once.
+/// </para>
+/// </summary>
+public sealed class McpPerApiKeyRateLimiter : IDisposable
+{
+    private readonly PartitionedRateLimiter<HttpContext> _limiter;
+
+    public McpPerApiKeyRateLimiter(RateLimitPolicySettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        var permitLimit = Math.Max(settings.PermitLimit, 1);
+        var windowSeconds = Math.Max(settings.WindowSeconds, 1);
+        var window = TimeSpan.FromSeconds(windowSeconds);
+
+        _limiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
+            RateLimitPartition.GetFixedWindowLimiter(
+                ResolvePartitionKey(context),
+                _ => new FixedWindowRateLimiterOptions
+                {
+                    PermitLimit = permitLimit,
+                    Window = window,
+                    QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                    QueueLimit = 0,
+                    AutoReplenishment = true
+                }));
+    }
+
+    /// <summary>
+    /// Charges exactly one permit against the calling key's budget. The returned lease MUST be
+    /// disposed: a fixed-window limiter never refunds on dispose, so disposing an acquired lease is
+    /// the intended "spend one" effect, and disposing a rejected lease simply releases its metadata.
+    /// When <see cref="RateLimitLease.IsAcquired"/> is <c>false</c> the key is over quota for the
+    /// window and the caller must reject with <see cref="WriteRejectedAsync"/> before doing any
+    /// further authentication-stage work.
+    /// </summary>
+    public RateLimitLease AttemptAcquire(HttpContext context) =>
+        _limiter.AttemptAcquire(context, permitCount: 1);
+
+    /// <summary>
+    /// Writes the per-key 429 rejection using the same contract as the endpoint policy it replaces:
+    /// <c>429</c>, a <c>Retry-After</c> header derived from the rejected lease's replenishment
+    /// metadata (full window when available, minimum one second), the <c>McpPerApiKey</c> policy
+    /// header, and an <c>application/json</c> <see cref="ApiErrorResponse"/>. No-ops when the
+    /// response has already started, matching the endpoint limiter's <c>OnRejected</c> guard.
+    /// </summary>
+    public static async Task WriteRejectedAsync(
+        HttpContext context,
+        RateLimitLease lease,
+        CancellationToken cancellationToken)
+    {
+        if (context.Response.HasStarted)
+        {
+            return;
+        }
+
+        var retryAfterSeconds = 1;
+        if (lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+        {
+            retryAfterSeconds = Math.Max((int)Math.Ceiling(retryAfter.TotalSeconds), 1);
+        }
+
+        context.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.Response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+        context.Response.Headers["X-RateLimit-Policy"] = RateLimitingPolicyNames.McpPerApiKey;
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsJsonAsync(
+            new ApiErrorResponse(
+                ErrorCodes.TooManyRequests,
+                $"Rate limit exceeded. Retry after {retryAfterSeconds} seconds."),
+            cancellationToken);
+    }
+
+    private static string ResolvePartitionKey(HttpContext context)
+    {
+        // Mirror the former endpoint policy's partition derivation exactly: the validated opaque key
+        // ID (set by ApiKeyMiddleware before this runs) is the budget partition. Partitioning by user
+        // ID would make independent keys owned by the same user share one budget, contrary to the
+        // per-key contract (#1364). The client-address fallback never fires in practice because this
+        // limiter is only consulted after the key ID is stored, but it preserves the endpoint
+        // policy's defensive default.
+        if (context.Items.TryGetValue(ApiKeyMiddleware.ApiKeyIdItemKey, out var apiKeyId)
+            && apiKeyId is Guid apiKeyGuid)
+        {
+            return $"mcp-apikey:{apiKeyGuid}";
+        }
+
+        return $"mcp-apikey:{context.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+    }
+
+    public void Dispose() => _limiter.Dispose();
+}

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
@@ -1,0 +1,271 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Taskdeck.Api.Contracts;
+using Taskdeck.Api.Middleware;
+using Taskdeck.Api.RateLimiting;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
+using Taskdeck.Infrastructure.Persistence;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Unit tests for the #1384 fix: <see cref="ApiKeyMiddleware"/> enforces the per-key request budget
+/// (<see cref="McpPerApiKeyRateLimiter"/>) immediately after the key row is resolved and confirmed
+/// active, BEFORE the user-account lookup and the <c>UpdateLastUsedAsync</c> write. A valid but
+/// over-quota key must be rejected with the standard 429 contract without performing that
+/// authentication-stage database work, and the budget must be charged exactly once per admitted
+/// request (no double-charge, since the endpoint-stage policy is gone). Drives the real middleware
+/// against a real SQLite <see cref="TaskdeckDbContext"/> with a command interceptor so the absence of
+/// the Users query and the last-used UPDATE is observed at the SQL boundary, not merely asserted.
+/// </summary>
+public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
+{
+    private static readonly JsonSerializerOptions WebJson = new(JsonSerializerDefaults.Web);
+
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"taskdeck-perkey-{Guid.NewGuid():N}.db");
+    private readonly CapturingCommandInterceptor _interceptor = new();
+
+    [Fact]
+    public async Task OverQuotaValidKey_Returns429_BeforeUserLookupAndUsageWrite()
+    {
+        await using var db = await CreateSeededContextAsync();
+        const string plaintext = "tdsk_perkey_overquota_000000000000000000";
+        var (_, apiKeyId) = await SeedUserAndKeyAsync(db, plaintext);
+
+        // Budget of one, already spent for this key's partition, so the next admitted request is over
+        // quota. Pre-spend via a context carrying the same key-id partition the middleware will use.
+        using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(1, 60));
+        using (var preSpend = limiter.AttemptAcquire(ContextForPartition(apiKeyId)))
+        {
+            preSpend.IsAcquired.Should().BeTrue("the single permit is consumed to exhaust the budget");
+        }
+
+        var nextCalled = false;
+        var middleware = new ApiKeyMiddleware(_ => { nextCalled = true; return Task.CompletedTask; },
+            NullLogger<ApiKeyMiddleware>.Instance);
+
+        var context = CreateMcpContext(plaintext, limiter);
+        _interceptor.Clear(); // discard the seed SQL; capture only the request's queries.
+
+        await middleware.InvokeAsync(context, db);
+
+        // Rejected with the per-key 429 contract, before the pipeline continued.
+        context.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
+        nextCalled.Should().BeFalse("an over-quota request must not reach the MCP endpoint");
+
+        // The key lookup (ApiKeys SELECT) is unavoidable — it is how the key ID is known — but the
+        // Users lookup and the last-used UPDATE must NOT have run: that is the auth-stage database work
+        // #1384 shields from a valid-but-over-quota key.
+        _interceptor.Captured.Should().Contain(
+            sql => IsSelect(sql) && sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase),
+            "the key row is resolved before the budget check");
+        _interceptor.Captured.Should().NotContain(
+            sql => IsSelect(sql) && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
+            "the over-quota request must be rejected before the user-account lookup");
+        _interceptor.Captured.Should().NotContain(
+            sql => IsApiKeysUpdate(sql),
+            "the over-quota request must be rejected before the UpdateLastUsedAsync write");
+
+        // A per-key 429 is NOT an authentication failure: the pre-auth IP failure budget marker must
+        // stay unset so valid keys never spend that budget (#1368/#1381).
+        context.Items.ContainsKey(ApiKeyMiddleware.AuthenticationFailedItemKey).Should().BeFalse();
+
+        // 429 contract mirrors the former endpoint policy exactly.
+        context.Response.ContentType.Should().StartWith("application/json");
+        context.Response.Headers["Retry-After"].ToString().Should().NotBeNullOrWhiteSpace();
+        context.Response.Headers["X-RateLimit-Policy"].ToString()
+            .Should().Be(RateLimitingPolicyNames.McpPerApiKey);
+        var error = await ReadErrorAsync(context);
+        error.Should().NotBeNull();
+        error!.ErrorCode.Should().Be(ErrorCodes.TooManyRequests);
+        error.Message.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task UnderQuotaValidKey_PassesThrough_ReachingUserLookup()
+    {
+        await using var db = await CreateSeededContextAsync();
+        const string plaintext = "tdsk_perkey_underquota_00000000000000000";
+        await SeedUserAndKeyAsync(db, plaintext);
+
+        using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(5, 60));
+        var nextCalled = false;
+        var middleware = new ApiKeyMiddleware(_ => { nextCalled = true; return Task.CompletedTask; },
+            NullLogger<ApiKeyMiddleware>.Instance);
+
+        var context = CreateMcpContext(plaintext, limiter);
+        _interceptor.Clear();
+
+        await middleware.InvokeAsync(context, db);
+
+        nextCalled.Should().BeTrue("an under-quota valid key must pass through to the MCP endpoint");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK, "the terminal delegate left the default status");
+        // The mirror of the over-quota assertion: an admitted request DOES reach the user-account
+        // lookup that the over-quota path skips, confirming the per-key gate is what shields it.
+        _interceptor.Captured.Should().Contain(
+            sql => IsSelect(sql) && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
+            "an admitted request performs the user-account lookup the over-quota path skips");
+    }
+
+    [Fact]
+    public async Task PerKeyBudget_AdmitsExactlyPermitLimitRequests_ThenRejects_NoDoubleCharge()
+    {
+        await using var db = await CreateSeededContextAsync();
+        const string plaintext = "tdsk_perkey_countbudget_0000000000000000";
+        await SeedUserAndKeyAsync(db, plaintext);
+
+        const int permitLimit = 3;
+        using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(permitLimit, 60));
+        var middleware = new ApiKeyMiddleware(_ => Task.CompletedTask, NullLogger<ApiKeyMiddleware>.Instance);
+
+        // Exactly permitLimit requests are admitted (each charges one permit, once); the next is 429.
+        // If any admitted request were double-charged, fewer than permitLimit would succeed.
+        for (var i = 0; i < permitLimit; i++)
+        {
+            var admitted = CreateMcpContext(plaintext, limiter);
+            await middleware.InvokeAsync(admitted, db);
+            admitted.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests,
+                $"request {i + 1} of {permitLimit} is within the budget");
+        }
+
+        var rejected = CreateMcpContext(plaintext, limiter);
+        await middleware.InvokeAsync(rejected, db);
+        rejected.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests,
+            "the request past the per-key budget is rejected");
+        rejected.Response.Headers["X-RateLimit-Policy"].ToString()
+            .Should().Be(RateLimitingPolicyNames.McpPerApiKey);
+    }
+
+    // ── Helpers ──
+
+    private static bool IsSelect(string sql) => sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase);
+
+    // Match a genuine UPDATE statement against ApiKeys (the UpdateLastUsedAsync write), not a SELECT
+    // that merely lists the "UpdatedAt" column — hence StartsWith on the trimmed command text.
+    private static bool IsApiKeysUpdate(string sql) =>
+        sql.TrimStart().StartsWith("UPDATE", StringComparison.OrdinalIgnoreCase)
+        && sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase);
+
+    private async Task<TaskdeckDbContext> CreateSeededContextAsync()
+    {
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .AddInterceptors(_interceptor)
+            .Options;
+        var db = new TaskdeckDbContext(options);
+        await db.Database.MigrateAsync();
+        return db;
+    }
+
+    private static async Task<(Guid userId, Guid apiKeyId)> SeedUserAndKeyAsync(
+        TaskdeckDbContext db,
+        string plaintextKey)
+    {
+        var user = new User("perkey-user-" + Guid.NewGuid().ToString("N")[..8], $"{Guid.NewGuid():N}@example.com", "hash");
+        db.Users.Add(user);
+        var apiKey = new ApiKey(user.Id, ApiKeyService.HashKey(plaintextKey), plaintextKey[..8], "Per-key test");
+        db.ApiKeys.Add(apiKey);
+        await db.SaveChangesAsync();
+        return (user.Id, apiKey.Id);
+    }
+
+    private static DefaultHttpContext CreateMcpContext(string bearerKey, McpPerApiKeyRateLimiter limiter)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(limiter);
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        context.Request.Method = HttpMethods.Post;
+        context.Request.Path = "/mcp";
+        context.Request.Headers.Authorization = $"Bearer {bearerKey}";
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static DefaultHttpContext ContextForPartition(Guid apiKeyId)
+    {
+        var context = new DefaultHttpContext();
+        context.Items[ApiKeyMiddleware.ApiKeyIdItemKey] = apiKeyId;
+        return context;
+    }
+
+    private static async Task<ApiErrorResponse?> ReadErrorAsync(HttpContext context)
+    {
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        return await JsonSerializer.DeserializeAsync<ApiErrorResponse>(context.Response.Body, WebJson);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+        {
+            var path = _dbPath + suffix;
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (IOException)
+            {
+                // Best-effort temp cleanup; a leaked handle is not a test failure.
+            }
+        }
+    }
+
+    private sealed class CapturingCommandInterceptor : DbCommandInterceptor
+    {
+        private readonly ConcurrentQueue<string> _commands = new();
+
+        public IReadOnlyCollection<string> Captured => _commands;
+
+        public void Clear() => _commands.Clear();
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override InterceptionResult<int> NonQueryExecuting(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.NonQueryExecuting(command, eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> NonQueryExecutingAsync(
+            DbCommand command, CommandEventData eventData, InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            _commands.Enqueue(command.CommandText);
+            return base.NonQueryExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
@@ -148,6 +148,40 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
             .Should().Be(RateLimitingPolicyNames.McpPerApiKey);
     }
 
+    [Fact]
+    public async Task RateLimitingDisabled_LimiterAbsent_SkipsPerKeyCheck_AndPassesThrough()
+    {
+        // When rate limiting is disabled the singleton is never registered, so the optional resolution
+        // returns null and the middleware must not throttle — preserving "no MCP throttling when
+        // disabled". Modelled with a RequestServices that has no McpPerApiKeyRateLimiter.
+        await using var db = await CreateSeededContextAsync();
+        const string plaintext = "tdsk_perkey_disabled_000000000000000000";
+        await SeedUserAndKeyAsync(db, plaintext);
+
+        var nextCalled = false;
+        var middleware = new ApiKeyMiddleware(_ => { nextCalled = true; return Task.CompletedTask; },
+            NullLogger<ApiKeyMiddleware>.Instance);
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = new ServiceCollection().BuildServiceProvider() // no limiter registered
+        };
+        context.Request.Method = HttpMethods.Post;
+        context.Request.Path = "/mcp";
+        context.Request.Headers.Authorization = $"Bearer {plaintext}";
+        context.Response.Body = new MemoryStream();
+
+        // Many requests, none throttled — the check is skipped entirely.
+        for (var i = 0; i < 5; i++)
+        {
+            nextCalled = false;
+            await middleware.InvokeAsync(context, db);
+            context.Response.StatusCode.Should().NotBe(StatusCodes.Status429TooManyRequests,
+                "per-key throttling must be inert when the limiter is not registered");
+            nextCalled.Should().BeTrue("the request passes through to the endpoint");
+        }
+    }
+
     // ── Helpers ──
 
     private static bool IsSelect(string sql) => sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase);

--- a/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
@@ -376,6 +376,50 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     }
 
     [Fact]
+    public async Task McpEndpoint_PerKeyBudget_AllowsExactlyPermitLimitRequests_ThenRejects()
+    {
+        // #1384 "one budget, checked once": the per-key budget is now enforced in ApiKeyMiddleware
+        // (before the user lookup and last-used write) instead of as an endpoint-stage policy. A
+        // request that passes the early check must NOT be charged again downstream, so exactly
+        // PermitLimit valid requests succeed in a window and the next is 429. A double-charge would
+        // let fewer than PermitLimit through. The pre-auth IP budget is raised out of the way so only
+        // the per-key budget can reject (valid keys never spend the IP failure budget anyway).
+        const int permitLimit = 3;
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("RateLimiting:Enabled", "true");
+            builder.UseSetting("RateLimiting:McpAuthenticationPerIp:PermitLimit", "1000");
+            builder.UseSetting("RateLimiting:McpAuthenticationPerIp:WindowSeconds", "60");
+            builder.UseSetting("RateLimiting:McpPerApiKey:PermitLimit", permitLimit.ToString());
+            builder.UseSetting("RateLimiting:McpPerApiKey:WindowSeconds", "60");
+        });
+        using var jwtClient = factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(jwtClient, "mcp-perkey-count");
+        var apiKey = await CreateApiKeyAsync(jwtClient, "Count Budget Key");
+
+        using var mcpClient = factory.CreateClient();
+        mcpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        for (var i = 0; i < permitLimit; i++)
+        {
+            using var admitted = await PostMcpAsync(mcpClient, "/mcp", CreateInitializeRequest(i + 1));
+            admitted.StatusCode.Should().Be(HttpStatusCode.OK,
+                $"request {i + 1} of {permitLimit} is within the per-key budget and charged exactly once");
+        }
+
+        using var rejected = await PostMcpAsync(mcpClient, "/mcp", CreateInitializeRequest(permitLimit + 1));
+        rejected.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "the request past the per-key budget is rejected");
+        rejected.Headers.TryGetValues("Retry-After", out _).Should().BeTrue();
+        rejected.Headers.GetValues("X-RateLimit-Policy").Should().ContainSingle()
+            .Which.Should().Be(RateLimitingPolicyNames.McpPerApiKey);
+        rejected.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        var error = await rejected.Content.ReadFromJsonAsync<ApiErrorResponse>();
+        error.Should().NotBeNull();
+        error!.ErrorCode.Should().Be(ErrorCodes.TooManyRequests);
+    }
+
+    [Fact]
     public async Task McpEndpoint_RejectedCredentials_AreRateLimitedBeforeDatabaseLookup()
     {
         using var factory = _factory.WithWebHostBuilder(builder =>

--- a/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
@@ -1,9 +1,15 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Taskdeck.Api.RateLimiting;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Persistence;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -232,6 +238,158 @@ public class StandaloneMcpHostFilteringTests
                     .Which.Should().Be("McpAuthenticationPerIp");
             }
         });
+    }
+
+    // Parity proof for #1384 in the STANDALONE MCP host (#1372 exact-mirroring discipline): the
+    // per-key budget is enforced by ApiKeyMiddleware, which the standalone host wires identically to
+    // the co-hosted API. Boots the real --mcp --transport http entry point with McpPerApiKey=1/300s,
+    // seeds one valid API key directly into the host's SQLite database, then drives two requests on a
+    // single (serialized) connection: the first valid request is admitted (auth passes, one permit
+    // spent) and the second — the same key, now over quota — is rejected with the per-key 429 by
+    // ApiKeyMiddleware, before the endpoint. The pre-auth IP budget is raised out of the way so only
+    // the per-key budget can reject (a valid key never spends the IP failure budget anyway).
+    [Fact]
+    public async Task StandaloneMcpHttpHost_PerKeyBudget_RejectsOverQuotaValidKey()
+    {
+        const string plaintextKey = "tdsk_standalone_perkey_000000000000000000";
+        var port = ReserveFreeLoopbackPort();
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-mcp-perkey-{Guid.NewGuid():N}.db");
+        var envKeys = new[]
+        {
+            "ConnectionStrings__DefaultConnection",
+            "Connectors__EncryptionKey",
+            "AllowedHosts",
+            "RateLimiting__Enabled",
+            "RateLimiting__McpPerApiKey__PermitLimit",
+            "RateLimiting__McpPerApiKey__WindowSeconds",
+            "RateLimiting__McpAuthenticationPerIp__PermitLimit",
+            "RateLimiting__McpAuthenticationPerIp__WindowSeconds"
+        };
+        var originalEnvironment = envKeys.ToDictionary(key => key, Environment.GetEnvironmentVariable);
+
+        var appBuilt = new TaskCompletionSource<WebApplication>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Program.OnStandaloneMcpHttpAppBuilt = app =>
+        {
+            app.Lifetime.ApplicationStarted.Register(() => started.TrySetResult());
+            appBuilt.TrySetResult(app);
+        };
+
+        WebApplication? runningApp = null;
+        try
+        {
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            Environment.SetEnvironmentVariable(
+                "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
+            Environment.SetEnvironmentVariable("AllowedHosts", null);
+            Environment.SetEnvironmentVariable("RateLimiting__Enabled", "true");
+            // One request per key, long window: the second request from the same key is over quota.
+            Environment.SetEnvironmentVariable("RateLimiting__McpPerApiKey__PermitLimit", "1");
+            Environment.SetEnvironmentVariable("RateLimiting__McpPerApiKey__WindowSeconds", "300");
+            // Raise the pre-auth IP failure budget out of the way — only the per-key budget must reject.
+            Environment.SetEnvironmentVariable("RateLimiting__McpAuthenticationPerIp__PermitLimit", "1000");
+            Environment.SetEnvironmentVariable("RateLimiting__McpAuthenticationPerIp__WindowSeconds", "60");
+
+            var entryPoint = typeof(Program).Assembly.EntryPoint
+                ?? throw new InvalidOperationException("Taskdeck.Api assembly has no entry point.");
+            var args = new[] { "--mcp", "--transport", "http", "--port", port.ToString() };
+            var hostTask = Task.Run(async () =>
+            {
+                var result = entryPoint.Invoke(null, new object[] { args });
+                return result switch
+                {
+                    int exit => exit,
+                    Task<int> asyncExit => await asyncExit,
+                    Task plainTask => await ContinueWithZero(plainTask),
+                    _ => throw new InvalidOperationException(
+                        $"Unexpected entry point return: {result?.GetType().ToString() ?? "null"}.")
+                };
+            });
+
+            var completed = await Task.WhenAny(appBuilt.Task, hostTask).WaitAsync(StartupTimeout);
+            if (completed == hostTask)
+            {
+                var earlyExit = await hostTask;
+                throw new InvalidOperationException(
+                    $"Standalone MCP host exited during startup with code {earlyExit}.");
+            }
+
+            var app = await appBuilt.Task;
+            runningApp = app;
+            await started.Task.WaitAsync(StartupTimeout);
+
+            // Seed a valid key into the host's (already-migrated) database. The host serves only /mcp
+            // and no key-management REST surface, so the key is inserted directly. WAL + busy_timeout
+            // (same PRAGMAs the host uses) let this second connection write while the host is running.
+            await SeedApiKeyAsync(dbPath, plaintextKey);
+
+            using (var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") })
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", plaintextKey);
+
+                using (var first = await client.PostAsync("/mcp", new StringContent("{}")))
+                {
+                    first.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized,
+                        "a valid key must pass API-key authentication");
+                    first.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
+                        "the first request is within the per-key budget");
+                }
+
+                using (var second = await client.PostAsync("/mcp", new StringContent("{}")))
+                {
+                    second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+                        "the same key is now over its per-key budget and rejected by ApiKeyMiddleware");
+                    second.Headers.GetValues("X-RateLimit-Policy").Should().ContainSingle()
+                        .Which.Should().Be(RateLimitingPolicyNames.McpPerApiKey);
+                    second.Headers.TryGetValues("Retry-After", out _).Should().BeTrue();
+                }
+            }
+
+            await app.StopAsync();
+            runningApp = null;
+            var exitCode = await hostTask.WaitAsync(ShutdownTimeout);
+            exitCode.Should().Be(0, "the standalone MCP host must shut down cleanly");
+        }
+        finally
+        {
+            Program.OnStandaloneMcpHttpAppBuilt = null;
+            if (runningApp is not null)
+            {
+                try
+                {
+                    await runningApp.StopAsync();
+                }
+                catch
+                {
+                }
+            }
+
+            foreach (var (name, value) in originalEnvironment)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+
+            TryDeleteDatabase(dbPath);
+        }
+    }
+
+    private static async Task SeedApiKeyAsync(string dbPath, string plaintextKey)
+    {
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .AddInterceptors(new SqlitePragmaConnectionInterceptor(5000))
+            .Options;
+        await using (var db = new TaskdeckDbContext(options))
+        {
+            var user = new User("standalone-perkey", "standalone-perkey@example.com", "hash");
+            db.Users.Add(user);
+            db.ApiKeys.Add(new ApiKey(
+                user.Id, ApiKeyService.HashKey(plaintextKey), plaintextKey[..8], "Standalone per-key"));
+            await db.SaveChangesAsync();
+        }
+
+        // Release the pooled seed connection so the host is never blocked on this file handle.
+        SqliteConnection.ClearAllPools();
     }
 
     // Fail-fast proof for the standalone host's RateLimiting validation: the co-hosted API runs


### PR DESCRIPTION
## Summary

Closes #1384.

The MCP per-key rate limit (`McpPerApiKey`, 60/min per key) was an **endpoint-stage** policy that ran *after* `ApiKeyMiddleware` had already completed its authentication-stage database work. So a **valid but over-quota** key still paid, on every request before the 429: the SHA-256 hash, the `ApiKeys` lookup, the `Users` lookup, and the `UpdateLastUsedAsync` write. The advertised per-key quota bounded MCP *endpoint* work but not *auth-stage database* work — the only remaining bound on that path was the per-address pre-auth concurrency gate (parallelism capped, sequential throughput not).

## The one-budget design (checked once, at the earliest point)

The per-key budget is now enforced **inside `ApiKeyMiddleware`**, immediately after the `ApiKeys` row is resolved and confirmed active and **before** the `Users` lookup and the `UpdateLastUsedAsync` write:

- New shared singleton **`McpPerApiKeyRateLimiter`** — a fixed-window `PartitionedRateLimiter<HttpContext>` on the **same** `mcp-apikey:{keyId}` partition and the **same** `McpPerApiKey` settings as the removed endpoint policy, emitting the **identical** 429 contract (`429`, `Retry-After`, `X-RateLimit-Policy: McpPerApiKey`, `application/json` `ApiErrorResponse`).
- `ApiKeyMiddleware` stores the key-id item, then **charges exactly once**; on rejection it writes the 429 and returns before the user lookup / usage write.
- The endpoint-stage `RequireRateLimiting(McpPerApiKey)` (and the now-dead policy + partition helper) are **removed**, so a request that passes the early check is **never charged again** — one budget, checked once, no double-charge.
- Registered in the shared `AddTaskdeckRateLimiting` (gated on `Enabled`), which **both** the co-hosted API and the standalone MCP host call — so both pipelines get identical enforcement (#1372 mirroring discipline). `ApiKeyMiddleware` resolves it optionally, so "rate limiting disabled = no MCP throttling" is preserved.

### Pre-auth IP budget is not regressed (#1368/#1381)
A per-key rejection returns **429** and does **not** set `AuthenticationFailedItemKey`, so `McpAuthenticationRateLimitingMiddleware` does not spend the pre-auth IP **failure** budget for it. Valid keys still never touch the IP budget; only 401s do. The per-address concurrency admission gate and the abort-proof failure consumption are untouched.

## Both pipelines covered
- **Co-hosted:** `PipelineConfiguration` + the `McpHttpTransportApiKeyTests` integration suite (full `TestWebApplicationFactory` pipeline).
- **Standalone:** `Program.cs` `--mcp --transport http` host + a new real-host e2e that seeds a valid key into the host DB and drives the per-key 429.

## Tests
- `ApiKeyMiddlewarePerKeyRateLimitTests` (unit, real SQLite + command interceptor):
  - **Over-quota valid key → 429 before the `Users` SELECT and before the `ApiKeys` UPDATE** (asserted at the SQL boundary); no `AuthenticationFailedItemKey`; full 429 contract.
  - Under-quota valid key passes through and reaches the user lookup the over-quota path skips.
  - **One budget:** exactly `PermitLimit` (3) requests admitted, the next rejected — no double-charge.
- `McpHttpTransportApiKeyTests.McpEndpoint_PerKeyBudget_AllowsExactlyPermitLimitRequests_ThenRejects` — end-to-end boundary count through the real co-hosted pipeline (3 succeed, 4th 429 with the `McpPerApiKey` contract). The existing partition/isolation test still passes unchanged.
- `StandaloneMcpHostFilteringTests.StandaloneMcpHttpHost_PerKeyBudget_RejectsOverQuotaValidKey` — real standalone host, seeded key, per-key 429 with `McpPerApiKey` header.

## Verification (exact counts)
- `dotnet build backend/src/Taskdeck.Api/...` — succeeded, 0 warnings.
- `--filter ApiKeyMiddlewarePerKeyRateLimitTests` — 3/3 passed.
- `--filter McpHttpTransportApiKeyTests` — 49/49 passed.
- `--filter StandaloneMcpHostFilteringTests|McpAuthenticationRateLimitingMiddlewareTests|FallbackPolicyTests` — 19/19 passed.
- Full `Taskdeck.Api.Tests` project — **2072 passed, 0 failed** (4m49s).

## Out-of-scope finding (not fixed here; tracked separately)
While proving the over-quota path skips the usage write, the command interceptor showed `UpdateLastUsedAsync` never issues its `UPDATE`: `SetProperty(k => k.LastUsedAt /* DateTimeOffset? */, DateTimeOffset.UtcNow /* non-nullable */)` fails EF Core's SQLite translation (`(DateTimeOffset?)DateTimeOffset.UtcNow` is not a valid `SetProperty` value expression), and the exception is swallowed by the method's non-critical `try/catch`. So `ApiKey.LastUsedAt` is effectively never persisted today. This is pre-existing and unrelated to the #1384 rate-limit fix; filed as a separate issue.

## Intentional contract change (recorded per round-2 review, F3)

An ACTIVE key owned by an INACTIVE user now spends one per-key permit before its 401. On main, such a request died in `ApiKeyMiddleware` before the endpoint policy ever ran, so only the pre-auth IP failure budget was spent for it. The new behavior is stricter and consistent with this PR's goal (charge at the earliest point the key ID is known, bounding the Users lookup). The user-inactive 401 still sets `AuthenticationFailedItemKey`, so the IP failure budget is also still charged for it exactly as before.
