### PR TITLE
Run apply's read-safe permission gates at diff time (#1398)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -38,15 +38,21 @@ public class AutomationProposalService : IAutomationProposalService
     private readonly IUnitOfWork _unitOfWork;
     private readonly INotificationService _notificationService;
     private readonly IProposalProvenanceRepository? _provenanceRepository;
+    private readonly IAutomationPolicyEngine _policyEngine;
 
     public AutomationProposalService(
         IUnitOfWork unitOfWork,
         INotificationService? notificationService = null,
-        IProposalProvenanceRepository? provenanceRepository = null)
+        IProposalProvenanceRepository? provenanceRepository = null,
+        IAutomationPolicyEngine? policyEngine = null)
     {
         _unitOfWork = unitOfWork;
         _notificationService = notificationService ?? NoOpNotificationService.Instance;
         _provenanceRepository = provenanceRepository;
+        // Fall back to a plain engine over the same unit of work when DI does not supply one
+        // (direct construction in tests). The engine is stateless apart from _unitOfWork, so
+        // the fallback runs the identical read-safe permission gates the injected one does.
+        _policyEngine = policyEngine ?? new AutomationPolicyEngine(unitOfWork);
     }
 
     public async Task<Result<ProposalDto>> CreateProposalAsync(CreateProposalDto dto, CancellationToken cancellationToken = default)
@@ -414,8 +420,15 @@ public class AutomationProposalService : IAutomationProposalService
             if (!revisedExpiryValidation.IsSuccess)
                 return Result.Failure<string>(revisedExpiryValidation.ErrorCode, revisedExpiryValidation.ErrorMessage);
 
-            var revisedValidation = await ProposalOperationContractValidator.ValidateAsync(
-                _unitOfWork,
+            // Apply runs AutomationPolicyEngine.ValidatePermissionsAsync AFTER the policy gate
+            // (requester exists → 404, board exists → 404, requester board access → 403), and it
+            // ends by running the same operation-contract validation. Call that same engine method
+            // here so a proposal whose requester lost board access, or whose board/requester was
+            // deleted mid-review, cannot preview a clean diff and then fail Apply after approval
+            // (#1398 preview == apply). Ordering (structure → expiry → permissions+contract) matches
+            // Apply's ValidatePolicy-then-ValidatePermissionsAsync sequence exactly.
+            var revisedValidation = await _policyEngine.ValidatePermissionsAsync(
+                proposal.RequestedByUserId,
                 proposal.BoardId,
                 revisedOperations,
                 cancellationToken);
@@ -456,8 +469,15 @@ public class AutomationProposalService : IAutomationProposalService
         if (!expiryValidation.IsSuccess)
             return Result.Failure<string>(expiryValidation.ErrorCode, expiryValidation.ErrorMessage);
 
-        var originalValidation = await ProposalOperationContractValidator.ValidateAsync(
-            _unitOfWork,
+        // Apply runs AutomationPolicyEngine.ValidatePermissionsAsync AFTER the policy gate
+        // (requester exists → 404, board exists → 404, requester board access → 403), then the
+        // same operation-contract validation. Call that same engine method here — ahead of the
+        // cached-DiffPreview fast path below — so a revoked-access or deleted-board/requester
+        // proposal cannot preview a clean diff (even a stored one) and then fail Apply after
+        // approval (#1398 preview == apply). Structure → expiry → permissions+contract mirrors
+        // Apply's ValidatePolicy-then-ValidatePermissionsAsync order exactly.
+        var originalValidation = await _policyEngine.ValidatePermissionsAsync(
+            proposal.RequestedByUserId,
             proposal.BoardId,
             originalOperations,
             cancellationToken);

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
+using Taskdeck.Application.Tests.TestUtilities;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Enums;
@@ -18,6 +19,9 @@ public class AutomationProposalServiceTests
     private readonly Mock<INotificationService> _notificationServiceMock;
     private readonly Mock<IProposalProvenanceRepository> _provenanceRepoMock;
     private readonly Mock<IProposalRevisionRepository> _revisionRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly Mock<IBoardRepository> _boardRepoMock;
+    private readonly Mock<IBoardAccessRepository> _boardAccessRepoMock;
     private readonly AutomationProposalService _service;
 
     public AutomationProposalServiceTests()
@@ -27,9 +31,15 @@ public class AutomationProposalServiceTests
         _notificationServiceMock = new Mock<INotificationService>();
         _provenanceRepoMock = new Mock<IProposalProvenanceRepository>();
         _revisionRepoMock = new Mock<IProposalRevisionRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _boardRepoMock = new Mock<IBoardRepository>();
+        _boardAccessRepoMock = new Mock<IBoardAccessRepository>();
 
         _unitOfWorkMock.Setup(u => u.AutomationProposals).Returns(_proposalRepoMock.Object);
         _unitOfWorkMock.Setup(u => u.ProposalRevisions).Returns(_revisionRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Boards).Returns(_boardRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.BoardAccesses).Returns(_boardAccessRepoMock.Object);
         // Default: no saved revision, so GetProposalDiffAsync uses the original path.
         // The revision-aware test overrides this per-proposal.
         _revisionRepoMock
@@ -38,6 +48,20 @@ public class AutomationProposalServiceTests
         _notificationServiceMock
             .Setup(s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), default))
             .ReturnsAsync(Result.Success(true));
+        // Diff now runs the same read-safe permission gates Apply runs
+        // (AutomationPolicyEngine.ValidatePermissionsAsync): requester exists, board exists,
+        // requester has board access. Default them to PASS so healthy-path diff tests reach
+        // their intended gate; the #1398 parity tests below override these to revoke access
+        // or delete the board/requester.
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User("difftester", "diff@example.com", "hashedPassword"));
+        _boardRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestDataBuilder.CreateBoard());
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         _service = new AutomationProposalService(
             _unitOfWorkMock.Object,
@@ -1943,6 +1967,209 @@ public class AutomationProposalServiceTests
         result.IsSuccess.Should().BeFalse();
         result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
         result.ErrorMessage.Should().Be("Proposal has expired");
+    }
+
+    // A non-expired, single-operation proposal used by the #1398 permission-parity tests
+    // below. It passes the structure and expiry gates so execution reaches the permission
+    // gate (requester exists → board exists → board access) that Apply runs via
+    // AutomationPolicyEngine.ValidatePermissionsAsync.
+    private static AutomationProposal BuildPermissionGateProposal(Guid requesterId, Guid boardId)
+    {
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            requesterId,
+            "Create card",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { title = "Task", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", parameters, Guid.NewGuid().ToString()));
+
+        return proposal;
+    }
+
+    // Mirrors BuildPermissionGateProposal's operation as the DTO list Apply feeds to
+    // AutomationPolicyEngine.ValidatePermissionsAsync, so the same permission result can be
+    // computed against the shared mocks and asserted identical to the diff-preview result.
+    private static List<ProposalOperationDto> BuildPermissionGateApplyOperations(Guid proposalId, Guid boardId)
+        => new()
+        {
+            new ProposalOperationDto(
+                Guid.NewGuid(),
+                proposalId,
+                0,
+                "create",
+                "card",
+                null,
+                System.Text.Json.JsonSerializer.Serialize(new { title = "Task", boardId }),
+                Guid.NewGuid().ToString(),
+                null)
+        };
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectRevokedBoardAccess_MatchingApplyPermissionGate()
+    {
+        // #1398 third preview/apply asymmetry: Apply runs ValidatePermissionsAsync after the
+        // policy gate, so a proposal whose requester lost board access mid-review is rejected
+        // 403 at Apply. The diff path never ran that gate, previewing a clean 200 and then
+        // failing after approval. Preview now runs the same gate: preview == apply (403).
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // Requester exists and the board exists (constructor defaults), but access is revoked.
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act (preview)
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+
+        // Act (apply-side permission gate) on the equivalent operation DTOs.
+        var applyResult = await new AutomationPolicyEngine(_unitOfWorkMock.Object).ValidatePermissionsAsync(
+            requesterId, boardId, BuildPermissionGateApplyOperations(proposalId, boardId));
+
+        // Assert: preview rejects, and rejects identically to Apply (403, same message).
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        previewResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectDeletedBoard_MatchingApplyPermissionGate()
+    {
+        // #1398: a proposal whose board was deleted mid-review is rejected 404 at Apply
+        // (ValidatePermissionsAsync board-existence gate). Preview now runs the same gate.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // Board no longer exists (overrides the constructor default for this board id).
+        _boardRepoMock
+            .Setup(r => r.GetByIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Board?)null);
+
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+        var applyResult = await new AutomationPolicyEngine(_unitOfWorkMock.Object).ValidatePermissionsAsync(
+            requesterId, boardId, BuildPermissionGateApplyOperations(proposalId, boardId));
+
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.NotFound);
+
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        previewResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectDeletedRequester_MatchingApplyPermissionGate()
+    {
+        // #1398: a proposal whose requester (user) was deleted mid-review is rejected 404 at
+        // Apply (ValidatePermissionsAsync user-existence gate). Preview now runs the same gate.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // Requester no longer exists (overrides the constructor default for this user id).
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(requesterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+        var applyResult = await new AutomationPolicyEngine(_unitOfWorkMock.Object).ValidatePermissionsAsync(
+            requesterId, boardId, BuildPermissionGateApplyOperations(proposalId, boardId));
+
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.NotFound);
+
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        previewResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldEnforcePermissionGate_EvenWithStoredPreview()
+    {
+        // #1398, cached-preview fast path (the #1376 lesson): a proposal carrying a stored
+        // DiffPreview whose requester lost board access previously previewed 200 with that
+        // stale preview, then failed Apply 403. The permission gate now runs BEFORE the cached
+        // preview return, so preview == apply (403) and the stored preview is NOT surfaced.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+        proposal.SetDiffPreview("0. Create card \"Task\"");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        // Assert: the cached preview is NOT returned; the permission rejection is.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldEnforcePermissionGate_OnRevisedPath()
+    {
+        // #1398 on the revision-aware path: Apply materializes the latest revision and still
+        // runs ValidatePermissionsAsync (requester board access). A revised proposal whose
+        // requester lost access is rejected 403 at Apply; the revised diff path now runs the
+        // same gate rather than rendering the revised diff cleanly.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            requesterId,
+            "Create card",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+
+        var revisedParams = System.Text.Json.JsonSerializer.Serialize(new { title = "Revised card", boardId });
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "create",
+                    targetType = "card",
+                    parameters = revisedParams,
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default)).ReturnsAsync(revision);
+
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
     }
 
     #endregion

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -2172,6 +2172,130 @@ public class AutomationProposalServiceTests
         result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
     }
 
+    // The REAL Apply trust boundary over the same shared mocks: a concrete
+    // AutomationExecutorService wired with the real proposal service under test and a real
+    // AutomationPolicyEngine (no mocked gates). Parity tests drive this instead of calling
+    // the engine method directly, so they fail if the executor's gate sequence ever diverges
+    // from what the diff path mirrors — not just if the shared engine changes (#1413 LOW-3).
+    private AutomationExecutorService BuildRealApplyExecutor()
+        => new(
+            _unitOfWorkMock.Object,
+            _service,
+            new AutomationPolicyEngine(_unitOfWorkMock.Object),
+            new CardService(_unitOfWorkMock.Object),
+            new BoardService(_unitOfWorkMock.Object),
+            new ColumnService(_unitOfWorkMock.Object));
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldMatchRealApplyExecutor_WhenBoardAccessRevoked()
+    {
+        // #1413 LOW-3: the ...MatchingApplyPermissionGate tests above compare preview against
+        // the same engine method the service delegates to, so they cannot detect the REAL
+        // Apply path diverging. This test drives AutomationExecutorService.ExecuteProposalAsync
+        // end-to-end on an APPROVED, non-terminal, non-expired proposal over the same fixture
+        // state (requester board access revoked) and asserts the diff rejection is
+        // code-and-message identical to the executor's rejection.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+        proposal.Approve(Guid.NewGuid());
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act: preview, then the real Apply boundary.
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+        var applyResult = await BuildRealApplyExecutor()
+            .ExecuteProposalAsync(proposalId, Guid.NewGuid().ToString());
+
+        // Assert: the real executor rejects 403 at its permission gate, and preview rejects
+        // identically — code AND message.
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        previewResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldRejectRevokedAccess_ForTerminalAppliedProposal()
+    {
+        // #1413 LOW-1 behavior-change pin: for a TERMINAL Applied proposal whose requester
+        // later lost board access, diff previously returned the stored preview (200); it now
+        // returns 403. This is INTENDED: Apply short-circuits terminal status to idempotent
+        // success BEFORE its permission gate, so preview is deliberately stricter than Apply's
+        // terminal no-op — a revoked reviewer can no longer read board contents through a
+        // terminal proposal's diff. Coherent with the #1397 maintainer decision (frontend
+        // stops firing live diffs for terminal items). Both sides are pinned here so any
+        // future drift in either direction fails this test.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+        proposal.SetDiffPreview("0. Create card \"Task\"");
+        proposal.Approve(Guid.NewGuid());
+        proposal.MarkAsApplied();
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+        var applyResult = await BuildRealApplyExecutor()
+            .ExecuteProposalAsync(proposalId, Guid.NewGuid().ToString());
+
+        // Assert: preview rejects 403 (stored preview NOT surfaced) while the real Apply
+        // boundary short-circuits the already-applied proposal to idempotent success.
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        previewResult.Value.Should().BeNull();
+
+        applyResult.IsSuccess.Should().BeTrue(applyResult.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetProposalDiffAsync_ShouldReportExpiry_NotForbidden_WhenExpiredAndAccessRevoked()
+    {
+        // #1413 LOW-4 gate-ordering pin: a proposal that is BOTH expired AND has revoked
+        // requester access must fail with the expiry ValidationError — not Forbidden — from
+        // BOTH trust boundaries, because both run structure → expiry (ValidatePolicy order)
+        // BEFORE the permission gate. If either side ever reorders permissions ahead of
+        // structure/expiry, its error flips to Forbidden and this test fails on that side.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+        // Approve while still valid (the domain forbids approving an expired proposal),
+        // then force expiry — mirrors a proposal that expired after approval.
+        proposal.Approve(Guid.NewGuid());
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var previewResult = await _service.GetProposalDiffAsync(proposalId);
+        var applyResult = await BuildRealApplyExecutor()
+            .ExecuteProposalAsync(proposalId, Guid.NewGuid().ToString());
+
+        // Assert: BOTH sides report the expiry ValidationError, never Forbidden.
+        previewResult.IsSuccess.Should().BeFalse();
+        previewResult.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        previewResult.ErrorMessage.Should().Be("Proposal has expired");
+
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(previewResult.ErrorCode);
+        applyResult.ErrorMessage.Should().Be(previewResult.ErrorMessage);
+    }
+
     #endregion
 
     #region GetProposalsAsync Tests


### PR DESCRIPTION
Closes #1398

## Summary

Third preview/apply asymmetry from the #1395 round-2 parity review. PR #1395 (#1376) made the proposal diff path run Apply's structure + expiry gates (`AutomationPolicyEngine.ValidatePolicy`) at diff time. One gate still only ran at Apply: `AutomationExecutorService` runs `AutomationPolicyEngine.ValidatePermissionsAsync` **after** the policy gate, enforcing requester board access (→ 403), board existence (→ 404), and requester (user) existence (→ 404). None of these ran in `GetProposalDiffAsync`.

Scenario closed: a reviewer's board access is revoked, or the board/requester is deleted mid-review → the diff previewed a clean 200, then Apply failed 403/404 after approval — the preview-then-apply-fails trust violation.

## Fix

In `AutomationProposalService.GetProposalDiffAsync`, both diff paths (revised-payload path and original-operations path) now call the **same** engine method Apply calls — `_policyEngine.ValidatePermissionsAsync(requesterId, boardId, operations, ct)` — in place of the standalone contract-validation call. `ValidatePermissionsAsync` runs the read-safe requester-exists / board-exists / board-access gates and then the same operation-contract validation it always ran, so there is no logic duplication and the gates cannot drift.

- Ordering matches Apply exactly: structure → expiry (inline, mirroring `ValidatePolicy`) → `ValidatePermissionsAsync` (requester → board → access → contract).
- The permission call is placed **before** the cached-`DiffPreview` fast-path return, so a stored preview cannot bypass the gate (the #1376 cached-path lesson).
- `AutomationProposalService` now takes an optional `IAutomationPolicyEngine` (DI-injected in production; falls back to a plain engine over the same `IUnitOfWork` when constructed directly). Apply-side behavior is unchanged; the status-agnostic expiry contract is untouched.

Error codes/messages are identical to Apply because the same method produces them.

## Behavior change: terminal-status proposals (review round LOW-1)

Like the #1395 expiry gate, the new permission gates are **status-agnostic**: a diff request for a **terminal** proposal (e.g. `Applied`) whose requester has since lost board access — or whose board/requester was deleted — now returns 403/404 where it previously returned 200 with the stored preview. This is intended and is **stricter than Apply on terminal items**: Apply short-circuits an already-applied proposal to idempotent success *before* its permission gate, while preview now refuses to disclose board-derived diff content to a requester who can no longer read the board. Safe direction (a preview denial vs. a no-op success), and coherent with the recorded #1397 maintainer decision that the frontend stops firing live diff requests for terminal review items. Pinned by `GetProposalDiffAsync_ShouldRejectRevokedAccess_ForTerminalAppliedProposal`, which asserts both sides: diff 403, real executor idempotent success.

## Tests

Parity tests in `AutomationProposalServiceTests` (conventions of the existing #1376/#1374 diff-parity tests):

- `GetProposalDiffAsync_ShouldRejectRevokedBoardAccess_MatchingApplyPermissionGate` — 403, preview == apply (engine reference).
- `GetProposalDiffAsync_ShouldRejectDeletedBoard_MatchingApplyPermissionGate` — 404, preview == apply (engine reference).
- `GetProposalDiffAsync_ShouldRejectDeletedRequester_MatchingApplyPermissionGate` — 404, preview == apply (engine reference).
- `GetProposalDiffAsync_ShouldEnforcePermissionGate_EvenWithStoredPreview` — cached fast path enforces the gate (403), stored preview not surfaced.
- `GetProposalDiffAsync_ShouldEnforcePermissionGate_OnRevisedPath` — revision-aware path enforces the gate (403).

Review-round additions (LOW-1/3/4):

- `GetProposalDiffAsync_ShouldMatchRealApplyExecutor_WhenBoardAccessRevoked` — drives the REAL Apply boundary (`AutomationExecutorService.ExecuteProposalAsync` with a real `AutomationPolicyEngine`, no mocked gates) on an approved, non-terminal proposal over the same revoked-access fixture and asserts diff code+message == executor code+message. Non-self-referential: fails if the executor's gate sequence diverges from what diff mirrors.
- `GetProposalDiffAsync_ShouldRejectRevokedAccess_ForTerminalAppliedProposal` — pins the terminal-status behavior change (diff 403 vs. Apply idempotent success; see section above).
- `GetProposalDiffAsync_ShouldReportExpiry_NotForbidden_WhenExpiredAndAccessRevoked` — gate-ordering pin: expired AND revoked-access proposal returns the expiry `ValidationError` (never `Forbidden`) from BOTH diff and the real executor; fails if permissions are ever reordered ahead of structure/expiry on either side.

The shared test constructor defaults the permission gates to PASS (requester/board exist, access granted) so healthy-path diff tests reach their intended gate; the parity tests override those defaults.

## Verification

```
dotnet build backend/Taskdeck.sln -c Release
# Build succeeded. 0 Error(s).

dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~AutomationProposal"
# Domain.Tests:      Passed 117, Failed 0
# Application.Tests: Passed 77,  Failed 0
# Api.Tests:         Passed 66,  Failed 0
# Integration.Tests: Passed 1,   Failed 0

dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~AutomationExecutor"
# Application.Tests: Passed 14, Failed 0

dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~CrossUserDataIsolation"
# Api.Tests: Passed 38, Failed 0

dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~ProposalRevision"
# Domain.Tests: Passed 25, Failed 0 | Application.Tests: Passed 7, Failed 0 | Api.Tests: Passed 33, Failed 0

dotnet test ... --filter "FullyQualifiedName~McpToolsTests"
# Api.Tests: Passed 29, Failed 0  (real-DB MCP diff happy path)
```

Full backend suite intentionally not run here (coordinator owns that).

## Related

- Review round: LOW-2 (MCP `proposal_detail` serves stored `DiffPreview` ungated — same trust class, pre-existing) seeded as #1415, out of this PR's scope.
