### PR TITLE
Parameterize SQLite timestamp bounds so zero-fraction boundary rows compare correctly (#1403)

### DIFF
--- a/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
@@ -173,8 +173,17 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
         int limit,
         CancellationToken cancellationToken)
     {
+        // Normalize the bounds to UTC before parameterizing: EF's SQLite DateTimeOffset mapping
+        // PRESERVES the source offset (it does not convert to UTC), and this is the one timestamp
+        // seam fed raw user input — LogQueryService forwards user-supplied query.From/query.To (any
+        // offset) straight here. Un-normalized, a bound like 2026-07-17T00:00:00-05:00 (== 05:00Z)
+        // serializes as "...00:00:00-05:00" and its shifted wall-clock digits compare against the
+        // stored "+00:00" rows as a raw string, wrongly INCLUDING a stored row at 02:00Z (the string
+        // compare is decided at the hour digit, not by instant). ToUniversalTime() yields the same
+        // instant at "+00:00" so both sides share the suffix and TEXT order equals chronological
+        // order (same normalization as CountByDateAsync / DeleteOldEntriesAsync, issue #1403).
         var conditions = new List<string> { "al.Timestamp >= {0} AND al.Timestamp <= {1}" };
-        var parameters = new List<object> { from, to };
+        var parameters = new List<object> { from.ToUniversalTime(), to.ToUniversalTime() };
         var nextParam = 2;
 
         if (userId.HasValue)

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
@@ -272,12 +272,20 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
             // instead of excluding it — a fixed-width ".fffffff" bound sorts above the stored
             // "...ss+00:00" because '+' (0x2B) < '.' (0x2E) (issue #1403). Mirrors the proven
             // parameterized raw-SQL pattern in LlmQueueRepository.GetStuckProcessingNonCaptureAsync.
+            //
+            // Normalize the bounds to UTC first: EF's SQLite mapping PRESERVES the offset (it does not
+            // convert to UTC), so a caller-supplied non-UTC bound (e.g. -05:00) would serialize with a
+            // "-05:00" suffix and its shifted wall-clock digits would compare against the stored
+            // "+00:00" rows as a raw string — NOT by instant. ToUniversalTime() gives a "+00:00"-offset
+            // value of the same instant so both sides share the suffix and TEXT order equals chrono order.
+            var fromUtc = from.ToUniversalTime();
+            var toUtc = to.ToUniversalTime();
             var rows = await _context.Database
                 .SqlQuery<DateCountRow>(
                     $"""
                     SELECT SUBSTR(Timestamp, 1, 10) AS DateStr, COUNT(*) AS Count
                     FROM AuditLogs
-                    WHERE UserId = {userId} AND Timestamp >= {from} AND Timestamp <= {to}
+                    WHERE UserId = {userId} AND Timestamp >= {fromUtc} AND Timestamp <= {toUtc}
                     GROUP BY SUBSTR(Timestamp, 1, 10)
                     """)
                 .ToListAsync(cancellationToken);
@@ -317,13 +325,19 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
                 // Pass the DateTimeOffset cutoff as a parameter (not a hand-built ".fffffff" string):
                 // EF's SQLite provider serializes both the parameter and the stored Timestamp column with
                 // the same "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz" mapping (trailing fraction zeros trimmed, dot
-                // dropped at a zero fraction), and normalizes any non-UTC offset consistently on both
-                // sides. A row stored at exactly the cutoff with a zero-fraction tick then compares EQUAL,
-                // so the strictly-older `Timestamp < cutoff` contract KEEPS it instead of deleting it —
-                // a fixed-width bound sorts above the stored "...ss+00:00" because '+' (0x2B) < '.' (0x2E)
-                // (issue #1403). See OAuthAuthCodeRepository.DeleteExpiredAsync for the same shape.
+                // dropped at a zero fraction). A row stored at exactly the cutoff with a zero-fraction tick
+                // then compares EQUAL, so the strictly-older `Timestamp < cutoff` contract KEEPS it instead
+                // of deleting it — a fixed-width bound sorts above the stored "...ss+00:00" because
+                // '+' (0x2B) < '.' (0x2E) (issue #1403). See OAuthAuthCodeRepository.DeleteExpiredAsync.
+                //
+                // Normalize to UTC first: EF's SQLite mapping PRESERVES the offset (it does not convert to
+                // UTC), so a non-UTC cutoff (e.g. -05:00) would serialize with a "-05:00" suffix and its
+                // shifted wall-clock digits would compare against the stored "+00:00" rows as a raw string
+                // rather than by instant. ToUniversalTime() yields the same instant at "+00:00" so both
+                // sides share the suffix and TEXT order equals chronological order.
+                var cutoffUtc = olderThan.ToUniversalTime();
                 deleted = await _context.Database.ExecuteSqlInterpolatedAsync(
-                    $"DELETE FROM AuditLogs WHERE Id IN (SELECT Id FROM AuditLogs WHERE Timestamp < {olderThan} ORDER BY Timestamp ASC LIMIT {batchSize})",
+                    $"DELETE FROM AuditLogs WHERE Id IN (SELECT Id FROM AuditLogs WHERE Timestamp < {cutoffUtc} ORDER BY Timestamp ASC LIMIT {batchSize})",
                     cancellationToken);
             }
             else

--- a/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/AuditLogRepository.cs
@@ -263,16 +263,23 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
             // SQLite stores DateTimeOffset as a string; use SUBSTR to extract the date portion
             // and push the GROUP BY into SQL. The IX_AuditLogs_UserId_Timestamp index covers
             // the WHERE clause so this avoids a full table scan.
-            var fromStr = from.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
-            var toStr = to.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
-
+            //
+            // Pass the DateTimeOffset bounds as parameters (not hand-built ".fffffff" strings): EF's
+            // SQLite provider serializes BOTH the parameter and the stored Timestamp column with the
+            // same "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz" mapping (trailing fraction zeros trimmed, and the
+            // dot dropped entirely at a zero fraction). A row stored at exactly `from` with a
+            // zero-fraction tick then compares EQUAL, so the `Timestamp >= from` contract counts it
+            // instead of excluding it — a fixed-width ".fffffff" bound sorts above the stored
+            // "...ss+00:00" because '+' (0x2B) < '.' (0x2E) (issue #1403). Mirrors the proven
+            // parameterized raw-SQL pattern in LlmQueueRepository.GetStuckProcessingNonCaptureAsync.
             var rows = await _context.Database
-                .SqlQueryRaw<DateCountRow>(
-                    "SELECT SUBSTR(Timestamp, 1, 10) AS DateStr, COUNT(*) AS Count " +
-                    "FROM AuditLogs " +
-                    "WHERE UserId = {0} AND Timestamp >= {1} AND Timestamp <= {2} " +
-                    "GROUP BY SUBSTR(Timestamp, 1, 10)",
-                    userId, fromStr, toStr)
+                .SqlQuery<DateCountRow>(
+                    $"""
+                    SELECT SUBSTR(Timestamp, 1, 10) AS DateStr, COUNT(*) AS Count
+                    FROM AuditLogs
+                    WHERE UserId = {userId} AND Timestamp >= {from} AND Timestamp <= {to}
+                    GROUP BY SUBSTR(Timestamp, 1, 10)
+                    """)
                 .ToListAsync(cancellationToken);
 
             return rows
@@ -307,17 +314,16 @@ public class AuditLogRepository : Repository<AuditLog>, IAuditLogRepository
             int deleted;
             if (_context.Database.IsSqlite())
             {
-                // SQLite stores DateTimeOffset as a string in "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm" format.
-                // We must format the cutoff identically so the < comparison (string ordering) works correctly.
-                // See OAuthAuthCodeRepository.DeleteExpiredAsync for the same pattern.
-                // Normalize to UTC first so that a non-UTC DateTimeOffset (e.g. -05:00) is converted to
-                // its UTC-equivalent time before the "+00:00" suffix is appended; without this the time
-                // component would be wrong and entries in the wrong window could be kept or deleted.
-                var utcCutoff = olderThan.UtcDateTime;
-                var olderThanStr = utcCutoff.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
-                deleted = await _context.Database.ExecuteSqlRawAsync(
-                    "DELETE FROM AuditLogs WHERE Id IN (SELECT Id FROM AuditLogs WHERE Timestamp < {0} ORDER BY Timestamp ASC LIMIT {1})",
-                    new object[] { olderThanStr, batchSize },
+                // Pass the DateTimeOffset cutoff as a parameter (not a hand-built ".fffffff" string):
+                // EF's SQLite provider serializes both the parameter and the stored Timestamp column with
+                // the same "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz" mapping (trailing fraction zeros trimmed, dot
+                // dropped at a zero fraction), and normalizes any non-UTC offset consistently on both
+                // sides. A row stored at exactly the cutoff with a zero-fraction tick then compares EQUAL,
+                // so the strictly-older `Timestamp < cutoff` contract KEEPS it instead of deleting it —
+                // a fixed-width bound sorts above the stored "...ss+00:00" because '+' (0x2B) < '.' (0x2E)
+                // (issue #1403). See OAuthAuthCodeRepository.DeleteExpiredAsync for the same shape.
+                deleted = await _context.Database.ExecuteSqlInterpolatedAsync(
+                    $"DELETE FROM AuditLogs WHERE Id IN (SELECT Id FROM AuditLogs WHERE Timestamp < {olderThan} ORDER BY Timestamp ASC LIMIT {batchSize})",
                     cancellationToken);
             }
             else

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -53,13 +53,18 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         // Pass the DateTimeOffset cutoff as a parameter (not a hand-built ".fffffff" string): EF's
         // SQLite provider serializes both the parameter and the stored ExpiresAt column with the same
         // "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz" mapping (trailing fraction zeros trimmed, dot dropped at a
-        // zero fraction) and normalizes any non-UTC offset consistently on both sides. A code expiring
-        // at exactly the cutoff with a zero-fraction tick then compares EQUAL, so the strictly-older
-        // `ExpiresAt < cutoff` contract KEEPS it instead of deleting it — a fixed-width bound sorts above
-        // the stored "...ss+00:00" because '+' (0x2B) < '.' (0x2E) (issue #1403). Mirrors
-        // AuditLogRepository.DeleteOldEntriesAsync.
+        // zero fraction). A code expiring at exactly the cutoff with a zero-fraction tick then compares
+        // EQUAL, so the strictly-older `ExpiresAt < cutoff` contract KEEPS it instead of deleting it —
+        // a fixed-width bound sorts above the stored "...ss+00:00" because '+' (0x2B) < '.' (0x2E)
+        // (issue #1403). Mirrors AuditLogRepository.DeleteOldEntriesAsync.
+        //
+        // Normalize to UTC first: EF's SQLite mapping PRESERVES the offset (it does not convert to UTC),
+        // so a non-UTC cutoff (e.g. -05:00) would serialize with a "-05:00" suffix and its shifted
+        // wall-clock digits would compare against the stored "+00:00" rows as a raw string rather than by
+        // instant. ToUniversalTime() yields the same instant at "+00:00" so TEXT order equals chrono order.
+        var cutoffUtc = cutoff.ToUniversalTime();
         var affected = await _context.Database.ExecuteSqlInterpolatedAsync(
-            $"DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {cutoff} OR IsConsumed = 1",
+            $"DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {cutoffUtc} OR IsConsumed = 1",
             cancellationToken);
 
         return affected;

--- a/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
+++ b/backend/src/Taskdeck.Infrastructure/Repositories/OAuthAuthCodeRepository.cs
@@ -26,16 +26,21 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
         //   - ExpiresAt > now: prevents TOCTOU race where expiry passes between
         //     the application-level check and the SQL execution
         //
-        // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm" format.
-        // We must use the same format for string comparison to work correctly.
-        // Normalize via .UtcDateTime before appending the "+00:00" suffix, mirroring
-        // AuditLogRepository.DeleteOldEntriesAsync. Self-defending: `now` is UtcNow (zero offset)
-        // so normalization is a no-op today, but the site stays correct if its source ever changes.
+        // Bug boundary (issue #1403) is the COMPARISON side only: pass `now` as a DateTimeOffset
+        // parameter so EF's SQLite provider serializes it with the same "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz"
+        // mapping (trailing fraction zeros trimmed, dot dropped at a zero fraction) that stored ExpiresAt
+        // rows use, keeping `ExpiresAt > now` a chronological comparison at a zero-fraction tick instead
+        // of a fixed-width string mismatch.
+        //
+        // The WRITE side (ConsumedAt/UpdatedAt) deliberately keeps the fixed-width invariant string:
+        // issue #1403 notes the write side is unaffected (fixed-width strings parse fine), and the
+        // #1393 MED-B1 regression test pins the persisted TEXT to the invariant "...ss.fffffff+00:00"
+        // shape. `now` is UtcNow (zero offset) so .UtcDateTime normalization is a no-op today but keeps
+        // the written string correct if the source ever changes.
         var now = DateTimeOffset.UtcNow;
         var nowStr = now.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
-        var affected = await _context.Database.ExecuteSqlRawAsync(
-            "UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {0}, UpdatedAt = {1} WHERE Code = {2} AND IsConsumed = 0 AND ExpiresAt > {3}",
-            [nowStr, nowStr, code, nowStr],
+        var affected = await _context.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE OAuthAuthCodes SET IsConsumed = 1, ConsumedAt = {nowStr}, UpdatedAt = {nowStr} WHERE Code = {code} AND IsConsumed = 0 AND ExpiresAt > {now}",
             cancellationToken);
 
         return affected > 0;
@@ -45,15 +50,16 @@ public class OAuthAuthCodeRepository : Repository<OAuthAuthCode>, IOAuthAuthCode
     {
         // Use raw SQL to avoid loading all rows into memory (DoS risk with large tables).
         // Deletes both expired codes AND consumed codes to prevent unbounded table growth.
-        // EF Core SQLite stores DateTimeOffset as "yyyy-MM-dd HH:mm:ss.fffffff+HH:mm".
-        // Normalize to UTC first so that a non-UTC DateTimeOffset (e.g. -05:00) is converted to
-        // its UTC-equivalent time before the "+00:00" suffix is appended; without this the time
-        // component would be wrong and codes in the wrong window could be kept or deleted
-        // (mirrors AuditLogRepository.DeleteOldEntriesAsync).
-        var cutoffStr = cutoff.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00";
-        var affected = await _context.Database.ExecuteSqlRawAsync(
-            "DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {0} OR IsConsumed = 1",
-            [cutoffStr],
+        // Pass the DateTimeOffset cutoff as a parameter (not a hand-built ".fffffff" string): EF's
+        // SQLite provider serializes both the parameter and the stored ExpiresAt column with the same
+        // "yyyy-MM-dd HH:mm:ss.FFFFFFFzzz" mapping (trailing fraction zeros trimmed, dot dropped at a
+        // zero fraction) and normalizes any non-UTC offset consistently on both sides. A code expiring
+        // at exactly the cutoff with a zero-fraction tick then compares EQUAL, so the strictly-older
+        // `ExpiresAt < cutoff` contract KEEPS it instead of deleting it — a fixed-width bound sorts above
+        // the stored "...ss+00:00" because '+' (0x2B) < '.' (0x2E) (issue #1403). Mirrors
+        // AuditLogRepository.DeleteOldEntriesAsync.
+        var affected = await _context.Database.ExecuteSqlInterpolatedAsync(
+            $"DELETE FROM OAuthAuthCodes WHERE ExpiresAt < {cutoff} OR IsConsumed = 1",
             cancellationToken);
 
         return affected;

--- a/backend/tests/Taskdeck.Api.Tests/TimestampBoundaryComparisonTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TimestampBoundaryComparisonTests.cs
@@ -182,6 +182,14 @@ public class TimestampBoundaryComparisonTests : IClassFixture<HostedWorkerDisabl
         // under the pre-fix string bug (stored-below-bound and true-equality both yield "not
         // consumable"); parameterizing keeps `ExpiresAt > now` chronological for consistency and pins
         // the strict-greater contract against regression.
+        //
+        // DOCUMENTED LIMITATION: this test does NOT (and cannot) exercise the trimmed-vs-fixed-width
+        // boundary tick for TryConsumeAtomicAsync — the seeded expiries are far from `now`, and the
+        // exact-tick case would require injecting `now`, which is internal UtcNow. Consequently this
+        // test PASSES on the pre-fix code as well: the TryConsume comparison change is a
+        // defensive/consistency-only change (the `>` operator is immune at the exact tick), not a
+        // behavior fix. The revert-would-fail regression proof holds only for the `>=`/`<` sites
+        // (CountByDateAsync, DeleteOldEntriesAsync, DeleteExpiredAsync).
         var consumedExpired = await repo.TryConsumeAtomicAsync(expiredCodeValue);
         consumedExpired.Should().BeFalse(
             "a code whose zero-fraction ExpiresAt is at or before now must NOT consume (> is strict)");
@@ -229,6 +237,41 @@ public class TimestampBoundaryComparisonTests : IClassFixture<HostedWorkerDisabl
             .ToListAsync();
         survivors.Should().NotContain(olderRow.Id,
             "a row older than the cutoff INSTANT must be deleted regardless of the cutoff's offset");
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithNonUtcFromBound_ComparesByInstant_NotOffsetPreservedString()
+    {
+        // Guards BuildSqliteQueryAsync's offset normalization — the ONE timestamp seam fed raw user
+        // input (LogQueryService forwards user-supplied query.From/query.To straight in). The from
+        // bound 2017-08-20T00:00:00-05:00 is the INSTANT 05:00Z, so a stored row at 02:00Z lies
+        // BEFORE the range and must be EXCLUDED. Un-normalized, the bound serializes as
+        // "...00:00:00-05:00" whose hour digits ("00" < "02") sort it below the stored
+        // "...02:00:00+00:00" row, so the raw string compare `stored >= bound` is wrongly TRUE and
+        // the out-of-range row leaks into the result.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuditLogRepository>();
+
+        var beforeRange = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        var inRange = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        db.AuditLogs.AddRange(beforeRange, inRange);
+        await db.SaveChangesAsync();
+
+        // Year 2017 keeps this test's rows distinct from every other method in the class.
+        await SetTimestampAsync(db, beforeRange.Id, "2017-08-20 02:00:00+00:00");
+        await SetTimestampAsync(db, inRange.Id, "2017-08-20 06:00:00+00:00");
+
+        // from == 2017-08-20 05:00:00Z expressed at -05:00; to == 12:00:00Z.
+        var from = new DateTimeOffset(2017, 8, 20, 0, 0, 0, TimeSpan.FromHours(-5));
+        var to = new DateTimeOffset(2017, 8, 20, 12, 0, 0, TimeSpan.Zero);
+
+        var results = (await repo.QueryAsync(from, to)).Select(a => a.Id).ToList();
+
+        results.Should().NotContain(beforeRange.Id,
+            "a row before the from INSTANT must be excluded regardless of the bound's offset");
+        results.Should().Contain(inRange.Id,
+            "a row inside the instant range must be returned");
     }
 
     private static Task SetTimestampAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)

--- a/backend/tests/Taskdeck.Api.Tests/TimestampBoundaryComparisonTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TimestampBoundaryComparisonTests.cs
@@ -1,0 +1,205 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Persistence;
+using Xunit;
+
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Boundary regression tests for issue #1403: production repositories previously built SQLite
+/// DateTimeOffset comparison bounds as fixed-width ".fffffff" strings, but EF Core's SQLite
+/// provider stores DateTimeOffset TEXT with trailing fraction zeros TRIMMED and the dot dropped
+/// entirely at a zero fraction (empirically verified on PR #1391): a whole-second instant stores
+/// as "2026-07-17 00:00:00+00:00", not "...00:00:00.0000000+00:00".
+///
+/// At an exact zero-fraction boundary tick the stored TEXT sorts BELOW the hand-built bound string
+/// because after the shared "...HH:mm:ss" prefix the stored value continues with '+' (0x2B) while
+/// the fixed-width bound continues with '.' (0x2E), and '+' &lt; '.'. That off-by-one-tick violated
+/// four contracts. The fix parameterizes each comparison with the DateTimeOffset value itself, so EF
+/// serializes both the bound and the stored column with the same trimmed mapping and a zero-fraction
+/// boundary row compares equal.
+///
+/// Each test seeds the stored value at EXACTLY the bound with ZERO fractional ticks, written in the
+/// real EF-trimmed shape (no '.' fraction, e.g. "2023-03-04 00:00:00+00:00"), so the boundary is
+/// genuinely exercised. Under the pre-fix code these assertions fail; a comment at each site cites
+/// the '+' vs '.' byte comparison.
+///
+/// Runs on <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> (mirrors
+/// <c>AuditRetentionRepositoryIntegrationTests</c> / <c>AuditCultureInvariantRepositoryTests</c>) so
+/// the unconditionally-registered <c>AuditRetentionWorker</c> cannot delete seeded audit rows between
+/// seed and assertion. Each test uses a distinct year so the class-shared database cannot leak rows
+/// between methods.
+/// </summary>
+public class TimestampBoundaryComparisonTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
+{
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
+
+    public TimestampBoundaryComparisonTests(HostedWorkerDisabledTestWebApplicationFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task CountByDateAsync_CountsRowStoredAtExactlyFrom_WithZeroFractionTick()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuditLogRepository>();
+
+        // AuditLog.UserId is a real FK to Users, so seed a user to own the row.
+        var user = new User("ts-boundary-count", "ts-boundary-count@example.com", "hash");
+        db.Users.Add(user);
+
+        var entry = new AuditLog("Card", Guid.NewGuid(), AuditAction.Updated, user.Id);
+        db.AuditLogs.Add(entry);
+        await db.SaveChangesAsync();
+
+        // Stored at EXACTLY the `from` bound, zero fractional ticks, in the EF-trimmed shape (no '.').
+        await SetTimestampAsync(db, entry.Id, "2023-03-04 00:00:00+00:00");
+
+        var from = new DateTimeOffset(2023, 3, 4, 0, 0, 0, TimeSpan.Zero);
+        var to = from.AddDays(1);
+
+        var counts = await repo.CountByDateAsync(from, to, user.Id);
+
+        // Contract: `Timestamp >= from` is inclusive. Pre-fix, `from` was built as
+        // "2023-03-04 00:00:00.0000000+00:00" and the stored "2023-03-04 00:00:00+00:00" sorted below
+        // it ('+' 0x2B < '.' 0x2E), so the boundary row was WRONGLY excluded and the range returned 0.
+        counts.Should().ContainSingle(
+            "a row stored at exactly `from` with a zero-fraction tick must be counted (>= is inclusive)");
+        counts[0].Date.Should().Be(new DateOnly(2023, 3, 4));
+        counts[0].Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeleteOldEntriesAsync_KeepsRowStoredAtExactlyCutoff_WithZeroFractionTick()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuditLogRepository>();
+
+        var atCutoff = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        var strictlyOlder = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        db.AuditLogs.AddRange(atCutoff, strictlyOlder);
+        await db.SaveChangesAsync();
+
+        // atCutoff sits at EXACTLY the cutoff with a zero-fraction tick (EF-trimmed shape); strictlyOlder
+        // is one day earlier so at least one row is genuinely deletable.
+        await SetTimestampAsync(db, atCutoff.Id, "2019-03-04 00:00:00+00:00");
+        await SetTimestampAsync(db, strictlyOlder.Id, "2019-03-03 00:00:00+00:00");
+
+        var cutoff = new DateTimeOffset(2019, 3, 4, 0, 0, 0, TimeSpan.Zero);
+
+        var deleted = await repo.DeleteOldEntriesAsync(cutoff, batchSize: 1000);
+        deleted.Should().BeGreaterThanOrEqualTo(1, "the strictly-older row must be deleted");
+
+        // Verify against the database (AsNoTracking): the raw-SQL DELETE bypasses the change tracker.
+        var survivors = await db.AuditLogs.AsNoTracking()
+            .Where(a => a.Id == atCutoff.Id || a.Id == strictlyOlder.Id)
+            .Select(a => a.Id)
+            .ToListAsync();
+
+        // Contract: `Timestamp < cutoff` is STRICTLY older. Pre-fix, cutoff was built as
+        // "2019-03-04 00:00:00.0000000+00:00" and the stored "2019-03-04 00:00:00+00:00" sorted below it
+        // ('+' 0x2B < '.' 0x2E), so `< cutoff` was WRONGLY true and the boundary row was deleted.
+        survivors.Should().Contain(atCutoff.Id,
+            "a row stored at exactly the cutoff with a zero-fraction tick must NOT be deleted (< is strict)");
+        survivors.Should().NotContain(strictlyOlder.Id, "the strictly-older row must be deleted");
+    }
+
+    [Fact]
+    public async Task DeleteExpiredAsync_KeepsCodeExpiringAtExactlyCutoff_WithZeroFractionTick()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IOAuthAuthCodeRepository>();
+
+        // Construct with a valid future expiry (entity invariant), then backdate ExpiresAt via raw SQL.
+        var atCutoff = new OAuthAuthCode(
+            $"bound-{Guid.NewGuid():N}", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddMinutes(5));
+        var strictlyExpired = new OAuthAuthCode(
+            $"expired-{Guid.NewGuid():N}", Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddMinutes(5));
+        db.Set<OAuthAuthCode>().AddRange(atCutoff, strictlyExpired);
+        await db.SaveChangesAsync();
+
+        // atCutoff expires at EXACTLY the cutoff with a zero-fraction tick (EF-trimmed shape).
+        await SetExpiresAtAsync(db, atCutoff.Id, "2024-03-04 00:00:00+00:00");
+        await SetExpiresAtAsync(db, strictlyExpired.Id, "2024-03-03 00:00:00+00:00");
+
+        var cutoff = new DateTimeOffset(2024, 3, 4, 0, 0, 0, TimeSpan.Zero);
+
+        var deleted = await repo.DeleteExpiredAsync(cutoff);
+        deleted.Should().BeGreaterThanOrEqualTo(1, "the strictly-expired code must be deleted");
+
+        var remaining = await db.Set<OAuthAuthCode>().AsNoTracking()
+            .Where(c => c.Id == atCutoff.Id || c.Id == strictlyExpired.Id)
+            .Select(c => c.Id)
+            .ToListAsync();
+
+        // Contract: `ExpiresAt < cutoff` is STRICTLY older. Pre-fix, the stored zero-fraction
+        // "2024-03-04 00:00:00+00:00" sorted below the fixed-width cutoff ('+' 0x2B < '.' 0x2E), so
+        // `< cutoff` was WRONGLY true and the code was deleted at its exact expiry boundary.
+        remaining.Should().Contain(atCutoff.Id,
+            "a code expiring at exactly the cutoff with a zero-fraction tick must NOT be deleted (< is strict)");
+        remaining.Should().NotContain(strictlyExpired.Id, "the strictly-expired code must be deleted");
+    }
+
+    [Fact]
+    public async Task TryConsumeAtomicAsync_PinsStrictExpiryContract_WithZeroFractionTicks()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IOAuthAuthCodeRepository>();
+
+        // Live control: a whole-second FUTURE expiry, seeded THROUGH EF so ExpiresAt is stored in the
+        // real trimmed zero-fraction shape ("2099-01-01 00:00:00+00:00"). `ExpiresAt > now` is true.
+        var liveCodeValue = $"ts-live-{Guid.NewGuid():N}";
+        var liveCode = new OAuthAuthCode(
+            liveCodeValue, Guid.NewGuid(), "token", new DateTimeOffset(2099, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        // Expired: construct with a valid future expiry (entity invariant), then backdate to a past
+        // whole-second value with a zero fractional tick via raw SQL.
+        var expiredCodeValue = $"ts-expired-{Guid.NewGuid():N}";
+        var expiredCode = new OAuthAuthCode(
+            expiredCodeValue, Guid.NewGuid(), "token", DateTimeOffset.UtcNow.AddMinutes(5));
+
+        db.Set<OAuthAuthCode>().AddRange(liveCode, expiredCode);
+        await db.SaveChangesAsync();
+
+        await SetExpiresAtAsync(db, expiredCode.Id, "2020-01-01 00:00:00+00:00");
+
+        // Contract (see TryConsumeAtomicAsync): consumption requires `ExpiresAt > now` — STRICTLY
+        // greater — so a code at or before the current instant is expired and MUST NOT consume. `now`
+        // is DateTimeOffset.UtcNow inside the method and cannot be injected without changing the
+        // signature (out of scope), so this pins the strict contract with genuinely zero-fraction
+        // stored values on both sides of the boundary rather than forcing exact-instant equality.
+        //
+        // Unlike the `>=` / `<` sites, the `>` operator returns the same answer at exact equality even
+        // under the pre-fix string bug (stored-below-bound and true-equality both yield "not
+        // consumable"); parameterizing keeps `ExpiresAt > now` chronological for consistency and pins
+        // the strict-greater contract against regression.
+        var consumedExpired = await repo.TryConsumeAtomicAsync(expiredCodeValue);
+        consumedExpired.Should().BeFalse(
+            "a code whose zero-fraction ExpiresAt is at or before now must NOT consume (> is strict)");
+
+        var consumedLive = await repo.TryConsumeAtomicAsync(liveCodeValue);
+        consumedLive.Should().BeTrue(
+            "an unexpired code with a zero-fraction future ExpiresAt must consume successfully");
+
+        var reloaded = await db.Set<OAuthAuthCode>().AsNoTracking()
+            .SingleAsync(c => c.Id == liveCode.Id);
+        reloaded.IsConsumed.Should().BeTrue("the live code must be marked consumed by the atomic update");
+    }
+
+    private static Task SetTimestampAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)
+        => db.Database.ExecuteSqlRawAsync(
+            "UPDATE AuditLogs SET Timestamp = {0} WHERE Id = {1}", invariantTimestamp, id);
+
+    private static Task SetExpiresAtAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)
+        => db.Database.ExecuteSqlRawAsync(
+            "UPDATE OAuthAuthCodes SET ExpiresAt = {0} WHERE Id = {1}", invariantTimestamp, id);
+}

--- a/backend/tests/Taskdeck.Api.Tests/TimestampBoundaryComparisonTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TimestampBoundaryComparisonTests.cs
@@ -195,6 +195,42 @@ public class TimestampBoundaryComparisonTests : IClassFixture<HostedWorkerDisabl
         reloaded.IsConsumed.Should().BeTrue("the live code must be marked consumed by the atomic update");
     }
 
+    [Fact]
+    public async Task DeleteOldEntriesAsync_WithNonUtcCutoff_ComparesByInstant_NotOffsetPreservedString()
+    {
+        // Guards the offset-normalization the parameterized form must preserve. The bound and the
+        // stored "+00:00" rows must be compared by INSTANT, not by a naive string comparison of an
+        // offset-preserving serialization. Here the cutoff's wall-clock hour (03) is LOWER than the
+        // stored row's hour (05) even though the cutoff INSTANT (08:00 UTC) is LATER than the row
+        // (05:00 UTC) — so an un-normalized "...03:00:00-05:00" bound would sort ABOVE the stored
+        // "...05:00:00+00:00" row and wrongly KEEP a row that is chronologically older than the cutoff.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuditLogRepository>();
+
+        var olderRow = new AuditLog("Board", Guid.NewGuid(), AuditAction.Created);
+        db.AuditLogs.Add(olderRow);
+        await db.SaveChangesAsync();
+
+        // Stored at 05:00:00 UTC, zero fractional ticks (EF-trimmed shape). Year 2016 keeps the global
+        // delete's blast radius clear of every other test's rows (which use 2019+).
+        await SetTimestampAsync(db, olderRow.Id, "2016-09-10 05:00:00+00:00");
+
+        // Cutoff = 2016-09-10 03:00:00 -05:00 == 2016-09-10 08:00:00 UTC. The row (05:00 UTC) is
+        // chronologically older than the cutoff instant (08:00 UTC), so it MUST be deleted.
+        var cutoff = new DateTimeOffset(2016, 9, 10, 3, 0, 0, TimeSpan.FromHours(-5));
+
+        var deleted = await repo.DeleteOldEntriesAsync(cutoff, batchSize: 1000);
+        deleted.Should().BeGreaterThanOrEqualTo(1, "the row older than the cutoff instant must be deleted");
+
+        var survivors = await db.AuditLogs.AsNoTracking()
+            .Where(a => a.Id == olderRow.Id)
+            .Select(a => a.Id)
+            .ToListAsync();
+        survivors.Should().NotContain(olderRow.Id,
+            "a row older than the cutoff INSTANT must be deleted regardless of the cutoff's offset");
+    }
+
     private static Task SetTimestampAsync(TaskdeckDbContext db, Guid id, string invariantTimestamp)
         => db.Database.ExecuteSqlRawAsync(
             "UPDATE AuditLogs SET Timestamp = {0} WHERE Id = {1}", invariantTimestamp, id);


### PR DESCRIPTION
## Summary

Replaces the hand-built fixed-width `.fffffff` SQLite timestamp **bound strings** with parameterized `DateTimeOffset` predicates so EF Core serializes both the comparison bound and the stored column with the same mapping. Fixes the off-by-one-tick contract violation at a zero-fraction boundary (issue #1403, fix option 2). Review rounds additionally hardened offset handling: EF's SQLite mapping preserves the source offset, so every caller-supplied bound is now normalized with `.ToUniversalTime()` before parameterization — including the sibling `BuildSqliteQueryAsync` path fed raw user input.

## Root cause (byte comparison)

EF Core's SQLite provider stores `DateTimeOffset` TEXT with trailing fraction zeros **trimmed** and the dot dropped entirely at a zero fraction (verified on PR #1391): a whole-second instant stores as `2026-07-17 00:00:00+00:00`, not `...00:00:00.0000000+00:00`.

The old code built bounds with a fixed 7-digit fraction. At an exact zero-fraction boundary tick the stored TEXT sorts **below** the bound string because after the shared `...HH:mm:ss` prefix the stored value continues with `+` (0x2B) while the bound continues with `.` (0x2E), and `+` < `.`:

```
stored: 2026-07-17 00:00:00+00:00
bound:  2026-07-17 00:00:00.0000000+00:00
        └── '+' (0x2B) < '.' (0x2E) → stored < bound
```

Divergence from chronological order occurs only at exact equality: for `>=`/`<` the string result flips (bug); for `>`/`<=` it agrees.

## Sites changed

| Site | Comparison | Effect of the bug | Fix |
|------|-----------|-------------------|-----|
| `AuditLogRepository.CountByDateAsync` | `Timestamp >= from` | boundary row wrongly **excluded** | parameterize `from`/`to` (UTC-normalized); `SqlQueryRaw` → interpolated `SqlQuery<DateCountRow>` |
| `AuditLogRepository.DeleteOldEntriesAsync` (SQLite branch) | `Timestamp < cutoff` | boundary row wrongly **deleted** (contract is strictly-older) | parameterize `olderThan` (UTC-normalized); `ExecuteSqlRawAsync` → `ExecuteSqlInterpolatedAsync` |
| `OAuthAuthCodeRepository.DeleteExpiredAsync` | `ExpiresAt < cutoff` | boundary code wrongly **deleted** | parameterize `cutoff` (UTC-normalized); `ExecuteSqlRawAsync` → `ExecuteSqlInterpolatedAsync` |
| `OAuthAuthCodeRepository.TryConsumeAtomicAsync` | `ExpiresAt > now` (comparison side) | **no observable off-by-one** — the `>` operator returns the same answer at exact equality even under the string bug; this change is defensive/consistency-only | parameterize the `now` **comparison** with a `DateTimeOffset`; `ExecuteSqlRawAsync` → `ExecuteSqlInterpolatedAsync` |
| `AuditLogRepository.BuildSqliteQueryAsync` (lens-2 MEDIUM-1) | `Timestamp >= from AND Timestamp <= to` | sibling path with the same offset exposure, and the ONE site fed raw user input (`LogQueryService` forwards user-supplied `query.From`/`query.To`); a non-UTC bound compared as an offset-preserving string, not by instant | `.ToUniversalTime()` on both bounds before parameterization |

The proven in-repo pattern followed is `LlmQueueRepository.GetStuckProcessingNonCaptureAsync` / `TryClaimProcessingAsync` (parameterized raw SQL passing the `DateTimeOffset` directly). Raw SQL is retained everywhere (SQLite still cannot translate `DateTimeOffset` WHERE/ORDER BY via LINQ) — no regression to client-side evaluation.

### Offset normalization (adversarial-review HIGH, fixed in-PR)

Microsoft.Data.Sqlite's `DateTimeOffset` mapping **preserves the source offset** (verified empirically — it does not convert to UTC), so the initial parameterized commits regressed non-UTC callers: a cutoff of `2016-09-10 03:00:00-05:00` (= `08:00Z`) serialized as `...03:00:00-05:00` and compared against the stored `+00:00` rows as a raw string, wrongly keeping an older-than-cutoff row. Fixed by normalizing every caller-supplied bound via `.ToUniversalTime()` (a no-op for the common UTC caller, preserving the zero-fraction fix), with dedicated regression tests.

### TryConsumeAtomicAsync: write side intentionally unchanged

Only the `ExpiresAt > now` **comparison** is parameterized. The `ConsumedAt`/`UpdatedAt` **writes** keep the fixed-width invariant string because (a) issue #1403 states the write side is unaffected (fixed-width strings parse fine), and (b) the existing #1393 MED-B1 regression test (`AuditCultureInvariantRepositoryTests.TryConsumeAtomicAsync_...`) pins the persisted TEXT to the `...ss.fffffff+00:00` shape — parameterizing the write would trim it and break that assertion. `now` is internal `DateTimeOffset.UtcNow` (already `+00:00`), so no normalization is needed on the comparison side.

## Helper disposition

No shared bound-string-building helper methods existed — all sites built the string **inline** (`.ToString("yyyy-MM-dd HH:mm:ss.fffffff", CultureInfo.InvariantCulture) + "+00:00"`). Three inline builders are removed (`fromStr`/`toStr`, `olderThanStr`, `cutoffStr`); `TryConsumeAtomicAsync`'s `nowStr` is retained for the write side (see above). `using System.Globalization;` stays in both files (`AuditLogRepository` still uses it for `DateOnly.Parse`; `OAuthAuthCodeRepository` still uses it for the retained `nowStr` write).

## Tests

New `TimestampBoundaryComparisonTests` (Api.Tests, on `HostedWorkerDisabledTestWebApplicationFactory`, against real SQLite) — the zero-fraction tests seed the stored value at exactly the bound with **zero fractional ticks** in the real EF-trimmed shape (no `.` fraction); the offset tests make the bound's offset the deciding factor:

1. `CountByDateAsync_CountsRowStoredAtExactlyFrom_WithZeroFractionTick` — row at exactly `from` IS counted.
2. `DeleteOldEntriesAsync_KeepsRowStoredAtExactlyCutoff_WithZeroFractionTick` — row at exactly cutoff is NOT deleted; strictly-older row is.
3. `DeleteExpiredAsync_KeepsCodeExpiringAtExactlyCutoff_WithZeroFractionTick` — code expiring at exactly cutoff is NOT deleted; strictly-expired code is.
4. `TryConsumeAtomicAsync_PinsStrictExpiryContract_WithZeroFractionTicks` — pins the strict `>` contract with zero-fraction stored values on both sides of the boundary.
5. `DeleteOldEntriesAsync_WithNonUtcCutoff_ComparesByInstant_NotOffsetPreservedString` — non-UTC cutoff compares by instant (fails on un-normalized code with `deleted=0`).
6. `QueryAsync_WithNonUtcFromBound_ComparesByInstant_NotOffsetPreservedString` — user-input path: a row before the non-UTC `from` instant is excluded (fails on un-normalized code by including it).

**Regression proof (scoped precisely):** with the source fix reverted (tests kept), tests 1–3 **fail** on the pre-fix code — the revert-would-fail proof holds for the three `>=`/`<` sites (`CountByDateAsync`, `DeleteOldEntriesAsync`, `DeleteExpiredAsync`). Tests 5–6 fail on the un-normalized intermediate code. Test 4 (`TryConsumeAtomicAsync`) **passes on pre-fix code as well**: it does not — and cannot — exercise the trimmed-vs-fixed-width boundary tick, because `now` is internal `UtcNow` and the seeded expiries are far from it; the TryConsume comparison change is defensive/consistency-only (the `>` operator is immune at the exact tick). This limitation is documented in the test body.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release -m:1` — Build succeeded, 0 errors (pre-existing warnings only).
- `dotnet test ... --filter "FullyQualifiedName~TimestampBoundaryComparisonTests|...AuditCultureInvariantRepositoryTests|...AuditRetentionRepositoryIntegrationTests|...AuditLogRepositoryIntegrationTests|...OAuthTokenLifecycleTests"` — **Passed: 54, Failed: 0** (6 new tests + all existing audit/OAuth repository coverage; no regression).
- Pre-fix runs: zero-fraction boundary tests 1–3 fail on pre-fix code; offset tests 5–6 fail on un-normalized code (5: `deleted=0`; 6: out-of-range row included).

## Related

- Repo-wide sweep of remaining timestamp seams (LlmQueueRepository and others) is tracked in #1422; AuditLogRepository's query path is covered here.

Closes #1403
