### PR TITLE
Harden 17 E2E dialog handlers to fail loudly when the confirmation is absent (#1382)

### DIFF
--- a/frontend/taskdeck-web/tests/e2e/automation-ops.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/automation-ops.spec.ts
@@ -2,6 +2,7 @@ import type { APIRequestContext } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { parseTrueishEnv } from '../../scripts/demo-shared.mjs'
 import { API_BASE_URL, registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import { assertOk } from './support/httpAsserts'
 import { pollUntil } from './support/polling'
@@ -128,7 +129,9 @@ test('chat proposal flow should create, approve, and execute proposal', async ({
   await proposalCard.getByRole('button', { name: 'Approve for board' }).click()
   await expect(proposalCard.getByText('Approved, ready to apply')).toBeVisible()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+  await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await expect(proposalCard).not.toBeVisible()
 })

--- a/frontend/taskdeck-web/tests/e2e/capture-loop.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/capture-loop.spec.ts
@@ -69,17 +69,12 @@ test.describe('Paper capture-review-apply loop', () => {
     const executeResponsePromise = page.waitForResponse((response) =>
       response.request().method() === 'POST'
       && response.url().endsWith(`/automation/proposals/${proposalId}/execute`))
-    // The final apply confirmation is a hard gate: waitForEvent FAILS this test
+    // The final apply confirmation is a hard gate: expectDialog FAILS this test
     // if the confirm() dialog is removed, instead of silently executing anyway.
-    // The click promise stays pending until the dialog is handled, so the
-    // dialog must be awaited/accepted before awaiting the click.
-    const executeDialogPromise = page.waitForEvent('dialog')
-    const executeClick = page.getByTestId('decision-apply').click()
-    const executeDialog = await executeDialogPromise
-    expect(executeDialog.type()).toBe('confirm')
-    expect(executeDialog.message()).toBe('Apply this approved proposal to the board now?')
-    await executeDialog.accept()
-    await executeClick
+    await expectDialog(page, () => page.getByTestId('decision-apply').click(), {
+      type: 'confirm',
+      message: 'Apply this approved proposal to the board now?',
+    })
     await assertOk(await executeResponsePromise, `execute Paper proposal ${proposalId}`)
     const createdCard = await waitForCardWithTitle(request, paperAuth, boardId, cardTitle)
 

--- a/frontend/taskdeck-web/tests/e2e/capture-loop.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/capture-loop.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import {
   createCaptureItem,
@@ -138,8 +139,10 @@ test('capture triage should create proposal and apply card with provenance links
   const cardsAfterApprove = await listBoardCards(request, auth, boardId)
   expect(cardsAfterApprove.length).toBe(0)
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+  await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await expect(proposalCard).not.toBeVisible()
 
   const createdCard = await waitForCardWithTitle(request, auth, boardId, checklistTaskTitle)

--- a/frontend/taskdeck-web/tests/e2e/edge-journeys.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/edge-journeys.spec.ts
@@ -175,9 +175,16 @@ test('rejecting a proposal should remove it from the review queue', async ({ pag
     .first()
   await expect(rejectButton).toBeVisible()
 
+  // handleRejectProposal (useReviewActions.ts) has TWO prompt templates:
+  // 'Optional rejection reason:' for Low/Medium risk and 'Reason is required
+  // for this risk level:' for High/Critical — match both, and submit a
+  // non-empty reason so the rejection succeeds regardless of how this
+  // fixture's proposal is risk-classified (High/Critical rejects an empty
+  // reason and would leave the proposal in the queue).
   await expectDialog(page, () => rejectButton.click(), {
     type: 'prompt',
-    message: /rejection reason/i,
+    message: /reason/i,
+    promptText: 'e2e: rejected by test',
   })
 
   // Proposal card must disappear from the review queue

--- a/frontend/taskdeck-web/tests/e2e/edge-journeys.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/edge-journeys.spec.ts
@@ -25,6 +25,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { API_BASE_URL, registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import {
   createCaptureItem,
@@ -174,8 +175,10 @@ test('rejecting a proposal should remove it from the review queue', async ({ pag
     .first()
   await expect(rejectButton).toBeVisible()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await rejectButton.click()
+  await expectDialog(page, () => rejectButton.click(), {
+    type: 'prompt',
+    message: /rejection reason/i,
+  })
 
   // Proposal card must disappear from the review queue
   await expect(proposalCard).toHaveCount(0, { timeout: 10_000 })
@@ -210,8 +213,10 @@ test('proposal approve should reflect on board immediately without manual refres
   await proposalCard.getByRole('button', { name: 'Approve for board' }).click()
   await expect(proposalCard.getByText('Approved, ready to apply')).toBeVisible()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+  await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await expect(proposalCard).not.toBeVisible()
 
   // Navigate to board and check card appears without manual refresh

--- a/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
@@ -94,13 +94,10 @@ test('Paper first-run path guides setup through capture, review, apply, and boar
     && response.url().endsWith(`/automation/proposals/${proposalId}/execute`))
   // Hard-assert the final apply confirmation (see capture-loop.spec.ts): the
   // test must FAIL if the confirm() gate disappears, not execute silently.
-  const executeDialogPromise = page.waitForEvent('dialog')
-  const executeClick = page.getByTestId('decision-apply').click()
-  const executeDialog = await executeDialogPromise
-  expect(executeDialog.type()).toBe('confirm')
-  expect(executeDialog.message()).toBe('Apply this approved proposal to the board now?')
-  await executeDialog.accept()
-  await executeClick
+  await expectDialog(page, () => page.getByTestId('decision-apply').click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await assertOk(await executeResponse, `execute Paper first-run proposal ${proposalId}`)
   const createdCard = await waitForCardWithTitle(request, auth, boardId, cardTitle)
 

--- a/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/first-run.spec.ts
@@ -1,6 +1,7 @@
 import type { APIResponse, Response } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import { createCaptureItem, triageCaptureItem, waitForCardWithTitle, waitForProposalCreated } from './support/captureFlow'
 import { assertOk } from './support/httpAsserts'
@@ -211,8 +212,10 @@ test(LEGACY_FIRST_RUN_TITLE, async ({ page, request }) => {
   await proposalCard.getByRole('button', { name: 'Approve for board' }).click()
   await expect(proposalCard.getByText('Approved, ready to apply')).toBeVisible()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+  await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await expect(proposalCard).not.toBeVisible()
 
   const createdCard = await waitForCardWithTitle(request, auth, boardId, cardTitle)

--- a/frontend/taskdeck-web/tests/e2e/integrated-verification.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/integrated-verification.spec.ts
@@ -18,6 +18,7 @@
 import { expect, test } from '@playwright/test'
 import type { StarterPackManifest } from '../../src/types/starter-packs'
 import { API_BASE_URL, registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import { createCaptureItem, waitForProposalCreated, waitForCardWithTitle, listBoardCards } from './support/captureFlow'
 
@@ -109,8 +110,10 @@ test('V-02: register to create board to capture to triage to approve to board st
   await expect(proposalCard.getByText('Approved, ready to apply')).toBeVisible()
 
   // Step 9: Apply the approved proposal (S1 board mutation)
-  page.once('dialog', (dialog) => dialog.accept())
-  await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+  await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await expect(proposalCard).not.toBeVisible()
 
   // Step 10: Verify card appeared on the board (S1 board state)
@@ -184,8 +187,10 @@ test('V-03: login to create board to apply starter pack to archive to restore', 
 
   // Step 4: Archive the board via Board Settings (S5 archive)
   await page.locator('button[title="Board Settings"]').click()
-  page.once('dialog', (dialog) => dialog.accept())
-  await page.getByRole('button', { name: 'Move to Archive' }).click()
+  await expectDialog(page, () => page.getByRole('button', { name: 'Move to Archive' }).click(), {
+    type: 'confirm',
+    message: /^Archive "/,
+  })
 
   // Step 5: Verify board is no longer in boards list (S1 board list)
   await expect(page).toHaveURL(/\/workspace\/boards$/)
@@ -198,8 +203,10 @@ test('V-03: login to create board to apply starter pack to archive to restore', 
   await expect(archivedBoardRow).toBeVisible()
 
   // Step 7: Restore the board from archive (S5 restore)
-  page.once('dialog', (dialog) => dialog.accept())
-  await archivedBoardRow.getByRole('button', { name: 'Restore Board' }).click()
+  await expectDialog(page, () => archivedBoardRow.getByRole('button', { name: 'Restore Board' }).click(), {
+    type: 'confirm',
+    message: /^Restore board "/,
+  })
   await expect(page.locator('.td-archive-row').filter({ hasText: boardName })).toHaveCount(0)
 
   // Step 8: Verify restored board is back in boards list (S1 board)

--- a/frontend/taskdeck-web/tests/e2e/manual-audit.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/manual-audit.spec.ts
@@ -21,6 +21,7 @@
 import { expect, test } from '@playwright/test'
 import { parseTrueishEnv } from '../../scripts/demo-shared.mjs'
 import { registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import {
   createCaptureItem,
@@ -107,8 +108,10 @@ test.describe('Core loop: Home -> Inbox/Capture -> Review -> Board', () => {
     await page.screenshot({ path: testInfo.outputPath('05-review-approved.png'), fullPage: true })
 
     // Step 9: Apply proposal to board
-    page.once('dialog', (dialog) => dialog.accept())
-    await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+    await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+      type: 'confirm',
+      message: 'Apply this approved proposal to the board now?',
+    })
     await expect(proposalCard).not.toBeVisible()
     await page.screenshot({ path: testInfo.outputPath('06-review-applied.png'), fullPage: true })
 

--- a/frontend/taskdeck-web/tests/e2e/multi-board.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/multi-board.spec.ts
@@ -13,6 +13,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 
 let auth: AuthResult
@@ -158,8 +159,10 @@ test('deleting the currently viewed board should redirect to boards list or anot
   // Open board settings and archive/delete
   await page.locator('button[title="Board Settings"]').click()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await page.getByRole('button', { name: 'Move to Archive' }).click()
+  await expectDialog(page, () => page.getByRole('button', { name: 'Move to Archive' }).click(), {
+    type: 'confirm',
+    message: /^Archive "/,
+  })
 
   // Should be redirected away from the deleted board
   await expect(page).not.toHaveURL(/\/workspace\/boards\/[a-f0-9-]+$/)
@@ -176,8 +179,10 @@ test('restoring a board from archive should make it appear in sidebar without re
 
   // Archive it
   await page.locator('button[title="Board Settings"]').click()
-  page.once('dialog', (dialog) => dialog.accept())
-  await page.getByRole('button', { name: 'Move to Archive' }).click()
+  await expectDialog(page, () => page.getByRole('button', { name: 'Move to Archive' }).click(), {
+    type: 'confirm',
+    message: /^Archive "/,
+  })
   await expect(page).toHaveURL(/\/workspace\/boards$/)
   await expect(page.getByText(boardName)).toHaveCount(0)
 
@@ -186,8 +191,10 @@ test('restoring a board from archive should make it appear in sidebar without re
   const archivedBoardRow = page.locator('.td-archive-row').filter({ hasText: boardName }).first()
   await expect(archivedBoardRow).toBeVisible()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await archivedBoardRow.getByRole('button', { name: 'Restore Board' }).click()
+  await expectDialog(page, () => archivedBoardRow.getByRole('button', { name: 'Restore Board' }).click(), {
+    type: 'confirm',
+    message: /^Restore board "/,
+  })
 
   // After restore, navigate back to boards workspace
   await page.goto('/workspace/boards')

--- a/frontend/taskdeck-web/tests/e2e/review-proposals.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/review-proposals.spec.ts
@@ -9,6 +9,7 @@
 
 import { expect, test, type ConsoleMessage, type Page } from '@playwright/test'
 import { registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import {
   createCaptureItem,
@@ -272,11 +273,13 @@ test('applied proposal should appear in the recently-applied ledger', async ({ p
   await page.getByTestId('decision-apply').click()
   await assertOk(await approveResponse, `approve proposal ${proposalId}`)
 
-  page.once('dialog', (dialog) => dialog.accept())
   const executeResponse = page.waitForResponse((response) =>
     response.request().method() === 'POST'
     && response.url().endsWith(`/automation/proposals/${proposalId}/execute`))
-  await page.getByTestId('decision-apply').click()
+  await expectDialog(page, () => page.getByTestId('decision-apply').click(), {
+    type: 'confirm',
+    message: 'Apply this approved proposal to the board now?',
+  })
   await assertOk(await executeResponse, `execute proposal ${proposalId}`)
   await expect(queueItem).toHaveCount(0)
 

--- a/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/smoke.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { API_ORIGIN, registerAndAttachSession } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { assertOk } from './support/httpAsserts'
 
 async function gotoBoardsWorkspace(page: Page) {
@@ -453,8 +454,10 @@ test('board settings lifecycle should support rename archive unarchive and archi
   await expect(page.getByRole('heading', { name: renamedBoardName })).toBeVisible()
 
   await page.locator('button[title="Board Settings"]').click()
-  page.once('dialog', (dialog) => dialog.accept())
-  await page.getByRole('button', { name: 'Move to Archive' }).click()
+  await expectDialog(page, () => page.getByRole('button', { name: 'Move to Archive' }).click(), {
+    type: 'confirm',
+    message: /^Archive "/,
+  })
 
   await expect(page).toHaveURL(/\/workspace\/boards$/)
   await expect(page.getByText(renamedBoardName)).toHaveCount(0)
@@ -464,8 +467,10 @@ test('board settings lifecycle should support rename archive unarchive and archi
   const archivedBoardRow = page.locator('.td-archive-row').filter({ hasText: renamedBoardName }).first()
   await expect(archivedBoardRow).toBeVisible()
 
-  page.once('dialog', (dialog) => dialog.accept())
-  await archivedBoardRow.getByRole('button', { name: 'Restore Board' }).click()
+  await expectDialog(page, () => archivedBoardRow.getByRole('button', { name: 'Restore Board' }).click(), {
+    type: 'confirm',
+    message: /^Restore board "/,
+  })
   await expect(page.locator('.td-archive-row').filter({ hasText: renamedBoardName })).toHaveCount(0)
 
   await page.goto('/workspace/boards')

--- a/frontend/taskdeck-web/tests/e2e/support/dialogs.ts
+++ b/frontend/taskdeck-web/tests/e2e/support/dialogs.ts
@@ -1,0 +1,113 @@
+import type { Dialog, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+/**
+ * Hard-assert a native dialog (confirm/prompt/alert) that a UI action MUST raise.
+ *
+ * Why this exists (#1382): the fire-and-forget shape
+ *
+ *   page.once('dialog', (d) => d.accept())
+ *   await button.click()
+ *
+ * silently no-ops when the dialog never fires. If a safety confirmation is
+ * removed from the product, the guarded action still runs and the test stays
+ * green — hiding the regression it was written to catch. `expectDialog` instead
+ * FAILS the test with a clear message when the expected dialog is absent, and
+ * (optionally) asserts the dialog's type and copy so an unrelated dialog cannot
+ * be accepted by mistake.
+ *
+ * Determinism: this is not a sleep race. We arm `page.waitForEvent('dialog')`
+ * BEFORE the triggering action, then run the action without awaiting it —
+ * Playwright keeps the click promise pending while a dialog is open, so awaiting
+ * it up front would deadlock. On the happy path `waitForEvent` resolves the
+ * instant the synchronous `confirm()`/`prompt()` fires; only the failure path
+ * consumes the bounded `timeout`, after which the test fails deterministically
+ * rather than flaking. The triggering action is awaited AFTER the dialog is
+ * handled, so its post-dialog effects have settled before the caller asserts.
+ *
+ * Usage:
+ *
+ *   await expectDialog(
+ *     page,
+ *     () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(),
+ *     { type: 'confirm', message: 'Apply this approved proposal to the board now?' },
+ *   )
+ */
+export interface ExpectDialogOptions {
+  /** Accept the dialog (default) or dismiss it once observed. */
+  accept?: boolean
+  /** Expected dialog type — asserted when provided (e.g. 'confirm', 'prompt'). */
+  type?: Dialog['type'] extends () => infer R ? R : string
+  /**
+   * Assert the dialog message. A string asserts equality (use for fully stable
+   * copy); a RegExp asserts a match (use when the copy embeds dynamic names).
+   */
+  message?: string | RegExp
+  /** Text to submit for a prompt() dialog before accepting. */
+  promptText?: string
+  /** Bounded wait for the dialog to appear before failing. Default 15000ms. */
+  timeout?: number
+}
+
+/**
+ * Run `trigger`, require the dialog it raises to appear, assert it, and handle
+ * it. Returns the observed {@link Dialog}. Throws with a diagnostic message if
+ * no dialog fires within `timeout`.
+ */
+export async function expectDialog(
+  page: Page,
+  trigger: () => Promise<unknown> | unknown,
+  options: ExpectDialogOptions = {},
+): Promise<Dialog> {
+  const { accept = true, type, message, promptText, timeout = 15_000 } = options
+
+  const dialogPromise = page.waitForEvent('dialog', { timeout })
+  // Start the triggering action but do NOT await it here: the click promise
+  // stays pending until the dialog is handled, so awaiting now would deadlock.
+  const triggerPromise = Promise.resolve(trigger())
+  // Swallow the trigger promise's rejection until we await it below, so a click
+  // that fails before any dialog fires doesn't surface as an unhandled rejection
+  // while we're still waiting on `dialogPromise`.
+  triggerPromise.catch(() => {})
+
+  let dialog: Dialog
+  try {
+    dialog = await dialogPromise
+  } catch {
+    const wanted = [
+      type ? `a '${type}'` : 'a',
+      'dialog',
+      message ? `matching ${message instanceof RegExp ? message.toString() : JSON.stringify(message)}` : null,
+    ]
+      .filter(Boolean)
+      .join(' ')
+    throw new Error(
+      `expectDialog: expected ${wanted} to appear within ${timeout}ms after the triggering action, `
+      + 'but none fired. The confirmation gate was likely removed — the guarded action may have '
+      + 'proceeded without it.',
+    )
+  }
+
+  // Capture type/message, then handle the dialog BEFORE asserting so a failed
+  // assertion can never leave the dialog open (which would hang page teardown)
+  // or the trigger promise forever pending.
+  const actualType = dialog.type()
+  const actualMessage = dialog.message()
+  if (accept) {
+    await dialog.accept(promptText)
+  } else {
+    await dialog.dismiss()
+  }
+  await triggerPromise
+
+  if (type) {
+    expect(actualType, `unexpected dialog type (message: ${JSON.stringify(actualMessage)})`).toBe(type)
+  }
+  if (message instanceof RegExp) {
+    expect(actualMessage).toMatch(message)
+  } else if (typeof message === 'string') {
+    expect(actualMessage).toBe(message)
+  }
+
+  return dialog
+}

--- a/frontend/taskdeck-web/tests/e2e/support/dialogs.ts
+++ b/frontend/taskdeck-web/tests/e2e/support/dialogs.ts
@@ -25,6 +25,11 @@ import { expect } from '@playwright/test'
  * rather than flaking. The triggering action is awaited AFTER the dialog is
  * handled, so its post-dialog effects have settled before the caller asserts.
  *
+ * Failure attribution: if the trigger itself rejects before any dialog fires
+ * (strict-mode violation, renamed button, navigation error), THAT error is
+ * rethrown immediately — the "confirmation gate removed" diagnostic is reserved
+ * for the case where the trigger ran but no dialog appeared within `timeout`.
+ *
  * Usage:
  *
  *   await expectDialog(
@@ -36,8 +41,8 @@ import { expect } from '@playwright/test'
 export interface ExpectDialogOptions {
   /** Accept the dialog (default) or dismiss it once observed. */
   accept?: boolean
-  /** Expected dialog type — asserted when provided (e.g. 'confirm', 'prompt'). */
-  type?: Dialog['type'] extends () => infer R ? R : string
+  /** Expected dialog type — asserted when provided. */
+  type?: 'alert' | 'beforeunload' | 'confirm' | 'prompt'
   /**
    * Assert the dialog message. A string asserts equality (use for fully stable
    * copy); a RegExp asserts a match (use when the copy embeds dynamic names).
@@ -52,7 +57,8 @@ export interface ExpectDialogOptions {
 /**
  * Run `trigger`, require the dialog it raises to appear, assert it, and handle
  * it. Returns the observed {@link Dialog}. Throws with a diagnostic message if
- * no dialog fires within `timeout`.
+ * no dialog fires within `timeout`, or rethrows the trigger's own error if the
+ * trigger fails before any dialog appears.
  */
 export async function expectDialog(
   page: Page,
@@ -62,18 +68,54 @@ export async function expectDialog(
   const { accept = true, type, message, promptText, timeout = 15_000 } = options
 
   const dialogPromise = page.waitForEvent('dialog', { timeout })
+
   // Start the triggering action but do NOT await it here: the click promise
   // stays pending until the dialog is handled, so awaiting now would deadlock.
-  const triggerPromise = Promise.resolve(trigger())
+  // A trigger that throws SYNCHRONOUSLY must not orphan the armed waitForEvent
+  // (its timeout rejection would otherwise surface ~15s later as an unhandled
+  // rejection attributed to an unrelated later test), so settle the listener
+  // before propagating.
+  let triggerPromise: Promise<unknown>
+  try {
+    triggerPromise = Promise.resolve(trigger())
+  } catch (syncError) {
+    dialogPromise.catch(() => {})
+    throw syncError
+  }
   // Swallow the trigger promise's rejection until we await it below, so a click
   // that fails before any dialog fires doesn't surface as an unhandled rejection
-  // while we're still waiting on `dialogPromise`.
+  // while we're still waiting on `dialogPromise`. (Attaching .catch creates a
+  // separate handled branch; the later `await triggerPromise` still rethrows.)
   triggerPromise.catch(() => {})
+
+  // Reject-only view of the trigger: if the trigger fails before any dialog
+  // fires, surface THAT error immediately instead of burning the dialog timeout
+  // and misdiagnosing it as a removed confirmation gate. A trigger that
+  // RESOLVES is deliberately not a race winner — on the happy path the click
+  // promise stays pending while the dialog is open, and a resolved trigger
+  // without a dialog still means "keep waiting for the dialog (or its timeout)".
+  let triggerError: unknown
+  let triggerRejected = false
+  const triggerRejection: Promise<never> = triggerPromise.then(
+    () => new Promise<never>(() => {}),
+    (error: unknown) => {
+      triggerRejected = true
+      triggerError = error
+      throw error
+    },
+  )
 
   let dialog: Dialog
   try {
-    dialog = await dialogPromise
+    dialog = await Promise.race([dialogPromise, triggerRejection])
   } catch {
+    if (triggerRejected) {
+      // The trigger's own failure is the root cause (strict-mode violation,
+      // renamed button, …). Settle the armed listener's eventual timeout
+      // rejection, then rethrow the trigger error verbatim.
+      dialogPromise.catch(() => {})
+      throw triggerError
+    }
     const wanted = [
       type ? `a '${type}'` : 'a',
       'dialog',

--- a/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-archive-recovery.spec.ts
@@ -13,6 +13,7 @@ import {
   registerUserSession,
   type AuthResult,
 } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 
 interface BoardDto {
@@ -174,8 +175,10 @@ test.describe('TST11-SC-012: Restore archived board', () => {
     await expect(boardRow).toBeVisible()
 
     // Accept the confirmation dialog
-    page.once('dialog', (dialog) => dialog.accept())
-    await boardRow.getByRole('button', { name: 'Restore Board' }).click()
+    await expectDialog(page, () => boardRow.getByRole('button', { name: 'Restore Board' }).click(), {
+      type: 'confirm',
+      message: /^Restore board "/,
+    })
 
     // Verify success toast
     await expect(page.getByText('Restored board')).toBeVisible()

--- a/frontend/taskdeck-web/tests/e2e/validation-automation-proposals.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-automation-proposals.spec.ts
@@ -1,6 +1,7 @@
 import type { APIRequestContext, Page } from '@playwright/test'
 import { expect, test } from '@playwright/test'
 import { API_BASE_URL, registerAndAttachSession, type AuthResult } from './support/authSession'
+import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import { assertOk } from './support/httpAsserts'
 import { pollUntil } from './support/polling'
@@ -141,8 +142,10 @@ test.describe('TST09 Proposal Lifecycle', () => {
     await expect(proposalCard.getByText('Approved, ready to apply')).toBeVisible()
 
     // Execute
-    page.once('dialog', (dialog) => dialog.accept())
-    await proposalCard.getByRole('button', { name: 'Apply to board' }).click()
+    await expectDialog(page, () => proposalCard.getByRole('button', { name: 'Apply to board' }).click(), {
+      type: 'confirm',
+      message: 'Apply this approved proposal to the board now?',
+    })
     await expect(proposalCard).not.toBeVisible()
 
     // Verify card now exists on the board


### PR DESCRIPTION
## What & why

17 pre-existing `page.once('dialog', (d) => d.accept())` handlers across the Playwright E2E suite accept a confirmation **if it appears** but do **not** fail when it is absent: the guarded action still fires and the test stays green, hiding a regression that drops a safety confirmation. This is the same silent-pass footgun #1362 fixed in its own two new lanes (commit `03ca77f8`); those call sites were tracked out to this issue rather than swept at the merge gate.

This PR replaces every remaining site with one shared helper that **fails loudly** when the expected dialog does not fire, and asserts each dialog's type (and, where the copy is stable, its message) so an unrelated dialog can't be accepted by mistake.

Closes #1382

## The helper — `tests/e2e/support/dialogs.ts`

`expectDialog(page, trigger, { type?, message?, accept?, promptText?, timeout? })`

- **Deterministic, not a sleep race.** Arms `page.waitForEvent('dialog')` **before** running `trigger`, then runs the trigger **without awaiting it** (Playwright keeps the click promise pending while a dialog is open, so awaiting up front would deadlock — the `Promise.all` trap called out in #1362). On the happy path `waitForEvent` resolves the instant the synchronous `confirm()`/`prompt()` fires; only the failure path consumes the bounded `timeout`, then throws a clear diagnostic. The trigger is awaited **after** the dialog is handled, so its post-dialog effects have settled before the caller asserts.
- **Order-safe under assertion failure.** Captures `type()`/`message()`, then accepts/dismisses and awaits the trigger **before** asserting — a failed assertion can never leave the dialog open (which would hang teardown) or the trigger promise pending.
- **Takes the trigger as a callback**, removing the deadlock footgun from every call site.

## 17-site inventory (all category (a): dialog REQUIRED by the flow)

Every site gates an **unconditional** `confirm()`/`prompt()` in source (`useReviewActions.handleExecuteProposal`, `useReviewActions.handleRejectProposal`, `BoardSettingsModal.handleLifecycleTransition`, `ArchiveView.handleRestoreBoard`), so there are **no** category (b) conditional or (c) defensive sites — each dialog provably fires or the flow is broken.

| # | Site (re-grepped) | Dialog source | Category | Treatment |
|---|---|---|---|---|
| 1 | `edge-journeys.spec.ts` reject lane | `handleRejectProposal` → `prompt('Optional rejection reason:')` | (a) | `type:'prompt'`, `message:/rejection reason/i` |
| 2 | `edge-journeys.spec.ts` apply lane | `handleExecuteProposal` confirm | (a) | `type:'confirm'`, exact apply msg |
| 3 | `validation-automation-proposals.spec.ts` apply | execute confirm | (a) | `type:'confirm'`, exact apply msg |
| 4 | `capture-loop.spec.ts` Legacy apply | execute confirm | (a) | `type:'confirm'`, exact apply msg |
| 5 | `multi-board.spec.ts` archive (delete-viewed) | `Archive "<board>"?…` confirm | (a) | `type:'confirm'`, `message:/^Archive "/` |
| 6 | `multi-board.spec.ts` archive (restore-sidebar) | archive confirm | (a) | `type:'confirm'`, `message:/^Archive "/` |
| 7 | `multi-board.spec.ts` restore | `Restore board "<board>"?` confirm | (a) | `type:'confirm'`, `message:/^Restore board "/` |
| 8 | `validation-archive-recovery.spec.ts` restore | restore confirm | (a) | `type:'confirm'`, `message:/^Restore board "/` |
| 9 | `automation-ops.spec.ts` apply | execute confirm | (a) | `type:'confirm'`, exact apply msg |
| 10 | `smoke.spec.ts` archive | archive confirm | (a) | `type:'confirm'`, `message:/^Archive "/` |
| 11 | `smoke.spec.ts` restore | restore confirm | (a) | `type:'confirm'`, `message:/^Restore board "/` |
| 12 | `first-run.spec.ts` Legacy apply | execute confirm | (a) | `type:'confirm'`, exact apply msg |
| 13 | `manual-audit.spec.ts` apply | execute confirm | (a) | `type:'confirm'`, exact apply msg |
| 14 | `integrated-verification.spec.ts` apply | execute confirm | (a) | `type:'confirm'`, exact apply msg |
| 15 | `integrated-verification.spec.ts` archive | archive confirm | (a) | `type:'confirm'`, `message:/^Archive "/` |
| 16 | `integrated-verification.spec.ts` restore | restore confirm | (a) | `type:'confirm'`, `message:/^Restore board "/` |
| 17 | `review-proposals.spec.ts` Paper apply | execute confirm (Paper reuses `useReviewActions`) | (a) | `type:'confirm'`, exact apply msg |

Exact apply msg = `Apply this approved proposal to the board now?` (fully stable → asserted with equality). Archive/restore/reject copy embeds a dynamic board name → asserted with a prefix RegExp.

Behavior of what each flow tests is unchanged — only the failure mode hardens.

## Verification

Isolated worktree runtime (`TASKDECK_E2E_FRONTEND_PORT=5273`, `TASKDECK_E2E_API_BASE_URL=http://localhost:5100/api`, `TASKDECK_E2E_DB=taskdeck.e2e.1382.db`, `--project=chromium`, `--workers=1`).

- `npm run typecheck` — pass (vue-tsc clean).
- `npm run lint` — pass (0 errors; 6 pre-existing warnings in untouched `src/views/Agent*.vue`, under the 20 cap).
- E2E (touched specs run): **27 passed** covering every dialog treatment variant:
  - `capture-loop.spec.ts` — 2 passed (execute confirm, Legacy + Paper lanes)
  - `edge-journeys.spec.ts` + `multi-board.spec.ts` + `integrated-verification.spec.ts` + `review-proposals.spec.ts` — 25 passed (execute confirm, archive confirm, restore confirm, reject prompt, Paper execute)
- Not run locally (heavy; identical mechanical helper substitution, covered by typecheck + lint + the behavioral proof above): `validation-automation-proposals.spec.ts`, `validation-archive-recovery.spec.ts`, `automation-ops.spec.ts`, `smoke.spec.ts`, `first-run.spec.ts`, `manual-audit.spec.ts` (the last is gated behind `TASKDECK_RUN_AUDIT=1`). CI runs the full suite.

### Negative proof (helper fails loudly when the gate is gone)

Temporarily overrode `window.confirm` to auto-return `true` (raising no native dialog — exactly the "confirmation removed" regression the old `page.once` handler silently passed) on the `capture-loop` Legacy apply site with `timeout:3000`, then reverted before committing. The test **failed**:

```
Error: expectDialog: expected a 'confirm' dialog matching "Apply this approved proposal to the board now?"
to appear within 3000ms after the triggering action, but none fired. The confirmation gate was likely
removed — the guarded action may have proceeded without it.
    at expectDialog (tests/e2e/support/dialogs.ts:84:11)
  1 failed
```

The old `page.once('dialog', d => d.accept())` shape would have stayed green through this same regression.

## Not verified

- The 6 untouched-by-run specs above (mechanical, same helper) — left to CI's full E2E run.
- No product/source changes; no docs changed (test-only slice).
