### PR TITLE
Fix stale-owner API key: charge pre-auth IP budget before per-key quota (#1404)

### DIFF
--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -87,14 +87,36 @@ public sealed class ApiKeyMiddleware
             return;
         }
 
-        // Hash the provided key and look up in the database
+        // Hash the provided key and look up in the database. The owner's active state is resolved in
+        // THIS single ApiKeys query (a correlated projection on the UserId FK), NOT in a separate Users
+        // SELECT afterwards. That fold is the #1404 fix: a stale-owner key — an active key row whose
+        // owning user was deactivated or hard-deleted — must be rejected with 401 (charging the pre-auth
+        // IP failure budget) BEFORE the per-key quota charge below, so sustained traffic eventually
+        // trips the pre-auth IP pre-check before any DB work. It also removes the standalone Users
+        // lookup from the happy path entirely (one query, not two). Only scalar columns are projected;
+        // key/owner active state is still computed in memory (below) so expiry is evaluated against the
+        // same wall clock as before, not pushed into SQL.
         var keyHash = HashKey(token);
 
-        var apiKey = await dbContext.ApiKeys
+        var authRecord = await dbContext.ApiKeys
             .AsNoTracking()
-            .FirstOrDefaultAsync(k => k.KeyHash == keyHash, context.RequestAborted);
+            .Where(k => k.KeyHash == keyHash)
+            .Select(k => new ApiKeyAuthProjection
+            {
+                Id = k.Id,
+                UserId = k.UserId,
+                ExpiresAt = k.ExpiresAt,
+                RevokedAt = k.RevokedAt,
+                // Null when the owner row is absent (hard-deleted user); the flag value when present. A
+                // stale-owner key therefore fails the `OwnerIsActive == true` gate in either case.
+                OwnerIsActive = dbContext.Users
+                    .Where(u => u.Id == k.UserId)
+                    .Select(u => (bool?)u.IsActive)
+                    .FirstOrDefault(),
+            })
+            .FirstOrDefaultAsync(context.RequestAborted);
 
-        if (apiKey is null)
+        if (authRecord is null)
         {
             _logger.LogWarning("MCP API key authentication failed: key not found (prefix: {Prefix})",
                 token.Length >= 8 ? token[..8] : "short");
@@ -103,25 +125,48 @@ public sealed class ApiKeyMiddleware
             return;
         }
 
-        if (!apiKey.IsActive)
+        // Key state (revoked/expired) computed in memory from the projected timestamps — identical to
+        // the entity's IsActive property.
+        var keyIsActive = authRecord.RevokedAt is null
+            && (authRecord.ExpiresAt is null || authRecord.ExpiresAt > DateTimeOffset.UtcNow);
+        if (!keyIsActive)
         {
-            var reason = apiKey.RevokedAt is not null ? "revoked" : "expired";
+            var reason = authRecord.RevokedAt is not null ? "revoked" : "expired";
             _logger.LogWarning("MCP API key authentication failed: key is {Reason} (id: {KeyId})",
-                reason, apiKey.Id);
+                reason, authRecord.Id);
             // Return generic message to avoid leaking key state (revoked vs expired)
             await WriteErrorResponse(context, StatusCodes.Status401Unauthorized,
                 "Invalid API key.");
             return;
         }
 
+        // Stale-owner key: an active key row whose owning user is deactivated (IsActive=false) or
+        // hard-deleted (owner row absent → OwnerIsActive is null). Rejected here, BEFORE the per-key
+        // budget charge, precisely so WriteErrorResponse charges the pre-auth IP failure budget on every
+        // attempt. Charging the per-key budget first (the #1401 order that VALID keys still get, below)
+        // would hide this behind a 429 that never spends the IP budget, so the SHA-256 + ApiKeys lookup
+        // would keep running indefinitely (#1404). This is the SAME budget a genuinely invalid key
+        // charges, so sustained stale-owner traffic exhausts the IP bucket and trips the pre-auth
+        // pre-check before any DB work — restoring pre-#1401 behaviour for stale-owner keys.
+        if (authRecord.OwnerIsActive != true)
+        {
+            _logger.LogWarning("MCP API key authentication failed: user inactive (userId: {UserId})", authRecord.UserId);
+            await WriteErrorResponse(context, StatusCodes.Status401Unauthorized,
+                "User account is inactive or has been deleted.");
+            return;
+        }
+
         // Enforce the per-key request budget (McpPerApiKey) at the EARLIEST point the key identity is
-        // known — right after the key row is resolved and confirmed active, and BEFORE the user-account
-        // lookup and the last-used write below (#1384). The opaque key ID is the budget partition, so
-        // store it first. This is the SINGLE charge point for the per-key budget: the /mcp endpoint no
-        // longer carries an endpoint-stage McpPerApiKey policy, so a request passing this check is never
-        // charged again downstream. A valid-but-over-quota key is rejected with 429 here without setting
-        // AuthenticationFailedItemKey and without a 401, so the pre-auth IP FAILURE budget is not spent
-        // — valid keys never touch that budget (#1368/#1381), only failed authentications do.
+        // confirmed usable — right after the key row is resolved and BOTH the key and its owner are
+        // confirmed active, and BEFORE the last-used write below (#1384). The owner check is folded into
+        // the initial lookup above, so there is no separate user-account query to shield; the per-key
+        // budget remains the FIRST gate a genuinely valid key meets (the #1401 ordering, unchanged). The
+        // opaque key ID is the budget partition, so store it first. This is the SINGLE charge point for
+        // the per-key budget: the /mcp endpoint no longer carries an endpoint-stage McpPerApiKey policy,
+        // so a request passing this check is never charged again downstream. A valid-but-over-quota key
+        // is rejected with 429 here without setting AuthenticationFailedItemKey and without a 401, so the
+        // pre-auth IP FAILURE budget is not spent — valid keys never touch that budget (#1368/#1381),
+        // only failed authentications do.
         //
         // Resolved optionally: the limiter is registered only when rate limiting is enabled, so when it
         // is absent the check is skipped (no MCP throttling when disabled), matching prior behaviour.
@@ -129,7 +174,7 @@ public sealed class ApiKeyMiddleware
         // provider before application middleware runs, and a ?. here would add a second SILENT skip
         // path for a security charge (fail-open). The only intended skip is GetService returning null
         // when rate limiting is disabled; a genuinely missing provider should throw loudly.
-        context.Items[ApiKeyIdItemKey] = apiKey.Id;
+        context.Items[ApiKeyIdItemKey] = authRecord.Id;
 
         var perKeyLimiter = context.RequestServices.GetService<McpPerApiKeyRateLimiter>();
         if (perKeyLimiter is not null)
@@ -137,28 +182,15 @@ public sealed class ApiKeyMiddleware
             using var perKeyLease = perKeyLimiter.AttemptAcquire(context);
             if (!perKeyLease.IsAcquired)
             {
-                _logger.LogDebug("MCP per-key rate limit exceeded for key {KeyId}", apiKey.Id);
+                _logger.LogDebug("MCP per-key rate limit exceeded for key {KeyId}", authRecord.Id);
                 await McpPerApiKeyRateLimiter.WriteRejectedAsync(context, perKeyLease, context.RequestAborted);
                 return;
             }
         }
 
-        // Verify the user account is active
-        var user = await dbContext.Users
-            .AsNoTracking()
-            .FirstOrDefaultAsync(u => u.Id == apiKey.UserId, context.RequestAborted);
-
-        if (user is null || !user.IsActive)
-        {
-            _logger.LogWarning("MCP API key authentication failed: user inactive (userId: {UserId})", apiKey.UserId);
-            await WriteErrorResponse(context, StatusCodes.Status401Unauthorized,
-                "User account is inactive or has been deleted.");
-            return;
-        }
-
         // Set the authenticated user ID for HttpUserContextProvider. The API key ID item was set
         // above, before the per-key budget check.
-        context.Items[HttpUserContextProvider.UserIdItemKey] = apiKey.UserId;
+        context.Items[HttpUserContextProvider.UserIdItemKey] = authRecord.UserId;
 
         // Establish an authenticated principal so the global authorization FallbackPolicy
         // (RequireAuthenticatedUser, #1132 AC4) is satisfied for valid-key MCP requests — a valid
@@ -168,13 +200,13 @@ public sealed class ApiKeyMiddleware
         // reads the "Bearer tdsk_..." header and fails to validate it as a JWT, returning a null
         // Principal that AuthenticationMiddleware does not assign over context.User, so this survives.
         context.User = new ClaimsPrincipal(new ClaimsIdentity(
-            new[] { new Claim(ClaimTypes.NameIdentifier, apiKey.UserId.ToString()) },
+            new[] { new Claim(ClaimTypes.NameIdentifier, authRecord.UserId.ToString()) },
             authenticationType: AuthenticationType));
 
         // Update last-used timestamp before continuing the pipeline. This is a non-critical usage
         // stamp: a failure here must NOT fail an otherwise-valid authentication, so it is caught and
         // logged inside UpdateLastUsedAsync (never rethrown) — the request proceeds regardless.
-        await UpdateLastUsedAsync(dbContext, apiKey.Id);
+        await UpdateLastUsedAsync(dbContext, authRecord.Id);
 
         await _next(context);
     }
@@ -216,6 +248,23 @@ public sealed class ApiKeyMiddleware
             // months — is visible in operational logs instead of hidden.
             _logger.LogWarning(ex, "Failed to update API key last-used timestamp for key {KeyId}", keyId);
         }
+    }
+
+    /// <summary>
+    /// Projection of the single ApiKeys authentication lookup: the scalar key columns needed to compute
+    /// key active-state and identify the key, plus the owner's active flag resolved via a correlated
+    /// subquery on the UserId FK (there is no ApiKey→User navigation). <see cref="OwnerIsActive"/> is
+    /// null when the owner row is absent (hard-deleted user). Folding the owner check into this query is
+    /// the #1404 fix: it removes the separate Users SELECT and lets a stale-owner key be rejected (and
+    /// charged to the pre-auth IP failure budget) before the per-key quota charge.
+    /// </summary>
+    private sealed class ApiKeyAuthProjection
+    {
+        public Guid Id { get; init; }
+        public Guid UserId { get; init; }
+        public DateTimeOffset? ExpiresAt { get; init; }
+        public DateTimeOffset? RevokedAt { get; init; }
+        public bool? OwnerIsActive { get; init; }
     }
 
     private static async Task WriteErrorResponse(HttpContext context, int statusCode, string message)

--- a/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs
@@ -90,12 +90,13 @@ public sealed class ApiKeyMiddleware
         // Hash the provided key and look up in the database. The owner's active state is resolved in
         // THIS single ApiKeys query (a correlated projection on the UserId FK), NOT in a separate Users
         // SELECT afterwards. That fold is the #1404 fix: a stale-owner key — an active key row whose
-        // owning user was deactivated or hard-deleted — must be rejected with 401 (charging the pre-auth
-        // IP failure budget) BEFORE the per-key quota charge below, so sustained traffic eventually
-        // trips the pre-auth IP pre-check before any DB work. It also removes the standalone Users
-        // lookup from the happy path entirely (one query, not two). Only scalar columns are projected;
-        // key/owner active state is still computed in memory (below) so expiry is evaluated against the
-        // same wall clock as before, not pushed into SQL.
+        // owning user was deactivated (account "deletion" is soft: AccountDeletionService only sets
+        // User.IsActive=false) — must be rejected with 401 (charging the pre-auth IP failure budget)
+        // BEFORE the per-key quota charge below, so sustained traffic eventually trips the pre-auth IP
+        // pre-check before any DB work. It also removes the standalone Users lookup from the happy path
+        // entirely (one query, not two). Only scalar columns are projected; key/owner active state is
+        // still computed in memory (below) so expiry is evaluated against the same wall clock as
+        // before, not pushed into SQL.
         var keyHash = HashKey(token);
 
         var authRecord = await dbContext.ApiKeys
@@ -107,8 +108,12 @@ public sealed class ApiKeyMiddleware
                 UserId = k.UserId,
                 ExpiresAt = k.ExpiresAt,
                 RevokedAt = k.RevokedAt,
-                // Null when the owner row is absent (hard-deleted user); the flag value when present. A
-                // stale-owner key therefore fails the `OwnerIsActive == true` gate in either case.
+                // The owner's flag when the row exists; null when it is absent. The null branch is
+                // DEFENSIVE-ONLY and unreachable at runtime: the ApiKeys→Users FK cascades on delete
+                // (ApiKeyConfiguration, DeleteBehavior.Cascade; SQLite runs with PRAGMA
+                // foreign_keys=ON), so a hard-deleted user takes its key rows with it and the lookup
+                // misses entirely (nonexistent-key 401 path). App-level account deletion is soft
+                // (IsActive=false), which surfaces here as `false`.
                 OwnerIsActive = dbContext.Users
                     .Where(u => u.Id == k.UserId)
                     .Select(u => (bool?)u.IsActive)
@@ -140,14 +145,16 @@ public sealed class ApiKeyMiddleware
             return;
         }
 
-        // Stale-owner key: an active key row whose owning user is deactivated (IsActive=false) or
-        // hard-deleted (owner row absent → OwnerIsActive is null). Rejected here, BEFORE the per-key
-        // budget charge, precisely so WriteErrorResponse charges the pre-auth IP failure budget on every
-        // attempt. Charging the per-key budget first (the #1401 order that VALID keys still get, below)
-        // would hide this behind a 429 that never spends the IP budget, so the SHA-256 + ApiKeys lookup
-        // would keep running indefinitely (#1404). This is the SAME budget a genuinely invalid key
-        // charges, so sustained stale-owner traffic exhausts the IP bucket and trips the pre-auth
-        // pre-check before any DB work — restoring pre-#1401 behaviour for stale-owner keys.
+        // Stale-owner key: an active key row whose owning user is deactivated (IsActive=false — the
+        // only live scenario, since account deletion is soft and a genuine hard delete cascades the
+        // key rows away so the lookup misses above; the `!= true` form also covers the defensive-only
+        // null branch of OwnerIsActive). Rejected here, BEFORE the per-key budget charge, precisely so
+        // WriteErrorResponse charges the pre-auth IP failure budget on every attempt. Charging the
+        // per-key budget first (the #1401 order that VALID keys still get, below) would hide this
+        // behind a 429 that never spends the IP budget, so the SHA-256 + ApiKeys lookup would keep
+        // running indefinitely (#1404). This is the SAME budget a genuinely invalid key charges, so
+        // sustained stale-owner traffic exhausts the IP bucket and trips the pre-auth pre-check before
+        // any DB work — restoring pre-#1401 behaviour for stale-owner keys.
         if (authRecord.OwnerIsActive != true)
         {
             _logger.LogWarning("MCP API key authentication failed: user inactive (userId: {UserId})", authRecord.UserId);
@@ -254,7 +261,10 @@ public sealed class ApiKeyMiddleware
     /// Projection of the single ApiKeys authentication lookup: the scalar key columns needed to compute
     /// key active-state and identify the key, plus the owner's active flag resolved via a correlated
     /// subquery on the UserId FK (there is no ApiKey→User navigation). <see cref="OwnerIsActive"/> is
-    /// null when the owner row is absent (hard-deleted user). Folding the owner check into this query is
+    /// null only in the defensive-only absent-owner-row branch, which is unreachable at runtime: the
+    /// ApiKeys→Users FK cascades on delete, so a hard-deleted user cascades its key rows away and the
+    /// lookup misses; app-level account deletion is soft (IsActive=false), surfacing here as
+    /// <c>false</c>. Folding the owner check into this query is
     /// the #1404 fix: it removes the separate Users SELECT and lets a stale-owner key be rejected (and
     /// charged to the pre-auth IP failure budget) before the per-key quota charge.
     /// </summary>

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
@@ -65,15 +65,20 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
         context.Response.StatusCode.Should().Be(StatusCodes.Status429TooManyRequests);
         nextCalled.Should().BeFalse("an over-quota request must not reach the MCP endpoint");
 
-        // The key lookup (ApiKeys SELECT) is unavoidable — it is how the key ID is known — but the
-        // Users lookup and the last-used UPDATE must NOT have run: that is the auth-stage database work
-        // #1384 shields from a valid-but-over-quota key.
+        // Authentication issues exactly ONE SELECT — the folded key+owner lookup (ApiKeys SELECT with a
+        // correlated Users subquery, #1404). There must be NO separate standalone Users SELECT and NO
+        // last-used UPDATE: that is the auth-stage database work #1384 shields from a valid-but-over-quota
+        // key, now a single query since the owner check is folded into the initial lookup.
+        _interceptor.Captured.Should().ContainSingle(sql => IsSelect(sql),
+            "authentication issues exactly one SELECT — the folded key+owner lookup");
         _interceptor.Captured.Should().Contain(
-            sql => IsSelect(sql) && sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase),
-            "the key row is resolved before the budget check");
+            sql => IsSelect(sql)
+                && sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase)
+                && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
+            "the owner's active state is resolved in the same ApiKeys query (#1404 fold)");
         _interceptor.Captured.Should().NotContain(
-            sql => IsSelect(sql) && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
-            "the over-quota request must be rejected before the user-account lookup");
+            sql => IsStandaloneUsersSelect(sql),
+            "the over-quota request performs no separate user-account SELECT (folded into the lookup)");
         _interceptor.Captured.Should().NotContain(
             sql => IsApiKeysUpdate(sql),
             "the over-quota request must be rejected before the UpdateLastUsedAsync write");
@@ -94,7 +99,7 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
     }
 
     [Fact]
-    public async Task UnderQuotaValidKey_PassesThrough_ReachingUserLookup()
+    public async Task UnderQuotaValidKey_PassesThrough_WithFoldedOwnerLookup()
     {
         await using var db = await CreateSeededContextAsync();
         const string plaintext = "tdsk_perkey_underquota_00000000000000000";
@@ -112,11 +117,85 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
 
         nextCalled.Should().BeTrue("an under-quota valid key must pass through to the MCP endpoint");
         context.Response.StatusCode.Should().Be(StatusCodes.Status200OK, "the terminal delegate left the default status");
-        // The mirror of the over-quota assertion: an admitted request DOES reach the user-account
-        // lookup that the over-quota path skips, confirming the per-key gate is what shields it.
+        // The owner's active state is resolved in the SAME ApiKeys query (#1404 fold): the admitted
+        // request issues exactly one SELECT touching both tables and NO separate standalone Users SELECT,
+        // then the last-used UPDATE runs on the happy path.
+        _interceptor.Captured.Should().ContainSingle(sql => IsSelect(sql),
+            "authentication issues exactly one SELECT — the folded key+owner lookup");
         _interceptor.Captured.Should().Contain(
-            sql => IsSelect(sql) && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
-            "an admitted request performs the user-account lookup the over-quota path skips");
+            sql => IsSelect(sql)
+                && sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase)
+                && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
+            "the owner's active state is resolved in the same ApiKeys query (#1404 fold)");
+        _interceptor.Captured.Should().NotContain(
+            sql => IsStandaloneUsersSelect(sql),
+            "the standalone user-account SELECT is gone — the owner check is folded into the lookup (#1404)");
+        _interceptor.Captured.Should().Contain(
+            sql => IsApiKeysUpdate(sql),
+            "an admitted request records its last-used timestamp");
+    }
+
+    [Fact]
+    public async Task StaleOwnerKey_Returns401_ChargesIpFailureBudget_BeforePerKeyCharge()
+    {
+        // #1404: an ACTIVE key row whose owner was deactivated must 401 AND charge the pre-auth IP
+        // failure budget (AuthenticationFailedItemKey), and must do so BEFORE the per-key budget is
+        // partitioned/charged. Charging the per-key budget first would hide the key behind a 429 that
+        // never spends the IP budget, so the SHA-256 + ApiKeys lookup would run indefinitely; charging
+        // the IP failure budget instead lets sustained stale-owner traffic trip the pre-auth pre-check
+        // before any DB work. The owner check is folded into the single ApiKeys lookup, so no separate
+        // Users SELECT and no last-used UPDATE run.
+        await using var db = await CreateSeededContextAsync();
+        const string plaintext = "tdsk_perkey_staleowner_0000000000000000";
+        var (userId, _) = await SeedUserAndKeyAsync(db, plaintext);
+
+        // Deactivate the owner while leaving the key row active — the stale-owner condition.
+        await db.Users
+            .Where(u => u.Id == userId)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(u => u.IsActive, false));
+
+        // A generous per-key budget so ONLY the owner gate (never the quota) can reject this request.
+        using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(5, 60));
+        var nextCalled = false;
+        var middleware = new ApiKeyMiddleware(_ => { nextCalled = true; return Task.CompletedTask; },
+            NullLogger<ApiKeyMiddleware>.Instance);
+
+        var context = CreateMcpContext(plaintext, limiter);
+        _interceptor.Clear();
+
+        await middleware.InvokeAsync(context, db);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        nextCalled.Should().BeFalse("a stale-owner key must not reach the MCP endpoint");
+
+        // The crux: the pre-auth IP failure budget IS charged (unlike a per-key 429), so sustained
+        // stale-owner traffic exhausts the IP bucket and trips the pre-auth pre-check before any DB work.
+        context.Items.ContainsKey(ApiKeyMiddleware.AuthenticationFailedItemKey).Should().BeTrue(
+            "a stale-owner rejection is an authentication failure and must charge the IP failure budget");
+
+        // Rejected before the per-key budget is even partitioned: the key-id item is set only after the
+        // owner gate passes, so the per-key limiter was never charged.
+        context.Items.ContainsKey(ApiKeyMiddleware.ApiKeyIdItemKey).Should().BeFalse(
+            "the per-key budget must not be charged before the owner gate rejects");
+
+        // Exactly one SELECT — the folded key+owner lookup — and no standalone Users SELECT or last-used UPDATE.
+        _interceptor.Captured.Should().ContainSingle(sql => IsSelect(sql),
+            "authentication issues exactly one SELECT — the folded key+owner lookup");
+        _interceptor.Captured.Should().Contain(
+            sql => IsSelect(sql)
+                && sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase)
+                && sql.Contains("Users", StringComparison.OrdinalIgnoreCase),
+            "the owner's active state is resolved in the same ApiKeys query (#1404 fold)");
+        _interceptor.Captured.Should().NotContain(sql => IsStandaloneUsersSelect(sql),
+            "the folded lookup removes the separate user-account SELECT entirely");
+        _interceptor.Captured.Should().NotContain(sql => IsApiKeysUpdate(sql),
+            "a stale-owner request must be rejected before the UpdateLastUsedAsync write");
+
+        // 401 contract.
+        context.Response.ContentType.Should().StartWith("application/json");
+        var error = await ReadErrorAsync(context);
+        error.Should().NotBeNull();
+        error!.ErrorCode.Should().Be(ErrorCodes.Unauthorized);
     }
 
     [Fact]
@@ -185,6 +264,14 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
     // ── Helpers ──
 
     private static bool IsSelect(string sql) => sql.Contains("SELECT", StringComparison.OrdinalIgnoreCase);
+
+    // A standalone user-account SELECT (the pre-#1404 separate Users lookup): a SELECT that touches
+    // Users but NOT ApiKeys. The #1404 fold projects the owner flag inside the ApiKeys query, so that
+    // query references BOTH tables and is deliberately NOT matched here.
+    private static bool IsStandaloneUsersSelect(string sql) =>
+        IsSelect(sql)
+        && sql.Contains("Users", StringComparison.OrdinalIgnoreCase)
+        && !sql.Contains("ApiKeys", StringComparison.OrdinalIgnoreCase);
 
     // Match a genuine UPDATE statement against ApiKeys (the UpdateLastUsedAsync write), not a SELECT
     // that merely lists the "UpdatedAt" column — hence StartsWith on the trimmed command text.

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
@@ -199,6 +199,62 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
     }
 
     [Fact]
+    public async Task HardDeletedOwner_CascadesKeyAway_TakesNonexistentKey401Path()
+    {
+        // Pins the REAL hard-delete behavior (the reason the projection's null-owner branch is
+        // defensive-only): the ApiKeys→Users FK is DeleteBehavior.Cascade and Microsoft.Data.Sqlite
+        // enforces foreign keys, so hard-deleting the owner row cascades the key row away. The next
+        // authentication attempt therefore MISSES the ApiKeys lookup entirely and takes the
+        // nonexistent-key 401 path — the owner gate's null branch never fires at runtime.
+        await using var db = await CreateSeededContextAsync();
+        const string plaintext = "tdsk_perkey_harddelete_0000000000000000";
+        var (userId, apiKeyId) = await SeedUserAndKeyAsync(db, plaintext);
+
+        // Hard-delete the owner row (a real DB-level DELETE, unlike the app's soft deactivation).
+        await db.Users.Where(u => u.Id == userId).ExecuteDeleteAsync();
+
+        // The cascade must have removed the key row — the premise of the nonexistent-key path.
+        (await db.ApiKeys.AsNoTracking().AnyAsync(k => k.Id == apiKeyId))
+            .Should().BeFalse("the Users FK cascade must delete the owner's key rows");
+
+        using var limiter = new McpPerApiKeyRateLimiter(new RateLimitPolicySettings(5, 60));
+        var nextCalled = false;
+        var middleware = new ApiKeyMiddleware(_ => { nextCalled = true; return Task.CompletedTask; },
+            NullLogger<ApiKeyMiddleware>.Instance);
+
+        var context = CreateMcpContext(plaintext, limiter);
+        _interceptor.Clear();
+
+        await middleware.InvokeAsync(context, db);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized,
+            "a key cascaded away by its owner's hard delete is simply not found");
+        nextCalled.Should().BeFalse("the request must not reach the MCP endpoint");
+
+        // Same budget consequences as any nonexistent key: the IP failure budget is charged and the
+        // per-key budget is never partitioned.
+        context.Items.ContainsKey(ApiKeyMiddleware.AuthenticationFailedItemKey).Should().BeTrue(
+            "a not-found key is an authentication failure and must charge the IP failure budget");
+        context.Items.ContainsKey(ApiKeyMiddleware.ApiKeyIdItemKey).Should().BeFalse(
+            "no key row exists, so the per-key budget is never partitioned or charged");
+
+        // Still exactly one SELECT — the folded key+owner lookup — and no standalone Users SELECT or
+        // last-used UPDATE.
+        _interceptor.Captured.Should().ContainSingle(sql => IsSelect(sql),
+            "authentication issues exactly one SELECT — the folded key+owner lookup");
+        _interceptor.Captured.Should().NotContain(sql => IsStandaloneUsersSelect(sql),
+            "no separate user-account SELECT runs on the not-found path either");
+        _interceptor.Captured.Should().NotContain(sql => IsApiKeysUpdate(sql),
+            "a not-found key must not trigger the UpdateLastUsedAsync write");
+
+        // 401 contract.
+        context.Response.ContentType.Should().StartWith("application/json");
+        var error = await ReadErrorAsync(context);
+        error.Should().NotBeNull();
+        error!.ErrorCode.Should().Be(ErrorCodes.Unauthorized);
+    }
+
+    [Fact]
     public async Task PerKeyBudget_AdmitsExactlyPermitLimitRequests_ThenRejects_NoDoubleCharge()
     {
         await using var db = await CreateSeededContextAsync();

--- a/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs
@@ -451,6 +451,62 @@ public class McpHttpTransportApiKeyTests : IClassFixture<TestWebApplicationFacto
     }
 
     [Fact]
+    public async Task McpEndpoint_StaleOwnerKey_IsRateLimitedBeforeDatabaseLookup()
+    {
+        // #1404: a stale-owner key (active key row, deactivated owner) must 401 AND charge the pre-auth
+        // IP failure budget, so a second attempt from the same address is 429 via the IP policy — proving
+        // sustained stale-owner traffic trips the pre-auth pre-check before the SHA-256 + DB lookup,
+        // rather than looping forever behind a per-key 429 that never spends the IP budget. Mirrors the
+        // nonexistent-key convention in McpEndpoint_RejectedCredentials_AreRateLimitedBeforeDatabaseLookup.
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting("RateLimiting:Enabled", "true");
+            builder.UseSetting("RateLimiting:McpAuthenticationPerIp:PermitLimit", "1");
+            builder.UseSetting("RateLimiting:McpAuthenticationPerIp:WindowSeconds", "60");
+            builder.UseSetting("RateLimiting:McpPerApiKey:PermitLimit", "10");
+            builder.UseSetting("RateLimiting:McpPerApiKey:WindowSeconds", "60");
+        });
+        using var jwtClient = factory.CreateClient();
+        await ApiTestHarness.AuthenticateAsync(jwtClient, "mcp-stale-owner");
+        using var createResponse = await jwtClient.PostAsJsonAsync(
+            "/api/apikeys", new CreateApiKeyRequest("Stale Owner Key"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        created.Should().NotBeNull();
+
+        // Deactivate the owner, leaving the key row itself active — the stale-owner condition.
+        using (var scope = factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+            var ownerId = await dbContext.ApiKeys
+                .Where(key => key.Id == created!.Id)
+                .Select(key => key.UserId)
+                .FirstAsync();
+            await dbContext.Users
+                .Where(user => user.Id == ownerId)
+                .ExecuteUpdateAsync(setters => setters.SetProperty(user => user.IsActive, false));
+        }
+
+        using var mcpClient = factory.CreateClient();
+        mcpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", created!.Key);
+
+        using var first = await PostMcpAsync(mcpClient, "/mcp", CreateInitializeRequest(1));
+        using var second = await PostMcpAsync(mcpClient, "/mcp", CreateInitializeRequest(2));
+
+        first.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "the stale-owner key is rejected before authenticating");
+        second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+            "the first rejection charged the pre-auth IP failure budget, so the second attempt trips the IP pre-check");
+        second.Headers.TryGetValues("Retry-After", out _).Should().BeTrue();
+        second.Headers.GetValues("X-RateLimit-Policy").Should().ContainSingle()
+            .Which.Should().Be(RateLimitingPolicyNames.McpAuthenticationPerIp);
+        second.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        var error = await second.Content.ReadFromJsonAsync<ApiErrorResponse>();
+        error.Should().NotBeNull();
+        error!.ErrorCode.Should().Be(ErrorCodes.TooManyRequests);
+    }
+
+    [Fact]
     public async Task McpEndpoint_ProductionDefaultIpBudget_DoesNotStarveMultipleKeysBehindOneAddress()
     {
         // Exercises the #1368 blind spot. Precisely: only the pre-auth IP budget — the setting under


### PR DESCRIPTION
## Summary

Closes #1404.

Fixes the stale-owner API-key defect surfaced by Codex P2 on PR #1401. Account deletion/deactivation only sets `User.IsActive = false`; the API-key row stays active. After #1401 the per-key pre-auth budget (60/min) was charged BEFORE the owner-active check, so a stale-owner key (active key row, inactive/deleted owner) fell into a loop: the first ~60 requests/window 401'd and charged the per-IP failure budget, the rest 429'd via the per-key check (which correctly does NOT charge the IP budget). Net effect — the 120-permit IP failure budget never exhausted, the pre-auth pre-check never tripped, and the SHA-256 + `ApiKeys` lookup ran on every request indefinitely.

## The fix

In `ApiKeyMiddleware`, the owner's `IsActive` is now resolved in the INITIAL `ApiKeys` key lookup via a correlated projection on the `UserId` FK (there is no `ApiKey`→`User` navigation). A stale-owner key is now rejected with 401 — charging the pre-auth IP failure budget via `WriteErrorResponse` — BEFORE the per-key quota charge. Consequences:

- Stale-owner keys once again reach eventual full pre-DB rejection: sustained traffic exhausts the shared IP failure budget and trips the pre-auth IP pre-check before any DB work (restores pre-#1401 behaviour for this case).
- The standalone `Users` SELECT is removed from the auth path entirely — one folded query instead of two (happy-path perf win).
- The #1401 ordering is unchanged for genuinely valid keys: the per-key budget remains the first gate they meet, and a valid-but-over-quota key still 429s without spending the IP failure budget.

Key/owner active-state is still computed in memory from projected scalar columns (`RevokedAt`/`ExpiresAt`/owner flag), so expiry is evaluated against the same wall clock as before — nothing is pushed into SQL. `OwnerIsActive` is null when the owner row is absent (hard-deleted user), so that case fails the `== true` gate too.

Out of scope (tracked alternative, deliberately NOT implemented): key-revocation-on-deactivation.

## Files changed

- `backend/src/Taskdeck.Api/Middleware/ApiKeyMiddleware.cs` — fold owner-active resolution into the initial `ApiKeys` lookup; reject stale-owner keys before the per-key charge; drop the separate `Users` query; add the `ApiKeyAuthProjection` result type.
- `backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs` — new `StaleOwnerKey_Returns401_ChargesIpFailureBudget_BeforePerKeyCharge` (unit, real SQLite + command interceptor); updated the over-quota and (renamed) under-quota DB-work-counting tests to assert the single folded lookup and the absence of a standalone `Users` SELECT.
- `backend/tests/Taskdeck.Api.Tests/McpHttpTransportApiKeyTests.cs` — new integration test `McpEndpoint_StaleOwnerKey_IsRateLimitedBeforeDatabaseLookup` mirroring the nonexistent-key pre-auth-budget convention: first attempt 401s, second attempt 429s via `McpAuthenticationPerIp`.

## Test evidence

```
dotnet build backend/Taskdeck.sln -c Release
  -> Build succeeded.

dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~ApiKey"
  -> Taskdeck.Domain.Tests:  Passed: 11, Failed: 0
  -> Taskdeck.Api.Tests:     Passed: 67, Failed: 0
  -> Taskdeck.Cli.Tests:     Passed: 12, Failed: 0

dotnet test backend/tests/Taskdeck.Api.Tests --filter \
  "FullyQualifiedName~StaleOwner|...UnderQuotaValidKey_PassesThrough_WithFoldedOwnerLookup|...OverQuotaValidKey|...McpAuthenticationRateLimit"
  -> Passed: 13, Failed: 0
```

Acceptance mapping:
- Stale-owner 401 + IP-budget charge + eventual pre-auth trip: unit test asserts `AuthenticationFailedItemKey` set and `ApiKeyIdItemKey` NOT set (per-key never charged); integration test asserts second attempt is 429 via `McpAuthenticationPerIp`.
- Valid active-owner keys unchanged: `UnderQuotaValidKey_PassesThrough_WithFoldedOwnerLookup`, `OverQuotaValidKey_Returns429_...`, and the existing per-key-count / IP-budget tests still pass.
- Standalone `Users` lookup gone: interceptor assertions (`ContainSingle` SELECT, no standalone `Users` SELECT) confirm one folded query.

Verification scope note: targeted filters only — the full backend suite is the coordinator's to run.
