### PR TITLE
Move WorkspaceApiTests to the worker-disabled factory so background workers cannot mutate seeded queue rows (#1418)

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/WorkspaceApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkspaceApiTests.cs
@@ -15,7 +15,8 @@ namespace Taskdeck.Api.Tests;
 
 // Uses the worker-disabled factory (issue #1418, convention #1335): this class seeds a
 // Processing capture that LlmQueueToProposalWorker would otherwise claim and flip to a terminal
-// state mid-test (and Today_* seeds are likewise protected from ProposalHousekeepingWorker).
+// state mid-test (and Home's PendingReview proposal seeds are likewise shielded from
+// ProposalHousekeepingWorker expiry).
 // Safe because no test here depends on a live worker — all set statuses directly and assert
 // aggregation.
 public class WorkspaceApiTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>

--- a/backend/tests/Taskdeck.Api.Tests/WorkspaceApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/WorkspaceApiTests.cs
@@ -13,11 +13,16 @@ using Xunit;
 
 namespace Taskdeck.Api.Tests;
 
-public class WorkspaceApiTests : IClassFixture<TestWebApplicationFactory>
+// Uses the worker-disabled factory (issue #1418, convention #1335): this class seeds a
+// Processing capture that LlmQueueToProposalWorker would otherwise claim and flip to a terminal
+// state mid-test (and Today_* seeds are likewise protected from ProposalHousekeepingWorker).
+// Safe because no test here depends on a live worker — all set statuses directly and assert
+// aggregation.
+public class WorkspaceApiTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {
-    private readonly TestWebApplicationFactory _factory;
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
 
-    public WorkspaceApiTests(TestWebApplicationFactory factory)
+    public WorkspaceApiTests(HostedWorkerDisabledTestWebApplicationFactory factory)
     {
         _factory = factory;
     }


### PR DESCRIPTION
## Problem

`WorkspaceApiTests.Home_ShouldReturnCurrentUserSummaryOnly` flakes under full-suite CPU contention.

## Root cause

`WorkspaceApiTests` used `IClassFixture<TestWebApplicationFactory>` — the worker-ENABLED base factory (`UseEnvironment("Development")`, `Workers:EnableAutoQueueProcessing` defaults true, `Workers:QueuePollIntervalSeconds=1`). The test seeds a capture in `RequestStatus.Processing`. The live `LlmQueueToProposalWorker` capture lane (`GetOldestProcessingCaptureAsync`) claims exactly that row and mutates it to a terminal state. Under contention the worker's 1s poll occasionally lands before the test's `GET /api/workspace/home`, flipping `FailedCount` 1→2 and making `CapturesNeedingTriage` return 3 instead of the expected 2.

This is the exact failure mode documented in `HostedWorkerDisabledTestWebApplicationFactory`'s header comment (issue #1335).

## Fix

Move the class onto `HostedWorkerDisabledTestWebApplicationFactory`, which removes all application background workers from the test host so no worker can pre-empt seeded queue rows. Three edit points in `backend/tests/Taskdeck.Api.Tests/WorkspaceApiTests.cs` (class fixture, field type, constructor parameter), plus a class comment citing #1418/#1335.

## Not a product bug

`GetCaptureSummaryByUserAsync` is correctly user-scoped — the aggregation itself is right. This is purely a test-harness isolation issue: the seeded `Processing` capture was being claimed by a live worker mid-test. No test in the class depends on a live worker; every test sets statuses directly and asserts aggregation, and the `Today_*` seeds are likewise protected from `ProposalHousekeepingWorker`.

## Convention

Follows the issue #1335 isolation boundary: use the worker-disabled factory for any test that seeds state an app worker polls or mutates. Isolation lives in the fixture, not in `backend/src` — production and every worker-dependent test class keep the workers via the base factory.

## Verification

`dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~WorkspaceApiTests"` run twice:
- Run 1: Passed 12, Failed 0, Skipped 0
- Run 2: Passed 12, Failed 0, Skipped 0

(The race is non-deterministic and won't repro reliably in isolation; these runs prove the factory swap breaks nothing.)

Closes #1418
