### PR TITLE
Run Apply's structure gate at approve time (approve == apply, #1416)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -234,21 +234,32 @@ public class AutomationProposalService : IAutomationProposalService
             if (proposal == null)
                 return Result.Failure<ProposalDto>(ErrorCodes.NotFound, $"Proposal with ID {id} not found");
 
-            // Structure gate at approve time (#1416 approve == apply): a reviewer must not be able
-            // to commit to a proposal the executor will refuse. Apply validates the EFFECTIVE
-            // operation set (latest saved revision, else the original operations) via
-            // AutomationPolicyEngine.ValidateOperationStructure, and GetProposalDiffAsync mirrors the
-            // same revision-aware materialization; mirror both here so a zero-operation (or otherwise
-            // structurally invalid) proposal is rejected with the identical 400 ValidationError Apply
-            // returns, instead of being approved and only failing at Apply — the last "user commits
-            // to something the executor will refuse" step in this trust class (siblings
-            // #1370 → #1374, #1376 → #1395, #1398 → #1413).
+            // Approve-time gates (#1416 approve == apply): a reviewer must not be able to commit
+            // to a proposal the executor will refuse. Apply validates the EFFECTIVE operation set
+            // (latest saved revision, else the original operations) through
+            // AutomationPolicyEngine.ValidatePolicy (structure, then expiry) followed by
+            // ValidatePermissionsAsync (requester exists → 404, board exists → 404, board access
+            // → 403, then operation-contract validation → 400/403/404), and GetProposalDiffAsync
+            // mirrors the same revision-aware materialization and gate order. Approve now enforces:
+            //   1. Structure → 400 ValidationError (same validator, same shape as diff/apply).
+            //   2. Expiry → 409 InvalidOperation, via the domain transition's own guard
+            //      (AutomationProposal.Approve throws "Cannot approve expired proposal").
+            //      Deliberately NOT the diff path's 400 read-parity shape: approving is a state
+            //      transition, so a 409 conflict is the correct refusal for an expired proposal.
+            //   3. Permissions + operation contract → the same 400/403/404 results Apply produces,
+            //      via the same _policyEngine.ValidatePermissionsAsync call the diff path runs.
+            // Ordering mirrors the diff/apply sequence exactly (structure → expiry → permissions):
+            // the permission gate is skipped for an expired proposal so the domain guard's 409 owns
+            // expiry — an expired proposal with revoked access reports expiry, never Forbidden,
+            // matching the #1413 LOW-4 ordering pin on the diff path. A zero-op AND expired
+            // proposal likewise reports the 400 structure error first, as it does on diff and apply.
+            // This closes the last "user commits to something the executor will refuse" step in
+            // this trust class (siblings #1370 → #1374, #1376 → #1395, #1398 → #1413).
             //
             // Gate only genuinely approvable (PendingReview) proposals: for any other status the
             // domain transition's terminal-status short-circuit owns the response (409 "Cannot
-            // approve proposal in status X"), which this slice leaves untouched — running the
-            // structure gate on a terminal proposal would wrongly report a 400 structure error in
-            // place of that 409.
+            // approve proposal in status X"), which this slice leaves untouched — running these
+            // gates on a terminal proposal would wrongly report a 400/403/404 in place of that 409.
             if (proposal.Status == ProposalStatus.PendingReview)
             {
                 var effectiveOperations = await ResolveEffectiveOperationsAsync(proposal, cancellationToken);
@@ -258,16 +269,19 @@ public class AutomationProposalService : IAutomationProposalService
                 var structureValidation = ProposalOperationStructureValidator.Validate(effectiveOperations.Value);
                 if (!structureValidation.IsSuccess)
                     return Result.Failure<ProposalDto>(structureValidation.ErrorCode, structureValidation.ErrorMessage);
+
+                if (!proposal.IsExpired)
+                {
+                    var permissionValidation = await _policyEngine.ValidatePermissionsAsync(
+                        proposal.RequestedByUserId,
+                        proposal.BoardId,
+                        effectiveOperations.Value,
+                        cancellationToken);
+                    if (!permissionValidation.IsSuccess)
+                        return Result.Failure<ProposalDto>(permissionValidation.ErrorCode, permissionValidation.ErrorMessage);
+                }
             }
 
-            // Expiry is enforced by the domain transition itself: AutomationProposal.Approve throws
-            // InvalidOperation ("Cannot approve expired proposal") → 409. That established 409 is the
-            // approve-time expiry contract this slice preserves; it deliberately does NOT adopt the
-            // diff/preview path's 400 "Proposal has expired" read-parity shape, because approving is
-            // a state transition and a 409 conflict is the correct semantics for refusing to advance
-            // an expired proposal. Structure runs first (matching ValidatePolicy's structure-then-
-            // expiry order), so a zero-op AND expired proposal reports the 400 structure error on
-            // approve just as it does on diff and apply.
             proposal.Approve(decidedByUserId);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
@@ -285,7 +299,7 @@ public class AutomationProposalService : IAutomationProposalService
 
     /// <summary>
     /// Resolves the effective operation set Apply will execute, for the approve-time structure
-    /// gate — the latest saved <see cref="ProposalRevision"/> when one exists (mirroring
+    /// and permission/contract gates — the latest saved <see cref="ProposalRevision"/> when one exists (mirroring
     /// <c>AutomationExecutorService.MaterializeEffectiveProposalAsync</c> and the revision-aware
     /// <see cref="GetProposalDiffAsync"/> path), otherwise the proposal's original operations —
     /// so approve validates exactly what Apply will run (#1416 approve == apply). A revision is

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -234,6 +234,40 @@ public class AutomationProposalService : IAutomationProposalService
             if (proposal == null)
                 return Result.Failure<ProposalDto>(ErrorCodes.NotFound, $"Proposal with ID {id} not found");
 
+            // Structure gate at approve time (#1416 approve == apply): a reviewer must not be able
+            // to commit to a proposal the executor will refuse. Apply validates the EFFECTIVE
+            // operation set (latest saved revision, else the original operations) via
+            // AutomationPolicyEngine.ValidateOperationStructure, and GetProposalDiffAsync mirrors the
+            // same revision-aware materialization; mirror both here so a zero-operation (or otherwise
+            // structurally invalid) proposal is rejected with the identical 400 ValidationError Apply
+            // returns, instead of being approved and only failing at Apply — the last "user commits
+            // to something the executor will refuse" step in this trust class (siblings
+            // #1370 → #1374, #1376 → #1395, #1398 → #1413).
+            //
+            // Gate only genuinely approvable (PendingReview) proposals: for any other status the
+            // domain transition's terminal-status short-circuit owns the response (409 "Cannot
+            // approve proposal in status X"), which this slice leaves untouched — running the
+            // structure gate on a terminal proposal would wrongly report a 400 structure error in
+            // place of that 409.
+            if (proposal.Status == ProposalStatus.PendingReview)
+            {
+                var effectiveOperations = await ResolveEffectiveOperationsAsync(proposal, cancellationToken);
+                if (!effectiveOperations.IsSuccess)
+                    return Result.Failure<ProposalDto>(effectiveOperations.ErrorCode, effectiveOperations.ErrorMessage);
+
+                var structureValidation = ProposalOperationStructureValidator.Validate(effectiveOperations.Value);
+                if (!structureValidation.IsSuccess)
+                    return Result.Failure<ProposalDto>(structureValidation.ErrorCode, structureValidation.ErrorMessage);
+            }
+
+            // Expiry is enforced by the domain transition itself: AutomationProposal.Approve throws
+            // InvalidOperation ("Cannot approve expired proposal") → 409. That established 409 is the
+            // approve-time expiry contract this slice preserves; it deliberately does NOT adopt the
+            // diff/preview path's 400 "Proposal has expired" read-parity shape, because approving is
+            // a state transition and a 409 conflict is the correct semantics for refusing to advance
+            // an expired proposal. Structure runs first (matching ValidatePolicy's structure-then-
+            // expiry order), so a zero-op AND expired proposal reports the 400 structure error on
+            // approve just as it does on diff and apply.
             proposal.Approve(decidedByUserId);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
@@ -247,6 +281,42 @@ public class AutomationProposalService : IAutomationProposalService
         {
             return Result.Failure<ProposalDto>(ex.ErrorCode, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Resolves the effective operation set Apply will execute, for the approve-time structure
+    /// gate — the latest saved <see cref="ProposalRevision"/> when one exists (mirroring
+    /// <c>AutomationExecutorService.MaterializeEffectiveProposalAsync</c> and the revision-aware
+    /// <see cref="GetProposalDiffAsync"/> path), otherwise the proposal's original operations —
+    /// so approve validates exactly what Apply will run (#1416 approve == apply). A revision is
+    /// structure-validated at save time, so the parse-failure branch is defensive: if the
+    /// effective payload cannot be materialized, Apply would fail the same way, so surface the
+    /// identical <see cref="ErrorCodes.ValidationError"/>.
+    /// </summary>
+    private async Task<Result<IReadOnlyCollection<ProposalOperationDto>>> ResolveEffectiveOperationsAsync(
+        AutomationProposal proposal,
+        CancellationToken cancellationToken)
+    {
+        var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
+        if (latestRevision is not null)
+        {
+            if (!ProposalRevisionPayload.TryParseOperations(
+                    proposal.Id,
+                    latestRevision.RevisedPayload,
+                    out var revisedOperations,
+                    out var errorMessage))
+            {
+                return Result.Failure<IReadOnlyCollection<ProposalOperationDto>>(ErrorCodes.ValidationError, errorMessage);
+            }
+
+            return Result.Success<IReadOnlyCollection<ProposalOperationDto>>(revisedOperations);
+        }
+
+        var originalOperations = proposal.Operations
+            .OrderBy(o => o.Sequence)
+            .Select(MapOperationToDto)
+            .ToList();
+        return Result.Success<IReadOnlyCollection<ProposalOperationDto>>(originalOperations);
     }
 
     public async Task<Result<ProposalDto>> RejectProposalAsync(Guid id, Guid decidedByUserId, UpdateProposalStatusDto dto, CancellationToken cancellationToken = default)

--- a/backend/tests/Taskdeck.Api.Tests/ErrorContract/ProposalErrorContractTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ErrorContract/ProposalErrorContractTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Api.Contracts;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Exceptions;
 using Xunit;
 
@@ -45,6 +46,37 @@ public class ProposalErrorContractTests : IClassFixture<TestWebApplicationFactor
             content: null);
 
         await ApiTestHarness.AssertErrorContractAsync(response, HttpStatusCode.NotFound, ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task ApproveProposal_ZeroOperationProposal_Returns400WithErrorContract()
+    {
+        // #1416 approve == apply, endpoint contract: a raw HTTP client (also MCP/CLI) must not be
+        // able to approve a zero-operation proposal the executor will refuse at Apply. The approve
+        // transition now runs Apply's structure gate server-side and returns the same 400
+        // ValidationError contract every other 4xx proposal response uses.
+        using var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "prop-err-appr-zeroop");
+
+        var createResponse = await client.PostAsJsonAsync(
+            "/api/automation/proposals",
+            new CreateProposalDto(
+                SourceType: ProposalSourceType.Chat,
+                RequestedByUserId: user.UserId,
+                Summary: "Zero-operation proposal",
+                RiskLevel: RiskLevel.Low,
+                CorrelationId: Guid.NewGuid().ToString()));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var proposal = await createResponse.Content.ReadFromJsonAsync<ProposalDto>();
+        proposal.Should().NotBeNull();
+        proposal!.Operations.Should().BeEmpty();
+
+        var approveResponse = await client.PostAsync(
+            $"/api/automation/proposals/{proposal.Id}/approve",
+            content: null);
+
+        await ApiTestHarness.AssertErrorContractAsync(
+            approveResponse, HttpStatusCode.BadRequest, ErrorCodes.ValidationError);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -292,7 +292,7 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     [Theory]
     [InlineData("2026-07-14T09:30:00")]
     [InlineData("07/14/2026")]
-    public async Task RevisedDueDate_InvalidFormat_ShouldFailPreviewAndApply(string dueDate)
+    public async Task RevisedDueDate_InvalidFormat_ShouldFailPreviewAndApprove(string dueDate)
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-invalid-due");
@@ -314,12 +314,18 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: approve runs the same gates preview/apply run, so the invalid
+        // revision is rejected at approve with the identical error contract instead of being
+        // approved and only failing at apply.
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
+
+        // Never approved -> the executor's status guard refuses execution outright (409),
+        // pinning that a statically invalid revision can no longer reach the apply stage at all.
         var executeRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/automation/proposals/{proposal.Id}/execute");
         executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
         var executeResponse = await client.SendAsync(executeRequest);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
     }
 
     [Fact]
@@ -369,7 +375,7 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
-    public async Task RevisedUpdate_WithOnlyFalseClearDueDate_ShouldFailPreviewAndApply()
+    public async Task RevisedUpdate_WithOnlyFalseClearDueDate_ShouldFailPreviewAndApprove()
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-noop-update");
@@ -391,17 +397,19 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: the contract-violating revision is rejected at approve with the
+        // identical error; the never-approved proposal then cannot reach the apply stage (409).
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
         var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var cards = await ReadCardsAsync(client, board.Id);
         cards.Should().ContainSingle(candidate => candidate.Id == card.Id && candidate.Title == "Unchanged card");
     }
 
     [Fact]
-    public async Task RevisedLabelOperation_WithoutCardId_ShouldFailPreviewAndApply()
+    public async Task RevisedLabelOperation_WithoutCardId_ShouldFailPreviewAndApprove()
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-label-missing-card");
@@ -423,14 +431,16 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: rejected at approve with the identical error; the
+        // never-approved proposal then cannot reach the apply stage (409).
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
         var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
     }
 
     [Fact]
-    public async Task RevisedUpdate_WithEmptyLabelId_ShouldFailPreviewAndApply()
+    public async Task RevisedUpdate_WithEmptyLabelId_ShouldFailPreviewAndApprove()
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-empty-label-id");
@@ -452,10 +462,12 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: rejected at approve with the identical error; the
+        // never-approved proposal then cannot reach the apply stage (409).
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
         var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var cards = await ReadCardsAsync(client, board.Id);
         cards.Should().ContainSingle(candidate => candidate.Id == card.Id && candidate.Labels.Count == 0);
@@ -466,7 +478,7 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     [InlineData("add_-label")]
     [InlineData("remove__label")]
     [InlineData("add..label")]
-    public async Task RevisedLabelOperation_WithUnregisteredAlias_ShouldFailPreviewAndApply(string actionType)
+    public async Task RevisedLabelOperation_WithUnregisteredAlias_ShouldFailPreviewAndApprove(string actionType)
     {
         var suffix = Guid.NewGuid().ToString("N")[..8];
         var client = _factory.CreateClient();
@@ -490,17 +502,19 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: rejected at approve with the identical error; the
+        // never-approved proposal then cannot reach the apply stage (409).
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
         var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var cards = await ReadCardsAsync(client, board.Id);
         cards.Should().ContainSingle(candidate => candidate.Id == card.Id && candidate.Labels.Count == 0);
     }
 
     [Fact]
-    public async Task RevisedCreate_WithoutRequiredTitle_ShouldFailPreviewAndApply()
+    public async Task RevisedCreate_WithoutRequiredTitle_ShouldFailPreviewAndApprove()
     {
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, "rev-create-missing-title");
@@ -520,10 +534,12 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: rejected at approve with the identical error; the
+        // never-approved proposal then cannot reach the apply stage (409).
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
         var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         (await ReadCardsAsync(client, board.Id)).Should().BeEmpty();
     }
@@ -533,10 +549,63 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
     [InlineData("add-label")]
     public async Task RevisedLabelName_WithAmbiguousBoardMatches_ShouldFailPreviewAndApply(string actionType)
     {
+        // #1416 restructure: approve now runs the same gates apply runs, so a revision that is
+        // ALREADY ambiguous at approve time is rejected at approve (parity pinned below). The
+        // apply-side ambiguity rejection therefore only remains reachable through the genuinely
+        // time-dependent path — approve while the name is unique, then the ambiguity appears
+        // AFTER approval — which is exactly what this test now pins: preview and apply both
+        // reject the approved-but-no-longer-appliable proposal with the same error.
         var suffix = Guid.NewGuid().ToString("N")[..8];
         var client = _factory.CreateClient();
         var user = await ApiTestHarness.AuthenticateAsync(client, $"rev-label-ambiguous-{suffix}");
         var (board, column) = await CreateBoardWithColumnAsync(client, $"rev-label-ambiguous-board-{suffix}");
+        var card = await CreateCardAsync(client, board.Id, column.Id, "Unchanged ambiguous label card");
+        var labelName = $"urgent-{suffix}";
+        _ = await CreateLabelAsync(client, board.Id, labelName);
+        var proposal = await CreateUpdateProposalAsync(client, user.UserId, board.Id, card.Id);
+        var parameters = actionType == "update"
+            ? JsonSerializer.Serialize(new { cardId = card.Id, labels = new[] { labelName } })
+            : JsonSerializer.Serialize(new { cardId = card.Id, labelName });
+
+        var revisionResponse = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new
+            {
+                revisedPayload = BuildSingleOperationRevisionPayload(
+                    actionType, "card", parameters, card.Id.ToString()),
+                reason = "name-based label operation, unique at approval time"
+            });
+        revisionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Unique name: valid at approve time, so approve accepts — exactly what apply would do.
+        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
+            .StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // The ambiguity appears AFTER approval (a case-insensitive duplicate label).
+        _ = await CreateLabelAsync(client, board.Id, labelName.ToUpperInvariant());
+
+        var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
+        await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
+
+        var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+
+        var cards = await ReadCardsAsync(client, board.Id);
+        cards.Should().ContainSingle(candidate => candidate.Id == card.Id && candidate.Labels.Count == 0);
+    }
+
+    [Theory]
+    [InlineData("update")]
+    [InlineData("add-label")]
+    public async Task RevisedLabelName_AlreadyAmbiguousAtApproveTime_ShouldFailApprove(string actionType)
+    {
+        // #1416 approve == apply, static-ambiguity direction: when the ambiguity already exists
+        // at approve time, approve rejects with the same ValidationError preview/apply produce,
+        // so the reviewer can never commit to a name-based operation the executor would refuse.
+        var suffix = Guid.NewGuid().ToString("N")[..8];
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, $"rev-label-preambig-{suffix}");
+        var (board, column) = await CreateBoardWithColumnAsync(client, $"rev-label-preambig-board-{suffix}");
         var card = await CreateCardAsync(client, board.Id, column.Id, "Unchanged ambiguous label card");
         var labelName = $"urgent-{suffix}";
         _ = await CreateLabelAsync(client, board.Id, labelName);
@@ -559,10 +628,11 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
+
         var executeResponse = await ExecuteProposalAsync(client, proposal.Id);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var cards = await ReadCardsAsync(client, board.Id);
         cards.Should().ContainSingle(candidate => candidate.Id == card.Id && candidate.Labels.Count == 0);
@@ -611,12 +681,14 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await ownerClient.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertErrorContractAsync(diffResponse, HttpStatusCode.BadRequest, "ValidationError");
 
-        (await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: the identity-redirecting revision is rejected at approve with
+        // the identical error; the never-approved proposal then cannot reach the apply stage (409).
+        var approveResponse = await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertErrorContractAsync(approveResponse, HttpStatusCode.BadRequest, "ValidationError");
         var executeRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/automation/proposals/{proposal.Id}/execute");
         executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
         var executeResponse = await ownerClient.SendAsync(executeRequest);
-        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.BadRequest, "ValidationError");
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var victimCards = await ReadCardsAsync(victimClient, victimBoard.Id);
         victimCards.Should().ContainSingle(card => card.Id == victimCard.Id && card.Title == "Victim card");
@@ -647,10 +719,12 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await ownerClient.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertForbiddenAsync(diffResponse);
 
-        (await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: the cross-user revision is rejected at approve with the same
+        // Forbidden apply produces; the never-approved proposal cannot reach the apply stage (409).
+        var approveResponse = await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertForbiddenAsync(approveResponse);
         var executeResponse = await ExecuteProposalAsync(ownerClient, proposal.Id);
-        await ApiTestHarness.AssertForbiddenAsync(executeResponse);
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var victimCards = await ReadCardsAsync(victimClient, victimBoard.Id);
         victimCards.Should().ContainSingle(card => card.Id == victimCard.Id && card.Title == "Victim card");
@@ -679,12 +753,14 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await ownerClient.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertForbiddenAsync(diffResponse);
 
-        (await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: the cross-board revision is rejected at approve with the same
+        // Forbidden apply produces; the never-approved proposal cannot reach the apply stage (409).
+        var approveResponse = await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertForbiddenAsync(approveResponse);
         var executeRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/automation/proposals/{proposal.Id}/execute");
         executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
         var executeResponse = await ownerClient.SendAsync(executeRequest);
-        await ApiTestHarness.AssertForbiddenAsync(executeResponse);
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var victimCards = await ReadCardsAsync(victimClient, victimBoard.Id);
         victimCards.Should().NotContain(card => card.Title == "Cross-board card");
@@ -713,10 +789,12 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         var diffResponse = await ownerClient.GetAsync($"/api/automation/proposals/{proposal.Id}/diff");
         await ApiTestHarness.AssertForbiddenAsync(diffResponse);
 
-        (await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null))
-            .StatusCode.Should().Be(HttpStatusCode.OK);
+        // #1416 approve == apply: the cross-board column revision is rejected at approve with the
+        // same Forbidden apply produces; the never-approved proposal cannot reach apply (409).
+        var approveResponse = await ownerClient.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        await ApiTestHarness.AssertForbiddenAsync(approveResponse);
         var executeResponse = await ExecuteProposalAsync(ownerClient, proposal.Id);
-        await ApiTestHarness.AssertForbiddenAsync(executeResponse);
+        await ApiTestHarness.AssertErrorContractAsync(executeResponse, HttpStatusCode.Conflict, "InvalidOperation");
 
         var victimCards = await ReadCardsAsync(victimClient, victimBoard.Id);
         victimCards.Should().NotContain(card => card.Title == "Cross-board column card");

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceEdgeCaseTests.cs
@@ -20,6 +20,7 @@ public class AutomationProposalServiceEdgeCaseTests
 {
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IAutomationProposalRepository> _proposalRepoMock;
+    private readonly Mock<IProposalRevisionRepository> _revisionRepoMock;
     private readonly Mock<INotificationService> _notificationServiceMock;
     private readonly AutomationProposalService _service;
 
@@ -27,9 +28,16 @@ public class AutomationProposalServiceEdgeCaseTests
     {
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _proposalRepoMock = new Mock<IAutomationProposalRepository>();
+        _revisionRepoMock = new Mock<IProposalRevisionRepository>();
         _notificationServiceMock = new Mock<INotificationService>();
 
         _unitOfWorkMock.Setup(u => u.AutomationProposals).Returns(_proposalRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.ProposalRevisions).Returns(_revisionRepoMock.Object);
+        // Default: no saved revision, so the approve-time structure gate (#1416) validates the
+        // proposal's original operations rather than an effective revision.
+        _revisionRepoMock
+            .Setup(r => r.GetLatestByProposalIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProposalRevision?)null);
         _notificationServiceMock
             .Setup(s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), default))
             .ReturnsAsync(Result.Success(true));
@@ -42,8 +50,11 @@ public class AutomationProposalServiceEdgeCaseTests
     [Fact]
     public async Task ApproveProposalAsync_ShouldReturnFailure_WhenProposalIsExpired()
     {
-        // Arrange: proposal whose ExpiresAt is in the past
+        // Arrange: proposal whose ExpiresAt is in the past. It carries an operation so it clears
+        // the approve-time structure gate (#1416) and the domain expiry guard is what rejects it.
         var proposal = CreatePendingProposal();
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", "{\"title\":\"Test\"}", Guid.NewGuid().ToString()));
         SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
 
         _proposalRepoMock
@@ -78,6 +89,10 @@ public class AutomationProposalServiceEdgeCaseTests
     public async Task ApproveProposalAsync_ShouldReturnConflict_WhenSaveChangesDetectsConcurrency()
     {
         var proposal = CreatePendingProposal();
+        // Carries an operation so approve clears the structure gate (#1416) and reaches SaveChanges,
+        // where the simulated concurrency collision surfaces.
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", "{\"title\":\"Test\"}", Guid.NewGuid().ToString()));
         var deciderId = Guid.NewGuid();
 
         _proposalRepoMock

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceEdgeCaseTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceEdgeCaseTests.cs
@@ -4,8 +4,10 @@ using Moq;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
+using Taskdeck.Application.Tests.TestUtilities;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
 using Taskdeck.Domain.Exceptions;
 using Xunit;
 
@@ -21,6 +23,9 @@ public class AutomationProposalServiceEdgeCaseTests
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly Mock<IAutomationProposalRepository> _proposalRepoMock;
     private readonly Mock<IProposalRevisionRepository> _revisionRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly Mock<IBoardRepository> _boardRepoMock;
+    private readonly Mock<IBoardAccessRepository> _boardAccessRepoMock;
     private readonly Mock<INotificationService> _notificationServiceMock;
     private readonly AutomationProposalService _service;
 
@@ -29,15 +34,33 @@ public class AutomationProposalServiceEdgeCaseTests
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _proposalRepoMock = new Mock<IAutomationProposalRepository>();
         _revisionRepoMock = new Mock<IProposalRevisionRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _boardRepoMock = new Mock<IBoardRepository>();
+        _boardAccessRepoMock = new Mock<IBoardAccessRepository>();
         _notificationServiceMock = new Mock<INotificationService>();
 
         _unitOfWorkMock.Setup(u => u.AutomationProposals).Returns(_proposalRepoMock.Object);
         _unitOfWorkMock.Setup(u => u.ProposalRevisions).Returns(_revisionRepoMock.Object);
-        // Default: no saved revision, so the approve-time structure gate (#1416) validates the
-        // proposal's original operations rather than an effective revision.
+        _unitOfWorkMock.Setup(u => u.Users).Returns(_userRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.Boards).Returns(_boardRepoMock.Object);
+        _unitOfWorkMock.Setup(u => u.BoardAccesses).Returns(_boardAccessRepoMock.Object);
+        // Default: no saved revision, so the approve-time gates (#1416) validate the proposal's
+        // original operations rather than an effective revision.
         _revisionRepoMock
             .Setup(r => r.GetLatestByProposalIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((ProposalRevision?)null);
+        // Approve now also runs Apply's permission/contract gate (#1416): requester exists,
+        // board exists, requester has board access. Default them to PASS so these edge-case
+        // tests reach their intended seam (expiry guard, SaveChanges concurrency collision).
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new User("edgetester", "edge@example.com", "hashedPassword"));
+        _boardRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestDataBuilder.CreateBoard());
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         _notificationServiceMock
             .Setup(s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), default))
             .ReturnsAsync(Result.Success(true));
@@ -89,10 +112,17 @@ public class AutomationProposalServiceEdgeCaseTests
     public async Task ApproveProposalAsync_ShouldReturnConflict_WhenSaveChangesDetectsConcurrency()
     {
         var proposal = CreatePendingProposal();
-        // Carries an operation so approve clears the structure gate (#1416) and reaches SaveChanges,
-        // where the simulated concurrency collision surfaces.
+        // Carries an in-scope board-update operation so approve clears the structure AND
+        // permission/contract gates (#1416) and reaches SaveChanges, where the simulated
+        // concurrency collision surfaces.
         proposal.AddOperation(new AutomationProposalOperation(
-            proposal.Id, 0, "create", "card", "{\"title\":\"Test\"}", Guid.NewGuid().ToString()));
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            $"{{\"boardId\":\"{proposal.BoardId}\",\"name\":\"Renamed\"}}",
+            Guid.NewGuid().ToString(),
+            targetId: proposal.BoardId!.Value.ToString()));
         var deciderId = Guid.NewGuid();
 
         _proposalRepoMock

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -407,16 +407,25 @@ public class AutomationProposalServiceTests
         // Arrange
         var proposalId = Guid.NewGuid();
         var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
             Guid.NewGuid(),
             "Test proposal",
             RiskLevel.Low,
-            Guid.NewGuid().ToString());
-        // A structurally valid proposal (#1416): approve now runs Apply's structure gate, so the
-        // happy path must carry at least one operation just as a real approvable proposal does.
+            Guid.NewGuid().ToString(),
+            boardId);
+        // A fully valid proposal (#1416): approve now runs Apply's structure AND
+        // permission/contract gates, so the happy path must carry an operation that clears both
+        // (an in-scope board update), with the fixture's requester/board/access defaults passing.
         proposal.AddOperation(new AutomationProposalOperation(
-            proposal.Id, 0, "create", "card", "{\"title\":\"Test\"}", Guid.NewGuid().ToString()));
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Renamed board" }),
+            Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
 
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
             .ReturnsAsync(proposal);
@@ -519,12 +528,14 @@ public class AutomationProposalServiceTests
         // being falsely rejected by the zero-op check on the stale original operations.
         var proposalId = Guid.NewGuid();
         var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
             Guid.NewGuid(),
             "Originally empty, revised valid",
             RiskLevel.Low,
-            Guid.NewGuid().ToString());
+            Guid.NewGuid().ToString(),
+            boardId);
 
         var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
         {
@@ -533,9 +544,10 @@ public class AutomationProposalServiceTests
                 new
                 {
                     sequence = 0,
-                    actionType = "create",
-                    targetType = "card",
-                    parameters = "{\"title\":\"Revised\"}",
+                    actionType = "update",
+                    targetType = "board",
+                    targetId = boardId.ToString(),
+                    parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Revised name" }),
                     idempotencyKey = Guid.NewGuid().ToString()
                 }
             }
@@ -555,6 +567,248 @@ public class AutomationProposalServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Status.Should().Be(ProposalStatus.Approved);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldRejectRevokedBoardAccess_MatchingApplyPermissionGate()
+    {
+        // #1416 trust-class completion: Apply runs ValidatePermissionsAsync after the policy gate,
+        // so a proposal whose requester lost board access mid-review is rejected 403 at Apply (and,
+        // since #1413, at diff). Approve previously ran no permission gate, so the reviewer's
+        // approval succeeded 200 and only Apply failed 403. Approve now runs the same gate:
+        // approve == apply (403, same message).
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // Requester exists and the board exists (constructor defaults), but access is revoked.
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        // Act (approve)
+        var approveResult = await _service.ApproveProposalAsync(proposalId, Guid.NewGuid());
+
+        // Act (apply-side permission gate) on the equivalent operation DTOs.
+        var applyResult = await new AutomationPolicyEngine(_unitOfWorkMock.Object).ValidatePermissionsAsync(
+            requesterId, boardId, BuildPermissionGateApplyOperations(proposalId, boardId));
+
+        // Assert: approve rejects, and rejects identically to Apply (403, same message).
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+
+        approveResult.IsSuccess.Should().BeFalse();
+        approveResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        approveResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldRejectDeletedBoard_MatchingApplyPermissionGate()
+    {
+        // #1416: a proposal whose board was deleted mid-review is rejected 404 at Apply
+        // (ValidatePermissionsAsync board-existence gate) and at diff (#1413). Approve now runs
+        // the same gate instead of approving 200 and failing 404 at Apply.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // Board no longer exists (overrides the constructor default for this board id).
+        _boardRepoMock
+            .Setup(r => r.GetByIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Board?)null);
+
+        var approveResult = await _service.ApproveProposalAsync(proposalId, Guid.NewGuid());
+        var applyResult = await new AutomationPolicyEngine(_unitOfWorkMock.Object).ValidatePermissionsAsync(
+            requesterId, boardId, BuildPermissionGateApplyOperations(proposalId, boardId));
+
+        applyResult.IsSuccess.Should().BeFalse();
+        applyResult.ErrorCode.Should().Be(ErrorCodes.NotFound);
+
+        approveResult.IsSuccess.Should().BeFalse();
+        approveResult.ErrorCode.Should().Be(applyResult.ErrorCode);
+        approveResult.ErrorMessage.Should().Be(applyResult.ErrorMessage);
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldRejectContractViolation_OnRevisedOperations()
+    {
+        // #1416: ValidatePermissionsAsync ends with ProposalOperationContractValidator, so a
+        // saved revision whose operations violate the operation contract (here: a board update
+        // with no updatable fields) is rejected 400 at Apply. Approve validates the same
+        // effective revised set through the same engine call, so the reviewer cannot approve it.
+        var proposalId = Guid.NewGuid();
+        var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Valid original, contract-violating revision",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Valid original" }),
+            Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "update",
+                    targetType = "board",
+                    targetId = boardId.ToString(),
+                    // No 'name', 'description', or 'isArchived': fails the operation contract.
+                    parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId }),
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposal.Id, 1, deciderId, revisedPayload, "Strip fields");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _revisionRepoMock
+            .Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
+            .ReturnsAsync(revision);
+
+        var result = await _service.ApproveProposalAsync(proposalId, deciderId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be(
+            "Update board operation requires at least one of 'name', 'description', or 'isArchived'");
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldReportExpiry_NotForbidden_WhenExpiredAndAccessRevoked()
+    {
+        // Gate-ordering pin (mirrors the #1413 LOW-4 pin on the diff path, adapted to approve's
+        // 409 expiry semantics): a proposal that is BOTH expired AND has revoked requester access
+        // must fail with the expiry 409 InvalidOperation — never Forbidden — because approve runs
+        // structure → expiry → permissions in the same order as diff/apply. If someone reorders
+        // the permission gate ahead of the expiry short-circuit, this test fails on Forbidden.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildPermissionGateProposal(requesterId, boardId);
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.ApproveProposalAsync(proposalId, Guid.NewGuid());
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidOperation);
+        result.ErrorCode.Should().NotBe(ErrorCodes.Forbidden);
+        result.ErrorMessage.Should().Contain("expired");
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldReturnValidationError_WhenSavedRevisionPayloadIsInvalid()
+    {
+        // #1416 defensive branch pin: a saved revision is validated at save time, so a malformed
+        // RevisedPayload should be unreachable — but if the effective payload cannot be
+        // materialized, Apply fails 400 (MaterializeEffectiveProposalAsync), so approve must
+        // surface the identical ValidationError instead of approving a proposal Apply will refuse.
+        var proposalId = Guid.NewGuid();
+        var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Valid original, corrupt revision",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Valid original" }),
+            Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        var revision = new ProposalRevision(proposal.Id, 1, deciderId, "{not valid json", "Corrupt");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _revisionRepoMock
+            .Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
+            .ReturnsAsync(revision);
+
+        var result = await _service.ApproveProposalAsync(proposalId, deciderId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("RevisedPayload must be valid JSON");
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldRejectProposalRevisedToEmpty_MatchingApplyGate()
+    {
+        // #1416 inverse revision-aware direction: an originally-VALID proposal whose latest
+        // revision materializes to zero operations must be rejected at approve, exactly as Apply
+        // rejects it when materializing the effective revision — validating only the original
+        // operations would approve a proposal the executor refuses. Locks both directions of the
+        // revision-aware gate together with ShouldValidateEffectiveRevision_NotOriginalOperations.
+        var proposalId = Guid.NewGuid();
+        var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Valid original, revised to empty",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Valid original" }),
+            Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        var revision = new ProposalRevision(
+            proposal.Id, 1, deciderId, "{\"operations\":[]}", "Strip all operations");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _revisionRepoMock
+            .Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
+            .ReturnsAsync(revision);
+
+        var result = await _service.ApproveProposalAsync(proposalId, deciderId);
+
+        // Same failure Apply produces when the effective revision has no operations.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("RevisedPayload operations must contain at least one operation");
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -413,6 +413,10 @@ public class AutomationProposalServiceTests
             "Test proposal",
             RiskLevel.Low,
             Guid.NewGuid().ToString());
+        // A structurally valid proposal (#1416): approve now runs Apply's structure gate, so the
+        // happy path must carry at least one operation just as a real approvable proposal does.
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", "{\"title\":\"Test\"}", Guid.NewGuid().ToString()));
 
         _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
             .ReturnsAsync(proposal);
@@ -433,6 +437,124 @@ public class AutomationProposalServiceTests
                     n.Type == NotificationType.ProposalOutcome),
                 default),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldRejectZeroOperationProposal_MatchingApplyStructureGate()
+    {
+        // #1416 approve == apply: a zero-operation PendingReview proposal previously approved
+        // cleanly (status → Approved) and only failed later at Apply with 400 "Proposal must
+        // contain at least one operation". Approve now runs the SAME structure gate Apply runs via
+        // AutomationPolicyEngine.ValidateOperationStructure (and that GetProposalDiffAsync mirrors),
+        // rejecting it with the identical ValidationError before the transition commits.
+        var proposalId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Zero-op proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString());
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Act
+        var result = await _service.ApproveProposalAsync(proposalId, Guid.NewGuid());
+
+        // Assert: same failure Apply's structure validation produces, and the transition is refused.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Be("Proposal must contain at least one operation");
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+        _notificationServiceMock.Verify(
+            s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldRejectExpiredProposal_WithConflict()
+    {
+        // #1416 expiry contract: an expired PendingReview proposal must not be approvable. Approve
+        // enforces this through the domain transition itself (AutomationProposal.Approve throws
+        // InvalidOperation → 409), the established approve-time expiry semantics this slice
+        // preserves — deliberately NOT the diff/preview path's 400 "Proposal has expired" read
+        // shape, because approving is a state transition and 409 conflict is the correct code for
+        // refusing to advance an expired proposal. The proposal carries an operation so it clears
+        // the structure gate and the expiry guard is what rejects it.
+        var proposalId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Expiring proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString());
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", "{\"title\":\"Test\"}", Guid.NewGuid().ToString()));
+        // Force the proposal past its expiry without changing status (mirrors a proposal that
+        // expired while pending). ExpiresAt is private-set on the entity.
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        // Act
+        var result = await _service.ApproveProposalAsync(proposalId, Guid.NewGuid());
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidOperation);
+        result.ErrorMessage.Should().Contain("expired");
+        proposal.Status.Should().Be(ProposalStatus.PendingReview);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldValidateEffectiveRevision_NotOriginalOperations()
+    {
+        // #1416 approve == apply, revision-aware: Apply executes the latest saved revision
+        // (AutomationExecutorService.MaterializeEffectiveProposalAsync), so approve's structure
+        // gate must validate that SAME effective set. A proposal whose ORIGINAL operations are
+        // empty but whose latest revision is valid is approvable — matching Apply — rather than
+        // being falsely rejected by the zero-op check on the stale original operations.
+        var proposalId = Guid.NewGuid();
+        var deciderId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Originally empty, revised valid",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString());
+
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "create",
+                    targetType = "card",
+                    parameters = "{\"title\":\"Revised\"}",
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposal.Id, 1, deciderId, revisedPayload, "Add an operation");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+        _revisionRepoMock
+            .Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
+            .ReturnsAsync(revision);
+
+        // Act
+        var result = await _service.ApproveProposalAsync(proposalId, deciderId);
+
+        // Assert: the valid effective revision clears the structure gate and the proposal approves.
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(ProposalStatus.Approved);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1416.

The Approve transition skipped proposal validation: a zero-operation `PendingReview` proposal could be approved (status -> `Approved`) and only failed later at Apply with 400 "Proposal must contain at least one operation" — and a structurally valid proposal whose requester lost board access (or whose board/requester was deleted, or whose revised operations violate the operation contract) likewise approved 200 and only failed at Apply. This was the last "user commits to something the executor will refuse" step in the preview == apply trust class (siblings #1370 -> #1374, #1376 -> #1395, #1398 -> #1413).

`AutomationProposalService.ApproveProposalAsync` now runs Apply's structure AND permission/contract gates before committing the transition (permission gate added in the lens-2 review fix round, commit `48ccf0ef`).

## Gates enforced at approve time

**1. Structure gate (400 `ValidationError`)** — mirrors the apply path exactly. Apply validates the EFFECTIVE operation set (latest saved revision, else the original operations) via `AutomationPolicyEngine.ValidateOperationStructure` (`AutomationPolicyEngine.cs:92-108` -> `ProposalOperationStructureValidator.Validate`), and `GetProposalDiffAsync` mirrors the same revision-aware materialization. Approve resolves the same effective operations (revision-aware, mirroring `AutomationExecutorService.MaterializeEffectiveProposalAsync`, `AutomationExecutorService.cs:241-261`) and runs the identical validator, returning the same 400 `ValidationError` "Proposal must contain at least one operation" the diff/apply paths return.

- Revision-aware on purpose: a revision is structure-validated at save time (`ProposalRevisionService.cs:46-53`; `ProposalRevisionPayload.TryParseOperations` rejects an empty operations array), so validating only the original operations would be wrong in both directions — falsely rejecting an originally-empty-but-validly-revised proposal Apply accepts, and falsely approving an originally-valid-but-revised-to-empty proposal Apply refuses. Both directions are test-pinned.

**2. Expiry gate (409 `InvalidOperation`)** — already enforced, preserved. The domain transition is the prior art: `AutomationProposal.Approve` throws `DomainException(ErrorCodes.InvalidOperation, "Cannot approve expired proposal")` (`AutomationProposal.cs:96-97`), mapping to 409 (`ResultExtensions.cs:24`). This is the established approve-time expiry contract — a real 409 — and it deliberately does NOT adopt the diff/preview path's 400 "Proposal has expired" read-parity shape, because approving is a state transition and 409 conflict is the correct semantics for refusing to advance an expired proposal.

**3. Permission + operation-contract gate (400/403/404)** — the same `_policyEngine.ValidatePermissionsAsync(requesterId, boardId, effectiveOperations, ct)` call Apply runs (`AutomationExecutorService.cs:138-152`) and the diff path runs post-#1398/#1413: requester exists -> 404, board exists -> 404, requester board access -> 403, then `ProposalOperationContractValidator` -> 400/403/404. Error code and message propagate unchanged, so approve rejects exactly what Apply would reject.

**Gate ordering** mirrors the diff/apply sequence exactly: structure -> expiry -> permissions. The permission gate is skipped for an expired proposal so the domain guard's 409 owns expiry (an expired proposal with revoked access reports expiry, never Forbidden — the #1413 LOW-4 ordering pin adapted to approve's 409 semantics, test-pinned). A zero-op AND expired proposal reports the 400 structure error first, as on diff and apply.

## Deliberately NOT changed

- Reject / Dismiss / Defer / Mark* transitions and every other lifecycle semantic.
- Terminal-status short-circuits: all gates run only for `PendingReview` proposals; any other status keeps the domain 409 "Cannot approve proposal in status X".
- The diff and apply paths (already carry these gates).
- No frontend changes — PR #1414 (issue #1397) handles the frontend presentation separately.
- Approve/reject/get response DTO shape (returns original operations even when a revision exists) — pre-existing, tracked as #1424.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release -m:1` — clean, 0 errors.
- `dotnet test ... Taskdeck.Application.Tests --filter "FullyQualifiedName~AutomationProposalService"` — 86 passed / 0 failed. Approve coverage now pins: zero-op -> 400; expired -> 409; revoked access -> 403 and deleted board -> 404 (each dual-asserted identical to the apply-side engine result); contract-violating revision -> 400; expired+revoked -> 409 (ordering pin); malformed revision payload -> 400; revised-to-empty -> 400; originally-empty-but-validly-revised -> approves; valid proposal -> approves.
- `dotnet test ... Taskdeck.Api.Tests` targeted: ProposalErrorContractTests + AutomationProposalsApiTests — 48 passed (incl. endpoint-level `ApproveProposal_ZeroOperationProposal_Returns400WithErrorContract`); approve-touching regression set (McpTools, ProposalApprovalRace, CaptureToBoardGoldenPath, CrossUserDataIsolation, CardsApi, CaptureApi, TranscriptTriageLlmGoldenPath, LiveBrowserRegressionApi, AuthzRegressionMatrix) — 134 passed; ConcurrencyRaceConditionStressTests — 30 passed.

## Review trail

- Round 1 (self, adversarial): 0 C / 0 H / 0 M / 2 LOW — LOW-1 dismissed (adjudicated SOUND by lens 2), LOW-2 tracked as #1424.
- Round 2 (lens-2 independent, coordinator-adjudicated): MERGE-SAFE, 1 MEDIUM (permission gate — fixed in `48ccf0ef`) + LOW-A (malformed-revision pin) + LOW-B (revised-to-empty pin), all fixed with evidence comment on the PR.
