### PR TITLE
Remove dead ApiKeyService.ValidateKeyAsync usage-recording path (#1409)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/ApiKeyService.cs
+++ b/backend/src/Taskdeck.Application/Services/ApiKeyService.cs
@@ -53,35 +53,6 @@ public class ApiKeyService
         return (plaintextKey, apiKey);
     }
 
-    /// <summary>
-    /// Validate an API key and return the associated entity if valid.
-    /// Returns null if the key is invalid, expired, or revoked.
-    /// </summary>
-    /// <remarks>
-    /// DEAD PATH / dual-writer trap: this method currently has no production callers. MCP
-    /// authentication is performed by ApiKeyMiddleware, which records usage directly via
-    /// ExecuteUpdateAsync — wiring this method into that pipeline would double-write
-    /// LastUsedAt/UpdatedAt on every authenticated request. Either remove this path or make it
-    /// the single usage writer (dropping the middleware's direct update), not both; see #1409.
-    /// </remarks>
-    public async Task<ApiKey?> ValidateKeyAsync(string plaintextKey, CancellationToken cancellationToken = default)
-    {
-        if (string.IsNullOrWhiteSpace(plaintextKey) || !plaintextKey.StartsWith(ApiKey.KeyPrefix))
-            return null;
-
-        var keyHash = HashKey(plaintextKey);
-        var apiKey = await _unitOfWork.ApiKeys.GetByKeyHashAsync(keyHash, cancellationToken);
-
-        if (apiKey is null || !apiKey.IsActive)
-            return null;
-
-        // Record usage (fire-and-forget style, non-critical)
-        apiKey.RecordUsage();
-        await _unitOfWork.SaveChangesAsync(cancellationToken);
-
-        return apiKey;
-    }
-
     /// <summary>List all API keys for a user.</summary>
     public async Task<IEnumerable<ApiKey>> ListKeysAsync(Guid userId, CancellationToken cancellationToken = default)
     {

--- a/backend/src/Taskdeck.Domain/Entities/ApiKey.cs
+++ b/backend/src/Taskdeck.Domain/Entities/ApiKey.cs
@@ -85,11 +85,4 @@ public class ApiKey : Entity
         RevokedAt = DateTimeOffset.UtcNow;
         Touch();
     }
-
-    /// <summary>Record that this key was used for a successful authentication.</summary>
-    public void RecordUsage()
-    {
-        LastUsedAt = DateTimeOffset.UtcNow;
-        Touch();
-    }
 }

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ApiKeyTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ApiKeyTests.cs
@@ -104,17 +104,6 @@ public class ApiKeyTests
     }
 
     [Fact]
-    public void RecordUsage_UpdatesLastUsedAt()
-    {
-        var apiKey = new ApiKey(Guid.NewGuid(), "hash", "tdsk_abc", "Key");
-
-        apiKey.RecordUsage();
-
-        apiKey.LastUsedAt.Should().NotBeNull();
-        apiKey.LastUsedAt.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
-    }
-
-    [Fact]
     public void IsActive_RevokedKey_ReturnsFalse()
     {
         var apiKey = new ApiKey(Guid.NewGuid(), "hash", "tdsk_abc", "Key");


### PR DESCRIPTION
## What

Removes the dead `ApiKeyService.ValidateKeyAsync` usage-recording path and its supporting domain helper.

### Removed
- `ApiKeyService.ValidateKeyAsync(string, CancellationToken)` (Application) — plus the `#1409` dead-path / dual-writer warning comment on it.
- `ApiKey.RecordUsage()` (Domain) — its only production caller was `ValidateKeyAsync`; zero production callers remain after that removal.
- `ApiKeyTests.RecordUsage_UpdatesLastUsedAt` (Domain.Tests) — the only test exercising `RecordUsage()`.

## Why

`ValidateKeyAsync` had zero callers and was a dual-writer trap. MCP authentication is performed by `ApiKeyMiddleware`, which records usage directly via `ExecuteUpdateAsync` (#1402/#1406; owner `IsActive` folded into the initial `ApiKeys` lookup in #1404/PR #1412). If anyone had wired `ValidateKeyAsync` into that pipeline it would double-write `LastUsedAt`/`UpdatedAt` on every authenticated request. Recorded decision (#1409): remove it rather than wire it.

`ApiKey.RecordUsage()` followed it out: a grep after removing `ValidateKeyAsync` showed no remaining production callers (only the one domain unit test, which is removed here). The `LastUsedAt` property itself is untouched — the middleware still persists it via `ExecuteUpdateAsync`.

`ApiKeyService` implements no interface (concrete class registered in DI), so there was no interface member to remove. Surviving methods (`CreateKeyAsync`, `ListKeysAsync`, `RevokeKeyAsync`, `GenerateKey`, `HashKey`) are unchanged.

## Compiler-proof

`dotnet build backend/Taskdeck.sln -c Release -m:1` is clean (0 errors) after removing both members. A clean build with no unresolved references is proof that neither `ValidateKeyAsync` nor `RecordUsage()` had any remaining caller in production or test code.

## Verification

- Build: `dotnet build backend/Taskdeck.sln -c Release -m:1` — 0 errors (11 pre-existing unrelated warnings).
- Tests: `dotnet test backend/Taskdeck.sln -c Release -m:1 --filter "FullyQualifiedName~ApiKey"` — all green:
  - Domain.Tests: 10 passed (was 11; the removed `RecordUsage` test accounts for the delta).
  - Api.Tests (ApiKey middleware / MCP auth): 68 passed.
  - Cli.Tests (ApiKey command handler): 12 passed.
  - Total: 90 passed, 0 failed, 0 skipped.

## Scope note

No cascade beyond this slice — no other members became unreferenced.

Closes #1409
