### PR TITLE
Present expired proposals via stored preview instead of a live diff that 400s (#1397)

### DIFF
--- a/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
@@ -46,8 +46,11 @@ defineEmits<{
       <span class="td-review-card__expired-notice" role="status">
         This proposal has expired and can no longer be applied.
       </span>
+      <!-- Expired proposals stay inspectable via their stored preview (#1397): this
+           renders the stored diffPreview under a read-only banner, never a live
+           `/diff` request (which now 400s for expired proposals). -->
       <button class="td-btn td-btn--secondary td-btn--sm" @click="$emit('toggle-diff', proposal.id)">
-        {{ selectedDiffProposalId === proposal.id ? 'Hide Diff' : 'View Diff' }}
+        {{ selectedDiffProposalId === proposal.id ? 'Hide stored preview' : 'View stored preview' }}
       </button>
       <button
         class="td-btn td-btn--secondary td-btn--sm"

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalActions.vue
@@ -5,6 +5,7 @@ import { normalizeProposalStatus } from '../../utils/automation'
 import {
   isProposalApplyActionable,
   isProposalApproveActionable,
+  isProposalReadOnly,
   isProposalRejectActionable,
 } from '../../composables/useReviewProposals'
 
@@ -20,15 +21,27 @@ const props = defineProps<{
 // Reject are only available while the proposal is still pending and unexpired;
 // Apply-to-board is the Approved-and-actionable arm of apply-actionable.
 const canReject = computed(() => isProposalRejectActionable(props.proposal, props.isExpired))
-// Approve and Reject share the same precondition (a still-live PendingReview
-// proposal), but each routes through its own named helper so they can diverge
-// later without a hidden alias coupling them (e.g. an approve-only permission gate).
+// Approve additionally requires at least one operation (#1397): a zero-op
+// proposal is rejected by Apply and by /diff, so the rail must not offer it.
+// The Legacy card has no revision knowledge, so no hasSavedRevision escape here
+// (a revised-in-Paper zero-op proposal is conservatively un-approvable in Legacy).
 const canApprove = computed(() => isProposalApproveActionable(props.proposal, props.isExpired))
 const canExecute = computed(
   () =>
     isProposalApplyActionable(props.proposal, props.isExpired) &&
     normalizeProposalStatus(props.proposal.status) === 'Approved',
 )
+
+// #1397 LOW-4: the diff toggle's label follows the READ-ONLY classification, not
+// just expiry — a terminal non-expired proposal (Applied/Rejected/Failed shown
+// via "show completed") also renders the stored preview, so its button must not
+// promise a live diff (which would 400).
+const isReadOnly = computed(() => isProposalReadOnly(props.proposal, props.isExpired))
+const diffToggleLabel = computed(() => {
+  const open = props.selectedDiffProposalId === props.proposal.id
+  if (isReadOnly.value) return open ? 'Hide stored preview' : 'View stored preview'
+  return open ? 'Hide Diff' : 'View Diff'
+})
 
 defineEmits<{
   (e: 'approve', proposalId: string): void
@@ -50,7 +63,7 @@ defineEmits<{
            renders the stored diffPreview under a read-only banner, never a live
            `/diff` request (which now 400s for expired proposals). -->
       <button class="td-btn td-btn--secondary td-btn--sm" @click="$emit('toggle-diff', proposal.id)">
-        {{ selectedDiffProposalId === proposal.id ? 'Hide stored preview' : 'View stored preview' }}
+        {{ diffToggleLabel }}
       </button>
       <button
         class="td-btn td-btn--secondary td-btn--sm"
@@ -98,7 +111,7 @@ defineEmits<{
       </div>
 
       <button class="td-btn td-btn--secondary td-btn--sm" @click="$emit('toggle-diff', proposal.id)">
-        {{ selectedDiffProposalId === proposal.id ? 'Hide Diff' : 'View Diff' }}
+        {{ diffToggleLabel }}
       </button>
       <button
         class="td-btn td-btn--primary td-btn--sm"

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
@@ -212,16 +212,28 @@ function riskLevelClass(riskLevel: Proposal['riskLevel']): string {
           the original submission.
         </span>
         <!-- diffPreview is creation-time content revisions never update, so a
-             revised proposal's stored preview is NOT what a revision-aware Apply
-             would have executed — disclose it (#1397 MEDIUM-2). -->
+             revised proposal's stored preview — or the recorded-operations
+             fallback when no preview was captured — is NOT what a revision-aware
+             Apply would have executed. Disclose it, worded for whichever is on
+             screen (the fallback is not a "stored preview") (#1397 MEDIUM-2 /
+             #1414 review). -->
         <span
-          v-if="selectedDiffRevised"
+          v-if="selectedDiffRevised && selectedDiff"
           class="td-review-card__diff-note td-review-card__diff-note--warn"
           role="status"
           data-testid="review-diff-revised-note"
         >
           This proposal was revised after submission — the stored preview shows the original
           operations, not the revised ones.
+        </span>
+        <span
+          v-else-if="selectedDiffRevised && storedOperationsFallback"
+          class="td-review-card__diff-note td-review-card__diff-note--warn"
+          role="status"
+          data-testid="review-diff-revised-note"
+        >
+          This proposal was revised after submission — the recorded operations show the
+          original submission, not the revised one.
         </span>
         <pre
           v-if="selectedDiff"

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Proposal } from '../../types/automation'
 import {
   normalizeProposalRiskLevel,
   normalizeProposalSourceType,
   normalizeProposalStatus,
 } from '../../utils/automation'
+import type { ReviewDiffMode } from '../../composables/useReviewActions'
 import ReviewProposalActions from './ReviewProposalActions.vue'
 import ReviewProposalDetails from './ReviewProposalDetails.vue'
 
@@ -14,9 +16,22 @@ const props = defineProps<{
   isBusy: boolean
   selectedDiffProposalId: string | null
   selectedDiff: string | null
+  selectedDiffMode: ReviewDiffMode | null
   captureHref: string
   proposalHref: string
 }>()
+
+// Whether the diff pane has anything to show for this proposal. Read-only
+// (stored) and invalid states always render their banner/notice; a live diff
+// only renders once its content arrives, so a slow fetch shows nothing rather
+// than flashing a premature "no changes" (#1397).
+const diffPaneVisible = computed(
+  () =>
+    props.selectedDiffProposalId === props.proposal.id &&
+    (props.selectedDiffMode === 'stored' ||
+      props.selectedDiffMode === 'invalid' ||
+      !!props.selectedDiff),
+)
 
 defineEmits<{
   (e: 'approve', proposalId: string): void
@@ -162,9 +177,52 @@ function riskLevelClass(riskLevel: Proposal['riskLevel']): string {
       @open-board="$emit('open-board', $event)"
     />
 
-    <div v-if="selectedDiffProposalId === proposal.id && selectedDiff" class="td-review-card__diff-wrapper">
-      <span class="td-review-card__diff-label">Operation details</span>
-      <pre class="td-review-card__diff" role="region" aria-label="Proposal operation diff">{{ selectedDiff }}</pre>
+    <div
+      v-if="diffPaneVisible"
+      class="td-review-card__diff-wrapper"
+      data-testid="review-diff-wrapper"
+    >
+      <!-- Read-only / terminal: stored preview under an explicit banner (#1397) -->
+      <template v-if="selectedDiffMode === 'stored'">
+        <span class="td-review-card__diff-banner" role="status" data-testid="review-diff-banner">
+          {{ reviewStatusLabel(proposal.status) }} · read-only — showing the stored preview.
+        </span>
+        <pre
+          v-if="selectedDiff"
+          class="td-review-card__diff"
+          role="region"
+          aria-label="Stored proposal preview"
+          data-testid="review-diff-stored"
+        >{{ selectedDiff }}</pre>
+        <span
+          v-else
+          class="td-review-card__diff-note"
+          data-testid="review-diff-stored-empty"
+        >
+          No stored preview is available for this proposal.
+        </span>
+      </template>
+
+      <!-- Invalid: no operations to apply — Apply would reject it too (#1397) -->
+      <span
+        v-else-if="selectedDiffMode === 'invalid'"
+        class="td-review-card__diff-note td-review-card__diff-note--warn"
+        role="status"
+        data-testid="review-diff-invalid"
+      >
+        This proposal contains no operations to apply, so Apply would reject it.
+      </span>
+
+      <!-- Live diff for a still-actionable proposal -->
+      <template v-else>
+        <span class="td-review-card__diff-label">Operation details</span>
+        <pre
+          class="td-review-card__diff"
+          role="region"
+          aria-label="Proposal operation diff"
+          data-testid="review-diff-pre"
+        >{{ selectedDiff }}</pre>
+      </template>
     </div>
   </article>
 </template>
@@ -297,6 +355,22 @@ function riskLevelClass(riskLevel: Proposal['riskLevel']): string {
   font-size: var(--td-font-xs);
   color: var(--td-text-tertiary);
   font-weight: 500;
+}
+
+.td-review-card__diff-banner {
+  font-size: var(--td-font-xs);
+  font-weight: 600;
+  color: var(--td-color-warning);
+}
+
+.td-review-card__diff-note {
+  font-size: var(--td-font-xs);
+  color: var(--td-text-secondary);
+}
+
+.td-review-card__diff-note--warn {
+  color: var(--td-color-warning);
+  font-weight: 600;
 }
 
 .td-review-card__diff {

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
@@ -37,6 +37,25 @@ const diffPaneVisible = computed(
       !!props.selectedDiff),
 )
 
+// Read-only fallback when the proposal never captured a `diffPreview` (normal
+// creation flows leave it null — Codex review on #1414): derive a minimal
+// operation listing from the proposal's own recorded operations so a
+// terminal/expired proposal that still HAS operations is inspectable instead of
+// a dead "no stored preview" end. Local rendering only — the live `/diff` 400s
+// for these proposals (#1397).
+const storedOperationsFallback = computed(() => {
+  if (props.selectedDiffMode !== 'stored' || props.selectedDiff) return null
+  const ops = props.proposal.operations ?? []
+  if (ops.length === 0) return null
+  return [...ops]
+    .sort((a, b) => a.sequence - b.sequence)
+    .map(
+      (op, index) =>
+        `${index + 1}. ${op.actionType} ${op.targetType}${op.targetId ? ` (${op.targetId})` : ''}`,
+    )
+    .join('\n')
+})
+
 defineEmits<{
   (e: 'approve', proposalId: string): void
   (e: 'reject', proposalId: string, riskLevel: Proposal['riskLevel']): void
@@ -211,6 +230,17 @@ function riskLevelClass(riskLevel: Proposal['riskLevel']): string {
           aria-label="Stored proposal preview"
           data-testid="review-diff-stored"
         >{{ selectedDiff }}</pre>
+        <template v-else-if="storedOperationsFallback">
+          <span class="td-review-card__diff-note" data-testid="review-diff-stored-ops-note">
+            No stored preview was captured — showing the proposal's recorded operations.
+          </span>
+          <pre
+            class="td-review-card__diff"
+            role="region"
+            aria-label="Recorded proposal operations"
+            data-testid="review-diff-stored-operations"
+          >{{ storedOperationsFallback }}</pre>
+        </template>
         <span
           v-else
           class="td-review-card__diff-note"

--- a/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
+++ b/frontend/taskdeck-web/src/components/review/ReviewProposalCard.vue
@@ -17,6 +17,10 @@ const props = defineProps<{
   selectedDiffProposalId: string | null
   selectedDiff: string | null
   selectedDiffMode: ReviewDiffMode | null
+  /** The backend's actual /diff rejection reason for `invalid` mode (#1397 MEDIUM-1). */
+  selectedDiffInvalidReason: string | null
+  /** True when the stored preview's proposal has saved revisions; null = unknown (#1397 MEDIUM-2). */
+  selectedDiffRevised: boolean | null
   captureHref: string
   proposalHref: string
 }>()
@@ -185,7 +189,20 @@ function riskLevelClass(riskLevel: Proposal['riskLevel']): string {
       <!-- Read-only / terminal: stored preview under an explicit banner (#1397) -->
       <template v-if="selectedDiffMode === 'stored'">
         <span class="td-review-card__diff-banner" role="status" data-testid="review-diff-banner">
-          {{ reviewStatusLabel(proposal.status) }} · read-only — showing the stored preview.
+          {{ reviewStatusLabel(proposal.status) }} · read-only — showing the stored preview from
+          the original submission.
+        </span>
+        <!-- diffPreview is creation-time content revisions never update, so a
+             revised proposal's stored preview is NOT what a revision-aware Apply
+             would have executed — disclose it (#1397 MEDIUM-2). -->
+        <span
+          v-if="selectedDiffRevised"
+          class="td-review-card__diff-note td-review-card__diff-note--warn"
+          role="status"
+          data-testid="review-diff-revised-note"
+        >
+          This proposal was revised after submission — the stored preview shows the original
+          operations, not the revised ones.
         </span>
         <pre
           v-if="selectedDiff"
@@ -203,14 +220,17 @@ function riskLevelClass(riskLevel: Proposal['riskLevel']): string {
         </span>
       </template>
 
-      <!-- Invalid: no operations to apply — Apply would reject it too (#1397) -->
+      <!-- Invalid: the backend rejected the diff with its Apply-time gates; render
+           the backend's ACTUAL reason (expired vs zero-op), never a hardcoded
+           one (#1397 MEDIUM-1). The fallback covers a missing message only. -->
       <span
         v-else-if="selectedDiffMode === 'invalid'"
         class="td-review-card__diff-note td-review-card__diff-note--warn"
         role="status"
         data-testid="review-diff-invalid"
       >
-        This proposal contains no operations to apply, so Apply would reject it.
+        {{ selectedDiffInvalidReason || 'This proposal contains no operations to apply' }} — Apply
+        will reject this proposal.
       </span>
 
       <!-- Live diff for a still-actionable proposal -->

--- a/frontend/taskdeck-web/src/composables/useErrorMapper.ts
+++ b/frontend/taskdeck-web/src/composables/useErrorMapper.ts
@@ -60,6 +60,22 @@ export function getValidationReason(err: unknown): string | null {
   return message && message.length > 0 ? message : null
 }
 
+/**
+ * True when the error is a backend 403 or 404 for a proposal read — the signals
+ * `AuthorizeProposalAsync(requireWriteAccess:false)` returns when the caller no
+ * longer has board access (403) or the proposal/board/requester is gone (404;
+ * the backend 404s a revoked read to avoid leaking existence). Review surfaces
+ * use this to RETRACT a stored preview whose access was revoked mid-session,
+ * while ignoring transient errors (5xx/network) that must NOT tear down an
+ * otherwise-inspectable local preview (#1414 P2: re-check access on reveal).
+ */
+export function isAccessDeniedError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const candidate = err as { response?: { status?: number } }
+  const status = candidate.response?.status
+  return status === 403 || status === 404
+}
+
 export function getErrorDisplay(err: unknown, fallback: string): { message: string; code: string | null } {
   const apiError = parseApiError(err)
   if (apiError) {

--- a/frontend/taskdeck-web/src/composables/useErrorMapper.ts
+++ b/frontend/taskdeck-web/src/composables/useErrorMapper.ts
@@ -45,6 +45,21 @@ export function isValidationError(err: unknown): boolean {
   )
 }
 
+/**
+ * The backend-provided reason for an invalid-preview 400 ValidationError,
+ * trimmed — or `null` when the backend sent no message (or a whitespace-only
+ * one). Unlike `getErrorDisplay`, this deliberately does NOT substitute the
+ * generic "Please check your input" ValidationError copy: the invalid-diff
+ * presentation renders its own specific fallback ("This proposal contains no
+ * operations…") when the reason is absent, and a masking generic string would
+ * suppress it (#1397 / #1414 review).
+ */
+export function getValidationReason(err: unknown): string | null {
+  const apiError = parseApiError(err)
+  const message = apiError?.message?.trim()
+  return message && message.length > 0 ? message : null
+}
+
 export function getErrorDisplay(err: unknown, fallback: string): { message: string; code: string | null } {
   const apiError = parseApiError(err)
   if (apiError) {

--- a/frontend/taskdeck-web/src/composables/useErrorMapper.ts
+++ b/frontend/taskdeck-web/src/composables/useErrorMapper.ts
@@ -27,17 +27,20 @@ export function parseApiError(err: unknown): ApiError | null {
 }
 
 /**
- * True when the error is a backend 400 ValidationError. The automation `/diff`
- * endpoint returns this (PR #1395 / #1376) when it runs Apply's gates at diff
- * time — "Proposal has expired" or "Proposal must contain at least one
- * operation". Review surfaces render that as an explicit invalid/expired
- * presentation instead of tearing down the pane + toasting (#1397).
+ * True when the error is a backend 400 ValidationError — BOTH the status and
+ * the errorCode must match, so an unrelated 400 (or a ValidationError code on
+ * another status) is never classified as the review-gate verdict. The
+ * automation `/diff` endpoint returns this (PR #1395 / #1376) when it runs
+ * Apply's gates at diff time — "Proposal has expired" or "Proposal must
+ * contain at least one operation". Review surfaces render the backend's ACTUAL
+ * message as an explicit invalid presentation instead of tearing down the pane
+ * + toasting (#1397).
  */
 export function isValidationError(err: unknown): boolean {
   if (typeof err !== 'object' || err === null) return false
   const candidate = err as { response?: { status?: number; data?: { errorCode?: string } } }
   return (
-    candidate.response?.status === 400 ||
+    candidate.response?.status === 400 &&
     candidate.response?.data?.errorCode === 'ValidationError'
   )
 }

--- a/frontend/taskdeck-web/src/composables/useErrorMapper.ts
+++ b/frontend/taskdeck-web/src/composables/useErrorMapper.ts
@@ -26,6 +26,22 @@ export function parseApiError(err: unknown): ApiError | null {
   return null
 }
 
+/**
+ * True when the error is a backend 400 ValidationError. The automation `/diff`
+ * endpoint returns this (PR #1395 / #1376) when it runs Apply's gates at diff
+ * time — "Proposal has expired" or "Proposal must contain at least one
+ * operation". Review surfaces render that as an explicit invalid/expired
+ * presentation instead of tearing down the pane + toasting (#1397).
+ */
+export function isValidationError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const candidate = err as { response?: { status?: number; data?: { errorCode?: string } } }
+  return (
+    candidate.response?.status === 400 ||
+    candidate.response?.data?.errorCode === 'ValidationError'
+  )
+}
+
 export function getErrorDisplay(err: unknown, fallback: string): { message: string; code: string | null } {
   const apiError = parseApiError(err)
   if (apiError) {

--- a/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
+++ b/frontend/taskdeck-web/src/composables/useProposalRevisions.ts
@@ -23,7 +23,13 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
   let loadGeneration = 0
   let saveGeneration = 0
 
-  async function loadRevisionState(proposalId: string) {
+  // `silent: true` suppresses the failure toast — for augment-only callers
+  // (e.g. the read-only stored preview, which is already rendered locally and
+  // only uses revision metadata to gate a disclosure caveat, #1397 round 3):
+  // a failed metadata GET must not error-toast over a perfectly presentable
+  // preview. Authoritative callers (the approve guard, the live diff path)
+  // stay loud.
+  async function loadRevisionState(proposalId: string, options?: { silent?: boolean }) {
     const gen = ++loadGeneration
     try {
       const revisions = await proposalRevisionsApi.getRevisions(proposalId)
@@ -40,7 +46,9 @@ export function useProposalRevisions(activeProposal: Ref<ApiProposal | null>) {
       latestRevision.value = null
       // Leave revisionsLoaded false: the count is not authoritative, so callers
       // must fetch (let the backend decide) rather than short-circuit to a no-op.
-      toast.error(getErrorDisplay(e, 'Failed to load revision history').message)
+      if (!options?.silent) {
+        toast.error(getErrorDisplay(e, 'Failed to load revision history').message)
+      }
     }
   }
 

--- a/frontend/taskdeck-web/src/composables/useReviewActions.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewActions.ts
@@ -4,13 +4,38 @@ import { useToastStore } from '../store/toastStore'
 import { createRequestId } from '../utils/requestId'
 import { normalizeProposalRiskLevel } from '../utils/automation'
 import type { Proposal as ApiProposal } from '../types/automation'
-import { getErrorDisplay } from './useErrorMapper'
+import { getErrorDisplay, isValidationError } from './useErrorMapper'
+import { isProposalReadOnly } from './useReviewProposals'
 import { usePerformanceMark } from './usePerformanceMark'
+
+/**
+ * How the review diff pane presents its content (#1397):
+ * - `live`    — a freshly fetched `/diff` for a still-actionable proposal.
+ * - `stored`  — a read-only/terminal proposal's stored `diffPreview` (no live
+ *               request; may be null → "no stored preview available").
+ * - `invalid` — the backend rejected the diff (400) or the proposal has no
+ *               operations; Apply would reject it too, so the reviewer must see
+ *               that verdict rather than a generic error toast.
+ */
+export type ReviewDiffMode = 'live' | 'stored' | 'invalid'
+
+// Fallback expiry classifier for callers that don't supply the surface's
+// reactive clock. Trusts the server-authoritative `isExpired` flag and the
+// domain `Expired` status; it cannot see a proposal whose expiresAt has passed
+// mid-session, so surfaces that need that (Legacy) pass their own function.
+function defaultIsProposalExpired(proposal: ApiProposal): boolean {
+  return proposal.isExpired === true || proposal.status === 'Expired'
+}
 
 export function useReviewActions(
   proposals: Ref<ApiProposal[]>,
   dismissableProposalIds: ComputedRef<string[]>,
   loadProposals: () => Promise<void>,
+  // Same client-side expiry rule the surrounding surface uses (from
+  // useReviewProposals). Defaults to the server-authoritative `isExpired` flag /
+  // domain Expired status so callers that don't drive a reactive clock (e.g.
+  // Paper, which owns its own diff flow) still classify read-only correctly.
+  isProposalExpired: (proposal: ApiProposal) => boolean = defaultIsProposalExpired,
 ) {
   const toast = useToastStore()
   const diffRenderPerf = usePerformanceMark('proposal-diff-render')
@@ -23,7 +48,14 @@ export function useReviewActions(
   const bulkDismissBusy = ref(false)
   const selectedDiffProposalId = ref<string | null>(null)
   const selectedDiff = ref<string | null>(null)
+  const selectedDiffMode = ref<ReviewDiffMode | null>(null)
   let latestDiffRequestId = 0
+
+  function resetDiffState() {
+    selectedDiffProposalId.value = null
+    selectedDiff.value = null
+    selectedDiffMode.value = null
+  }
 
   async function handleApproveProposal(proposalId: string) {
     try {
@@ -103,27 +135,59 @@ export function useReviewActions(
   async function handleToggleDiff(proposalId: string) {
     if (selectedDiffProposalId.value === proposalId) {
       latestDiffRequestId += 1
-      selectedDiffProposalId.value = null
-      selectedDiff.value = null
+      resetDiffState()
+      return
+    }
+
+    const proposal = proposals.value.find((p) => p.id === proposalId)
+    // Anchor the pane to this proposal before any await so a concurrent toggle
+    // or a stale response can be detected/ignored.
+    const requestId = ++latestDiffRequestId
+    selectedDiffProposalId.value = proposalId
+    selectedDiff.value = null
+    selectedDiffMode.value = null
+
+    if (!proposal) {
+      // The card only emits ids from the visible list, but guard so a vanished
+      // proposal leaves a clean pane rather than a hung loading state.
+      resetDiffState()
+      return
+    }
+
+    // Read-only / terminal proposals (expired, Applied, Rejected, Failed,
+    // Dismissed) never fire the live diff — PR #1395 makes `/diff` 400 for them.
+    // Present the stored `diffPreview` under an explicit read-only banner; when
+    // there is no stored preview, the banner + "no stored preview" state, never
+    // an error toast + cleared pane (#1397).
+    if (isProposalReadOnly(proposal, isProposalExpired(proposal))) {
+      selectedDiff.value = proposal.diffPreview
+      selectedDiffMode.value = 'stored'
       return
     }
 
     diffRenderPerf.start()
-    const requestId = ++latestDiffRequestId
-
     try {
-      selectedDiffProposalId.value = proposalId
-      selectedDiff.value = null
-
       const diff = await automationApi.getProposalDiff(proposalId)
       if (requestId !== latestDiffRequestId || selectedDiffProposalId.value !== proposalId) return
 
       selectedDiff.value = diff
+      selectedDiffMode.value = 'live'
     } catch (e: unknown) {
       if (requestId !== latestDiffRequestId || selectedDiffProposalId.value !== proposalId) return
 
-      selectedDiffProposalId.value = null
-      selectedDiff.value = null
+      // A 400 ValidationError means the backend ran Apply's gates at diff time
+      // (#1376/#1395): the proposal has no operations (or expired mid-flight).
+      // Apply would reject it too, so surface that verdict inline instead of a
+      // generic toast + torn-down pane, so the reviewer sees it before approving.
+      if (isValidationError(e)) {
+        selectedDiff.value = null
+        selectedDiffMode.value = 'invalid'
+        return
+      }
+
+      // Any other failure (e.g. a 404 because it was deleted elsewhere) stays a
+      // toast with a clean teardown.
+      resetDiffState()
       toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)
     } finally {
       diffRenderPerf.end()
@@ -182,6 +246,7 @@ export function useReviewActions(
     bulkDismissBusy,
     selectedDiffProposalId,
     selectedDiff,
+    selectedDiffMode,
     handleApproveProposal,
     handleRejectProposal,
     handleDeferProposal,

--- a/frontend/taskdeck-web/src/composables/useReviewActions.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewActions.ts
@@ -3,9 +3,9 @@ import { automationApi } from '../api/automationApi'
 import { proposalRevisionsApi } from '../api/proposalRevisionsApi'
 import { useToastStore } from '../store/toastStore'
 import { createRequestId } from '../utils/requestId'
-import { normalizeProposalRiskLevel } from '../utils/automation'
+import { normalizeProposalRiskLevel, normalizeProposalStatus } from '../utils/automation'
 import type { Proposal as ApiProposal } from '../types/automation'
-import { getErrorDisplay, getValidationReason, isValidationError } from './useErrorMapper'
+import { getErrorDisplay, getValidationReason, isAccessDeniedError, isValidationError } from './useErrorMapper'
 import { isProposalReadOnly } from './useReviewProposals'
 import { usePerformanceMark } from './usePerformanceMark'
 
@@ -22,11 +22,18 @@ import { usePerformanceMark } from './usePerformanceMark'
 export type ReviewDiffMode = 'live' | 'stored' | 'invalid'
 
 // Fallback expiry classifier for callers that don't supply the surface's
-// reactive clock. Trusts the server-authoritative `isExpired` flag and the
-// domain `Expired` status; it cannot see a proposal whose expiresAt has passed
-// mid-session, so surfaces that need that (Legacy) pass their own function.
+// reactive clock. Status-scoped to match the canonical rule
+// (useReviewProposals.isProposalExpired): the server-authoritative `isExpired`
+// flag is time-based and status-AGNOSTIC on the backend, so it is trusted ONLY
+// for a live PendingReview/Approved proposal — a terminal proposal whose expiry
+// later passed keeps its terminal status, never flips to "Expired". It cannot
+// see a still-pending proposal whose expiresAt passes mid-session without the
+// server flag, so surfaces that need that (Legacy) pass their own clock fn.
 function defaultIsProposalExpired(proposal: ApiProposal): boolean {
-  return proposal.isExpired === true || proposal.status === 'Expired'
+  const normalized = normalizeProposalStatus(proposal.status)
+  if (normalized === 'Expired') return true
+  if (normalized === 'PendingReview' || normalized === 'Approved') return proposal.isExpired === true
+  return false
 }
 
 export function useReviewActions(
@@ -88,12 +95,34 @@ export function useReviewActions(
     }
   }
 
+  // #1414 P2: revealing the stored `diffPreview` locally skips the `/diff` call
+  // that used to re-run AuthorizeProposalAsync, so re-authorize on reveal. Render
+  // the stored preview SYNCHRONOUSLY (the #1397 seam invariant: local content is
+  // never network-gated), then probe access via GET proposal (which returns 200
+  // for a still-readable terminal/expired proposal — unlike `/diff`, it does not
+  // 400 on expiry). ONLY a genuine 403/404 retracts the preview; a transient
+  // error must not tear down an inspectable local preview. The refreshed DTO is
+  // deliberately NOT rendered — #1397 keeps the decision-time stored artifact
+  // (a live re-render can drift). Guarded by requestId + proposal id so a late
+  // response for a toggled-off / switched proposal cannot tear down the wrong pane.
+  async function verifyStoredPreviewAccess(proposalId: string, requestId: number) {
+    try {
+      await automationApi.getProposal(proposalId)
+    } catch (e: unknown) {
+      if (!isAccessDeniedError(e)) return
+      if (requestId !== latestDiffRequestId || selectedDiffProposalId.value !== proposalId) return
+      resetDiffState()
+      toast.error('This proposal is no longer available to you.')
+    }
+  }
+
   function presentStoredPreview(proposal: ApiProposal, requestId: number) {
     selectedDiff.value = proposal.diffPreview
     selectedDiffMode.value = 'stored'
     selectedDiffInvalidReason.value = null
     selectedDiffRevised.value = null
     void loadStoredRevisedSignal(proposal.id, requestId)
+    void verifyStoredPreviewAccess(proposal.id, requestId)
   }
 
   // #1397 LOW-5: the pane's presentation is chosen at toggle time, but a proposal

--- a/frontend/taskdeck-web/src/composables/useReviewActions.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewActions.ts
@@ -5,7 +5,7 @@ import { useToastStore } from '../store/toastStore'
 import { createRequestId } from '../utils/requestId'
 import { normalizeProposalRiskLevel } from '../utils/automation'
 import type { Proposal as ApiProposal } from '../types/automation'
-import { getErrorDisplay, isValidationError } from './useErrorMapper'
+import { getErrorDisplay, getValidationReason, isValidationError } from './useErrorMapper'
 import { isProposalReadOnly } from './useReviewProposals'
 import { usePerformanceMark } from './usePerformanceMark'
 
@@ -251,10 +251,10 @@ export function useReviewActions(
       if (isValidationError(e)) {
         selectedDiff.value = null
         selectedDiffMode.value = 'invalid'
-        selectedDiffInvalidReason.value = getErrorDisplay(
-          e,
-          'The backend rejected this proposal preview',
-        ).message
+        // Use the backend's ACTUAL reason, but treat a blank message as absent so
+        // the card's specific "no operations" fallback copy applies rather than
+        // the generic ValidationError string masking it (#1397 / #1414 review).
+        selectedDiffInvalidReason.value = getValidationReason(e)
         return
       }
 

--- a/frontend/taskdeck-web/src/composables/useReviewActions.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewActions.ts
@@ -1,5 +1,6 @@
-import { ref, type ComputedRef, type Ref } from 'vue'
+import { ref, watch, type ComputedRef, type Ref } from 'vue'
 import { automationApi } from '../api/automationApi'
+import { proposalRevisionsApi } from '../api/proposalRevisionsApi'
 import { useToastStore } from '../store/toastStore'
 import { createRequestId } from '../utils/requestId'
 import { normalizeProposalRiskLevel } from '../utils/automation'
@@ -13,9 +14,10 @@ import { usePerformanceMark } from './usePerformanceMark'
  * - `live`    — a freshly fetched `/diff` for a still-actionable proposal.
  * - `stored`  — a read-only/terminal proposal's stored `diffPreview` (no live
  *               request; may be null → "no stored preview available").
- * - `invalid` — the backend rejected the diff (400) or the proposal has no
- *               operations; Apply would reject it too, so the reviewer must see
- *               that verdict rather than a generic error toast.
+ * - `invalid` — the backend rejected the diff (400 ValidationError); the
+ *               backend's actual reason is carried in `selectedDiffInvalidReason`
+ *               and Apply would reject the proposal for the same reason, so the
+ *               reviewer must see that verdict rather than a generic error toast.
  */
 export type ReviewDiffMode = 'live' | 'stored' | 'invalid'
 
@@ -49,13 +51,77 @@ export function useReviewActions(
   const selectedDiffProposalId = ref<string | null>(null)
   const selectedDiff = ref<string | null>(null)
   const selectedDiffMode = ref<ReviewDiffMode | null>(null)
+  // The backend's actual rejection reason for `invalid` mode (e.g. "Proposal has
+  // expired" vs "Proposal must contain at least one operation") — the pane must
+  // render the REAL reason, never a hardcoded one (#1397 MEDIUM-1).
+  const selectedDiffInvalidReason = ref<string | null>(null)
+  // Whether the stored preview's proposal has saved revisions: true/false once
+  // known, null while unknown (fetch pending or failed). `diffPreview` is
+  // creation-time content that revisions never update, so a revised proposal's
+  // stored preview shows the ORIGINAL submission — the banner must disclose
+  // that (#1397 MEDIUM-2).
+  const selectedDiffRevised = ref<boolean | null>(null)
   let latestDiffRequestId = 0
 
   function resetDiffState() {
     selectedDiffProposalId.value = null
     selectedDiff.value = null
     selectedDiffMode.value = null
+    selectedDiffInvalidReason.value = null
+    selectedDiffRevised.value = null
   }
+
+  // Best-effort disclosure signal for the stored preview (#1397 MEDIUM-2): fetch
+  // the revision list so the banner can state when the stored (original) preview
+  // is NOT what a later revision would have applied. On failure the flag stays
+  // null (unknown) — the banner already attributes the content to the original
+  // submission, so we fail toward the generic wording rather than blocking the
+  // stored preview or false-claiming "never revised".
+  async function loadStoredRevisedSignal(proposalId: string, requestId: number) {
+    try {
+      const revisions = await proposalRevisionsApi.getRevisions(proposalId)
+      if (requestId !== latestDiffRequestId || selectedDiffProposalId.value !== proposalId) return
+      selectedDiffRevised.value = revisions.length > 0
+    } catch {
+      if (requestId !== latestDiffRequestId || selectedDiffProposalId.value !== proposalId) return
+      selectedDiffRevised.value = null
+    }
+  }
+
+  function presentStoredPreview(proposal: ApiProposal, requestId: number) {
+    selectedDiff.value = proposal.diffPreview
+    selectedDiffMode.value = 'stored'
+    selectedDiffInvalidReason.value = null
+    selectedDiffRevised.value = null
+    void loadStoredRevisedSignal(proposal.id, requestId)
+  }
+
+  // #1397 LOW-5: the pane's presentation is chosen at toggle time, but a proposal
+  // can turn read-only WHILE its pane is open — a status change (approve→execute,
+  // a refresh mapping in a terminal state) or the surface's expiry clock ticking
+  // past expiresAt. Re-derive: an open live/invalid pane flips to the stored
+  // read-only presentation the moment the classification flips, instead of
+  // keeping a live-looking pane on a proposal that is no longer actionable.
+  watch(
+    () => {
+      const id = selectedDiffProposalId.value
+      if (!id) return false
+      const proposal = proposals.value.find((p) => p.id === id)
+      if (!proposal) return false
+      return isProposalReadOnly(proposal, isProposalExpired(proposal))
+    },
+    (readOnly) => {
+      if (!readOnly) return
+      if (selectedDiffMode.value === 'stored' || selectedDiffMode.value === null) return
+      const id = selectedDiffProposalId.value
+      const proposal = id ? proposals.value.find((p) => p.id === id) : undefined
+      if (!proposal) return
+      // Cancel any in-flight live fetch so its late response can't overwrite
+      // the read-only presentation.
+      const requestId = ++latestDiffRequestId
+      presentStoredPreview(proposal, requestId)
+    },
+  )
 
   async function handleApproveProposal(proposalId: string) {
     try {
@@ -146,6 +212,8 @@ export function useReviewActions(
     selectedDiffProposalId.value = proposalId
     selectedDiff.value = null
     selectedDiffMode.value = null
+    selectedDiffInvalidReason.value = null
+    selectedDiffRevised.value = null
 
     if (!proposal) {
       // The card only emits ids from the visible list, but guard so a vanished
@@ -160,8 +228,7 @@ export function useReviewActions(
     // there is no stored preview, the banner + "no stored preview" state, never
     // an error toast + cleared pane (#1397).
     if (isProposalReadOnly(proposal, isProposalExpired(proposal))) {
-      selectedDiff.value = proposal.diffPreview
-      selectedDiffMode.value = 'stored'
+      presentStoredPreview(proposal, requestId)
       return
     }
 
@@ -176,12 +243,18 @@ export function useReviewActions(
       if (requestId !== latestDiffRequestId || selectedDiffProposalId.value !== proposalId) return
 
       // A 400 ValidationError means the backend ran Apply's gates at diff time
-      // (#1376/#1395): the proposal has no operations (or expired mid-flight).
-      // Apply would reject it too, so surface that verdict inline instead of a
-      // generic toast + torn-down pane, so the reviewer sees it before approving.
+      // (#1376/#1395). It carries one of two distinct reasons — "Proposal must
+      // contain at least one operation" or "Proposal has expired" (the expiry
+      // race: the surface's 60s clock can lag a server-side expiry). Apply would
+      // reject it for the SAME reason, so surface the backend's actual message
+      // inline instead of a generic toast + torn-down pane (#1397 MEDIUM-1).
       if (isValidationError(e)) {
         selectedDiff.value = null
         selectedDiffMode.value = 'invalid'
+        selectedDiffInvalidReason.value = getErrorDisplay(
+          e,
+          'The backend rejected this proposal preview',
+        ).message
         return
       }
 
@@ -247,6 +320,8 @@ export function useReviewActions(
     selectedDiffProposalId,
     selectedDiff,
     selectedDiffMode,
+    selectedDiffInvalidReason,
+    selectedDiffRevised,
     handleApproveProposal,
     handleRejectProposal,
     handleDeferProposal,

--- a/frontend/taskdeck-web/src/composables/useReviewActions.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewActions.ts
@@ -112,7 +112,13 @@ export function useReviewActions(
     },
     (readOnly) => {
       if (!readOnly) return
-      if (selectedDiffMode.value === 'stored' || selectedDiffMode.value === null) return
+      // SEAM INVARIANT (#1397 round 3): a read-only conversion invalidates
+      // EVERY non-stored pane state — including the loading state, where
+      // selectedDiffMode is still null while the live /diff is in flight. Only
+      // an already-stored presentation is skippable; a null mode with an open
+      // pane id means a fetch is pending, and NOT converting here would let its
+      // late response render live UI on a read-only proposal.
+      if (selectedDiffMode.value === 'stored') return
       const id = selectedDiffProposalId.value
       const proposal = id ? proposals.value.find((p) => p.id === id) : undefined
       if (!proposal) return

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -50,6 +50,27 @@ export function isProposalApproveActionable(proposal: ApiProposal, isExpired: bo
   return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isExpired
 }
 
+// A proposal is "read-only" once it is expired (client-side clock or domain
+// Expired) or in any terminal status (Applied/Rejected/Failed/Expired/Dismissed).
+// PR #1395 made the backend `/diff` reject these with 400 ("Proposal has
+// expired"), so review surfaces must NOT fire the live diff for them — they
+// present the stored `diffPreview` under an explicit read-only banner instead
+// (#1397 maintainer decision: expired proposals stay inspectable via stored
+// content without burdening the UI with a live request that 400s). Callers pass
+// the same `isProposalExpired(proposal)` the rest of the surface uses so Paper
+// and Legacy can never drift (#1124 / ADR-0038).
+export function isProposalReadOnly(proposal: ApiProposal, isExpired: boolean): boolean {
+  if (isExpired) return true
+  const status = normalizeProposalStatus(proposal.status)
+  return (
+    status === 'Applied' ||
+    status === 'Rejected' ||
+    status === 'Failed' ||
+    status === 'Expired' ||
+    status === 'Dismissed'
+  )
+}
+
 export function isProposalStale(proposal: ApiProposal, nowMs: number): boolean {
   if (!proposal || normalizeProposalStatus(proposal.status) !== 'PendingReview') return false
   // Guard against missing/invalid createdAt: a falsy value (new Date(null) is

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -44,10 +44,23 @@ export function isProposalRejectActionable(proposal: ApiProposal, isExpired: boo
   return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isExpired
 }
 
-// Approve shares Reject's precondition today (a live, non-expired PendingReview proposal),
-// but is named distinctly so the two can diverge without one silently aliasing the other.
-export function isProposalApproveActionable(proposal: ApiProposal, isExpired: boolean): boolean {
-  return normalizeProposalStatus(proposal.status) === 'PendingReview' && !isExpired
+// Approve requires a live, non-expired PendingReview proposal AND a structurally
+// applyable one: a zero-operation proposal is rejected by Apply (and by `/diff`,
+// #1376/#1395), so approving it only defers a guaranteed 400 — the rail must not
+// offer it (#1397 LOW-3; backend approve-time validation tracked in #1416).
+// `hasSavedRevision` is the #1235 escape hatch: a saved revision carries
+// operations the backend renders/applies revision-aware even when the ORIGINAL
+// operations are empty. Callers without revision knowledge (the Legacy card)
+// omit it — a revised-in-Paper zero-op proposal viewed in Legacy is then
+// conservatively un-approvable there until refreshed in Paper.
+export function isProposalApproveActionable(
+  proposal: ApiProposal,
+  isExpired: boolean,
+  options?: { hasSavedRevision?: boolean },
+): boolean {
+  if (normalizeProposalStatus(proposal.status) !== 'PendingReview' || isExpired) return false
+  if ((proposal.operations?.length ?? 0) === 0 && !options?.hasSavedRevision) return false
+  return true
 }
 
 // A proposal is "read-only" once it is expired (client-side clock or domain

--- a/frontend/taskdeck-web/src/composables/useReviewProposals.ts
+++ b/frontend/taskdeck-web/src/composables/useReviewProposals.ts
@@ -163,7 +163,17 @@ export function useReviewProposals() {
     const normalized = normalizeProposalStatus(proposal.status)
     if (normalized === 'Expired') return true
     if (normalized === 'PendingReview' || normalized === 'Approved') {
-      return new Date(proposal.expiresAt).getTime() <= nowMs.value
+      // Honor the server-authoritative `isExpired` flag in addition to the local
+      // 60s clock: the client clock can lag inside the tick window or skew behind
+      // server time, and if the server has already expired the proposal the live
+      // `/diff` 400s — the read-only guards must classify it as expired so the
+      // review surfaces present the stored preview instead (#1414 P2). The flag
+      // is time-based and status-AGNOSTIC on the backend (`IsExpired => UtcNow >
+      // ExpiresAt`), so it is consulted ONLY inside this Pending/Approved branch:
+      // a terminal proposal whose expiry later passed must keep its terminal
+      // classification (Applied/Rejected/…), never flip to "Expired" — otherwise
+      // `visibleProposals`, the status labels, and the expired notice regress.
+      return proposal.isExpired === true || new Date(proposal.expiresAt).getTime() <= nowMs.value
     }
     return false
   }

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalActions.spec.ts
@@ -87,6 +87,27 @@ describe('ReviewProposalActions gating', () => {
     expect(wrapper.findAll('button').some((b) => b.text() === 'Reject')).toBe(false)
   })
 
+  it('labels the diff button as a stored preview on the expired path (#1397)', () => {
+    // Expired proposals no longer offer a live "View Diff" (which now 400s); the
+    // button reveals the stored preview instead, so its label must say so.
+    const wrapper = mountActions({
+      proposal: makeProposal({ status: 'Expired' }),
+      isExpired: true,
+    })
+    expect(wrapper.findAll('button').some((b) => b.text() === 'View stored preview')).toBe(true)
+    expect(wrapper.findAll('button').some((b) => b.text() === 'View Diff')).toBe(false)
+  })
+
+  it('toggles the stored-preview label when the expired proposal diff is open (#1397)', () => {
+    const proposal = makeProposal({ status: 'Expired' })
+    const wrapper = mountActions({
+      proposal,
+      isExpired: true,
+      selectedDiffProposalId: proposal.id,
+    })
+    expect(wrapper.findAll('button').some((b) => b.text() === 'Hide stored preview')).toBe(true)
+  })
+
   it('disables every transition button while busy', () => {
     const wrapper = mountActions({
       proposal: makeProposal({ status: 'PendingReview' }),

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalActions.spec.ts
@@ -29,7 +29,22 @@ function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
     appliedAt: null,
     failureReason: null,
     correlationId: 'corr-1',
-    operations: [],
+    // One operation by default: a zero-op proposal is structurally invalid for
+    // Approve (#1397), so the actionability tests use a realistic applyable
+    // fixture and the zero-op case is asserted explicitly below.
+    operations: [
+      {
+        id: 'op-1',
+        proposalId: 'p-1',
+        sequence: 0,
+        actionType: 'CreateCard',
+        targetType: 'Card',
+        targetId: null,
+        parameters: '{}',
+        idempotencyKey: 'k-1',
+        expectedVersion: null,
+      },
+    ],
     ...overrides,
   } as Proposal
 }
@@ -125,5 +140,30 @@ describe('ReviewProposalActions gating', () => {
       expect(isDisabled(wrapper, 'Reject')).toBe(true)
       expect(isDisabled(wrapper, 'Apply to board')).toBe(true)
     }
+  })
+
+  it('disables Approve for a zero-operation pending proposal (#1397 LOW-3)', () => {
+    // Apply (and /diff) reject a zero-op proposal with 400; offering Approve
+    // only defers that failure past the reviewer's decision. Reject stays
+    // available so the reviewer can still clear it.
+    const wrapper = mountActions({
+      proposal: makeProposal({ status: 'PendingReview', operations: [] }),
+    })
+    expect(isDisabled(wrapper, 'Approve for board')).toBe(true)
+    expect(isDisabled(wrapper, 'Reject')).toBe(false)
+  })
+
+  it('labels the diff button as a stored preview for terminal non-expired statuses (#1397 LOW-4)', () => {
+    // Applied/Rejected/Failed proposals (visible via "show completed") render the
+    // stored preview too — the label must follow the read-only classification,
+    // not just expiry.
+    for (const status of ['Applied', 'Rejected', 'Failed'] as const) {
+      const wrapper = mountActions({ proposal: makeProposal({ status }) })
+      expect(wrapper.findAll('button').some((b) => b.text() === 'View stored preview')).toBe(true)
+      expect(wrapper.findAll('button').some((b) => b.text() === 'View Diff')).toBe(false)
+    }
+    // A live pending proposal keeps the live-diff label.
+    const live = mountActions({ proposal: makeProposal({ status: 'PendingReview' }) })
+    expect(live.findAll('button').some((b) => b.text() === 'View Diff')).toBe(true)
   })
 })

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
@@ -183,6 +183,42 @@ describe('ReviewProposalCard diff presentation (#1397)', () => {
     expect(wrapper.find('[data-testid="review-diff-banner"]').text()).toContain('original submission')
   })
 
+  it('discloses a revision on the recorded-operations fallback, not as a "stored preview" (#1397 MEDIUM-2 / #1414)', () => {
+    // A revised read-only proposal with no captured preview renders the
+    // recorded-operations fallback — so the disclosure must be worded for that,
+    // never claim a "stored preview" that does not exist.
+    const wrapper = mountCard({
+      proposal: makeProposal({
+        status: 'Expired',
+        operations: [
+          {
+            id: 'op-1',
+            proposalId: 'p-1',
+            sequence: 0,
+            actionType: 'CreateCard',
+            targetType: 'Card',
+            targetId: null,
+            parameters: '{}',
+            idempotencyKey: 'k-1',
+            expectedVersion: null,
+          },
+        ],
+      }),
+      isExpired: true,
+      selectedDiffMode: 'stored',
+      selectedDiff: null,
+      selectedDiffRevised: true,
+    })
+
+    const note = wrapper.find('[data-testid="review-diff-revised-note"]')
+    expect(note.exists()).toBe(true)
+    expect(note.text()).toContain('revised')
+    expect(note.text()).toContain('recorded operations')
+    expect(note.text()).not.toContain('stored preview')
+    // The recorded-operations fallback is what's on screen (not a stored pre).
+    expect(wrapper.find('[data-testid="review-diff-stored-operations"]').exists()).toBe(true)
+  })
+
   it('omits the revised note when the revision state is unknown or absent', () => {
     for (const revised of [false, null]) {
       const wrapper = mountCard({

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
@@ -78,7 +78,7 @@ describe('ReviewProposalCard diff presentation (#1397)', () => {
     expect(stored.text()).toContain('Archived')
   })
 
-  it('shows the banner and a no-stored-preview note when there is no stored content', () => {
+  it('shows the banner and a no-stored-preview note when there is no stored content and no operations', () => {
     const wrapper = mountCard({
       proposal: makeProposal({ status: 'Expired' }),
       isExpired: true,
@@ -92,6 +92,52 @@ describe('ReviewProposalCard diff presentation (#1397)', () => {
     expect(storedEmpty.text()).toContain('No stored preview')
     // Never falls through to a live "Operation details" pane for a settled proposal.
     expect(wrapper.find('[data-testid="review-diff-pre"]').exists()).toBe(false)
+  })
+
+  it('falls back to the recorded operations when no stored preview was captured (#1397 / Codex)', () => {
+    // Normal creation flows never populate diffPreview: a read-only proposal
+    // that still has operations must render a local operation listing, not a
+    // dead "no stored preview" end (and never a live /diff call — prop-driven
+    // here, so no network is possible by construction).
+    const wrapper = mountCard({
+      proposal: makeProposal({
+        status: 'Expired',
+        operations: [
+          {
+            id: 'op-2',
+            proposalId: 'p-1',
+            sequence: 1,
+            actionType: 'MoveCard',
+            targetType: 'Card',
+            targetId: 'card-9',
+            parameters: '{}',
+            idempotencyKey: 'k-2',
+            expectedVersion: null,
+          },
+          {
+            id: 'op-1',
+            proposalId: 'p-1',
+            sequence: 0,
+            actionType: 'CreateCard',
+            targetType: 'Card',
+            targetId: null,
+            parameters: '{}',
+            idempotencyKey: 'k-1',
+            expectedVersion: null,
+          },
+        ],
+      }),
+      isExpired: true,
+      selectedDiffMode: 'stored',
+      selectedDiff: null,
+    })
+
+    expect(wrapper.find('[data-testid="review-diff-stored-ops-note"]').exists()).toBe(true)
+    const ops = wrapper.find('[data-testid="review-diff-stored-operations"]')
+    expect(ops.exists()).toBe(true)
+    // Sequence-ordered: CreateCard (seq 0) before MoveCard (seq 1).
+    expect(ops.text()).toMatch(/1\. CreateCard Card[\s\S]*2\. MoveCard Card \(card-9\)/)
+    expect(wrapper.find('[data-testid="review-diff-stored-empty"]').exists()).toBe(false)
   })
 
   it('renders the invalid verdict with the zero-op fallback when no backend reason is supplied', () => {

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
@@ -40,6 +40,8 @@ function mountCard(props: {
   isExpired?: boolean
   selectedDiff?: string | null
   selectedDiffMode?: ReviewDiffMode | null
+  selectedDiffInvalidReason?: string | null
+  selectedDiffRevised?: boolean | null
 }) {
   const proposal = props.proposal ?? makeProposal()
   return mount(ReviewProposalCard, {
@@ -50,6 +52,8 @@ function mountCard(props: {
       selectedDiffProposalId: proposal.id,
       selectedDiff: props.selectedDiff ?? null,
       selectedDiffMode: props.selectedDiffMode ?? null,
+      selectedDiffInvalidReason: props.selectedDiffInvalidReason ?? null,
+      selectedDiffRevised: props.selectedDiffRevised ?? null,
       captureHref: '/workspace/inbox',
       proposalHref: '/workspace/review#proposal-p-1',
     },
@@ -90,7 +94,7 @@ describe('ReviewProposalCard diff presentation (#1397)', () => {
     expect(wrapper.find('[data-testid="review-diff-pre"]').exists()).toBe(false)
   })
 
-  it('renders the invalid verdict for a proposal with no operations', () => {
+  it('renders the invalid verdict with the zero-op fallback when no backend reason is supplied', () => {
     const wrapper = mountCard({
       selectedDiffMode: 'invalid',
       selectedDiff: null,
@@ -100,6 +104,50 @@ describe('ReviewProposalCard diff presentation (#1397)', () => {
     expect(invalid.exists()).toBe(true)
     expect(invalid.text()).toContain('no operations')
     expect(invalid.text()).toContain('reject')
+  })
+
+  it('renders the backend reason verbatim in the invalid verdict (#1397 MEDIUM-1)', () => {
+    // The expiry-race 400 carries "Proposal has expired" — the card must render
+    // THAT, never the hardcoded zero-op copy.
+    const wrapper = mountCard({
+      selectedDiffMode: 'invalid',
+      selectedDiff: null,
+      selectedDiffInvalidReason: 'Proposal has expired',
+    })
+
+    const invalid = wrapper.find('[data-testid="review-diff-invalid"]')
+    expect(invalid.exists()).toBe(true)
+    expect(invalid.text()).toContain('Proposal has expired')
+    expect(invalid.text()).not.toContain('no operations')
+  })
+
+  it('discloses a revision on the stored preview (#1397 MEDIUM-2)', () => {
+    const wrapper = mountCard({
+      proposal: makeProposal({ status: 'Applied' }),
+      selectedDiffMode: 'stored',
+      selectedDiff: '0. Create card "Original"',
+      selectedDiffRevised: true,
+    })
+
+    const note = wrapper.find('[data-testid="review-diff-revised-note"]')
+    expect(note.exists()).toBe(true)
+    expect(note.text()).toContain('revised')
+    expect(note.text()).toContain('original')
+    // The banner itself already attributes the content to the original submission.
+    expect(wrapper.find('[data-testid="review-diff-banner"]').text()).toContain('original submission')
+  })
+
+  it('omits the revised note when the revision state is unknown or absent', () => {
+    for (const revised of [false, null]) {
+      const wrapper = mountCard({
+        proposal: makeProposal({ status: 'Expired' }),
+        isExpired: true,
+        selectedDiffMode: 'stored',
+        selectedDiff: 'stored',
+        selectedDiffRevised: revised,
+      })
+      expect(wrapper.find('[data-testid="review-diff-revised-note"]').exists()).toBe(false)
+    }
   })
 
   it('renders the live diff pane for a still-actionable proposal', () => {

--- a/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/review/ReviewProposalCard.diff.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import type { Proposal } from '../../../types/automation'
+import type { ReviewDiffMode } from '../../../composables/useReviewActions'
+import ReviewProposalCard from '../../../components/review/ReviewProposalCard.vue'
+
+// #1397: PR #1395 made `/diff` 400 for expired/terminal proposals. The Legacy
+// card must present the stored preview under a read-only banner (never a live
+// diff), a "no stored preview" note when there is nothing stored, and an
+// explicit invalid verdict when a proposal has no operations Apply would accept.
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  const now = new Date().toISOString()
+  return {
+    id: 'p-1',
+    sourceType: 'Chat',
+    sourceReferenceId: null,
+    boardId: 'board-1',
+    requestedByUserId: 'u-1',
+    status: 'PendingReview',
+    riskLevel: 'Low',
+    summary: 'Test proposal',
+    diffPreview: null,
+    validationIssues: null,
+    createdAt: now,
+    updatedAt: now,
+    expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+    decidedAt: null,
+    decidedByUserId: null,
+    appliedAt: null,
+    failureReason: null,
+    correlationId: 'corr-1',
+    operations: [],
+    ...overrides,
+  } as Proposal
+}
+
+function mountCard(props: {
+  proposal?: Proposal
+  isExpired?: boolean
+  selectedDiff?: string | null
+  selectedDiffMode?: ReviewDiffMode | null
+}) {
+  const proposal = props.proposal ?? makeProposal()
+  return mount(ReviewProposalCard, {
+    props: {
+      proposal,
+      isExpired: props.isExpired ?? false,
+      isBusy: false,
+      selectedDiffProposalId: proposal.id,
+      selectedDiff: props.selectedDiff ?? null,
+      selectedDiffMode: props.selectedDiffMode ?? null,
+      captureHref: '/workspace/inbox',
+      proposalHref: '/workspace/review#proposal-p-1',
+    },
+  })
+}
+
+describe('ReviewProposalCard diff presentation (#1397)', () => {
+  it('shows a read-only banner and the stored preview for an expired proposal', () => {
+    const wrapper = mountCard({
+      proposal: makeProposal({ status: 'Expired' }),
+      isExpired: true,
+      selectedDiffMode: 'stored',
+      selectedDiff: '0. Create card "Archived"',
+    })
+
+    const banner = wrapper.find('[data-testid="review-diff-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Expired')
+    expect(banner.text()).toContain('read-only')
+    const stored = wrapper.find('[data-testid="review-diff-stored"]')
+    expect(stored.exists()).toBe(true)
+    expect(stored.text()).toContain('Archived')
+  })
+
+  it('shows the banner and a no-stored-preview note when there is no stored content', () => {
+    const wrapper = mountCard({
+      proposal: makeProposal({ status: 'Expired' }),
+      isExpired: true,
+      selectedDiffMode: 'stored',
+      selectedDiff: null,
+    })
+
+    expect(wrapper.find('[data-testid="review-diff-banner"]').exists()).toBe(true)
+    const storedEmpty = wrapper.find('[data-testid="review-diff-stored-empty"]')
+    expect(storedEmpty.exists()).toBe(true)
+    expect(storedEmpty.text()).toContain('No stored preview')
+    // Never falls through to a live "Operation details" pane for a settled proposal.
+    expect(wrapper.find('[data-testid="review-diff-pre"]').exists()).toBe(false)
+  })
+
+  it('renders the invalid verdict for a proposal with no operations', () => {
+    const wrapper = mountCard({
+      selectedDiffMode: 'invalid',
+      selectedDiff: null,
+    })
+
+    const invalid = wrapper.find('[data-testid="review-diff-invalid"]')
+    expect(invalid.exists()).toBe(true)
+    expect(invalid.text()).toContain('no operations')
+    expect(invalid.text()).toContain('reject')
+  })
+
+  it('renders the live diff pane for a still-actionable proposal', () => {
+    const wrapper = mountCard({
+      selectedDiffMode: 'live',
+      selectedDiff: '0. Create card "Fix login"',
+    })
+
+    const pre = wrapper.find('[data-testid="review-diff-pre"]')
+    expect(pre.exists()).toBe(true)
+    expect(pre.text()).toContain('Fix login')
+    expect(wrapper.find('.td-review-card__diff-label').text()).toBe('Operation details')
+    expect(wrapper.find('[data-testid="review-diff-banner"]').exists()).toBe(false)
+  })
+
+  it('hides the pane entirely while a live diff is still loading (no premature empty state)', () => {
+    const wrapper = mountCard({
+      selectedDiffMode: 'live',
+      selectedDiff: null,
+    })
+
+    // Live mode + no content yet → nothing rendered (mirrors the pre-fetch state),
+    // so a slow request never flashes a misleading "no changes" line.
+    expect(wrapper.find('[data-testid="review-diff-wrapper"]').exists()).toBe(false)
+  })
+})

--- a/frontend/taskdeck-web/src/tests/composables/useErrorMapper.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useErrorMapper.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getErrorDisplay, mapErrorToMessage, parseApiError } from '../../composables/useErrorMapper'
+import {
+  getErrorDisplay,
+  isValidationError,
+  mapErrorToMessage,
+  parseApiError,
+} from '../../composables/useErrorMapper'
 
 describe('useErrorMapper', () => {
   describe('mapErrorToMessage', () => {
@@ -64,6 +69,37 @@ describe('useErrorMapper', () => {
           },
         },
       })).toBeNull()
+    })
+  })
+
+  describe('isValidationError', () => {
+    // #1397 MEDIUM-1: the classifier requires status 400 AND the ValidationError
+    // code — neither alone may classify as the review-gate verdict.
+    it('is true only when status is 400 AND errorCode is ValidationError', () => {
+      expect(isValidationError({
+        response: { status: 400, data: { errorCode: 'ValidationError', message: 'Proposal has expired' } },
+      })).toBe(true)
+    })
+
+    it('is false for a 400 without the ValidationError code', () => {
+      expect(isValidationError({
+        response: { status: 400, data: { errorCode: 'Conflict', message: 'nope' } },
+      })).toBe(false)
+      expect(isValidationError({ response: { status: 400, data: {} } })).toBe(false)
+      expect(isValidationError({ response: { status: 400 } })).toBe(false)
+    })
+
+    it('is false for a ValidationError code on another status', () => {
+      expect(isValidationError({
+        response: { status: 500, data: { errorCode: 'ValidationError', message: 'boom' } },
+      })).toBe(false)
+    })
+
+    it('is false for non-object and shapeless inputs', () => {
+      expect(isValidationError(null)).toBe(false)
+      expect(isValidationError(undefined)).toBe(false)
+      expect(isValidationError('bad')).toBe(false)
+      expect(isValidationError(new Error('boom'))).toBe(false)
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/composables/useErrorMapper.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useErrorMapper.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getErrorDisplay,
+  getValidationReason,
   isValidationError,
   mapErrorToMessage,
   parseApiError,
@@ -130,6 +131,35 @@ describe('useErrorMapper', () => {
         message: 'Fallback message',
         code: null,
       })
+    })
+  })
+
+  describe('getValidationReason', () => {
+    // #1397 / #1414 review: the invalid-diff presentation renders its own
+    // specific "no operations" fallback when the backend gave no reason. This
+    // helper must therefore treat a blank message as absent (return null) and
+    // must NOT substitute the generic ValidationError copy that would mask it.
+    it('returns the trimmed backend message when one is present', () => {
+      expect(getValidationReason({
+        response: { status: 400, data: { errorCode: 'ValidationError', message: '  Proposal has expired  ' } },
+      })).toBe('Proposal has expired')
+    })
+
+    it('returns null for an empty backend message', () => {
+      expect(getValidationReason({
+        response: { status: 400, data: { errorCode: 'ValidationError', message: '' } },
+      })).toBeNull()
+    })
+
+    it('returns null for a whitespace-only backend message', () => {
+      expect(getValidationReason({
+        response: { status: 400, data: { errorCode: 'ValidationError', message: '   ' } },
+      })).toBeNull()
+    })
+
+    it('returns null when the input is not an API error shape', () => {
+      expect(getValidationReason(new Error('Local runtime failure'))).toBeNull()
+      expect(getValidationReason(null)).toBeNull()
     })
   })
 })

--- a/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useProposalRevisions.spec.ts
@@ -13,12 +13,14 @@ vi.mock('../../api/proposalRevisionsApi', () => ({
   },
 }))
 
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}))
+
 vi.mock('../../store/toastStore', () => ({
-  useToastStore: () => ({
-    success: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-  }),
+  useToastStore: () => toastMocks,
 }))
 
 function makeProposal(overrides: Partial<ApiProposal> = {}): ApiProposal {
@@ -229,6 +231,28 @@ describe('useProposalRevisions', () => {
 
     expect(revisionCount.value).toBe(0)
     expect(latestRevision.value).toBeNull()
+  })
+
+  it('suppresses the failure toast for a silent load while keeping the state non-authoritative (#1397 round 3)', async () => {
+    // The augment-only callers (read-only stored preview) load revision metadata
+    // silently: no error toast on failure, but revisionsLoaded must STILL stay
+    // false so authoritative consumers never trust the unknown state.
+    vi.mocked(proposalRevisionsApi.getRevisions).mockRejectedValue(new Error('boom'))
+
+    const proposal = ref<ApiProposal | null>(makeProposal())
+    const { revisionsLoaded, revisionCount, loadRevisionState } = useProposalRevisions(proposal)
+
+    // The mount-time background load is NOT silent — it toasts.
+    await vi.waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalled()
+    })
+    toastMocks.error.mockClear()
+
+    await loadRevisionState('p-1', { silent: true })
+
+    expect(toastMocks.error).not.toHaveBeenCalled()
+    expect(revisionsLoaded.value).toBe(false)
+    expect(revisionCount.value).toBe(0)
   })
 
   it('discards stale load responses when proposal switches quickly', async () => {

--- a/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
@@ -158,6 +158,84 @@ describe('useReviewActions', () => {
 
     expect(actions.selectedDiffProposalId.value).toBeNull()
     expect(actions.selectedDiff.value).toBeNull()
+    expect(actions.selectedDiffMode.value).toBeNull()
+  })
+
+  // --- #1397: read-only / expired proposals never fire the live diff ---
+
+  it('presents the stored preview without fetching for an expired proposal', async () => {
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Expired', diffPreview: 'stored diff text' }),
+    ]
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+
+    expect(automationApi.getProposalDiff).not.toHaveBeenCalled()
+    expect(actions.selectedDiffProposalId.value).toBe('p-1')
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored diff text')
+  })
+
+  it('presents the stored mode with no content when a read-only proposal has no stored preview', async () => {
+    proposals.value = [makeProposal({ id: 'p-1', status: 'Applied', diffPreview: null })]
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+
+    expect(automationApi.getProposalDiff).not.toHaveBeenCalled()
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBeNull()
+  })
+
+  it('classifies a proposal as read-only via the injected expiry rule (client-side clock)', async () => {
+    // Status is still PendingReview, but the surface reports it expired (its
+    // expiresAt passed mid-session). It must be treated as read-only, not fetched.
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'PendingReview', diffPreview: 'stored' }),
+    ]
+
+    const actions = useReviewActions(
+      proposals,
+      dismissableIds,
+      loadProposals,
+      () => true, // isProposalExpired
+    )
+    await actions.handleToggleDiff('p-1')
+
+    expect(automationApi.getProposalDiff).not.toHaveBeenCalled()
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored')
+  })
+
+  it('renders the invalid verdict (not a cleared pane) when /diff returns a 400 ValidationError', async () => {
+    proposals.value = [makeProposal({ id: 'p-1', status: 'PendingReview' })]
+    vi.mocked(automationApi.getProposalDiff).mockRejectedValue({
+      response: { status: 400, data: { errorCode: 'ValidationError', message: 'Proposal must contain at least one operation' } },
+    })
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+
+    expect(automationApi.getProposalDiff).toHaveBeenCalledWith('p-1')
+    // The pane stays open on this proposal, presenting the invalid verdict.
+    expect(actions.selectedDiffProposalId.value).toBe('p-1')
+    expect(actions.selectedDiffMode.value).toBe('invalid')
+    expect(actions.selectedDiff.value).toBeNull()
+  })
+
+  it('tears the pane down and toasts for a non-validation diff error (e.g. 404)', async () => {
+    proposals.value = [makeProposal({ id: 'p-1', status: 'PendingReview' })]
+    vi.mocked(automationApi.getProposalDiff).mockRejectedValue({
+      response: { status: 404, data: { errorCode: 'NotFound', message: 'Proposal not found' } },
+    })
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+
+    expect(actions.selectedDiffProposalId.value).toBeNull()
+    expect(actions.selectedDiffMode.value).toBeNull()
+    expect(actions.selectedDiff.value).toBeNull()
   })
 
   it('should dismiss a proposal successfully', async () => {

--- a/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
@@ -337,6 +337,45 @@ describe('useReviewActions', () => {
     expect(actions.selectedDiff.value).toBe('stored preview')
   })
 
+  it('converts an IN-FLIGHT live diff to stored on read-only flip and discards the late response (#1397 round 3)', async () => {
+    // While a live /diff is in flight the pane state is id-set + mode null. The
+    // read-only watcher must treat that loading state as convertible too: bump
+    // the request id (invalidating the pending response) and present the stored
+    // state — otherwise the late live response renders live UI on a proposal
+    // that is no longer actionable.
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'PendingReview', diffPreview: 'stored preview' }),
+    ]
+    let resolveDiff: ((value: string) => void) | undefined
+    vi.mocked(automationApi.getProposalDiff).mockImplementation(
+      () => new Promise<string>((resolve) => { resolveDiff = resolve }),
+    )
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    const togglePromise = actions.handleToggleDiff('p-1')
+    await nextTick()
+
+    // In flight: pane anchored, no mode yet.
+    expect(actions.selectedDiffProposalId.value).toBe('p-1')
+    expect(actions.selectedDiffMode.value).toBeNull()
+
+    // The proposal turns terminal while the fetch is pending.
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Applied', diffPreview: 'stored preview' }),
+    ]
+    await nextTick()
+
+    // Converted immediately — before the live response lands.
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored preview')
+
+    // The late live response must be discarded (request id was bumped).
+    resolveDiff?.('live diff content')
+    await togglePromise
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored preview')
+  })
+
   it('tears the pane down and toasts for a non-validation diff error (e.g. 404)', async () => {
     proposals.value = [makeProposal({ id: 'p-1', status: 'PendingReview' })]
     vi.mocked(automationApi.getProposalDiff).mockRejectedValue({

--- a/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useReviewActions } from '../../composables/useReviewActions'
 import { automationApi } from '../../api/automationApi'
+import { proposalRevisionsApi } from '../../api/proposalRevisionsApi'
 import type { Proposal as ApiProposal } from '../../types/automation'
 
 vi.mock('../../api/automationApi', () => ({
@@ -11,6 +12,12 @@ vi.mock('../../api/automationApi', () => ({
     executeProposal: vi.fn(),
     dismissProposals: vi.fn(),
     getProposalDiff: vi.fn(),
+  },
+}))
+
+vi.mock('../../api/proposalRevisionsApi', () => ({
+  proposalRevisionsApi: {
+    getRevisions: vi.fn(),
   },
 }))
 
@@ -55,6 +62,7 @@ describe('useReviewActions', () => {
     proposals = ref([makeProposal()])
     dismissableIds = computed(() => [])
     loadProposals = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([])
   })
 
   it('should approve a proposal and update the list', async () => {
@@ -208,7 +216,7 @@ describe('useReviewActions', () => {
     expect(actions.selectedDiff.value).toBe('stored')
   })
 
-  it('renders the invalid verdict (not a cleared pane) when /diff returns a 400 ValidationError', async () => {
+  it('renders the invalid verdict with the backend reason when /diff returns a 400 ValidationError', async () => {
     proposals.value = [makeProposal({ id: 'p-1', status: 'PendingReview' })]
     vi.mocked(automationApi.getProposalDiff).mockRejectedValue({
       response: { status: 400, data: { errorCode: 'ValidationError', message: 'Proposal must contain at least one operation' } },
@@ -218,10 +226,97 @@ describe('useReviewActions', () => {
     await actions.handleToggleDiff('p-1')
 
     expect(automationApi.getProposalDiff).toHaveBeenCalledWith('p-1')
-    // The pane stays open on this proposal, presenting the invalid verdict.
+    // The pane stays open on this proposal, presenting the invalid verdict with
+    // the backend's ACTUAL reason (#1397 MEDIUM-1).
     expect(actions.selectedDiffProposalId.value).toBe('p-1')
     expect(actions.selectedDiffMode.value).toBe('invalid')
+    expect(actions.selectedDiffInvalidReason.value).toBe('Proposal must contain at least one operation')
     expect(actions.selectedDiff.value).toBeNull()
+  })
+
+  it('carries the backend expiry reason for a 400 on the expiry race, not the zero-op copy', async () => {
+    // The 60s review clock can lag a server-side expiry: the proposal still
+    // classifies live client-side, the live diff fires, and the backend answers
+    // 400 "Proposal has expired". The presentation must carry THAT reason —
+    // mislabeling it as a zero-op structure problem is factually wrong
+    // (#1397 MEDIUM-1).
+    proposals.value = [makeProposal({ id: 'p-1', status: 'PendingReview' })]
+    vi.mocked(automationApi.getProposalDiff).mockRejectedValue({
+      response: { status: 400, data: { errorCode: 'ValidationError', message: 'Proposal has expired' } },
+    })
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+
+    expect(actions.selectedDiffMode.value).toBe('invalid')
+    expect(actions.selectedDiffInvalidReason.value).toBe('Proposal has expired')
+    expect(actions.selectedDiffInvalidReason.value).not.toContain('operation')
+  })
+
+  it('marks the stored preview as revised when the proposal has saved revisions', async () => {
+    // diffPreview is creation-time content revisions never update: a revised
+    // terminal proposal's stored preview shows the ORIGINAL submission, so the
+    // banner must disclose the revision (#1397 MEDIUM-2).
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Applied', diffPreview: 'original ops' }),
+    ]
+    vi.mocked(proposalRevisionsApi.getRevisions).mockResolvedValue([
+      {
+        id: 'rev-1', proposalId: 'p-1', revisionNumber: 1, editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}', revisedAt: new Date().toISOString(),
+        reason: 'edit', createdAt: new Date().toISOString(),
+      },
+    ])
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+    // Settle the fire-and-forget revision fetch.
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiffRevised.value).toBe(true)
+  })
+
+  it('leaves the revised flag unknown (null) when the revision fetch fails', async () => {
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Expired', diffPreview: 'stored' }),
+    ]
+    vi.mocked(proposalRevisionsApi.getRevisions).mockRejectedValue(new Error('boom'))
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // The stored preview still renders; the disclosure just stays generic.
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored')
+    expect(actions.selectedDiffRevised.value).toBeNull()
+  })
+
+  it('re-derives an open live pane to the stored presentation when the proposal turns read-only', async () => {
+    // #1397 LOW-5: a proposal can flip to terminal/expired WHILE its live pane is
+    // open (status change or clock tick). The pane must switch to the stored
+    // read-only presentation instead of keeping a live-looking diff.
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'PendingReview', diffPreview: 'stored preview' }),
+    ]
+    vi.mocked(automationApi.getProposalDiff).mockResolvedValue('live diff')
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+    expect(actions.selectedDiffMode.value).toBe('live')
+    expect(actions.selectedDiff.value).toBe('live diff')
+
+    // The proposal turns terminal (e.g. a refresh maps in an Applied state).
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Applied', diffPreview: 'stored preview' }),
+    ]
+    await nextTick()
+
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored preview')
   })
 
   it('tears the pane down and toasts for a non-validation diff error (e.g. 404)', async () => {

--- a/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
@@ -12,6 +12,7 @@ vi.mock('../../api/automationApi', () => ({
     executeProposal: vi.fn(),
     dismissProposals: vi.fn(),
     getProposalDiff: vi.fn(),
+    getProposal: vi.fn(),
   },
 }))
 
@@ -181,6 +182,44 @@ describe('useReviewActions', () => {
 
     expect(automationApi.getProposalDiff).not.toHaveBeenCalled()
     expect(actions.selectedDiffProposalId.value).toBe('p-1')
+    expect(actions.selectedDiffMode.value).toBe('stored')
+    expect(actions.selectedDiff.value).toBe('stored diff text')
+  })
+
+  it('retracts the stored preview when the access re-check returns 403 after reveal (#1414 P2 #2)', async () => {
+    // Revealing the stored preview re-authorizes via getProposal; a 403/404 means
+    // board access was revoked mid-session, so the locally-cached preview is torn
+    // down. Rendered synchronously first (the #1397 no-network-gate invariant),
+    // then retracted once the async probe reports revoked access.
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Expired', diffPreview: 'stored diff text' }),
+    ]
+    vi.mocked(automationApi.getProposal).mockRejectedValue({ response: { status: 403 } })
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+    // Let the async access probe settle.
+    await new Promise((resolve) => setTimeout(resolve))
+
+    expect(automationApi.getProposal).toHaveBeenCalledWith('p-1')
+    // Preview retracted once the probe reports revoked access.
+    expect(actions.selectedDiffMode.value).toBeNull()
+    expect(actions.selectedDiffProposalId.value).toBeNull()
+    expect(actions.selectedDiff.value).toBeNull()
+  })
+
+  it('keeps the stored preview when the access re-check returns a transient 500 (#1414 P2 #2)', async () => {
+    // Only a genuine 403/404 retracts — a transient error must not tear down an
+    // inspectable local preview.
+    proposals.value = [
+      makeProposal({ id: 'p-1', status: 'Expired', diffPreview: 'stored diff text' }),
+    ]
+    vi.mocked(automationApi.getProposal).mockRejectedValue({ response: { status: 500 } })
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+    await new Promise((resolve) => setTimeout(resolve))
+
     expect(actions.selectedDiffMode.value).toBe('stored')
     expect(actions.selectedDiff.value).toBe('stored diff text')
   })

--- a/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewActions.spec.ts
@@ -234,6 +234,24 @@ describe('useReviewActions', () => {
     expect(actions.selectedDiff.value).toBeNull()
   })
 
+  it('leaves the invalid reason null for a 400 with a blank message so the card fallback applies (#1397 / #1414)', async () => {
+    // A ValidationError 400 with an empty/whitespace message previously mapped to
+    // the generic "Please check your input" copy, which then MASKED the card's
+    // specific "no operations" fallback. Derive the reason as null instead so the
+    // caller-level fallback copy applies.
+    proposals.value = [makeProposal({ id: 'p-1', status: 'PendingReview' })]
+    vi.mocked(automationApi.getProposalDiff).mockRejectedValue({
+      response: { status: 400, data: { errorCode: 'ValidationError', message: '   ' } },
+    })
+
+    const actions = useReviewActions(proposals, dismissableIds, loadProposals)
+    await actions.handleToggleDiff('p-1')
+
+    expect(actions.selectedDiffMode.value).toBe('invalid')
+    expect(actions.selectedDiffInvalidReason.value).toBeNull()
+    expect(actions.selectedDiffInvalidReason.value).not.toBe('Please check your input and try again.')
+  })
+
   it('carries the backend expiry reason for a 400 on the expiry race, not the zero-op copy', async () => {
     // The 60s review clock can lag a server-side expiry: the proposal still
     // classifies live client-side, the live diff fires, and the backend answers

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -131,6 +131,23 @@ function makeProposal(overrides: Partial<{
     expiresAt: overrides.expiresAt ?? '2099-01-01T00:00:00Z',
     decidedAt: null,
     decidedByUserId: null,
+    // One operation by default: approve-actionability additionally requires a
+    // structurally applyable (non-zero-op) proposal (#1397); the status/expiry
+    // truth tables below assert against a realistic applyable fixture, and the
+    // zero-op arm is asserted explicitly in its own test.
+    operations: [
+      {
+        id: 'op-1',
+        proposalId: overrides.id ?? 'p-1',
+        sequence: 0,
+        actionType: 'CreateCard',
+        targetType: 'Card',
+        targetId: null,
+        parameters: '{}',
+        idempotencyKey: 'k-1',
+        expectedVersion: null,
+      },
+    ],
   }
 }
 
@@ -382,6 +399,22 @@ describe('useReviewProposals', () => {
         expect(isProposalApproveActionable(p, expired)).toBe(expectedReject)
       },
     )
+
+    // #1397 LOW-3: Approve additionally requires a structurally applyable
+    // proposal — Apply (and /diff) reject a zero-op proposal with 400, so the
+    // rail must not offer Approve for it. A saved revision is the #1235 escape:
+    // it carries operations the backend applies revision-aware.
+    it('isProposalApproveActionable rejects a zero-op pending proposal unless a saved revision exists', () => {
+      const zeroOp = { ...makeProposal({ status: 'PendingReview' }), operations: [] } as any
+      expect(isProposalApproveActionable(zeroOp, false)).toBe(false)
+      expect(isProposalApproveActionable(zeroOp, false, { hasSavedRevision: true })).toBe(true)
+      // Reject/apply gating is NOT structural — the reviewer can still clear it.
+      expect(isProposalRejectActionable(zeroOp, false)).toBe(true)
+
+      const missingOps = { ...makeProposal({ status: 'PendingReview' }) } as any
+      delete missingOps.operations
+      expect(isProposalApproveActionable(missingOps, false)).toBe(false)
+    })
 
     // Concrete verdicts (not just self-parity) so a logic flip is caught even
     // if the local mirror is wrong too.

--- a/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useReviewProposals.spec.ts
@@ -113,7 +113,7 @@ function watcherForCurrentSourceValue(expected: unknown) {
 
 function makeProposal(overrides: Partial<{
   id: string; status: string; sourceType: string; sourceReferenceId: string | null;
-  boardId: string | null; createdAt: string; expiresAt: string;
+  boardId: string | null; createdAt: string; expiresAt: string; isExpired: boolean;
 }> = {}) {
   return {
     id: overrides.id ?? 'p-1',
@@ -129,6 +129,7 @@ function makeProposal(overrides: Partial<{
     createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     expiresAt: overrides.expiresAt ?? '2099-01-01T00:00:00Z',
+    isExpired: overrides.isExpired,
     decidedAt: null,
     decidedByUserId: null,
     // One operation by default: approve-actionability additionally requires a
@@ -319,6 +320,42 @@ describe('useReviewProposals', () => {
       const rp = useReviewProposals()
       const p = makeProposal({ status: 'Applied' })
       expect(rp.isProposalExpired(p as any)).toBe(false)
+    })
+
+    it('honors the server isExpired flag for a PendingReview proposal whose client clock has not yet elapsed (#1414 P2 #1)', () => {
+      // Clock lag/skew: the server has already expired the proposal (isExpired:
+      // true) but the client's 60s clock still reads a moment before expiresAt.
+      // Without honoring the flag the read-only guards would fire a live /diff
+      // that 400s instead of presenting the stored preview.
+      const rp = useReviewProposals()
+      rp.nowMs.value = new Date('2026-06-01T00:00:00Z').getTime()
+      const p = makeProposal({
+        status: 'PendingReview',
+        expiresAt: '2026-06-01T00:00:30Z', // 30s in the "future" per the lagging client clock
+        isExpired: true,
+      })
+      expect(rp.isProposalExpired(p as any)).toBe(true)
+    })
+
+    it('honors the server isExpired flag for an Approved proposal whose client clock has not yet elapsed (#1414 P2 #1)', () => {
+      const rp = useReviewProposals()
+      rp.nowMs.value = new Date('2026-06-01T00:00:00Z').getTime()
+      const p = makeProposal({ status: 'Approved', expiresAt: '2099-01-01T00:00:00Z', isExpired: true })
+      expect(rp.isProposalExpired(p as any)).toBe(true)
+    })
+
+    it('does NOT flip a terminal Applied proposal to expired even when the server isExpired flag is true (#1414 P2 #1 boundary)', () => {
+      // The backend isExpired flag is time-based and status-agnostic (true for
+      // any past-expiry proposal). Consulting it must stay scoped to
+      // PendingReview/Approved — a terminal proposal whose expiry later passed
+      // must keep its terminal classification, or visibleProposals would
+      // force-show completed items and the status labels would mislabel it.
+      const rp = useReviewProposals()
+      rp.nowMs.value = new Date('2026-06-04T00:00:00Z').getTime()
+      const applied = makeProposal({ status: 'Applied', expiresAt: '2026-05-01T00:00:00Z', isExpired: true })
+      const rejected = makeProposal({ status: 'Rejected', expiresAt: '2026-05-01T00:00:00Z', isExpired: true })
+      expect(rp.isProposalExpired(applied as any)).toBe(false)
+      expect(rp.isProposalExpired(rejected as any)).toBe(false)
     })
   })
 

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.coverage.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.coverage.spec.ts
@@ -84,6 +84,16 @@ vi.mock('../../utils/requestId', () => ({
 
 vi.mock('../../composables/useErrorMapper', () => ({
   getErrorDisplay: (_error: unknown, fallback: string) => ({ message: fallback }),
+  isValidationError: (error: unknown) => {
+    const typed = error as { response?: { status?: number; data?: { errorCode?: string } } } | null
+    return typed?.response?.status === 400 && typed?.response?.data?.errorCode === 'ValidationError'
+  },
+}))
+
+vi.mock('../../api/proposalRevisionsApi', () => ({
+  proposalRevisionsApi: {
+    getRevisions: vi.fn().mockResolvedValue([]),
+  },
 }))
 
 function buildProposal(overrides: Partial<Proposal> = {}): Proposal {
@@ -108,7 +118,21 @@ function buildProposal(overrides: Partial<Proposal> = {}): Proposal {
     appliedAt: null,
     failureReason: null,
     correlationId: 'triage-run-1',
-    operations: [],
+    // One operation by default: Approve is disabled for zero-op proposals
+    // (#1397), and these coverage flows click Approve on a realistic fixture.
+    operations: [
+      {
+        id: 'op-1',
+        proposalId: 'proposal-1',
+        sequence: 0,
+        actionType: 'CreateCard',
+        targetType: 'Card',
+        targetId: null,
+        parameters: '{}',
+        idempotencyKey: 'k-1',
+        expectedVersion: null,
+      },
+    ],
     presentation: {
       plainSummary: 'Test proposal summary.',
       impactSummary: '1 planned change.',

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
@@ -56,6 +56,7 @@ const mocks = vi.hoisted(() => ({
   executeProposal: vi.fn(),
   getProposalDiff: vi.fn(),
   dismissProposals: vi.fn(),
+  getRevisions: vi.fn(),
   getBoards: vi.fn(),
   successToast: vi.fn(),
   errorToast: vi.fn(),
@@ -93,8 +94,24 @@ vi.mock('../../utils/requestId', () => ({
   createRequestId: mocks.createRequestId,
 }))
 
+vi.mock('../../api/proposalRevisionsApi', () => ({
+  proposalRevisionsApi: {
+    getRevisions: mocks.getRevisions,
+  },
+}))
+
+// Mirrors the real getErrorDisplay closely enough for shell tests: the backend
+// message wins when present, else the fallback. isValidationError follows the
+// real 400-AND-ValidationError rule (#1397).
 vi.mock('../../composables/useErrorMapper', () => ({
-  getErrorDisplay: (_error: unknown, fallback: string) => ({ message: fallback }),
+  getErrorDisplay: (error: unknown, fallback: string) => {
+    const typed = error as { response?: { data?: { message?: string } } } | null
+    return { message: typed?.response?.data?.message || fallback, code: null }
+  },
+  isValidationError: (error: unknown) => {
+    const typed = error as { response?: { status?: number; data?: { errorCode?: string } } } | null
+    return typed?.response?.status === 400 && typed?.response?.data?.errorCode === 'ValidationError'
+  },
 }))
 
 function buildProposal(overrides: Partial<Proposal> = {}): Proposal {
@@ -230,6 +247,7 @@ describe('ReviewView', () => {
     mocks.rejectProposal.mockResolvedValue(buildProposal({ status: 'Rejected' }))
     mocks.executeProposal.mockResolvedValue(buildProposal({ status: 'Applied' }))
     mocks.getProposalDiff.mockResolvedValue('diff')
+    mocks.getRevisions.mockResolvedValue([])
     mocks.dismissProposals.mockResolvedValue({ dismissed: 1 })
     mocks.createRequestId.mockReturnValue('request-1')
   })
@@ -1032,5 +1050,65 @@ describe('ReviewView', () => {
     expect(wrapper.text()).toContain('Operation details')
     expect(wrapper.find('.td-review-card__diff').exists()).toBe(true)
     expect(wrapper.find('.td-review-card__diff-label').exists()).toBe(true)
+  })
+
+  it('shows the stored preview with a read-only banner for an expired proposal without firing /diff (#1397)', async () => {
+    mocks.getProposals.mockResolvedValue([
+      buildProposal({
+        id: 'proposal-expired-stored',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Archived plan"',
+      }),
+    ])
+
+    const { wrapper } = await mountAt('/workspace/review')
+
+    const storedBtn = wrapper
+      .get('#proposal-proposal-expired-stored')
+      .findAll('button')
+      .find((node) => node.text() === 'View stored preview')!
+    await storedBtn.trigger('click')
+    await Promise.resolve()
+    await wrapper.vm.$nextTick()
+
+    // Expired proposals stay inspectable via stored content; the live /diff
+    // (which now 400s for them) is never fired and no error toast appears.
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    const banner = wrapper.find('[data-testid="review-diff-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('read-only')
+    expect(wrapper.find('[data-testid="review-diff-stored"]').text()).toContain('Archived plan')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+  })
+
+  it('renders the backend expiry reason inline when /diff 400s on the expiry race (#1397 MEDIUM-1)', async () => {
+    // The 60s review clock can lag a server-side expiry: the card still shows
+    // the live "View Diff", the request fires, and the backend answers 400
+    // "Proposal has expired". The pane must present THAT reason — not a
+    // zero-op message, not a toast, not a cleared pane.
+    mocks.getProposals.mockResolvedValue([buildProposal({ id: 'proposal-race' })])
+    mocks.getProposalDiff.mockRejectedValue({
+      response: {
+        status: 400,
+        data: { errorCode: 'ValidationError', message: 'Proposal has expired' },
+      },
+    })
+
+    const { wrapper } = await mountAt('/workspace/review')
+
+    const viewDiffBtn = wrapper
+      .get('#proposal-proposal-race')
+      .findAll('button')
+      .find((node) => node.text() === 'View Diff')!
+    await viewDiffBtn.trigger('click')
+    await Promise.resolve()
+    await wrapper.vm.$nextTick()
+
+    const invalid = wrapper.find('[data-testid="review-diff-invalid"]')
+    expect(invalid.exists()).toBe(true)
+    expect(invalid.text()).toContain('Proposal has expired')
+    expect(invalid.text()).not.toContain('no operations')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
   })
 })

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
@@ -102,7 +102,9 @@ vi.mock('../../api/proposalRevisionsApi', () => ({
 
 // Mirrors the real getErrorDisplay closely enough for shell tests: the backend
 // message wins when present, else the fallback. isValidationError follows the
-// real 400-AND-ValidationError rule (#1397).
+// real 400-AND-ValidationError rule (#1397). getValidationReason returns the
+// trimmed backend message or null when blank, so the caller's specific fallback
+// copy applies rather than a masking generic string (#1397 / #1414).
 vi.mock('../../composables/useErrorMapper', () => ({
   getErrorDisplay: (error: unknown, fallback: string) => {
     const typed = error as { response?: { data?: { message?: string } } } | null
@@ -111,6 +113,11 @@ vi.mock('../../composables/useErrorMapper', () => ({
   isValidationError: (error: unknown) => {
     const typed = error as { response?: { status?: number; data?: { errorCode?: string } } } | null
     return typed?.response?.status === 400 && typed?.response?.data?.errorCode === 'ValidationError'
+  },
+  getValidationReason: (error: unknown) => {
+    const typed = error as { response?: { data?: { message?: string } } } | null
+    const message = typed?.response?.data?.message?.trim()
+    return message && message.length > 0 ? message : null
   },
 }))
 

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1036,7 +1036,7 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
-  it('renders the invalid verdict (not a toast) when /diff 400s for a pending proposal (#1397)', async () => {
+  it('renders the invalid verdict with the backend reason (not a toast) when /diff 400s for a pending proposal (#1397)', async () => {
     mocks.getProposalDiff.mockRejectedValueOnce({
       response: {
         status: 400,
@@ -1049,14 +1049,137 @@ describe('PaperReviewView', () => {
     await flushPromises()
 
     expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-400')
-    // The 400 is presented inline, not toasted, and the pane is not torn down.
+    // The 400 is presented inline with the backend's actual message, not
+    // toasted, and the pane is not torn down.
     const invalid = wrapper.find('[data-testid="paper-review-diff-invalid"]')
     expect(invalid.exists()).toBe(true)
-    expect(invalid.text()).toContain('no operations')
+    expect(invalid.text()).toContain('must contain at least one operation')
     expect(mocks.errorToast).not.toHaveBeenCalled()
     expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(true)
 
     wrapper.unmount()
+  })
+
+  it('renders the backend expiry reason for a 400 on the expiry race, not the zero-op copy (#1397 MEDIUM-1)', async () => {
+    // The 60s review clock can lag a server-side expiry: the proposal still
+    // classifies live client-side → the live diff fires → the backend answers
+    // 400 "Proposal has expired". The pane must present THAT reason; telling
+    // the reviewer the proposal "contains no operations" would be false.
+    mocks.getProposalDiff.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: { errorCode: 'ValidationError', message: 'Proposal has expired' },
+      },
+    })
+    const wrapper = await mountView([makeProposal({ id: 'diff-race' })])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    const invalid = wrapper.find('[data-testid="paper-review-diff-invalid"]')
+    expect(invalid.exists()).toBe(true)
+    expect(invalid.text()).toContain('Proposal has expired')
+    expect(invalid.text()).not.toContain('no operations')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('discloses a revision on the stored preview of a terminal proposal (#1397 MEDIUM-2)', async () => {
+    // diffPreview is creation-time content revisions never update: a
+    // revised-then-settled proposal's stored preview shows the ORIGINAL
+    // submission, so the banner must say the proposal was revised.
+    const now = new Date().toISOString()
+    mocks.getRevisions.mockResolvedValue([
+      {
+        id: 'rev-1',
+        proposalId: 'diff-revised-expired',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'diff-revised-expired',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Original ops"',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(true)
+    const revisedNote = wrapper.find('[data-testid="paper-review-diff-revised-note"]')
+    expect(revisedNote.exists()).toBe(true)
+    expect(revisedNote.text()).toContain('revised')
+    expect(revisedNote.text()).toContain('original')
+    // The live-mode "reflects your saved edit" caveat must NOT certify the
+    // stored (pre-revision) content.
+    expect(wrapper.find('[data-testid="paper-review-diff-revision-caveat"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('blocks Approve for a zero-operation pending proposal with an explicit verdict (#1397 LOW-3)', async () => {
+    const wrapper = await mountView([
+      makeProposal({ id: 'noop-approve', diffPreview: null, operations: [] }),
+    ])
+
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.infoToast).toHaveBeenCalledWith(
+      expect.stringContaining('no operations'),
+    )
+
+    wrapper.unmount()
+  })
+
+  it('re-derives an open live pane to the stored presentation when the expiry clock passes (#1397 LOW-5)', async () => {
+    // Open the live diff on a pending proposal that expires in 30s, then tick
+    // the 60s review clock past its expiresAt: the pane must flip to the stored
+    // read-only presentation instead of keeping the live-looking diff on a
+    // proposal that is no longer actionable. Only setInterval and Date are
+    // faked so flushPromises (setTimeout-based) keeps working.
+    vi.useFakeTimers({ toFake: ['setInterval', 'Date'] })
+    try {
+      mocks.getProposalDiff.mockResolvedValueOnce('0. Create card "Live"')
+      const wrapper = await mountView([
+        makeProposal({
+          id: 'flip-exp',
+          status: 'PendingReview',
+          expiresAt: new Date(Date.now() + 30_000).toISOString(),
+          diffPreview: '0. Create card "Stored"',
+        }),
+      ])
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+      await flushPromises()
+      expect(wrapper.find('[data-testid="paper-review-diff-pre"]').text()).toContain('Live')
+      expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(false)
+
+      // One 60s clock tick → nowMs passes expiresAt → the proposal is expired.
+      vi.advanceTimersByTime(60_000)
+      await flushPromises()
+      await wrapper.vm.$nextTick()
+
+      const banner = wrapper.find('[data-testid="paper-review-diff-banner"]')
+      expect(banner.exists()).toBe(true)
+      expect(banner.text()).toContain('read-only')
+      expect(wrapper.find('[data-testid="paper-review-diff-pre"]').text()).toContain('Stored')
+
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('fetches the revision-aware diff for a 0-operation proposal that has a saved revision', async () => {

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1012,13 +1012,41 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
-  it('shows the banner and a no-stored-preview note for an expired proposal with no stored content (#1397)', async () => {
+  it('falls back to the recorded operations for an expired proposal with no stored preview (#1397 / Codex)', async () => {
+    // Normal creation flows never populate diffPreview, so an expired proposal
+    // with operations must still be inspectable via a locally rendered
+    // operation listing — no /diff call, no dead "no stored preview" end.
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'diff-expired-ops',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: null,
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(true)
+    const opsFallback = wrapper.find('[data-testid="paper-review-diff-stored-operations"]')
+    expect(opsFallback.exists()).toBe(true)
+    expect(opsFallback.text()).toContain('Create Card')
+    expect(wrapper.find('[data-testid="paper-review-diff-stored-empty"]').exists()).toBe(false)
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('shows the banner and a no-stored-preview note for an expired zero-op proposal with no stored content (#1397)', async () => {
     const wrapper = await mountView([
       makeProposal({
         id: 'diff-expired-empty',
         status: 'Expired',
         expiresAt: new Date(Date.now() - 60_000).toISOString(),
         diffPreview: null,
+        operations: [],
       }),
     ])
 

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1167,6 +1167,12 @@ describe('PaperReviewView', () => {
     expect(mocks.infoToast).toHaveBeenCalledWith(
       expect.stringContaining('no operations'),
     )
+    // Pin the PENDING-distinctive copy (not the Approved variant): an
+    // always-true `approvedZeroOp` bug would swap this for the Approved wording
+    // and drop the "Reject or file it away" guidance — assert it explicitly.
+    expect(mocks.infoToast).toHaveBeenCalledWith(
+      expect.stringContaining('Reject or file it away instead'),
+    )
 
     wrapper.unmount()
   })
@@ -1208,6 +1214,297 @@ describe('PaperReviewView', () => {
     expect(mocks.approveProposal).not.toHaveBeenCalled()
     expect(mocks.infoToast).toHaveBeenCalledWith(expect.stringContaining('no operations'))
 
+    wrapper.unmount()
+  })
+
+  it('holds the shared busy lock during the zero-op guard load so Defer cannot snooze the proposal mid-flight (#1414 round 4 P2-A)', async () => {
+    // P2-A: while the zero-op guard awaits its revision load, applyGuardBusy now
+    // joins the shared busy lock, so Defer/Reject are inert. Without it a Defer
+    // landing during the await — with the #proposal- hash carve-out keeping the
+    // same proposal selected — could snooze a proposal the resumed Apply then
+    // approves.
+    const now = new Date().toISOString()
+    let resolveRevisions: ((value: unknown[]) => void) | undefined
+    mocks.getRevisions.mockImplementation(
+      () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+    )
+    mocks.approveProposal.mockResolvedValueOnce(
+      makeProposal({ id: 'noop-busy', status: 'Approved' }),
+    )
+    const wrapper = await mountView(
+      [makeProposal({ id: 'noop-busy', diffPreview: null, operations: [] })],
+      '/workspace/review#proposal-noop-busy',
+    )
+
+    // Apply parks on the revision load; the guard now holds the shared busy lock.
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await Promise.resolve()
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+
+    // Defer mid-await is swallowed by the shared busy lock — no snooze request.
+    await wrapper.find('[data-testid="decision-defer"]').trigger('click')
+    await Promise.resolve()
+    expect(mocks.deferProposal).not.toHaveBeenCalled()
+
+    // Settle with a saved revision → known, non-zero state → Apply proceeds and
+    // the never-snoozed proposal is approved.
+    resolveRevisions?.([
+      {
+        id: 'rev-busy',
+        proposalId: 'noop-busy',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    await flushPromises()
+    expect(mocks.approveProposal).toHaveBeenCalledWith('noop-busy')
+    expect(mocks.deferProposal).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('holds the shared busy lock so Reject cannot settle the proposal during the zero-op guard load (#1414 round 4 P2-A)', async () => {
+    // The P2-A invariant names Defer AND Reject. onReject now carries the same
+    // internal busy guard as onDefer; assert a Reject landing mid-await is inert
+    // (no reject request), so the resumed Apply cannot approve a just-rejected
+    // proposal.
+    const now = new Date().toISOString()
+    let resolveRevisions: ((value: unknown[]) => void) | undefined
+    mocks.getRevisions.mockImplementation(
+      () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+    )
+    mocks.approveProposal.mockResolvedValueOnce(
+      makeProposal({ id: 'noop-reject-busy', status: 'Approved' }),
+    )
+    const wrapper = await mountView(
+      [makeProposal({ id: 'noop-reject-busy', diffPreview: null, operations: [] })],
+      '/workspace/review#proposal-noop-reject-busy',
+    )
+
+    // Apply parks on the revision load; the guard holds the shared busy lock.
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await Promise.resolve()
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+
+    // Reject mid-await is swallowed by the shared busy lock — no reject request.
+    await wrapper.find('[data-testid="decision-reject"]').trigger('click')
+    await Promise.resolve()
+    expect(mocks.rejectProposal).not.toHaveBeenCalled()
+
+    // Settle with a saved revision → known, non-zero → Apply proceeds; the
+    // never-rejected proposal is approved.
+    resolveRevisions?.([
+      {
+        id: 'rev-reject-busy',
+        proposalId: 'noop-reject-busy',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    await flushPromises()
+    expect(mocks.approveProposal).toHaveBeenCalledWith('noop-reject-busy')
+    expect(mocks.rejectProposal).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('does not approve a zero-op proposal that is deferred when the guard load resolves — the post-await isProposalDeferred arm blocks it (#1414 round 4 P2-A)', async () => {
+    // Exercises the `isProposalDeferred(current)` arm of the post-await re-check
+    // specifically: a snoozed proposal stays PendingReview + non-expired, so
+    // `isApplyActionable` alone stays TRUE — only the deferred arm blocks it.
+    // The proposal is deep-linked (hash carve-out keeps a snoozed item visible)
+    // and its revision load is still pending at click time, forcing the async
+    // guard path where the re-check runs.
+    const now = new Date().toISOString()
+    let resolveRevisions: ((value: unknown[]) => void) | undefined
+    mocks.getRevisions.mockImplementation(
+      () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+    )
+    const wrapper = await mountView(
+      [
+        makeProposal({
+          id: 'noop-deferred',
+          diffPreview: null,
+          operations: [],
+          // Snoozed into the future but still PendingReview (isApplyActionable stays true).
+          deferredUntil: new Date(Date.now() + 60 * 60_000).toISOString(),
+        }),
+      ],
+      '/workspace/review#proposal-noop-deferred',
+    )
+
+    // Apply parks on the revision load (revisionsLoaded still false).
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await Promise.resolve()
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+
+    // Settle with a saved revision → known, non-zero: absent the deferred re-check
+    // this would approve a snoozed proposal. The isProposalDeferred arm blocks it.
+    resolveRevisions?.([
+      {
+        id: 'rev-deferred',
+        proposalId: 'noop-deferred',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    await flushPromises()
+
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.executeProposal).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('executes a plain Approved proposal with operations without entering the zero-op guard (#1414 round 4 P2-B regression)', async () => {
+    // The common Approved-execute path must be untouched by the P2-B reorder: a
+    // non-empty-operations Approved proposal skips the zero-op guard entirely and
+    // dispatches execute directly (confirm-gated).
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mocks.executeProposal.mockResolvedValueOnce(
+      makeProposal({ id: 'approved-ops', status: 'Applied' }),
+    )
+    const wrapper = await mountView([
+      makeProposal({ id: 'approved-ops', status: 'Approved' }),
+    ])
+
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.executeProposal).toHaveBeenCalledWith('approved-ops', expect.anything())
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.infoToast).not.toHaveBeenCalledWith(
+      expect.stringContaining('no operations'),
+    )
+
+    confirmSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('does not approve a zero-op proposal that leaves the actionable state under the guard load — the post-await re-check blocks it (#1414 round 4 P2-A)', async () => {
+    // P2-A defense-in-depth: identity is not enough. A non-local change (here the
+    // 60s expiry clock; equally a realtime status/defer update from another
+    // surface) can settle the proposal out of an actionable state WHILE the guard
+    // load is in flight. The post-await re-check re-evaluates actionability on the
+    // CURRENT object and no-ops when it is no longer applyable.
+    vi.useFakeTimers()
+    try {
+      const base = new Date('2026-06-13T12:00:00.000Z').getTime()
+      vi.setSystemTime(base)
+      const nowIso = new Date(base).toISOString()
+      let resolveRevisions: ((value: unknown[]) => void) | undefined
+      mocks.getRevisions.mockImplementation(
+        () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+      )
+      const wrapper = await mountView([
+        makeProposal({
+          id: 'noop-expire',
+          diffPreview: null,
+          operations: [],
+          // Live at mount, expires before the first 60s clock tick.
+          expiresAt: new Date(base + 30_000).toISOString(),
+        }),
+      ])
+
+      // Apply parks on the revision load (revisionsLoaded still false).
+      await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+      await flushPromises()
+      expect(mocks.approveProposal).not.toHaveBeenCalled()
+
+      // The clock ticks past expiry while the load is still pending.
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      // Settle with a saved revision → known, non-zero: absent the re-check this
+      // would approve a now-expired proposal. The re-check blocks it.
+      resolveRevisions?.([
+        {
+          id: 'rev-expire',
+          proposalId: 'noop-expire',
+          revisionNumber: 1,
+          editorUserId: 'u-1',
+          revisedPayload: '{"operations":[]}',
+          revisedAt: nowIso,
+          reason: 'edit',
+          createdAt: nowIso,
+        },
+      ])
+      await flushPromises()
+      await wrapper.vm.$nextTick()
+
+      expect(mocks.approveProposal).not.toHaveBeenCalled()
+      expect(mocks.executeProposal).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('routes an Approved zero-op proposal through the guard instead of executing a doomed apply (#1414 round 4 P2-B)', async () => {
+    // P2-B: an already-Approved zero-op proposal (pre-#1423 data, or another
+    // client that approved via the still-permissive approve endpoint) must hit
+    // the same zero-op verdict, not a guaranteed Apply-time 400 round-trip. The
+    // Approved-execute dispatch now sits AFTER the guard.
+    const wrapper = await mountView([
+      makeProposal({ id: 'approved-noop', status: 'Approved', diffPreview: null, operations: [] }),
+    ])
+
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.executeProposal).not.toHaveBeenCalled()
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.infoToast).toHaveBeenCalledWith(
+      expect.stringContaining('applying it to the board will be rejected'),
+    )
+
+    wrapper.unmount()
+  })
+
+  it('still executes an Approved proposal that carries a saved revision once the guard clears it (#1414 round 4 P2-B)', async () => {
+    // The guard must not break the normal Approved-execute path: an Approved
+    // proposal whose original operations are empty but which carries a saved
+    // revision (#1235) is applied revision-aware, so it still executes.
+    const now = new Date().toISOString()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mocks.getRevisions.mockResolvedValue([
+      {
+        id: 'rev-approved',
+        proposalId: 'approved-revised',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[{"actionType":"CreateCard"}]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    mocks.executeProposal.mockResolvedValueOnce(
+      makeProposal({ id: 'approved-revised', status: 'Applied' }),
+    )
+    const wrapper = await mountView([
+      makeProposal({ id: 'approved-revised', status: 'Approved', diffPreview: null, operations: [] }),
+    ])
+
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.executeProposal).toHaveBeenCalledWith('approved-revised', expect.anything())
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+
+    confirmSpy.mockRestore()
     wrapper.unmount()
   })
 

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -961,7 +961,7 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
-  it('shows the empty-diff state without fetching for a no-operation proposal', async () => {
+  it('shows the invalid state without fetching for a no-operation proposal (#1397)', async () => {
     const wrapper = await mountView([
       makeProposal({ id: 'diff-noop', diffPreview: null, operations: [] }),
     ])
@@ -969,10 +969,92 @@ describe('PaperReviewView', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
     await flushPromises()
 
-    // No diffPreview + no operations → the backend `/diff` would 404, so the view
-    // shows the empty state directly without firing the request.
+    // No operations → the backend `/diff` would 400 ("must contain at least one
+    // operation"), the same verdict Apply gives. The reviewer must see that
+    // rejection BEFORE approving, so the view shows the explicit invalid state
+    // without firing the request — never a "No changes" surface it could approve.
     expect(mocks.getProposalDiff).not.toHaveBeenCalled()
-    expect(wrapper.find('[data-testid="paper-review-diff-empty"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="paper-review-diff-empty"]').exists()).toBe(false)
+    const invalid = wrapper.find('[data-testid="paper-review-diff-invalid"]')
+    expect(invalid.exists()).toBe(true)
+    expect(invalid.text()).toContain('no operations')
+    expect(invalid.text()).toContain('reject')
+
+    wrapper.unmount()
+  })
+
+  it('presents the stored preview under a read-only banner for an expired proposal without firing /diff (#1397)', async () => {
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'diff-expired',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Archived plan"',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    // Expired proposals stay inspectable via their stored preview, but the live
+    // `/diff` (which now 400s for them) is never fired.
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    const banner = wrapper.find('[data-testid="paper-review-diff-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('Expired')
+    expect(banner.text()).toContain('read-only')
+    expect(banner.text()).toContain('stored preview')
+    const pre = wrapper.find('[data-testid="paper-review-diff-pre"]')
+    expect(pre.exists()).toBe(true)
+    expect(pre.text()).toContain('Archived plan')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('shows the banner and a no-stored-preview note for an expired proposal with no stored content (#1397)', async () => {
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'diff-expired-empty',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: null,
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(true)
+    const storedEmpty = wrapper.find('[data-testid="paper-review-diff-stored-empty"]')
+    expect(storedEmpty.exists()).toBe(true)
+    expect(storedEmpty.text()).toContain('No stored preview')
+    // Never an error toast + cleared pane for a settled proposal.
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('renders the invalid verdict (not a toast) when /diff 400s for a pending proposal (#1397)', async () => {
+    mocks.getProposalDiff.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: { errorCode: 'ValidationError', message: 'Proposal must contain at least one operation' },
+      },
+    })
+    const wrapper = await mountView([makeProposal({ id: 'diff-400' })])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).toHaveBeenCalledWith('diff-400')
+    // The 400 is presented inline, not toasted, and the pane is not torn down.
+    const invalid = wrapper.find('[data-testid="paper-review-diff-invalid"]')
+    expect(invalid.exists()).toBe(true)
+    expect(invalid.text()).toContain('no operations')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff"]').exists()).toBe(true)
 
     wrapper.unmount()
   })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1171,6 +1171,101 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
+  it('awaits an in-flight revision load before blocking Approve on a zero-op proposal (#1397 P2-A)', async () => {
+    // The revision list is the authority for whether a zero-op proposal is truly
+    // empty (a saved revision carries operations Apply runs revision-aware). If
+    // the revision GET is still in flight when Apply is clicked, the guard must
+    // settle it FIRST — not skip the guard and fall through to approve (which the
+    // old guard did whenever revisionsLoaded was false).
+    let resolveRevisions: ((value: unknown[]) => void) | undefined
+    mocks.getRevisions.mockImplementation(
+      () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+    )
+    const wrapper = await mountView([
+      makeProposal({ id: 'noop-inflight', diffPreview: null, operations: [] }),
+    ])
+
+    // Revision load is still pending → the guard is not yet authoritative.
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await Promise.resolve()
+
+    // The click is parked on the revision load — approve has NOT fired.
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+
+    // Settle the revision GET with an empty list → the proposal is truly zero-op.
+    resolveRevisions?.([])
+    await flushPromises()
+
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.infoToast).toHaveBeenCalledWith(expect.stringContaining('no operations'))
+
+    wrapper.unmount()
+  })
+
+  it('falls through to the backend Apply when the revision load fails for a zero-op proposal (#1397 P2-A)', async () => {
+    // A FAILED revision load leaves revisionsLoaded false: emptiness cannot be
+    // proven, so the guard defers to the backend rather than blocking (approve-
+    // time backend validation is tracked in #1416). This fall-through now only
+    // happens AFTER a load attempt.
+    mocks.getRevisions.mockRejectedValue(new Error('revisions boom'))
+    mocks.approveProposal.mockResolvedValueOnce(
+      makeProposal({ id: 'noop-failload', status: 'Approved' }),
+    )
+    const wrapper = await mountView([
+      makeProposal({ id: 'noop-failload', diffPreview: null, operations: [] }),
+    ])
+
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await flushPromises()
+
+    expect(mocks.approveProposal).toHaveBeenCalledWith('noop-failload')
+    expect(mocks.infoToast).not.toHaveBeenCalledWith(expect.stringContaining('no operations'))
+
+    wrapper.unmount()
+  })
+
+  it('discloses a revision on the recorded-operations fallback when no stored preview was captured (#1397 MEDIUM-2 / #1414)', async () => {
+    // A revised-then-settled proposal that never captured a diffPreview renders
+    // the recorded-operations fallback, not a stored preview — so the disclosure
+    // copy must say the RECORDED OPERATIONS show the original submission, never
+    // "the stored preview" (which does not exist here).
+    const now = new Date().toISOString()
+    mocks.getRevisions.mockResolvedValue([
+      {
+        id: 'rev-1',
+        proposalId: 'diff-revised-ops',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'diff-revised-ops',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: null,
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    // The ops fallback is what's on screen (no captured stored preview).
+    expect(wrapper.find('[data-testid="paper-review-diff-stored-operations"]').exists()).toBe(true)
+    const revisedNote = wrapper.find('[data-testid="paper-review-diff-revised-note"]')
+    expect(revisedNote.exists()).toBe(true)
+    expect(revisedNote.text()).toContain('revised')
+    expect(revisedNote.text()).toContain('recorded operations')
+    expect(revisedNote.text()).not.toContain('stored preview')
+
+    wrapper.unmount()
+  })
+
   it('re-derives an open live pane to the stored presentation when the expiry clock passes (#1397 LOW-5)', async () => {
     // Open the live diff on a pending proposal that expires in 30s, then tick
     // the 60s review clock past its expiresAt: the pane must flip to the stored

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1012,6 +1012,61 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
+  it('diverts to the stored preview when a proposal expires during the revision-load await, never firing a live /diff (#1414 final round)', async () => {
+    // onPreviewDiff checks read-only BEFORE its revision-load await. If the
+    // proposal expires on the 60s clock DURING that await, the post-await
+    // re-check must re-classify it as read-only and present the stored preview —
+    // NOT fall through to a live /diff that #1395 400s (which would defeat
+    // #1397's stored-preview guarantee). Identity alone doesn't catch this: the
+    // id is unchanged, only the (clock-derived) expiry state flipped.
+    vi.useFakeTimers()
+    try {
+      const base = new Date('2026-06-13T12:00:00.000Z').getTime()
+      vi.setSystemTime(base)
+      let resolveRevisions: ((value: unknown[]) => void) | undefined
+      mocks.getRevisions.mockImplementation(
+        () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+      )
+      const wrapper = await mountView([
+        makeProposal({
+          id: 'preview-expire',
+          // Live at entry, expires before the first 60s clock tick.
+          expiresAt: new Date(base + 30_000).toISOString(),
+          diffPreview: '0. Create card "Racing preview"',
+        }),
+      ])
+
+      // Space opens preview; not read-only at entry, so onPreviewDiff parks on
+      // its revision-load await (revisionsLoaded still false).
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+      await Promise.resolve()
+      expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+
+      // The clock ticks past expiry while the revision load is still pending.
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      // Settle the revision load → the post-await re-check sees the now-expired
+      // proposal and diverts to the stored preview.
+      resolveRevisions?.([])
+      await flushPromises()
+      await wrapper.vm.$nextTick()
+
+      // The forbidden live /diff was never fired; the stored preview is shown.
+      expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+      const banner = wrapper.find('[data-testid="paper-review-diff-banner"]')
+      expect(banner.exists()).toBe(true)
+      expect(banner.text()).toContain('read-only')
+      const pre = wrapper.find('[data-testid="paper-review-diff-pre"]')
+      expect(pre.exists()).toBe(true)
+      expect(pre.text()).toContain('Racing preview')
+      expect(mocks.errorToast).not.toHaveBeenCalled()
+
+      wrapper.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('falls back to the recorded operations for an expired proposal with no stored preview (#1397 / Codex)', async () => {
     // Normal creation flows never populate diffPreview, so an expired proposal
     // with operations must still be inspectable via a locally rendered

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1171,12 +1171,12 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
-  it('awaits an in-flight revision load before blocking Approve on a zero-op proposal (#1397 P2-A)', async () => {
-    // The revision list is the authority for whether a zero-op proposal is truly
-    // empty (a saved revision carries operations Apply runs revision-aware). If
-    // the revision GET is still in flight when Apply is clicked, the guard must
-    // settle it FIRST — not skip the guard and fall through to approve (which the
-    // old guard did whenever revisionsLoaded was false).
+  it('parks re-entrant Apply clicks while the revision load is in flight, then blocks a zero-op proposal (#1397 round 3)', async () => {
+    // SEAM INVARIANT: a zero-op proposal may only be approved when revision
+    // state is KNOWN. While the guard's revision load is awaited, further Apply
+    // clicks are IGNORED — a re-entrant loadRevisionState would cancel the
+    // earlier load via its generation counter and resume the first click with
+    // revisionsLoaded still false (the round-3 Codex race).
     let resolveRevisions: ((value: unknown[]) => void) | undefined
     mocks.getRevisions.mockImplementation(
       () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
@@ -1184,15 +1184,24 @@ describe('PaperReviewView', () => {
     const wrapper = await mountView([
       makeProposal({ id: 'noop-inflight', diffPreview: null, operations: [] }),
     ])
+    // Mount fires the watcher's background load (call 1); the Apply click's own
+    // load is call 2.
+    expect(mocks.getRevisions).toHaveBeenCalledTimes(1)
 
-    // Revision load is still pending → the guard is not yet authoritative.
+    // First click parks on the revision load — approve has NOT fired.
     await wrapper.find('[data-testid="decision-apply"]').trigger('click')
     await Promise.resolve()
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.getRevisions).toHaveBeenCalledTimes(2)
 
-    // The click is parked on the revision load — approve has NOT fired.
+    // Rapid second click: guard busy — ignored entirely (no third load that
+    // would cancel the first, and no approve).
+    await wrapper.find('[data-testid="decision-apply"]').trigger('click')
+    await Promise.resolve()
+    expect(mocks.getRevisions).toHaveBeenCalledTimes(2)
     expect(mocks.approveProposal).not.toHaveBeenCalled()
 
-    // Settle the revision GET with an empty list → the proposal is truly zero-op.
+    // Settle the guard's own GET with an empty list → truly zero-op → blocked.
     resolveRevisions?.([])
     await flushPromises()
 
@@ -1202,15 +1211,12 @@ describe('PaperReviewView', () => {
     wrapper.unmount()
   })
 
-  it('falls through to the backend Apply when the revision load fails for a zero-op proposal (#1397 P2-A)', async () => {
-    // A FAILED revision load leaves revisionsLoaded false: emptiness cannot be
-    // proven, so the guard defers to the backend rather than blocking (approve-
-    // time backend validation is tracked in #1416). This fall-through now only
-    // happens AFTER a load attempt.
+  it('blocks Apply when the revision load fails for a zero-op proposal — unknown state never approves (#1397 round 3)', async () => {
+    // REVERSES the round-2 fall-through semantic: a failed load leaves revision
+    // state UNKNOWN, and unknown now blocks approve instead of deferring to the
+    // backend (whose approve path would accept, then guarantee the Apply-time
+    // 400). #1416 remains the backend root-cause fix.
     mocks.getRevisions.mockRejectedValue(new Error('revisions boom'))
-    mocks.approveProposal.mockResolvedValueOnce(
-      makeProposal({ id: 'noop-failload', status: 'Approved' }),
-    )
     const wrapper = await mountView([
       makeProposal({ id: 'noop-failload', diffPreview: null, operations: [] }),
     ])
@@ -1218,8 +1224,10 @@ describe('PaperReviewView', () => {
     await wrapper.find('[data-testid="decision-apply"]').trigger('click')
     await flushPromises()
 
-    expect(mocks.approveProposal).toHaveBeenCalledWith('noop-failload')
-    expect(mocks.infoToast).not.toHaveBeenCalledWith(expect.stringContaining('no operations'))
+    expect(mocks.approveProposal).not.toHaveBeenCalled()
+    expect(mocks.infoToast).toHaveBeenCalledWith(
+      expect.stringContaining('Revision history is unavailable'),
+    )
 
     wrapper.unmount()
   })
@@ -1262,6 +1270,83 @@ describe('PaperReviewView', () => {
     expect(revisedNote.text()).toContain('revised')
     expect(revisedNote.text()).toContain('recorded operations')
     expect(revisedNote.text()).not.toContain('stored preview')
+
+    wrapper.unmount()
+  })
+
+  it('renders the stored preview synchronously while the revision GET is pending; the caveat augments after it resolves (#1397 round 3)', async () => {
+    // SEAM INVARIANT: the stored preview is local content and must render the
+    // moment Space is pressed — the revision metadata GET only gates the
+    // revised-note caveat and runs asynchronously afterwards. A slow GET must
+    // never make the toggle look dead.
+    const now = new Date().toISOString()
+    let resolveRevisions: ((value: unknown[]) => void) | undefined
+    mocks.getRevisions.mockImplementation(
+      () => new Promise((resolve) => { resolveRevisions = resolve as (value: unknown[]) => void }),
+    )
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'sync-stored',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Stored now"',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await wrapper.vm.$nextTick()
+
+    // GET still pending — the preview is ALREADY up.
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').text()).toContain('Stored now')
+    expect(wrapper.find('[data-testid="paper-review-diff-loading"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="paper-review-diff-revised-note"]').exists()).toBe(false)
+
+    // The metadata resolves with a revision → the caveat augments in place.
+    resolveRevisions?.([
+      {
+        id: 'rev-1',
+        proposalId: 'sync-stored',
+        revisionNumber: 1,
+        editorUserId: 'u-1',
+        revisedPayload: '{"operations":[]}',
+        revisedAt: now,
+        reason: 'edit',
+        createdAt: now,
+      },
+    ])
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="paper-review-diff-revised-note"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').text()).toContain('Stored now')
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('keeps the stored preview up with no error toast when the revision GET fails (#1397 round 3)', async () => {
+    // The augment-only revision load is silent: a failed metadata GET must not
+    // error-toast over a locally presentable preview, and the preview stays up.
+    mocks.getRevisions.mockRejectedValue(new Error('revisions boom'))
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'silent-stored',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Still here"',
+      }),
+    ])
+    // The mount-time background load (non-silent) already failed during
+    // mountView; clear its toast so the assertion isolates the preview path.
+    mocks.errorToast.mockClear()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').text()).toContain('Still here')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-testid="paper-review-diff-revised-note"]').exists()).toBe(false)
 
     wrapper.unmount()
   })

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -1067,6 +1067,87 @@ describe('PaperReviewView', () => {
     }
   })
 
+  it('presents the stored preview for a server-expired PendingReview proposal whose client clock still reads live, never firing /diff (#1414 P2 #1)', async () => {
+    // Server says isExpired:true (clock lag/skew) but the client 60s clock has
+    // not yet passed expiresAt. Honoring the server flag classifies the proposal
+    // read-only, so the stored preview is shown instead of a live /diff that 400s.
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'server-expired',
+        status: 'PendingReview',
+        expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(), // client clock: still live
+        isExpired: true, // server: already expired
+        diffPreview: '0. Create card "Server expired"',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposalDiff).not.toHaveBeenCalled()
+    const banner = wrapper.find('[data-testid="paper-review-diff-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain('read-only')
+    const pre = wrapper.find('[data-testid="paper-review-diff-pre"]')
+    expect(pre.exists()).toBe(true)
+    expect(pre.text()).toContain('Server expired')
+
+    wrapper.unmount()
+  })
+
+  it('retracts the stored preview and warns when access is revoked (getProposal 403) after reveal (#1414 P2 #2)', async () => {
+    // Revealing the stored preview re-authorizes via getProposal; a 403/404 means
+    // board access was revoked mid-session, so the locally-cached preview must be
+    // torn down rather than left on screen.
+    mocks.getProposal.mockRejectedValueOnce({ response: { status: 403 } })
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'revoked',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Secret"',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(mocks.getProposal).toHaveBeenCalledWith('revoked')
+    // Pane torn down; no stored preview left on screen.
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="paper-review-diff-pre"]').exists()).toBe(false)
+    expect(mocks.errorToast).toHaveBeenCalledWith(
+      expect.stringContaining('no longer available'),
+    )
+
+    wrapper.unmount()
+  })
+
+  it('keeps the stored preview on a transient (500) error from the access re-check (#1414 P2 #2)', async () => {
+    // Only a genuine 403/404 retracts the preview — a transient error must not
+    // tear down an otherwise-inspectable local preview.
+    mocks.getProposal.mockRejectedValueOnce({ response: { status: 500 } })
+    const wrapper = await mountView([
+      makeProposal({
+        id: 'transient',
+        status: 'Expired',
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+        diffPreview: '0. Create card "Still here"',
+      }),
+    ])
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', cancelable: true }))
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="paper-review-diff-banner"]').exists()).toBe(true)
+    const pre = wrapper.find('[data-testid="paper-review-diff-pre"]')
+    expect(pre.exists()).toBe(true)
+    expect(pre.text()).toContain('Still here')
+    expect(mocks.errorToast).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
   it('falls back to the recorded operations for an expired proposal with no stored preview (#1397 / Codex)', async () => {
     // Normal creation flows never populate diffPreview, so an expired proposal
     // with operations must still be inspectable via a locally rendered

--- a/frontend/taskdeck-web/src/views/LegacyReviewView.vue
+++ b/frontend/taskdeck-web/src/views/LegacyReviewView.vue
@@ -41,13 +41,14 @@ const {
   proposalActionBusyId,
   selectedDiffProposalId,
   selectedDiff,
+  selectedDiffMode,
   handleApproveProposal,
   handleRejectProposal,
   handleExecuteProposal,
   handleToggleDiff,
   handleDismissProposal,
   handleDismissApplied,
-} = useReviewActions(proposals, dismissableProposalIds, loadProposals)
+} = useReviewActions(proposals, dismissableProposalIds, loadProposals, isProposalExpired)
 
 const _vl = useVirtualList({
   count: computed(() => visibleProposals.value.length),
@@ -220,6 +221,7 @@ onUnmounted(() => {
               :is-busy="proposalActionBusyId === visibleProposals[virtualRow.index]!.id"
               :selected-diff-proposal-id="selectedDiffProposalId"
               :selected-diff="selectedDiff"
+              :selected-diff-mode="selectedDiffMode"
               :capture-href="captureHrefForProposal(visibleProposals[virtualRow.index]!)"
               :proposal-href="proposalHref(visibleProposals[virtualRow.index]!)"
               @approve="handleApproveProposal"

--- a/frontend/taskdeck-web/src/views/LegacyReviewView.vue
+++ b/frontend/taskdeck-web/src/views/LegacyReviewView.vue
@@ -42,6 +42,8 @@ const {
   selectedDiffProposalId,
   selectedDiff,
   selectedDiffMode,
+  selectedDiffInvalidReason,
+  selectedDiffRevised,
   handleApproveProposal,
   handleRejectProposal,
   handleExecuteProposal,
@@ -222,6 +224,8 @@ onUnmounted(() => {
               :selected-diff-proposal-id="selectedDiffProposalId"
               :selected-diff="selectedDiff"
               :selected-diff-mode="selectedDiffMode"
+              :selected-diff-invalid-reason="selectedDiffInvalidReason"
+              :selected-diff-revised="selectedDiffRevised"
               :capture-href="captureHrefForProposal(visibleProposals[virtualRow.index]!)"
               :proposal-href="proposalHref(visibleProposals[virtualRow.index]!)"
               @approve="handleApproveProposal"

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -94,7 +94,7 @@ const {
   handleExecuteProposal,
   handleDismissProposal,
   handleDismissApplied,
-} = useReviewActions(proposals, ownedDismissableIds, loadProposals)
+} = useReviewActions(proposals, ownedDismissableIds, loadProposals, isProposalExpired)
 
 // --- Active proposal ---------------------------------------------------
 
@@ -188,15 +188,21 @@ const previewDiffProposalId = ref<string | null>(null)
 const previewDiffLoading = ref(false)
 const previewDiffSection = ref<HTMLElement | null>(null)
 // How the diff pane presents (#1397): `live` fetched diff, `stored` read-only
-// diffPreview for a terminal/expired proposal, or `invalid` when the proposal
-// has no operations (Apply would reject it). Null while nothing is shown.
+// diffPreview for a terminal/expired proposal, or `invalid` when the backend's
+// Apply-time gates reject the proposal. Null while nothing is shown.
 const previewDiffMode = ref<'live' | 'stored' | 'invalid' | null>(null)
+// The ACTUAL rejection reason for `invalid` mode — the backend's message for a
+// /diff 400 ("Proposal has expired" vs "Proposal must contain at least one
+// operation"), or the local zero-op wording for the pre-fetch guard. The pane
+// must never hardcode one reason for every 400 (#1397 MEDIUM-1).
+const previewDiffInvalidReason = ref<string | null>(null)
 let latestDiffRequestId = 0
 
 function clearPreviewDiff() {
   previewDiffProposalId.value = null
   previewDiff.value = null
   previewDiffMode.value = null
+  previewDiffInvalidReason.value = null
   previewDiffLoading.value = false
 }
 
@@ -230,6 +236,32 @@ watch(
       latestDiffRequestId += 1
       clearPreviewDiff()
     }
+  },
+)
+
+// #1397 LOW-5: the pane's presentation is chosen when it opens, but the active
+// proposal can turn read-only WHILE the pane is open — a status change (e.g.
+// apply lands, a refresh maps a terminal state in) or the 60s expiry clock
+// ticking past expiresAt. Re-derive: an open live/invalid pane flips to the
+// stored read-only presentation the moment the classification flips.
+watch(
+  () => {
+    const p = activeProposal.value
+    if (!p || previewDiffProposalId.value !== p.id) return false
+    return isProposalReadOnly(p, isProposalExpired(p))
+  },
+  (readOnly) => {
+    if (!readOnly) return
+    if (previewDiffMode.value === 'stored' || previewDiffMode.value === null) return
+    const p = activeProposal.value
+    if (!p || previewDiffProposalId.value !== p.id) return
+    // Cancel any in-flight live fetch so a late response can't overwrite the
+    // read-only presentation.
+    latestDiffRequestId += 1
+    previewDiff.value = p.diffPreview
+    previewDiffMode.value = 'stored'
+    previewDiffInvalidReason.value = null
+    previewDiffLoading.value = false
   },
 )
 
@@ -601,6 +633,20 @@ function onApply() {
     void handleExecuteProposal(p.id)
     return
   }
+  // #1397 LOW-3: approving a zero-operation proposal only defers a guaranteed
+  // Apply 400 ("Proposal must contain at least one operation"). Block it here —
+  // but only when the revision list is authoritatively loaded and empty, because
+  // a saved revision carries operations the backend applies revision-aware
+  // (#1235). If revisions are unknown (load pending/failed), let the backend
+  // decide (approve-time validation is tracked in #1416).
+  if (
+    (p.operations?.length ?? 0) === 0 &&
+    revisionsLoaded.value &&
+    revisionCount.value === 0
+  ) {
+    toast.info('This proposal contains no operations to apply — Apply will reject it. Reject or file it away instead.')
+    return
+  }
   void handleApproveProposal(p.id)
 }
 
@@ -679,9 +725,15 @@ async function onPreviewDiff() {
   // Present the stored `diffPreview` under an explicit read-only banner; when no
   // stored preview exists, the banner + a "no stored preview" state, never an
   // error toast (#1397 maintainer decision: stay inspectable, don't burden the
-  // UI). This runs before the revision settle so a settled proposal never fires
-  // a request.
+  // UI). Settle the revision list first (a metadata GET, not the /diff that
+  // 400s): `diffPreview` is creation-time content revisions never update, so
+  // the banner must disclose when this stored (original) preview is NOT what a
+  // revision-aware Apply would have executed (#1397 MEDIUM-2).
   if (isProposalReadOnly(p, isProposalExpired(p))) {
+    if (!revisionsLoaded.value) {
+      await loadRevisionState(p.id)
+      if (activeProposal.value?.id !== p.id) return
+    }
     latestDiffRequestId += 1
     previewDiffProposalId.value = p.id
     previewDiff.value = p.diffPreview
@@ -718,6 +770,7 @@ async function onPreviewDiff() {
     previewDiffProposalId.value = p.id
     previewDiff.value = null
     previewDiffMode.value = 'invalid'
+    previewDiffInvalidReason.value = 'This proposal contains no operations to apply'
     previewDiffLoading.value = false
     scrollDiffIntoView()
     return
@@ -727,6 +780,7 @@ async function onPreviewDiff() {
   previewDiffProposalId.value = p.id
   previewDiff.value = null
   previewDiffMode.value = 'live'
+  previewDiffInvalidReason.value = null
   previewDiffLoading.value = true
   // Scroll to the loading state immediately so a slow `/diff` doesn't look like a
   // no-op on a long review surface (the final result re-scrolls when it lands).
@@ -742,12 +796,18 @@ async function onPreviewDiff() {
   } catch (e: unknown) {
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
     // A 400 ValidationError means the backend ran Apply's gates at diff time
-    // (#1376/#1395): the proposal lost its operations or expired mid-flight.
-    // Apply would reject it too, so present the invalid verdict inline rather
-    // than tearing the pane down + toasting a generic error.
+    // (#1376/#1395). It carries one of two distinct reasons — "Proposal must
+    // contain at least one operation" or "Proposal has expired" (the expiry
+    // race: the 60s review clock can lag a server-side expiry). Present the
+    // backend's ACTUAL message inline — never one hardcoded reason for every
+    // 400 — rather than tearing the pane down + toasting (#1397 MEDIUM-1).
     if (isValidationError(e)) {
       previewDiff.value = null
       previewDiffMode.value = 'invalid'
+      previewDiffInvalidReason.value = getErrorDisplay(
+        e,
+        'The backend rejected this proposal preview',
+      ).message
       previewDiffLoading.value = false
       scrollDiffIntoView()
       return
@@ -896,10 +956,23 @@ function onQueueFilterChange(filter: QueueFilter) {
           role="status"
           data-testid="paper-review-diff-banner"
         >
-          {{ previewReadOnlyLabel }} · read-only — showing the stored preview.
+          {{ previewReadOnlyLabel }} · read-only — showing the stored preview from the
+          original submission.
+        </p>
+        <!-- diffPreview is creation-time content revisions never update, so a revised
+             proposal's stored preview is NOT what a revision-aware Apply would have
+             executed — disclose it (#1397 MEDIUM-2). -->
+        <p
+          v-if="previewDiffMode === 'stored' && revisionCount > 0"
+          class="paper-review-deep__diff-caveat tk-meta"
+          role="status"
+          data-testid="paper-review-diff-revised-note"
+        >
+          ✎ This proposal was <strong>revised</strong> after submission — the stored
+          preview shows the original operations, not the revised ones.
         </p>
         <p
-          v-else-if="revisionCount > 0 && previewDiffMode === 'live'"
+          v-if="revisionCount > 0 && previewDiffMode === 'live'"
           class="paper-review-deep__diff-caveat tk-meta"
           data-testid="paper-review-diff-revision-caveat"
         >
@@ -914,14 +987,17 @@ function onQueueFilterChange(filter: QueueFilter) {
           >
             Loading diff…
           </p>
-          <!-- Invalid: no operations to apply — Apply would reject it too (#1397) -->
+          <!-- Invalid: the backend's Apply-time gates reject this proposal; render
+               the ACTUAL reason (expired vs zero-op), never a hardcoded one
+               (#1397 MEDIUM-1). -->
           <p
             v-else-if="previewDiffMode === 'invalid'"
             class="paper-review-deep__diff-invalid tk-meta"
             role="status"
             data-testid="paper-review-diff-invalid"
           >
-            This proposal contains no operations to apply, so Apply would reject it.
+            {{ previewDiffInvalidReason || 'This proposal contains no operations to apply' }}
+            — Apply will reject this proposal.
           </p>
           <!-- Read-only proposal with no stored preview to fall back on (#1397) -->
           <p

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -13,7 +13,7 @@ import { useReviewActions } from '../../composables/useReviewActions'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
 import { useReviewKeymap } from '../../composables/useReviewKeymap'
 import { useProposalRevisions } from '../../composables/useProposalRevisions'
-import { getErrorDisplay, getValidationReason, isValidationError } from '../../composables/useErrorMapper'
+import { getErrorDisplay, getValidationReason, isAccessDeniedError, isValidationError } from '../../composables/useErrorMapper'
 import { automationApi } from '../../api/automationApi'
 import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
@@ -282,11 +282,16 @@ watch(
     if (!p || previewDiffProposalId.value !== p.id) return
     // Cancel any in-flight live fetch so a late response can't overwrite the
     // read-only presentation.
-    latestDiffRequestId += 1
+    const requestId = ++latestDiffRequestId
     previewDiff.value = p.diffPreview
     previewDiffMode.value = 'stored'
     previewDiffInvalidReason.value = null
     previewDiffLoading.value = false
+    // #1414 P2: this conversion newly presents the stored preview, so re-check
+    // access (parity with the Legacy watcher, which routes through
+    // presentStoredPreview). The prior live pane was access-checked at open, but
+    // access can be revoked in the window before it expires into read-only.
+    void verifyStoredPreviewAccess(p.id, requestId)
   },
 )
 
@@ -784,18 +789,40 @@ function onToggleProvenance() {
   toast.info('Provenance toggle is not wired yet; provenance is rendered inline below.')
 }
 
+// #1414 P2: revealing the stored `diffPreview` locally skips the `/diff` call
+// that used to re-run AuthorizeProposalAsync, so re-authorize on reveal. Render
+// SYNCHRONOUSLY (the #1397 seam invariant: local content is never network-gated),
+// then probe access via GET proposal — which returns 200 for a still-readable
+// terminal/expired proposal (unlike `/diff`, it does not 400 on expiry). ONLY a
+// genuine 403/404 retracts the preview; a transient error must not tear down an
+// inspectable local preview. The refreshed DTO is deliberately NOT rendered:
+// #1397 keeps the decision-time stored artifact (a live re-render can drift).
+// Guarded by requestId + proposal id so a late response for a toggled-off or
+// switched proposal cannot tear down the wrong pane.
+async function verifyStoredPreviewAccess(proposalId: string, requestId: number) {
+  try {
+    await automationApi.getProposal(proposalId)
+  } catch (e: unknown) {
+    if (!isAccessDeniedError(e)) return
+    if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== proposalId) return
+    clearPreviewDiff()
+    toast.error('This proposal is no longer available to you.')
+  }
+}
+
 // Present a proposal's STORED preview read-only (no live `/diff`). The stored
 // `diffPreview` is LOCAL content and renders synchronously. Bumping the diff
 // request id also cancels any live fetch that this preview supersedes, so a
 // late 400 from a superseded request cannot overwrite the stored pane.
 function presentStoredPreview(target: ApiProposal) {
-  latestDiffRequestId += 1
+  const requestId = ++latestDiffRequestId
   previewDiffProposalId.value = target.id
   previewDiff.value = target.diffPreview
   previewDiffMode.value = 'stored'
   previewDiffInvalidReason.value = null
   previewDiffLoading.value = false
   scrollDiffIntoView()
+  void verifyStoredPreviewAccess(target.id, requestId)
 }
 
 async function onPreviewDiff() {

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -8,12 +8,12 @@ import type { RecentlyAppliedRow } from './review/ReviewRecentApplied.vue'
 import ReviewMain from './review/ReviewMain.vue'
 import ReviewRevisionEditor from './review/ReviewRevisionEditor.vue'
 import ReviewRightRail from './review/ReviewRightRail.vue'
-import { useReviewProposals } from '../../composables/useReviewProposals'
+import { useReviewProposals, isProposalReadOnly } from '../../composables/useReviewProposals'
 import { useReviewActions } from '../../composables/useReviewActions'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
 import { useReviewKeymap } from '../../composables/useReviewKeymap'
 import { useProposalRevisions } from '../../composables/useProposalRevisions'
-import { getErrorDisplay } from '../../composables/useErrorMapper'
+import { getErrorDisplay, isValidationError } from '../../composables/useErrorMapper'
 import { automationApi } from '../../api/automationApi'
 import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
@@ -187,7 +187,27 @@ const previewDiff = ref<string | null>(null)
 const previewDiffProposalId = ref<string | null>(null)
 const previewDiffLoading = ref(false)
 const previewDiffSection = ref<HTMLElement | null>(null)
+// How the diff pane presents (#1397): `live` fetched diff, `stored` read-only
+// diffPreview for a terminal/expired proposal, or `invalid` when the proposal
+// has no operations (Apply would reject it). Null while nothing is shown.
+const previewDiffMode = ref<'live' | 'stored' | 'invalid' | null>(null)
 let latestDiffRequestId = 0
+
+function clearPreviewDiff() {
+  previewDiffProposalId.value = null
+  previewDiff.value = null
+  previewDiffMode.value = null
+  previewDiffLoading.value = false
+}
+
+// The read-only banner label for the active proposal's stored preview: 'Expired'
+// when the clock/domain says so, otherwise its terminal status.
+const previewReadOnlyLabel = computed(() => {
+  const p = activeProposal.value
+  if (!p) return ''
+  if (isProposalExpired(p)) return 'Expired'
+  return normalizeProposalStatus(p.status)
+})
 // Guards against a double-click firing two feedback POSTs (the backend is idempotent as a backstop).
 const reportingProposalId = ref<string | null>(null)
 
@@ -208,9 +228,7 @@ watch(
   (id) => {
     if (previewDiffProposalId.value && previewDiffProposalId.value !== id) {
       latestDiffRequestId += 1
-      previewDiffProposalId.value = null
-      previewDiff.value = null
-      previewDiffLoading.value = false
+      clearPreviewDiff()
     }
   },
 )
@@ -652,40 +670,54 @@ async function onPreviewDiff() {
   // Already showing this proposal's diff → toggle it off.
   if (previewDiffProposalId.value === p.id) {
     latestDiffRequestId += 1
-    previewDiffProposalId.value = null
-    previewDiff.value = null
+    clearPreviewDiff()
+    return
+  }
+
+  // Read-only / terminal proposals (expired, Applied, Rejected, Failed,
+  // Dismissed) never fire the live diff — PR #1395 makes `/diff` 400 for them.
+  // Present the stored `diffPreview` under an explicit read-only banner; when no
+  // stored preview exists, the banner + a "no stored preview" state, never an
+  // error toast (#1397 maintainer decision: stay inspectable, don't burden the
+  // UI). This runs before the revision settle so a settled proposal never fires
+  // a request.
+  if (isProposalReadOnly(p, isProposalExpired(p))) {
+    latestDiffRequestId += 1
+    previewDiffProposalId.value = p.id
+    previewDiff.value = p.diffPreview
+    previewDiffMode.value = 'stored'
     previewDiffLoading.value = false
+    scrollDiffIntoView()
     return
   }
 
   // A saved revision is rendered revision-aware by the backend (#1235), so a
   // proposal with a revision must fetch even when its ORIGINAL operations are
   // empty. Settle the revision list first so a still-loading revisionCount of 0
-  // can't short-circuit a revised proposal to the empty surface.
+  // can't short-circuit a revised proposal to the invalid surface.
   if (!revisionsLoaded.value) {
     await loadRevisionState(p.id)
     if (activeProposal.value?.id !== p.id) return
   }
 
-  // No-op proposals: the backend `/diff` (GetProposalDiffAsync) rejects a
-  // zero-operation proposal with 400 ValidationError "Proposal must contain at
-  // least one operation" — the same rejection Apply gives (#1376 preview == apply;
-  // 404 now only means the proposal itself was not found). The view already
-  // renders a "No operation preview" change section for that state, so show the
-  // empty-diff surface directly rather than firing a request that 400s. Only take
-  // this path when the revision list is authoritatively loaded and empty — a
-  // saved revision carries operations the backend renders revision-aware (#1235),
-  // and if the revision load failed we fetch so the backend, not a stale count,
-  // decides.
+  // Zero-operation proposals: the backend `/diff` rejects them with 400
+  // ValidationError "Proposal must contain at least one operation" — the same
+  // rejection Apply gives (#1376 preview == apply). Surface that verdict as an
+  // explicit invalid state (with or without a cached preview) so the reviewer
+  // sees the rejection BEFORE approving, instead of a "No changes" surface they
+  // could approve into a 400. Only take this path when the revision list is
+  // authoritatively loaded and empty — a saved revision carries operations the
+  // backend renders revision-aware (#1235), and if the revision load failed we
+  // fetch so the backend, not a stale count, decides. #1397
   if (
-    !p.diffPreview &&
     (p.operations?.length ?? 0) === 0 &&
     revisionsLoaded.value &&
     revisionCount.value === 0
   ) {
     latestDiffRequestId += 1
     previewDiffProposalId.value = p.id
-    previewDiff.value = ''
+    previewDiff.value = null
+    previewDiffMode.value = 'invalid'
     previewDiffLoading.value = false
     scrollDiffIntoView()
     return
@@ -694,6 +726,7 @@ async function onPreviewDiff() {
   const requestId = ++latestDiffRequestId
   previewDiffProposalId.value = p.id
   previewDiff.value = null
+  previewDiffMode.value = 'live'
   previewDiffLoading.value = true
   // Scroll to the loading state immediately so a slow `/diff` doesn't look like a
   // no-op on a long review surface (the final result re-scrolls when it lands).
@@ -704,17 +737,24 @@ async function onPreviewDiff() {
     // Ignore stale responses and ones whose target proposal has changed.
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
     previewDiff.value = diff
+    previewDiffMode.value = 'live'
     scrollDiffIntoView()
   } catch (e: unknown) {
     if (requestId !== latestDiffRequestId || previewDiffProposalId.value !== p.id) return
-    // The no-op case (no diff to show) is handled by the guard above BEFORE
-    // fetching, so a failure here is a real error: a 404 because the proposal was
-    // deleted/dismissed from another session, or a 400 ValidationError because the
-    // backend now runs Apply's gates at diff time (#1376) — "Proposal has expired"
-    // or "Proposal must contain at least one operation". Surface it rather than
-    // silently rendering an empty diff for a proposal Apply would reject.
-    previewDiffProposalId.value = null
-    previewDiff.value = null
+    // A 400 ValidationError means the backend ran Apply's gates at diff time
+    // (#1376/#1395): the proposal lost its operations or expired mid-flight.
+    // Apply would reject it too, so present the invalid verdict inline rather
+    // than tearing the pane down + toasting a generic error.
+    if (isValidationError(e)) {
+      previewDiff.value = null
+      previewDiffMode.value = 'invalid'
+      previewDiffLoading.value = false
+      scrollDiffIntoView()
+      return
+    }
+    // Any other failure (e.g. a 404 because the proposal was deleted/dismissed
+    // from another session) stays a toast with a clean teardown.
+    clearPreviewDiff()
     toast.error(getErrorDisplay(e, 'Failed to load proposal diff').message)
   } finally {
     if (requestId === latestDiffRequestId) {
@@ -730,9 +770,7 @@ async function onSaveRevision(payload: Parameters<typeof saveRevision>[0]) {
   // pre-revision preview (#1235). Re-opening the diff fetches the revision-aware one.
   if (previewDiffProposalId.value) {
     latestDiffRequestId += 1
-    previewDiffProposalId.value = null
-    previewDiff.value = null
-    previewDiffLoading.value = false
+    clearPreviewDiff()
   }
 }
 
@@ -851,8 +889,17 @@ function onQueueFilterChange(filter: QueueFilter) {
           <h3 class="tk-h3 paper-review-deep__diff-title">Operation details</h3>
           <span class="tk-meta paper-review-deep__diff-sub">Press Space to hide</span>
         </header>
+        <!-- Read-only banner: a terminal/expired proposal's stored preview (#1397) -->
         <p
-          v-if="revisionCount > 0"
+          v-if="previewDiffMode === 'stored'"
+          class="paper-review-deep__diff-banner tk-meta"
+          role="status"
+          data-testid="paper-review-diff-banner"
+        >
+          {{ previewReadOnlyLabel }} · read-only — showing the stored preview.
+        </p>
+        <p
+          v-else-if="revisionCount > 0 && previewDiffMode === 'live'"
           class="paper-review-deep__diff-caveat tk-meta"
           data-testid="paper-review-diff-revision-caveat"
         >
@@ -867,6 +914,23 @@ function onQueueFilterChange(filter: QueueFilter) {
           >
             Loading diff…
           </p>
+          <!-- Invalid: no operations to apply — Apply would reject it too (#1397) -->
+          <p
+            v-else-if="previewDiffMode === 'invalid'"
+            class="paper-review-deep__diff-invalid tk-meta"
+            role="status"
+            data-testid="paper-review-diff-invalid"
+          >
+            This proposal contains no operations to apply, so Apply would reject it.
+          </p>
+          <!-- Read-only proposal with no stored preview to fall back on (#1397) -->
+          <p
+            v-else-if="previewDiffMode === 'stored' && !previewDiff"
+            class="paper-review-deep__diff-empty tk-meta"
+            data-testid="paper-review-diff-stored-empty"
+          >
+            No stored preview is available for this proposal.
+          </p>
           <p
             v-else-if="!previewDiff"
             class="paper-review-deep__diff-empty tk-meta"
@@ -878,7 +942,7 @@ function onQueueFilterChange(filter: QueueFilter) {
             v-else
             class="paper-review-deep__diff-pre"
             role="region"
-            aria-label="Proposal operation diff"
+            :aria-label="previewDiffMode === 'stored' ? 'Stored proposal preview' : 'Proposal operation diff'"
             data-testid="paper-review-diff-pre"
           >{{ previewDiff }}</pre>
         </div>
@@ -980,6 +1044,16 @@ function onQueueFilterChange(filter: QueueFilter) {
 .paper-review-deep__diff-caveat {
   margin: 0 0 8px;
   color: var(--ink-2);
+}
+.paper-review-deep__diff-banner {
+  margin: 0 0 8px;
+  font-weight: 600;
+  color: var(--ember, #c2410c);
+}
+.paper-review-deep__diff-invalid {
+  padding: 16px;
+  font-weight: 600;
+  color: var(--ember, #c2410c);
 }
 .paper-review-deep__diff-empty {
   padding: 16px;

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -271,7 +271,12 @@ watch(
   },
   (readOnly) => {
     if (!readOnly) return
-    if (previewDiffMode.value === 'stored' || previewDiffMode.value === null) return
+    // SEAM INVARIANT (#1397 round 3, aligned with the Legacy watcher): a
+    // read-only conversion invalidates EVERY non-stored pane state. Paper sets
+    // previewDiffMode 'live' synchronously before its fetch, so unlike Legacy a
+    // null mode cannot coexist with an open pane id today — but the guard must
+    // not depend on that: only an already-stored presentation is skippable.
+    if (previewDiffMode.value === 'stored') return
     const p = activeProposal.value
     if (!p || previewDiffProposalId.value !== p.id) return
     // Cancel any in-flight live fetch so a late response can't overwrite the
@@ -636,9 +641,16 @@ function onFileAwayBulk() {
   void handleDismissApplied()
 }
 
+// #1397 P2-A (round 3): re-entry lock for the zero-op approve guard. While its
+// revision load is awaited, further Apply clicks are ignored — a re-entrant
+// loadRevisionState would bump the load generation and CANCEL the earlier load,
+// resuming the first click's await with revisionsLoaded still false.
+const applyGuardBusy = ref(false)
+
 async function onApply() {
   const p = activeProposal.value
   if (!p) return
+  if (applyGuardBusy.value) return
   if (revisionBusy.value) {
     toast.info('Save or cancel the revision before applying this proposal.')
     return
@@ -652,29 +664,37 @@ async function onApply() {
     void handleExecuteProposal(p.id)
     return
   }
-  // #1397 P2-A: approving a zero-operation proposal only defers a guaranteed
-  // Apply 400 ("Proposal must contain at least one operation") — UNLESS a saved
-  // revision carries operations the backend applies revision-aware (#1235). The
-  // revision list is the authority for that, so settle it FIRST when it hasn't
-  // loaded yet — exactly as the read-only diff path does (onPreviewDiff) —
-  // instead of letting a still-pending GET skip the guard and fall through to
-  // approve.
-  if ((p.operations?.length ?? 0) === 0 && !revisionsLoaded.value) {
-    await loadRevisionState(p.id)
-    // The active proposal can change during the await; only keep deciding on it.
-    if (activeProposal.value?.id !== p.id) return
+  // #1397 P2-A: SEAM INVARIANT — a zero-operation proposal may only be approved
+  // when its revision state is KNOWN (revisionsLoaded true). A saved revision
+  // carries operations the backend applies revision-aware (#1235); without the
+  // list we cannot distinguish "truly empty" from "revised". So when the state
+  // is unknown, settle it here (mirroring the diff path) — and if it is STILL
+  // unknown after the attempt (failed, or cancelled by a concurrent load from
+  // another surface), do NOT approve. No fall-through: unknown blocks approve.
+  // #1416 (approve-time backend validation) remains the root-cause backend fix.
+  if ((p.operations?.length ?? 0) === 0) {
+    if (!revisionsLoaded.value) {
+      applyGuardBusy.value = true
+      try {
+        await loadRevisionState(p.id)
+      } finally {
+        applyGuardBusy.value = false
+      }
+      // The active proposal can change during the await; only keep deciding on it.
+      if (activeProposal.value?.id !== p.id) return
+    }
+    if (!revisionsLoaded.value) {
+      // Load failed or was cancelled — the revision-history-unavailable error
+      // toast (from loadRevisionState) covers the failure case; this names why
+      // Apply did not proceed.
+      toast.info('Revision history is unavailable, so this proposal cannot be verified for Apply. Try again.')
+      return
+    }
+    if (revisionCount.value === 0) {
+      toast.info('This proposal contains no operations to apply — Apply will reject it. Reject or file it away instead.')
+      return
+    }
   }
-  if (
-    (p.operations?.length ?? 0) === 0 &&
-    revisionsLoaded.value &&
-    revisionCount.value === 0
-  ) {
-    toast.info('This proposal contains no operations to apply — Apply will reject it. Reject or file it away instead.')
-    return
-  }
-  // A revision load that FAILED leaves revisionsLoaded false: we cannot prove the
-  // proposal is zero-op, so defer to the backend (approve-time validation is
-  // tracked in #1416). This fall-through now only happens AFTER a load attempt.
   void handleApproveProposal(p.id)
 }
 
@@ -753,21 +773,27 @@ async function onPreviewDiff() {
   // Present the stored `diffPreview` under an explicit read-only banner; when no
   // stored preview exists, the banner + a "no stored preview" state, never an
   // error toast (#1397 maintainer decision: stay inspectable, don't burden the
-  // UI). Settle the revision list first (a metadata GET, not the /diff that
-  // 400s): `diffPreview` is creation-time content revisions never update, so
-  // the banner must disclose when this stored (original) preview is NOT what a
-  // revision-aware Apply would have executed (#1397 MEDIUM-2).
+  // UI).
+  //
+  // SEAM INVARIANT (#1397 round 3): the stored preview is LOCAL content and
+  // renders SYNCHRONOUSLY — no network gate may delay or veto it. The revision
+  // metadata GET (which only gates the revised-note caveat, #1397 MEDIUM-2:
+  // `diffPreview` is creation-time content revisions never update) runs async
+  // AFTERWARDS, augment-only and silent: a slow GET must not make the toggle
+  // look dead, and a failed GET must not error-toast over a presentable
+  // preview. Staleness of the caveat itself is handled inside loadRevisionState
+  // (generation counter + active-proposal-id re-check).
   if (isProposalReadOnly(p, isProposalExpired(p))) {
-    if (!revisionsLoaded.value) {
-      await loadRevisionState(p.id)
-      if (activeProposal.value?.id !== p.id) return
-    }
     latestDiffRequestId += 1
     previewDiffProposalId.value = p.id
     previewDiff.value = p.diffPreview
     previewDiffMode.value = 'stored'
+    previewDiffInvalidReason.value = null
     previewDiffLoading.value = false
     scrollDiffIntoView()
+    if (!revisionsLoaded.value) {
+      void loadRevisionState(p.id, { silent: true })
+    }
     return
   }
 

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -13,7 +13,7 @@ import { useReviewActions } from '../../composables/useReviewActions'
 import { usePaperReviewSelectors } from '../../composables/usePaperReviewSelectors'
 import { useReviewKeymap } from '../../composables/useReviewKeymap'
 import { useProposalRevisions } from '../../composables/useProposalRevisions'
-import { getErrorDisplay, isValidationError } from '../../composables/useErrorMapper'
+import { getErrorDisplay, getValidationReason, isValidationError } from '../../composables/useErrorMapper'
 import { automationApi } from '../../api/automationApi'
 import { useSessionStore } from '../../store/sessionStore'
 import { useToastStore } from '../../store/toastStore'
@@ -636,7 +636,7 @@ function onFileAwayBulk() {
   void handleDismissApplied()
 }
 
-function onApply() {
+async function onApply() {
   const p = activeProposal.value
   if (!p) return
   if (revisionBusy.value) {
@@ -652,12 +652,18 @@ function onApply() {
     void handleExecuteProposal(p.id)
     return
   }
-  // #1397 LOW-3: approving a zero-operation proposal only defers a guaranteed
-  // Apply 400 ("Proposal must contain at least one operation"). Block it here —
-  // but only when the revision list is authoritatively loaded and empty, because
-  // a saved revision carries operations the backend applies revision-aware
-  // (#1235). If revisions are unknown (load pending/failed), let the backend
-  // decide (approve-time validation is tracked in #1416).
+  // #1397 P2-A: approving a zero-operation proposal only defers a guaranteed
+  // Apply 400 ("Proposal must contain at least one operation") — UNLESS a saved
+  // revision carries operations the backend applies revision-aware (#1235). The
+  // revision list is the authority for that, so settle it FIRST when it hasn't
+  // loaded yet — exactly as the read-only diff path does (onPreviewDiff) —
+  // instead of letting a still-pending GET skip the guard and fall through to
+  // approve.
+  if ((p.operations?.length ?? 0) === 0 && !revisionsLoaded.value) {
+    await loadRevisionState(p.id)
+    // The active proposal can change during the await; only keep deciding on it.
+    if (activeProposal.value?.id !== p.id) return
+  }
   if (
     (p.operations?.length ?? 0) === 0 &&
     revisionsLoaded.value &&
@@ -666,6 +672,9 @@ function onApply() {
     toast.info('This proposal contains no operations to apply — Apply will reject it. Reject or file it away instead.')
     return
   }
+  // A revision load that FAILED leaves revisionsLoaded false: we cannot prove the
+  // proposal is zero-op, so defer to the backend (approve-time validation is
+  // tracked in #1416). This fall-through now only happens AFTER a load attempt.
   void handleApproveProposal(p.id)
 }
 
@@ -823,10 +832,10 @@ async function onPreviewDiff() {
     if (isValidationError(e)) {
       previewDiff.value = null
       previewDiffMode.value = 'invalid'
-      previewDiffInvalidReason.value = getErrorDisplay(
-        e,
-        'The backend rejected this proposal preview',
-      ).message
+      // Use the backend's ACTUAL reason, but treat a blank message as absent so
+      // the template's specific "no operations" fallback copy applies rather than
+      // the generic ValidationError string masking it (#1397 / #1414 review).
+      previewDiffInvalidReason.value = getValidationReason(e)
       previewDiffLoading.value = false
       scrollDiffIntoView()
       return
@@ -979,16 +988,27 @@ function onQueueFilterChange(filter: QueueFilter) {
           original submission.
         </p>
         <!-- diffPreview is creation-time content revisions never update, so a revised
-             proposal's stored preview is NOT what a revision-aware Apply would have
-             executed — disclose it (#1397 MEDIUM-2). -->
+             proposal's stored preview — or the recorded-operations fallback when no
+             preview was captured — is NOT what a revision-aware Apply would have
+             executed. Disclose it, and word it for whichever is actually on screen
+             (the fallback is not a "stored preview") (#1397 MEDIUM-2 / #1414 review). -->
         <p
-          v-if="previewDiffMode === 'stored' && revisionCount > 0"
+          v-if="previewDiffMode === 'stored' && revisionCount > 0 && previewDiff"
           class="paper-review-deep__diff-caveat tk-meta"
           role="status"
           data-testid="paper-review-diff-revised-note"
         >
           ✎ This proposal was <strong>revised</strong> after submission — the stored
           preview shows the original operations, not the revised ones.
+        </p>
+        <p
+          v-else-if="previewDiffMode === 'stored' && revisionCount > 0 && storedOperationsFallback"
+          class="paper-review-deep__diff-caveat tk-meta"
+          role="status"
+          data-testid="paper-review-diff-revised-note"
+        >
+          ✎ This proposal was <strong>revised</strong> after submission — the recorded
+          operations show the original submission, not the revised one.
         </p>
         <p
           v-if="revisionCount > 0 && previewDiffMode === 'live'"

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -784,6 +784,20 @@ function onToggleProvenance() {
   toast.info('Provenance toggle is not wired yet; provenance is rendered inline below.')
 }
 
+// Present a proposal's STORED preview read-only (no live `/diff`). The stored
+// `diffPreview` is LOCAL content and renders synchronously. Bumping the diff
+// request id also cancels any live fetch that this preview supersedes, so a
+// late 400 from a superseded request cannot overwrite the stored pane.
+function presentStoredPreview(target: ApiProposal) {
+  latestDiffRequestId += 1
+  previewDiffProposalId.value = target.id
+  previewDiff.value = target.diffPreview
+  previewDiffMode.value = 'stored'
+  previewDiffInvalidReason.value = null
+  previewDiffLoading.value = false
+  scrollDiffIntoView()
+}
+
 async function onPreviewDiff() {
   const p = activeProposal.value
   if (!p) return
@@ -823,13 +837,7 @@ async function onPreviewDiff() {
   // the live `/diff` fetch below. See issue #1397 for the option analysis and the
   // experiment path before making that flip.
   if (isProposalReadOnly(p, isProposalExpired(p))) {
-    latestDiffRequestId += 1
-    previewDiffProposalId.value = p.id
-    previewDiff.value = p.diffPreview
-    previewDiffMode.value = 'stored'
-    previewDiffInvalidReason.value = null
-    previewDiffLoading.value = false
-    scrollDiffIntoView()
+    presentStoredPreview(p)
     if (!revisionsLoaded.value) {
       void loadRevisionState(p.id, { silent: true })
     }
@@ -843,6 +851,22 @@ async function onPreviewDiff() {
   if (!revisionsLoaded.value) {
     await loadRevisionState(p.id)
     if (activeProposal.value?.id !== p.id) return
+    // #1414 final round: identity is not enough. The proposal can transition to
+    // read-only DURING the revision-load await — expire on the 60s clock, be
+    // refreshed to a terminal status, or be executed from another session — all
+    // with the SAME id, so the identity check above passes. Re-run the read-only
+    // classification on the CURRENT object and divert to the stored preview
+    // rather than falling through to a live `/diff` that #1395 guarantees will
+    // 400 for a terminal/expired proposal (which would defeat #1397's stored-
+    // preview guarantee and show the invalid/error surface). Mirrors the onApply
+    // post-await re-check. The read-only watcher (which converts an ALREADY-open
+    // pane) cannot cover this window: previewDiffProposalId is not set to this id
+    // until after the await, so the watcher is inert here.
+    const current = activeProposal.value
+    if (current && isProposalReadOnly(current, isProposalExpired(current))) {
+      presentStoredPreview(current)
+      return
+    }
   }
 
   // Zero-operation proposals: the backend `/diff` rejects them with 400

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -214,6 +214,25 @@ const previewReadOnlyLabel = computed(() => {
   if (isProposalExpired(p)) return 'Expired'
   return normalizeProposalStatus(p.status)
 })
+
+// Read-only fallback when the proposal never captured a `diffPreview` (normal
+// creation flows leave it null — Codex review on #1414): derive a minimal
+// operation listing from the proposal's own recorded operations so a
+// terminal/expired proposal that still HAS operations is inspectable instead of
+// a dead "no stored preview" end. Local rendering only — the live `/diff` 400s
+// for these proposals (#1397).
+const storedOperationsFallback = computed(() => {
+  if (previewDiffMode.value !== 'stored' || previewDiff.value) return null
+  const ops = activeProposal.value?.operations ?? []
+  if (ops.length === 0) return null
+  return [...ops]
+    .sort((a, b) => a.sequence - b.sequence)
+    .map(
+      (op, index) =>
+        `${index + 1}. ${formatActionLabel(op.actionType)} · ${op.targetType}${op.targetId ? ` (${op.targetId})` : ''}`,
+    )
+    .join('\n')
+})
 // Guards against a double-click firing two feedback POSTs (the backend is idempotent as a backstop).
 const reportingProposalId = ref<string | null>(null)
 
@@ -999,7 +1018,16 @@ function onQueueFilterChange(filter: QueueFilter) {
             {{ previewDiffInvalidReason || 'This proposal contains no operations to apply' }}
             — Apply will reject this proposal.
           </p>
-          <!-- Read-only proposal with no stored preview to fall back on (#1397) -->
+          <!-- Read-only proposal without a stored preview: fall back to the
+               proposal's own recorded operations before giving up (#1397 /
+               Codex review on #1414). -->
+          <pre
+            v-else-if="storedOperationsFallback"
+            class="paper-review-deep__diff-pre"
+            role="region"
+            aria-label="Recorded proposal operations"
+            data-testid="paper-review-diff-stored-operations"
+          >{{ storedOperationsFallback }}</pre>
           <p
             v-else-if="previewDiffMode === 'stored' && !previewDiff"
             class="paper-review-deep__diff-empty tk-meta"

--- a/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
+++ b/frontend/taskdeck-web/src/views/paper/PaperReviewView.vue
@@ -59,6 +59,7 @@ const {
   isProposalExpired,
   isApplyActionable,
   isRejectActionable,
+  isProposalDeferred,
   isProposalDismissable,
   isStaleProposal,
   clearProposalDeepLink,
@@ -593,8 +594,18 @@ const whyNowBody = computed(() => {
 // --- Action wiring -----------------------------------------------------
 
 const revisionBusy = computed(() => revisionEditing.value || revisionSaving.value)
+// #1414 round 4 P2-A: the zero-op apply guard's revision-load await participates
+// in the SHARED decision lock. While it is in flight the whole rail (buttons via
+// :busy, keymap via its !busy gate) is disabled — otherwise a Defer/Reject
+// during the await, with the #proposal- hash carve-out keeping selection
+// stable, could change the proposal's state under the resumed Apply.
+const applyGuardBusy = ref(false)
 const busy = computed(
-  () => proposalActionBusyId.value !== null || revisionBusy.value || bulkDismissBusy.value,
+  () =>
+    proposalActionBusyId.value !== null ||
+    revisionBusy.value ||
+    bulkDismissBusy.value ||
+    applyGuardBusy.value,
 )
 
 // True once the active proposal is settled (Applied/Rejected/Failed/Expired/
@@ -641,12 +652,6 @@ function onFileAwayBulk() {
   void handleDismissApplied()
 }
 
-// #1397 P2-A (round 3): re-entry lock for the zero-op approve guard. While its
-// revision load is awaited, further Apply clicks are ignored — a re-entrant
-// loadRevisionState would bump the load generation and CANCEL the earlier load,
-// resuming the first click's await with revisionsLoaded still false.
-const applyGuardBusy = ref(false)
-
 async function onApply() {
   const p = activeProposal.value
   if (!p) return
@@ -659,19 +664,16 @@ async function onApply() {
     toast.info('This proposal is no longer actionable. Refresh review to see current status.')
     return
   }
-  const status = normalizeProposalStatus(p.status)
-  if (status === 'Approved') {
-    void handleExecuteProposal(p.id)
-    return
-  }
-  // #1397 P2-A: SEAM INVARIANT — a zero-operation proposal may only be approved
-  // when its revision state is KNOWN (revisionsLoaded true). A saved revision
-  // carries operations the backend applies revision-aware (#1235); without the
-  // list we cannot distinguish "truly empty" from "revised". So when the state
-  // is unknown, settle it here (mirroring the diff path) — and if it is STILL
-  // unknown after the attempt (failed, or cancelled by a concurrent load from
-  // another surface), do NOT approve. No fall-through: unknown blocks approve.
-  // #1416 (approve-time backend validation) remains the root-cause backend fix.
+  // #1397 P2-A: SEAM INVARIANT — a zero-operation proposal is only approved (or
+  // executed, #1414 round 4 P2-B: this guard sits BEFORE the Approved dispatch,
+  // so pre-#1423 Approved zero-op data gets the same verdict instead of a doomed
+  // execute round-trip) when its revision state is KNOWN (revisionsLoaded true).
+  // A saved revision carries operations the backend applies revision-aware
+  // (#1235); without the list we cannot distinguish "truly empty" from
+  // "revised". Unknown after the attempt (failed, or cancelled by a concurrent
+  // load) blocks the action. Since #1423 the backend enforces this at approve
+  // time too (zero-op approve 400s server-side, revision-aware) — this guard is
+  // UX-only: it saves the round-trip and gives the inline verdict.
   if ((p.operations?.length ?? 0) === 0) {
     if (!revisionsLoaded.value) {
       applyGuardBusy.value = true
@@ -682,6 +684,13 @@ async function onApply() {
       }
       // The active proposal can change during the await; only keep deciding on it.
       if (activeProposal.value?.id !== p.id) return
+      // #1414 round 4 P2-A: identity is not enough — the proposal's STATE can
+      // change under the await from another surface or session (deferred,
+      // dismissed, status change) even while the shared busy lock holds this
+      // rail. Re-check actionability on the CURRENT object and no-op if it is
+      // no longer applyable or has been snoozed.
+      const current = activeProposal.value
+      if (!current || !isApplyActionable(current) || isProposalDeferred(current)) return
     }
     if (!revisionsLoaded.value) {
       // Load failed or was cancelled — the revision-history-unavailable error
@@ -691,9 +700,20 @@ async function onApply() {
       return
     }
     if (revisionCount.value === 0) {
-      toast.info('This proposal contains no operations to apply — Apply will reject it. Reject or file it away instead.')
+      const approvedZeroOp =
+        normalizeProposalStatus((activeProposal.value ?? p).status) === 'Approved'
+      toast.info(
+        approvedZeroOp
+          ? 'This proposal contains no operations — applying it to the board will be rejected.'
+          : 'This proposal contains no operations to apply — Apply will reject it. Reject or file it away instead.',
+      )
       return
     }
+  }
+  const status = normalizeProposalStatus((activeProposal.value ?? p).status)
+  if (status === 'Approved') {
+    void handleExecuteProposal(p.id)
+    return
   }
   void handleApproveProposal(p.id)
 }
@@ -712,6 +732,13 @@ function onReject() {
     toast.info('Save or cancel the revision before rejecting this proposal.')
     return
   }
+  // #1414 round 4 P2-A: mirror onDefer/onFileAway — a decision must not fire
+  // while another action holds the shared lock (notably the zero-op apply
+  // guard's revision-load await). The keymap (!busy gate) and the disabled
+  // button already block Reject during that window; this internal guard keeps
+  // the invariant local so a future caller can't reopen the Defer/Reject-under-
+  // Apply race the P2-A busy join closed.
+  if (busy.value) return
   if (!isRejectActionable(p)) {
     toast.info('This proposal can no longer be rejected. Refresh review to see current status.')
     return
@@ -783,6 +810,18 @@ async function onPreviewDiff() {
   // look dead, and a failed GET must not error-toast over a presentable
   // preview. Staleness of the caveat itself is handled inside loadRevisionState
   // (generation counter + active-proposal-id re-check).
+  //
+  // PREVIEW-SOURCE SELECTION SEAM (#1397 Q1, maintainer ruling 2026-07-18):
+  // for a terminal/expired proposal we present the STORED `diffPreview`
+  // (`previewDiff.value = p.diffPreview` below) rather than a live diff. This is
+  // BY DESIGN — the stored preview is the artifact the reviewer actually saw at
+  // decision time; a live diff of a terminal proposal can drift from it (a later
+  // revision, board change, or backend re-render), which would break review-first
+  // provenance. The alternative (live diff for non-expired *terminal* proposals,
+  // Codex's Q1 suggestion) would be switched HERE: narrow this branch to only
+  // isExpired/domain-Expired and let non-expired terminal statuses fall through to
+  // the live `/diff` fetch below. See issue #1397 for the option analysis and the
+  // experiment path before making that flip.
   if (isProposalReadOnly(p, isProposalExpired(p))) {
     latestDiffRequestId += 1
     previewDiffProposalId.value = p.id


### PR DESCRIPTION
Closes #1397

## Summary

PR #1395 made `GET /api/automation/proposals/{id}/diff` return **400 ValidationError** ("Proposal has expired" / "Proposal must contain at least one operation") where it previously returned 200. That made expired proposals uninspectable (the pane cleared + an error toast) and let reviewers approve pending zero-op proposals that Apply then rejects.

Per the maintainer decision recorded on #1397 (2026-07-17): **expired proposals stay inspectable but must not burden the UI** — the frontend presents the stored `diffPreview` under an explicit read-only banner instead of firing a live diff. Backend contract is FINAL; this slice is frontend-only (`frontend/taskdeck-web`).

## What changed

- **Shared helpers**
  - `useReviewProposals.ts` — new `isProposalReadOnly(proposal, isExpired)`: true when expired (client clock or domain) or terminal (Applied/Rejected/Failed/Expired/Dismissed).
  - `useErrorMapper.ts` — new `isValidationError(err)`: detects the backend 400 ValidationError (status 400 or `errorCode === 'ValidationError'`).

- **Legacy shell** (`useReviewActions.ts`, `LegacyReviewView.vue`, `ReviewProposalCard.vue`, `ReviewProposalActions.vue`)
  - `handleToggleDiff` now: read-only/terminal → **no live request**, presents stored `diffPreview` in a `stored` mode (banner + preview, or a "no stored preview available" note); a 400 from `/diff` → `invalid` mode (no operations; Apply would reject) rather than toast + cleared pane; other errors (e.g. 404) keep the toast + clean teardown.
  - `useReviewActions` takes an injected `isProposalExpired` so the Legacy surface's reactive clock drives read-only classification (Paper keeps its own diff flow).
  - The card renders the three states with distinct `data-testid`s; the live pane still only renders once content arrives (a slow fetch never flashes a premature empty line).
  - The expired-path button is relabeled **View/Hide stored preview** (finding 3) — it no longer promises a live diff that 400s.

- **Paper shell** (`PaperReviewView.vue`)
  - `onPreviewDiff` gains the same read-only short-circuit (stored banner / no-stored-preview) before the revision settle, and renders a 400 as the `invalid` verdict.
  - Pending zero-op proposals (with or without a cached preview) now show an explicit **invalid** state ("contains no operations; Apply would reject it") instead of a "No changes" surface the reviewer could approve (finding 4).

## Maintainer-decision reference

Issue #1397 addendum (2026-07-17): expired proposals remain inspectable via stored content, presented read-only, without a live diff request. Terminal items fall under the same treatment.

## Test evidence

All commands run from `frontend/taskdeck-web` in the worktree.

- `npm run typecheck` — clean (vue-tsc, 0 errors).
- `npm run lint` — 0 errors (6 pre-existing warnings in untouched files, under the max-warnings threshold).
- `npx vitest --run src/tests/composables/useReviewActions.spec.ts src/tests/components/review/ReviewProposalActions.spec.ts src/tests/components/review/ReviewProposalCard.diff.spec.ts --maxWorkers=2` → **3 files, 32 passed**.
- `npx vitest --run src/tests/views/paper/review/PaperReviewView.spec.ts --maxWorkers=2` → **1 file, 49 passed**.
- `npx vitest --run src/tests/views/ReviewView.spec.ts src/tests/views/ReviewView.coverage.spec.ts src/tests/composables/useReviewProposals.spec.ts src/tests/composables/useErrorMapper.spec.ts --maxWorkers=2` → **4 files, 124 passed** (regression check on the touched surfaces).

New/updated tests pin, in both shells: (a) expired → no network call, stored preview + banner (and a no-stored-preview note when empty); (b) pending zero-op → explicit invalid state; (c) 400 from `/diff` → presented invalid state, not a silent clear + toast.

## Not verified

- No browser/Playwright run (targeted vitest + typecheck + lint only; full suite OOMs locally per repo notes — CI owns it).
- Backend unchanged; the 400 contract is taken as given from #1395.
