### PR TITLE
Fix ApiKeyMiddleware never persisting ApiKey.LastUsedAt (EF SQLite SetProperty translation)

### DIFF
--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -171,8 +171,9 @@ public sealed class ApiKeyMiddleware
             new[] { new Claim(ClaimTypes.NameIdentifier, apiKey.UserId.ToString()) },
             authenticationType: AuthenticationType));
 
-        // Update last-used timestamp before continuing the pipeline.
-        // This is non-critical so failures are swallowed.
+        // Update last-used timestamp before continuing the pipeline. This is a non-critical usage
+        // stamp: a failure here must NOT fail an otherwise-valid authentication, so it is caught and
+        // logged inside UpdateLastUsedAsync (never rethrown) — the request proceeds regardless.
         await UpdateLastUsedAsync(dbContext, apiKey.Id);
 
         await _next(context);
@@ -187,19 +188,33 @@ public sealed class ApiKeyMiddleware
 
     private async Task UpdateLastUsedAsync(TaskdeckDbContext dbContext, Guid keyId)
     {
+        // Hoist the timestamps into locals BEFORE building the ExecuteUpdate. Passing
+        // DateTimeOffset.UtcNow directly into SetProperty makes EF Core treat it as a value
+        // expression it must translate to SQL; the SQLite provider cannot map UtcNow and refuses the
+        // whole statement ("The following lambda argument to 'SetProperty' does not represent a valid
+        // value: 'DateTimeOffset.UtcNow'"), so the previous form silently never wrote LastUsedAt (or
+        // UpdatedAt) at all (#1402). A captured local is evaluated client-side and passed as a
+        // parameter, which translates cleanly. The LastUsedAt local is typed as the nullable target
+        // property so no (DateTimeOffset?)-cast node is introduced either. Both stamps share one
+        // instant.
+        var now = DateTimeOffset.UtcNow;
+        DateTimeOffset? lastUsedAt = now;
         try
         {
-            // Direct update to avoid concurrency issues with the read-only query above.
+            // Direct update to avoid concurrency issues with the read-only (AsNoTracking) query above.
             await dbContext.ApiKeys
                 .Where(k => k.Id == keyId)
                 .ExecuteUpdateAsync(setters => setters
-                    .SetProperty(k => k.LastUsedAt, DateTimeOffset.UtcNow)
-                    .SetProperty(k => k.UpdatedAt, DateTimeOffset.UtcNow));
+                    .SetProperty(k => k.LastUsedAt, lastUsedAt)
+                    .SetProperty(k => k.UpdatedAt, now));
         }
         catch (Exception ex)
         {
-            // Non-critical: if usage tracking fails, authentication still succeeds.
-            _logger.LogDebug(ex, "Failed to update API key last-used timestamp for key {KeyId}", keyId);
+            // Non-critical: last-used is a usage stamp, not an auth gate. Swallowing here keeps a
+            // failed timestamp write from failing an otherwise-valid authentication, but it is logged
+            // at Warning (not silently) so a regression like #1402 — where the write was broken for
+            // months — is visible in operational logs instead of hidden.
+            _logger.LogWarning(ex, "Failed to update API key last-used timestamp for key {KeyId}", keyId);
         }
     }
 

--- a/backend/src/Taskdeck.Application/Services/ApiKeyService.cs
+++ b/backend/src/Taskdeck.Application/Services/ApiKeyService.cs
@@ -57,6 +57,13 @@ public class ApiKeyService
     /// Validate an API key and return the associated entity if valid.
     /// Returns null if the key is invalid, expired, or revoked.
     /// </summary>
+    /// <remarks>
+    /// DEAD PATH / dual-writer trap: this method currently has no production callers. MCP
+    /// authentication is performed by ApiKeyMiddleware, which records usage directly via
+    /// ExecuteUpdateAsync — wiring this method into that pipeline would double-write
+    /// LastUsedAt/UpdatedAt on every authenticated request. Either remove this path or make it
+    /// the single usage writer (dropping the middleware's direct update), not both; see #1409.
+    /// </remarks>
     public async Task<ApiKey?> ValidateKeyAsync(string plaintextKey, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(plaintextKey) || !plaintextKey.StartsWith(ApiKey.KeyPrefix))

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewareLastUsedPersistenceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewareLastUsedPersistenceTests.cs
@@ -34,11 +34,22 @@ public sealed class ApiKeyMiddlewareLastUsedPersistenceTests : IDisposable
     public async Task AuthenticatedRequest_PersistsLastUsedAt_AsSaneUtcNow()
     {
         var before = DateTimeOffset.UtcNow.AddSeconds(-5);
+        // Backdate the seeded key's UpdatedAt to well outside the assertion window. The entity
+        // constructor stamps UpdatedAt at seed time — moments before the middleware runs — so a
+        // construction-time value would ALSO satisfy a "recent UTC-now" bound and the UpdatedAt
+        // assertion could not fail even if the middleware's .SetProperty(k => k.UpdatedAt, ...)
+        // line were deleted. Backdating forces the assertion to prove the value ADVANCED, i.e.
+        // that the UPDATE statement itself wrote it.
+        var backdatedUpdatedAt = DateTimeOffset.UtcNow.AddDays(-1);
 
         await using (var db = await CreateSeededContextAsync())
         {
             const string plaintext = "tdsk_lastused_persist_000000000000000000";
-            await SeedUserAndKeyAsync(db, plaintext);
+            var (_, apiKeyId) = await SeedUserAndKeyAsync(db, plaintext);
+            // Raw SQL: UpdatedAt has a protected setter and Touch() always stamps "now", so the
+            // backdate must go straight to the row.
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"UPDATE ApiKeys SET UpdatedAt = {backdatedUpdatedAt} WHERE Id = {apiKeyId}");
 
             var logger = new CapturingLogger();
             using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(5, 60));
@@ -67,6 +78,10 @@ public sealed class ApiKeyMiddlewareLastUsedPersistenceTests : IDisposable
         persisted.LastUsedAt.Should().NotBeNull("an authenticated request must persist LastUsedAt (#1402)");
         persisted.LastUsedAt!.Value.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
             "the persisted timestamp must be a sane UTC-now instant");
+        // Advancement past the backdated pre-call value (not merely "recent") is what proves the
+        // UPDATE wrote UpdatedAt — see the backdating comment above.
+        persisted.UpdatedAt.Should().BeAfter(backdatedUpdatedAt,
+            "UpdatedAt must ADVANCE past the backdated pre-call value, proving the UPDATE wrote it");
         persisted.UpdatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
             "UpdatedAt is written in the same statement and must not be discarded");
     }

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewareLastUsedPersistenceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewareLastUsedPersistenceTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Taskdeck.Api.Middleware;
+using Taskdeck.Api.RateLimiting;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Infrastructure.Persistence;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Regression tests for #1402: <see cref="ApiKeyMiddleware.UpdateLastUsedAsync"/> must actually
+/// persist <see cref="ApiKey.LastUsedAt"/> (and <see cref="Taskdeck.Domain.Common.Entity.UpdatedAt"/>)
+/// for an authenticated MCP request. Before the fix the <c>ExecuteUpdateAsync</c> set the nullable
+/// <c>LastUsedAt</c> target to a non-nullable <c>DateTimeOffset.UtcNow</c>; EF Core's SQLite provider
+/// refused to translate the resulting <c>(DateTimeOffset?)DateTimeOffset.UtcNow</c> value expression,
+/// the whole UPDATE threw, and the failure was swallowed at Debug level — so LastUsedAt was silently
+/// never written. These tests drive the real middleware against a real SQLite
+/// <see cref="TaskdeckDbContext"/> and read the row back through a FRESH context (ExecuteUpdate bypasses
+/// the change tracker), so a broken write cannot be masked by a tracked in-memory copy.
+/// </summary>
+public sealed class ApiKeyMiddlewareLastUsedPersistenceTests : IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"taskdeck-lastused-{Guid.NewGuid():N}.db");
+
+    [Fact]
+    public async Task AuthenticatedRequest_PersistsLastUsedAt_AsSaneUtcNow()
+    {
+        var before = DateTimeOffset.UtcNow.AddSeconds(-5);
+
+        await using (var db = await CreateSeededContextAsync())
+        {
+            const string plaintext = "tdsk_lastused_persist_000000000000000000";
+            await SeedUserAndKeyAsync(db, plaintext);
+
+            var logger = new CapturingLogger();
+            using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(5, 60));
+            var nextCalled = false;
+            var middleware = new ApiKeyMiddleware(_ => { nextCalled = true; return Task.CompletedTask; }, logger);
+
+            var context = CreateMcpContext(plaintext, limiter);
+            await middleware.InvokeAsync(context, db);
+
+            nextCalled.Should().BeTrue("a valid under-quota key must authenticate and pass through");
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+
+            // The write must have succeeded silently: no swallowed failure was logged.
+            logger.Entries.Should().NotContain(
+                e => e.Contains("last-used", StringComparison.OrdinalIgnoreCase),
+                "the last-used write must succeed, not be swallowed");
+        }
+
+        var after = DateTimeOffset.UtcNow.AddSeconds(5);
+
+        // Read the row back through a fresh context: ExecuteUpdate writes straight to the database,
+        // bypassing any change tracker, so this proves the value is actually persisted on disk.
+        await using var verifyDb = await CreateContextAsync();
+        var persisted = await verifyDb.ApiKeys.AsNoTracking().SingleAsync();
+
+        persisted.LastUsedAt.Should().NotBeNull("an authenticated request must persist LastUsedAt (#1402)");
+        persisted.LastUsedAt!.Value.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
+            "the persisted timestamp must be a sane UTC-now instant");
+        persisted.UpdatedAt.Should().BeOnOrAfter(before).And.BeOnOrBefore(after,
+            "UpdatedAt is written in the same statement and must not be discarded");
+    }
+
+    // ── Helpers ──
+
+    private async Task<TaskdeckDbContext> CreateSeededContextAsync()
+    {
+        var db = await CreateContextAsync();
+        await db.Database.MigrateAsync();
+        return db;
+    }
+
+    private Task<TaskdeckDbContext> CreateContextAsync()
+    {
+        var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        return Task.FromResult(new TaskdeckDbContext(options));
+    }
+
+    private static async Task<(Guid userId, Guid apiKeyId)> SeedUserAndKeyAsync(
+        TaskdeckDbContext db,
+        string plaintextKey)
+    {
+        var user = new User("lastused-user-" + Guid.NewGuid().ToString("N")[..8], $"{Guid.NewGuid():N}@example.com", "hash");
+        db.Users.Add(user);
+        var apiKey = new ApiKey(user.Id, ApiKeyService.HashKey(plaintextKey), plaintextKey[..8], "Last-used test");
+        db.ApiKeys.Add(apiKey);
+        await db.SaveChangesAsync();
+        return (user.Id, apiKey.Id);
+    }
+
+    private static DefaultHttpContext CreateMcpContext(string bearerKey, McpPerApiKeyRateLimiter limiter)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(limiter);
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        context.Request.Method = HttpMethods.Post;
+        context.Request.Path = "/mcp";
+        context.Request.Headers.Authorization = $"Bearer {bearerKey}";
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
+        {
+            var path = _dbPath + suffix;
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (IOException)
+            {
+                // Best-effort temp cleanup; a leaked handle is not a test failure.
+            }
+        }
+    }
+
+    /// <summary>Records formatted log messages so the test can assert the write did not silently fail.</summary>
+    private sealed class CapturingLogger : ILogger<ApiKeyMiddleware>
+    {
+        private readonly ConcurrentQueue<string> _entries = new();
+
+        public IReadOnlyCollection<string> Entries => _entries;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _entries.Enqueue(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`ApiKeyMiddleware.UpdateLastUsedAsync` never persisted `ApiKey.LastUsedAt`. The `ExecuteUpdateAsync`
passed `DateTimeOffset.UtcNow` inline as the `SetProperty` value expression; EF Core's SQLite
provider cannot translate that, threw for the **whole** statement, and the failure was swallowed at
Debug level — so `LastUsedAt` (and the `UpdatedAt` set alongside it) were silently never written.

Closes #1402.

## Reproduced translation error

Captured from a real SQLite `TaskdeckDbContext` driving the real middleware (red half of the new
test, exception recorded from the swallowing catch):

```
System.InvalidOperationException: The LINQ expression 'DbSet<ApiKey>()
    .Where(a => a.Id == __keyId_0)
    .ExecuteUpdate(setters => setters.SetProperty<DateTimeOffset?>(
        propertyExpression: k => k.LastUsedAt,
        valueExpression: (DateTimeOffset?)DateTimeOffset.UtcNow).SetProperty<DateTimeOffset>(
        propertyExpression: k => k.UpdatedAt,
        valueExpression: DateTimeOffset.UtcNow))' could not be translated. Additional information:
    The following lambda argument to 'SetProperty' does not represent a valid value:
    'DateTimeOffset.UtcNow'. See https://go.microsoft.com/fwlink/?linkid=2101038 for more information.
```

The provider refuses `DateTimeOffset.UtcNow` as a *value expression* it must translate to SQL. Note
the nullable target also introduces the `(DateTimeOffset?)DateTimeOffset.UtcNow` cast the issue
predicted.

## Fix

Hoist both timestamps into locals **before** building the `ExecuteUpdate`, so EF captures them as
client-evaluated parameters (which translate cleanly) instead of trying to translate `UtcNow`
server-side. The `LastUsedAt` local is typed `DateTimeOffset?` to match the nullable property, so no
`(DateTimeOffset?)`-cast node is introduced either. Both stamps share one instant.

```csharp
var now = DateTimeOffset.UtcNow;
DateTimeOffset? lastUsedAt = now;
await dbContext.ApiKeys
    .Where(k => k.Id == keyId)
    .ExecuteUpdateAsync(setters => setters
        .SetProperty(k => k.LastUsedAt, lastUsedAt)
        .SetProperty(k => k.UpdatedAt, now));
```

## Failure-handling decision

The last-used write stays non-critical: a failure must **not** fail an otherwise-valid
authentication (the write runs after the principal is established and just before `_next`, and that
ordering is preserved and documented in a comment). But the swallow was upgraded from `LogDebug` to
`LogWarning`, so a future regression like this one — broken but invisible — surfaces in operational
logs instead of hiding. The catch never rethrows; auth proceeds regardless.

## Consumer sweep (does anything read `LastUsedAt`?)

Two read consumers, both already null-safe — they surface the value as a nullable
`DateTimeOffset?` for display only; nothing branches on it:

- `ApiKeysController.List` → `ApiKeyListItem.LastUsedAt` (REST key-listing DTO).
- `ApiKeysCommandHandler.ListAsync` (CLI `api-keys list` JSON output).

`ApiKey.IsActive` / expiry logic uses `RevokedAt` and `ExpiresAt` only — **not** `LastUsedAt`. So
previously-null rows simply start populating on next use; no consumer breaks on null, and no
backfill/migration is needed.

## Tests

New: `ApiKeyMiddlewareLastUsedPersistenceTests.AuthenticatedRequest_PersistsLastUsedAt_AsSaneUtcNow`
— drives the real middleware against real SQLite, reads the row back through a **fresh** context
(ExecuteUpdate bypasses the change tracker so a broken write can't be masked), and asserts
`LastUsedAt` and `UpdatedAt` are persisted as a sane UTC-now instant with no swallowed failure
logged. Confirmed red before the fix (swallowed translation exception), green after.

## Verification

- Build: clean (Release).
- New test class: 10× green (10 pass / 0 fail).
- #1401-touched classes `ApiKeyMiddlewarePerKeyRateLimitTests` + `McpHttpTransportApiKeyTests`:
  53 pass / 0 fail (once).
- Full `Taskdeck.Api.Tests` project: **2082 pass / 0 fail**.
- Not run (coordinator owns at gate): full solution suite.
