### PR TITLE
Gate MCP proposal_detail preview through the diff-path gates (#1415)

### DIFF
--- a/backend/src/Taskdeck.Api/Mcp/ProposalResources.cs
+++ b/backend/src/Taskdeck.Api/Mcp/ProposalResources.cs
@@ -3,6 +3,8 @@ using ModelContextProtocol.Server;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
 
 namespace Taskdeck.Api.Mcp;
 
@@ -83,6 +85,26 @@ public class ProposalResources
         if (p.RequestedByUserId != userId)
             throw new InvalidOperationException("MCP: proposal not found or access denied");
 
+        // The stored DiffPreview must never be served raw: that is the MCP preview==apply
+        // trust-violation this resource closes (#1415), the same class the HTTP diff surface
+        // already closed (#1370/#1376/#1398/#1413). Route the preview through the diff-path
+        // gates instead. PendingReview/Approved proposals go through GetProposalDiffAsync — the
+        // single source of truth for the live, fully-gated diff (structure + expiry from
+        // #1376/#1395, requester-exists / board-exists / board-access from #1398/#1413). Decided
+        // (terminal) proposals serve the STORED preview (a live rebuild would describe a board
+        // that has since moved — the #1397 decision) but still re-check the requester/board-access
+        // gate, so a reviewer who lost board access — or whose board was deleted — is denied it.
+        var isTerminal = IsTerminalStatus(p.Status);
+        Result<string> previewResult = isTerminal
+            ? await _proposalService.GetTerminalProposalStoredPreviewAsync(p.Id)
+            : await _proposalService.GetProposalDiffAsync(p.Id);
+
+        // Surface the service's own error message exactly as the GetProposalByIdAsync failure
+        // above and the MCP write tools do (WriteTools/ProposalTools raise result.ErrorMessage) —
+        // no new MCP error shape is invented for the gate denial.
+        if (!previewResult.IsSuccess)
+            throw new InvalidOperationException($"MCP: {previewResult.ErrorMessage}");
+
         var operations = p.Operations.Select(op => new
         {
             sequence = op.Sequence,
@@ -101,7 +123,10 @@ public class ProposalResources
             boardId = p.BoardId,
             operations,
             operationCount = p.Operations.Count,
-            diffPreview = p.DiffPreview,
+            diffPreview = previewResult.Value,
+            // Explicit provenance marker: "live" = freshly gated diff for an open proposal;
+            // "stored" = historical preview for a decided (terminal) proposal (#1397/#1415).
+            diffPreviewSource = isTerminal ? "stored" : "live",
             createdAt = p.CreatedAt,
             updatedAt = p.UpdatedAt,
             expiresAt = p.ExpiresAt,
@@ -109,4 +134,16 @@ public class ProposalResources
             failureReason = p.FailureReason
         }, BoardResources.SerializerOptions);
     }
+
+    /// <summary>
+    /// True for decided (terminal) proposals — Applied, Rejected, Failed, Expired, Dismissed —
+    /// whose diff is historical and served from the stored preview. PendingReview and Approved
+    /// are open states whose diff is rebuilt live through the full gate chain.
+    /// </summary>
+    private static bool IsTerminalStatus(ProposalStatus status) =>
+        status is ProposalStatus.Applied
+            or ProposalStatus.Rejected
+            or ProposalStatus.Failed
+            or ProposalStatus.Expired
+            or ProposalStatus.Dismissed;
 }

--- a/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
@@ -54,19 +54,15 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
         return RiskLevel.Low;
     }
 
-    public async Task<Result> ValidatePermissionsAsync(Guid userId, Guid? boardId, IEnumerable<ProposalOperationDto> operations, CancellationToken cancellationToken = default)
+    public async Task<Result> ValidateBoardAccessAsync(Guid requesterUserId, Guid? boardId, CancellationToken cancellationToken = default)
     {
-        if (userId == Guid.Empty)
+        if (requesterUserId == Guid.Empty)
             return Result.Failure(ErrorCodes.ValidationError, "UserId cannot be empty");
 
         // Verify user exists
-        var user = await _unitOfWork.Users.GetByIdAsync(userId, cancellationToken);
+        var user = await _unitOfWork.Users.GetByIdAsync(requesterUserId, cancellationToken);
         if (user == null)
-            return Result.Failure(ErrorCodes.NotFound, $"User with ID {userId} not found");
-
-        var opList = operations.ToList();
-        if (!opList.Any())
-            return Result.Success();
+            return Result.Failure(ErrorCodes.NotFound, $"User with ID {requesterUserId} not found");
 
         // If board-scoped, verify board exists and user has access
         if (boardId.HasValue)
@@ -75,10 +71,32 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
             if (board == null)
                 return Result.Failure(ErrorCodes.NotFound, $"Board with ID {boardId} not found");
 
-            var hasAccess = await _unitOfWork.BoardAccesses.HasAccessAsync(boardId.Value, userId, null, cancellationToken);
+            var hasAccess = await _unitOfWork.BoardAccesses.HasAccessAsync(boardId.Value, requesterUserId, null, cancellationToken);
             if (!hasAccess)
                 return Result.Failure(ErrorCodes.Forbidden, $"User does not have access to board {boardId}");
         }
+
+        return Result.Success();
+    }
+
+    public async Task<Result> ValidatePermissionsAsync(Guid userId, Guid? boardId, IEnumerable<ProposalOperationDto> operations, CancellationToken cancellationToken = default)
+    {
+        var opList = operations.ToList();
+
+        // The requester half of the shared access gate always runs; the board half applies only
+        // when the proposal carries operations, preserving the long-standing empty-operations
+        // short-circuit (empty → requester checks, then Success, board untouched). Callers that
+        // must gate board access for an operation-less proposal (the terminal stored-preview
+        // read, #1415) call ValidateBoardAccessAsync directly with the boardId.
+        var accessValidation = await ValidateBoardAccessAsync(
+            userId,
+            opList.Count > 0 ? boardId : null,
+            cancellationToken);
+        if (!accessValidation.IsSuccess)
+            return accessValidation;
+
+        if (opList.Count == 0)
+            return Result.Success();
 
         return await ProposalOperationContractValidator.ValidateAsync(
             _unitOfWork,

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -495,6 +495,37 @@ public class AutomationProposalService : IAutomationProposalService
         return Result.Success(generatedDiff);
     }
 
+    public async Task<Result<string>> GetTerminalProposalStoredPreviewAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var proposal = await _unitOfWork.AutomationProposals.GetByIdAsync(id, cancellationToken);
+        if (proposal == null)
+            return Result.Failure<string>(ErrorCodes.NotFound, $"Proposal with ID {id} not found");
+
+        // A decided proposal's diff is historical: rebuilding it against the current board would
+        // describe changes that already happened (or were rejected), so the STORED preview is
+        // served rather than a live diff (#1397). But the requester/board-access gate must still
+        // hold — the SAME AutomationPolicyEngine.ValidatePermissionsAsync call the live diff path
+        // runs (#1398/#1413): requester exists → 404, board exists → 404, requester has board
+        // access → 403. This closes the MCP preview==apply asymmetry (#1415) where a reviewer who
+        // lost board access, or whose board was deleted, could still read the stored preview. The
+        // pre-decision structure/expiry gates are intentionally NOT run here (they no longer apply
+        // to a completed proposal), which is the sole deliberate divergence from the live diff path.
+        var operations = proposal.Operations
+            .OrderBy(o => o.Sequence)
+            .Select(MapOperationToDto)
+            .ToList();
+
+        var accessValidation = await _policyEngine.ValidatePermissionsAsync(
+            proposal.RequestedByUserId,
+            proposal.BoardId,
+            operations,
+            cancellationToken);
+        if (!accessValidation.IsSuccess)
+            return Result.Failure<string>(accessValidation.ErrorCode, accessValidation.ErrorMessage);
+
+        return Result.Success(proposal.DiffPreview ?? string.Empty);
+    }
+
     /// <summary>
     /// Enforces the same expiry gate Apply runs via
     /// <see cref="AutomationPolicyEngine.ValidatePolicy"/>: an expired proposal is rejected

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -523,6 +523,25 @@ public class AutomationProposalService : IAutomationProposalService
         if (!accessValidation.IsSuccess)
             return Result.Failure<string>(accessValidation.ErrorCode, accessValidation.ErrorMessage);
 
+        // ValidatePermissionsAsync short-circuits to success for a proposal that carries NO
+        // operations, BEFORE it reaches the board gate — so a board-scoped decided proposal with
+        // zero operations (creatable: CreateProposalAsync enforces no minimum op count) would skip
+        // the board-exists / board-access check and leak its stored preview to a revoked reviewer.
+        // Re-run exactly that half of the gate for the empty case, with the engine's own codes and
+        // messages, so the fail-closed guarantee holds uniformly (#1415). The requester-exists half
+        // already ran above (ValidatePermissionsAsync checks it ahead of its empty short-circuit).
+        if (operations.Count == 0 && proposal.BoardId.HasValue)
+        {
+            var board = await _unitOfWork.Boards.GetByIdAsync(proposal.BoardId.Value, cancellationToken);
+            if (board == null)
+                return Result.Failure<string>(ErrorCodes.NotFound, $"Board with ID {proposal.BoardId} not found");
+
+            var hasAccess = await _unitOfWork.BoardAccesses.HasAccessAsync(
+                proposal.BoardId.Value, proposal.RequestedByUserId, null, cancellationToken);
+            if (!hasAccess)
+                return Result.Failure<string>(ErrorCodes.Forbidden, $"User does not have access to board {proposal.BoardId}");
+        }
+
         return Result.Success(proposal.DiffPreview ?? string.Empty);
     }
 

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -503,46 +503,31 @@ public class AutomationProposalService : IAutomationProposalService
 
         // A decided proposal's diff is historical: rebuilding it against the current board would
         // describe changes that already happened (or were rejected), so the STORED preview is
-        // served rather than a live diff (#1397). But the requester/board-access gate must still
-        // hold — the SAME AutomationPolicyEngine.ValidatePermissionsAsync call the live diff path
-        // runs (#1398/#1413): requester exists → 404, board exists → 404, requester has board
-        // access → 403. This closes the MCP preview==apply asymmetry (#1415) where a reviewer who
-        // lost board access, or whose board was deleted, could still read the stored preview. The
-        // pre-decision structure/expiry gates are intentionally NOT run here (they no longer apply
-        // to a completed proposal), which is the sole deliberate divergence from the live diff path.
-        var operations = proposal.Operations
-            .OrderBy(o => o.Sequence)
-            .Select(MapOperationToDto)
-            .ToList();
-
-        var accessValidation = await _policyEngine.ValidatePermissionsAsync(
+        // served rather than a live diff (#1397). But the requester/board-access half of the gate
+        // must still hold — the shared AutomationPolicyEngine.ValidateBoardAccessAsync, the exact
+        // checks (and codes/messages) ValidatePermissionsAsync composes on the live diff path
+        // (#1398/#1413): requester exists → 404, board exists → 404, requester has board access
+        // → 403. This closes the MCP preview==apply asymmetry (#1415) where a reviewer who lost
+        // board access, or whose board was deleted, could still read the stored preview. The
+        // operation-contract validator and the pre-decision structure/expiry gates are
+        // intentionally NOT run: they no longer apply to a completed proposal, and re-validating
+        // a historical preview against LIVE board state would wrongly deny it whenever a
+        // referenced card/column/label was later deleted — or always, for an Applied create-card
+        // whose TargetId now resolves. Calling ValidateBoardAccessAsync directly also covers
+        // operation-less proposals uniformly, which the full gate's empty-operations
+        // short-circuit would skip.
+        var accessValidation = await _policyEngine.ValidateBoardAccessAsync(
             proposal.RequestedByUserId,
             proposal.BoardId,
-            operations,
             cancellationToken);
         if (!accessValidation.IsSuccess)
             return Result.Failure<string>(accessValidation.ErrorCode, accessValidation.ErrorMessage);
 
-        // ValidatePermissionsAsync short-circuits to success for a proposal that carries NO
-        // operations, BEFORE it reaches the board gate — so a board-scoped decided proposal with
-        // zero operations (creatable: CreateProposalAsync enforces no minimum op count) would skip
-        // the board-exists / board-access check and leak its stored preview to a revoked reviewer.
-        // Re-run exactly that half of the gate for the empty case, with the engine's own codes and
-        // messages, so the fail-closed guarantee holds uniformly (#1415). The requester-exists half
-        // already ran above (ValidatePermissionsAsync checks it ahead of its empty short-circuit).
-        if (operations.Count == 0 && proposal.BoardId.HasValue)
-        {
-            var board = await _unitOfWork.Boards.GetByIdAsync(proposal.BoardId.Value, cancellationToken);
-            if (board == null)
-                return Result.Failure<string>(ErrorCodes.NotFound, $"Board with ID {proposal.BoardId} not found");
-
-            var hasAccess = await _unitOfWork.BoardAccesses.HasAccessAsync(
-                proposal.BoardId.Value, proposal.RequestedByUserId, null, cancellationToken);
-            if (!hasAccess)
-                return Result.Failure<string>(ErrorCodes.Forbidden, $"User does not have access to board {proposal.BoardId}");
-        }
-
-        return Result.Success(proposal.DiffPreview ?? string.Empty);
+        // A never-stored preview passes through as null (never coerced to ""), so callers can
+        // distinguish never-stored from stored-but-empty. Under the MCP resource serializer's
+        // WhenWritingNull policy this omits the field — exactly how the raw DiffPreview field
+        // serialized before the gating.
+        return Result.Success(proposal.DiffPreview!);
     }
 
     /// <summary>

--- a/backend/src/Taskdeck.Application/Services/IAutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/IAutomationPolicyEngine.cs
@@ -7,6 +7,19 @@ namespace Taskdeck.Application.Services;
 public interface IAutomationPolicyEngine
 {
     RiskLevel ClassifyRisk(IEnumerable<ProposalOperationDto> operations);
+
+    /// <summary>
+    /// The shared requester/board half of the permission gate: requester non-empty
+    /// (ValidationError), requester exists (NotFound), and — when <paramref name="boardId"/> is
+    /// set — board exists (NotFound) and requester has board access (Forbidden). This is the
+    /// single source of the access-gate codes and messages: <see cref="ValidatePermissionsAsync"/>
+    /// composes it with the operation-contract validator for live previews and Apply, and the
+    /// terminal stored-preview read (#1415) calls it directly because a decided proposal's
+    /// historical preview must be access-gated WITHOUT re-validating its operations against
+    /// live board state.
+    /// </summary>
+    Task<Result> ValidateBoardAccessAsync(Guid requesterUserId, Guid? boardId, CancellationToken cancellationToken = default);
+
     Task<Result> ValidatePermissionsAsync(Guid userId, Guid? boardId, IEnumerable<ProposalOperationDto> operations, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/backend/src/Taskdeck.Application/Services/IAutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/IAutomationProposalService.cs
@@ -59,14 +59,18 @@ public interface IAutomationProposalService
 
     /// <summary>
     /// Serves the STORED diff preview for a decided (terminal) proposal — Applied, Rejected,
-    /// Failed, Expired, or Dismissed — after re-running the requester/board-access gate the
-    /// live diff path runs via <see cref="GetProposalDiffAsync"/> (requester exists → 404,
-    /// board exists → 404, requester has board access → 403; #1398/#1413). A reviewer who lost
-    /// board access, or whose board/requester was deleted, is therefore denied the stored
-    /// preview rather than reading stale board contents through it (#1415). The pre-decision
-    /// structure/expiry gates are deliberately skipped: they no longer apply once a proposal is
-    /// decided, and a live rebuild would describe a board that has since moved (the #1397
-    /// decision). Non-terminal proposals must use <see cref="GetProposalDiffAsync"/> instead.
+    /// Failed, Expired, or Dismissed — after re-running ONLY the requester/board-access half of
+    /// the gate, via the shared <c>IAutomationPolicyEngine.ValidateBoardAccessAsync</c> (requester
+    /// exists → 404, board exists → 404, requester has board access → 403; #1398/#1413). A
+    /// reviewer who lost board access, or whose board/requester was deleted, is therefore denied
+    /// the stored preview rather than reading stale board contents through it (#1415). The
+    /// operation-contract validator and the pre-decision structure/expiry gates are deliberately
+    /// NOT run: they no longer apply once a proposal is decided, and re-validating a historical
+    /// preview against live board state would wrongly deny it when referenced entities were later
+    /// deleted, or always for an Applied create whose TargetId now resolves (the #1397 decision:
+    /// terminal previews are historical, never rebuilt or re-checked against the moving board).
+    /// A never-stored preview is returned as null (not empty) so callers can distinguish absence.
+    /// Non-terminal proposals must use <see cref="GetProposalDiffAsync"/> instead.
     /// </summary>
     Task<Result<string>> GetTerminalProposalStoredPreviewAsync(Guid id, CancellationToken cancellationToken = default);
 

--- a/backend/src/Taskdeck.Application/Services/IAutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/IAutomationProposalService.cs
@@ -58,6 +58,19 @@ public interface IAutomationProposalService
     Task<Result<string>> GetProposalDiffAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Serves the STORED diff preview for a decided (terminal) proposal — Applied, Rejected,
+    /// Failed, Expired, or Dismissed — after re-running the requester/board-access gate the
+    /// live diff path runs via <see cref="GetProposalDiffAsync"/> (requester exists → 404,
+    /// board exists → 404, requester has board access → 403; #1398/#1413). A reviewer who lost
+    /// board access, or whose board/requester was deleted, is therefore denied the stored
+    /// preview rather than reading stale board contents through it (#1415). The pre-decision
+    /// structure/expiry gates are deliberately skipped: they no longer apply once a proposal is
+    /// decided, and a live rebuild would describe a board that has since moved (the #1397
+    /// decision). Non-terminal proposals must use <see cref="GetProposalDiffAsync"/> instead.
+    /// </summary>
+    Task<Result<string>> GetTerminalProposalStoredPreviewAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Dismisses completed proposals (Applied, Rejected, Failed, Expired) so they no longer appear in the default review list.
     /// </summary>
     Task<Result<int>> DismissProposalsAsync(IReadOnlyList<Guid> ids, CancellationToken cancellationToken = default);

--- a/backend/tests/Taskdeck.Api.Tests/McpResourcesTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpResourcesTests.cs
@@ -8,6 +8,7 @@ using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
 using Taskdeck.Infrastructure;
 using Taskdeck.Infrastructure.Persistence;
 using Xunit;
@@ -115,11 +116,20 @@ public class McpResourcesTests : IDisposable
     {
         using var scope = _serviceProvider.CreateScope();
         var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var boardService = scope.ServiceProvider.GetRequiredService<BoardService>();
         var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
 
         var user = new User("detail-prop-user", "detailprop@example.com", "Password1!");
         await uow.Users.AddAsync(user);
         await uow.SaveChangesAsync();
+
+        // Detail retrieval now routes the preview through the diff-path gates (#1415), so the
+        // proposal's operations must clear the shared operation-contract validator. Two board
+        // updates on the requester's own board keep the two-operation shape while passing.
+        var board = await boardService.CreateBoardAsync(new CreateBoardDto("DetailBoard", null), user.Id);
+        board.IsSuccess.Should().BeTrue();
+        var op0 = JsonSerializer.Serialize(new { name = "Rename one", boardId = board.Value.Id });
+        var op1 = JsonSerializer.Serialize(new { name = "Rename two", boardId = board.Value.Id });
 
         var proposal = await proposalService.CreateProposalAsync(new CreateProposalDto(
             SourceType: ProposalSourceType.Manual,
@@ -127,11 +137,13 @@ public class McpResourcesTests : IDisposable
             Summary: "Detail test",
             RiskLevel: RiskLevel.Low,
             CorrelationId: Guid.NewGuid().ToString(),
+            BoardId: board.Value.Id,
             Operations: new List<CreateProposalOperationDto>
             {
-                new(0, "create", "card", "{\"title\":\"test\"}", Guid.NewGuid().ToString()),
-                new(1, "move", "card", "{}", Guid.NewGuid().ToString())
+                new(0, "update", "board", op0, Guid.NewGuid().ToString(), TargetId: board.Value.Id.ToString()),
+                new(1, "update", "board", op1, Guid.NewGuid().ToString(), TargetId: board.Value.Id.ToString())
             }));
+        proposal.IsSuccess.Should().BeTrue();
 
         var resources = new ProposalResources(
             proposalService,
@@ -163,6 +175,162 @@ public class McpResourcesTests : IDisposable
 
         var act = () => resources.GetProposalDetail("not-a-guid");
         await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    // ── ProposalResources diff-gate tests (#1415) ────────────────────────────
+    // The proposal_detail resource must never serve the stored DiffPreview without the same
+    // diff-path gates the HTTP surface runs (#1370/#1376/#1398/#1413). Open proposals route
+    // through the live gated diff; decided (terminal) proposals serve the stored preview but
+    // still re-check the requester/board-access gate.
+
+    private async Task<Guid> CreateBoardScopedUserAsync(IServiceScope scope, string tag)
+    {
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var user = new User($"{tag}-{Guid.NewGuid():N}", $"{tag}-{Guid.NewGuid():N}@example.com", "Password1!");
+        await uow.Users.AddAsync(user);
+        await uow.SaveChangesAsync();
+        return user.Id;
+    }
+
+    private async Task<(Guid ProposalId, Guid BoardId)> CreateBoardScopedProposalAsync(IServiceScope scope, Guid userId)
+    {
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var boardService = scope.ServiceProvider.GetRequiredService<BoardService>();
+        var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
+
+        // Owner access is implicit and cannot be revoked without reassigning the board, so the
+        // board is owned by a separate user and the requester gets an explicit (revocable)
+        // BoardAccess row instead — a revoked-access test then just deletes that row.
+        var owner = new User($"owner-{Guid.NewGuid():N}", $"owner-{Guid.NewGuid():N}@example.com", "Password1!");
+        await uow.Users.AddAsync(owner);
+        await uow.SaveChangesAsync();
+
+        var board = await boardService.CreateBoardAsync(new CreateBoardDto("GateBoard", null), owner.Id);
+        board.IsSuccess.Should().BeTrue();
+
+        await uow.BoardAccesses.AddAsync(new BoardAccess(board.Value.Id, userId, UserRole.Editor, owner.Id));
+        await uow.SaveChangesAsync();
+
+        // An update-board op clears the shared operation-contract validator (a create-card op
+        // would require a columnId), so the resource test exercises the diff-path gates rather
+        // than op-shape rejection.
+        var parameters = JsonSerializer.Serialize(new { name = "Renamed board", boardId = board.Value.Id });
+        var created = await proposalService.CreateProposalAsync(new CreateProposalDto(
+            SourceType: ProposalSourceType.Manual,
+            RequestedByUserId: userId,
+            Summary: "Gate detail test",
+            RiskLevel: RiskLevel.Low,
+            CorrelationId: Guid.NewGuid().ToString(),
+            BoardId: board.Value.Id,
+            Operations: new List<CreateProposalOperationDto>
+            {
+                new(0, "update", "board", parameters, Guid.NewGuid().ToString(), TargetId: board.Value.Id.ToString())
+            }));
+        created.IsSuccess.Should().BeTrue();
+        return (created.Value.Id, board.Value.Id);
+    }
+
+    private async Task MakeTerminalWithStoredPreviewAsync(IServiceScope scope, Guid userId, Guid proposalId, string preview)
+    {
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var entity = await uow.AutomationProposals.GetByIdAsync(proposalId);
+        entity!.SetDiffPreview(preview);
+        await uow.AutomationProposals.UpdateAsync(entity);
+        await uow.SaveChangesAsync();
+
+        var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
+        (await proposalService.ApproveProposalAsync(proposalId, userId)).IsSuccess.Should().BeTrue();
+        (await proposalService.MarkAsAppliedAsync(proposalId)).IsSuccess.Should().BeTrue();
+    }
+
+    private async Task RevokeBoardAccessAsync(IServiceScope scope, Guid boardId, Guid userId)
+    {
+        var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var access = await uow.BoardAccesses.GetByBoardAndUserAsync(boardId, userId);
+        access.Should().NotBeNull();
+        await uow.BoardAccesses.DeleteAsync(access!);
+        await uow.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task ProposalResources_GetProposalDetail_NonTerminal_ReturnsLiveGatedDiff()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var userId = await CreateBoardScopedUserAsync(scope, "gate-live");
+        var (proposalId, _) = await CreateBoardScopedProposalAsync(scope, userId);
+
+        var resources = new ProposalResources(
+            scope.ServiceProvider.GetRequiredService<IAutomationProposalService>(),
+            new McpBoardResourcesTests.FixedUserContextProvider(userId));
+
+        var json = await resources.GetProposalDetail(proposalId.ToString());
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        // An open proposal reports its live, gate-passed diff marked "live".
+        root.GetProperty("status").GetString().Should().Be("PendingReview");
+        root.GetProperty("diffPreviewSource").GetString().Should().Be("live");
+        root.GetProperty("diffPreview").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ProposalResources_GetProposalDetail_Terminal_WithAccess_ReturnsStoredPreviewWithMarker()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var userId = await CreateBoardScopedUserAsync(scope, "gate-stored");
+        var (proposalId, _) = await CreateBoardScopedProposalAsync(scope, userId);
+        await MakeTerminalWithStoredPreviewAsync(scope, userId, proposalId, "STORED-HISTORICAL-PREVIEW");
+
+        var resources = new ProposalResources(
+            scope.ServiceProvider.GetRequiredService<IAutomationProposalService>(),
+            new McpBoardResourcesTests.FixedUserContextProvider(userId));
+
+        var json = await resources.GetProposalDetail(proposalId.ToString());
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        // A decided proposal serves its stored historical preview, explicitly marked "stored".
+        root.GetProperty("status").GetString().Should().Be("Applied");
+        root.GetProperty("diffPreviewSource").GetString().Should().Be("stored");
+        root.GetProperty("diffPreview").GetString().Should().Be("STORED-HISTORICAL-PREVIEW");
+    }
+
+    [Fact]
+    public async Task ProposalResources_GetProposalDetail_Terminal_RevokedBoardAccess_DeniesStoredPreview()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var userId = await CreateBoardScopedUserAsync(scope, "gate-revoked-term");
+        var (proposalId, boardId) = await CreateBoardScopedProposalAsync(scope, userId);
+        await MakeTerminalWithStoredPreviewAsync(scope, userId, proposalId, "SECRET-STORED-PREVIEW");
+        await RevokeBoardAccessAsync(scope, boardId, userId);
+
+        var resources = new ProposalResources(
+            scope.ServiceProvider.GetRequiredService<IAutomationProposalService>(),
+            new McpBoardResourcesTests.FixedUserContextProvider(userId));
+
+        // A requester who lost board access is denied — never handed the stored preview.
+        var act = () => resources.GetProposalDetail(proposalId.ToString());
+        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        ex.Message.Should().Contain("does not have access");
+        ex.Message.Should().NotContain("SECRET-STORED-PREVIEW");
+    }
+
+    [Fact]
+    public async Task ProposalResources_GetProposalDetail_NonTerminal_RevokedBoardAccess_Denies()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var userId = await CreateBoardScopedUserAsync(scope, "gate-revoked-open");
+        var (proposalId, boardId) = await CreateBoardScopedProposalAsync(scope, userId);
+        await RevokeBoardAccessAsync(scope, boardId, userId);
+
+        var resources = new ProposalResources(
+            scope.ServiceProvider.GetRequiredService<IAutomationProposalService>(),
+            new McpBoardResourcesTests.FixedUserContextProvider(userId));
+
+        // The live diff path runs the same permission gate: revoked access is denied here too.
+        var act = () => resources.GetProposalDetail(proposalId.ToString());
+        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        ex.Message.Should().Contain("does not have access");
     }
 
     // ── CaptureResources tests ───────────────────────────────────────────────

--- a/backend/tests/Taskdeck.Api.Tests/McpResourcesTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpResourcesTests.cs
@@ -274,6 +274,31 @@ public class McpResourcesTests : IDisposable
     }
 
     [Fact]
+    public async Task ProposalResources_GetProposalDetail_Approved_ReturnsLiveGatedDiff()
+    {
+        // Approved is an OPEN state (not terminal): a legitimate detail read of an approved,
+        // not-yet-executed proposal must succeed through the live gated diff path.
+        using var scope = _serviceProvider.CreateScope();
+        var userId = await CreateBoardScopedUserAsync(scope, "gate-approved");
+        var (proposalId, _) = await CreateBoardScopedProposalAsync(scope, userId);
+
+        var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
+        (await proposalService.ApproveProposalAsync(proposalId, userId)).IsSuccess.Should().BeTrue();
+
+        var resources = new ProposalResources(
+            proposalService,
+            new McpBoardResourcesTests.FixedUserContextProvider(userId));
+
+        var json = await resources.GetProposalDetail(proposalId.ToString());
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        root.GetProperty("status").GetString().Should().Be("Approved");
+        root.GetProperty("diffPreviewSource").GetString().Should().Be("live");
+        root.GetProperty("diffPreview").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
     public async Task ProposalResources_GetProposalDetail_Terminal_WithAccess_ReturnsStoredPreviewWithMarker()
     {
         using var scope = _serviceProvider.CreateScope();

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -2298,6 +2298,146 @@ public class AutomationProposalServiceTests
 
     #endregion
 
+    #region GetTerminalProposalStoredPreviewAsync Tests (#1415)
+
+    private static AutomationProposal BuildTerminalPreviewProposal(Guid requesterId, Guid boardId, string preview)
+    {
+        // An update-board operation clears the shared operation-contract validator against the
+        // default board mock (mirrors GetProposalDiffAsync_ShouldReturnStoredPreview_ForWellFormed…),
+        // so these tests exercise the requester/board-access gate rather than op-shape rejection.
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            requesterId,
+            "Rename board",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { name = "Renamed board", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        // SetDiffPreview requires PendingReview, so stamp the stored preview before deciding.
+        proposal.SetDiffPreview(preview);
+        proposal.Approve(Guid.NewGuid());
+        proposal.MarkAsApplied();
+        return proposal;
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnStoredPreview_WhenRequesterRetainsAccess()
+    {
+        // #1415: a decided proposal whose requester still has board access serves the STORED
+        // historical preview verbatim (no live rebuild), mirroring the #1397 frontend decision.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildTerminalPreviewProposal(requesterId, boardId, "0. Create card \"Task\"");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("0. Create card \"Task\"");
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnForbidden_WhenRequesterLostBoardAccess()
+    {
+        // #1415: the core trust-class fix. A requester who lost board access must be denied the
+        // stored preview with the SAME Forbidden the diff/apply permission gate returns — the
+        // stored preview is NOT surfaced.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildTerminalPreviewProposal(requesterId, boardId, "leaked-preview");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnNotFound_WhenBoardDeleted()
+    {
+        // #1415 board-exists gate: a decided proposal whose board was deleted returns 404, never
+        // the stored preview.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildTerminalPreviewProposal(requesterId, boardId, "orphan-preview");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardRepoMock
+            .Setup(r => r.GetByIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Board?)null);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnNotFound_WhenRequesterDeleted()
+    {
+        // #1415 requester-exists gate: a decided proposal whose requester was deleted returns 404.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildTerminalPreviewProposal(requesterId, boardId, "ghost-preview");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(requesterId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnNotFound_WhenProposalMissing()
+    {
+        var proposalId = Guid.NewGuid();
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync((AutomationProposal?)null);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldSkipExpiryGate_ServingStoredPreview_WhenExpiredButAccessRetained()
+    {
+        // #1415 deliberate divergence from the live diff path: the pre-decision structure/expiry
+        // gates no longer apply once a proposal is decided. An Applied proposal whose ExpiresAt has
+        // since passed still serves its stored historical preview (subject to board access), where
+        // GetProposalDiffAsync would report expiry. Only the requester/board-access gate is enforced.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildTerminalPreviewProposal(requesterId, boardId, "expired-but-historical");
+        SetExpiresAt(proposal, DateTime.UtcNow.AddMinutes(-10));
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("expired-but-historical");
+    }
+
+    #endregion
+
     #region GetProposalsAsync Tests
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -2302,9 +2302,10 @@ public class AutomationProposalServiceTests
 
     private static AutomationProposal BuildTerminalPreviewProposal(Guid requesterId, Guid boardId, string preview)
     {
-        // An update-board operation clears the shared operation-contract validator against the
-        // default board mock (mirrors GetProposalDiffAsync_ShouldReturnStoredPreview_ForWellFormed…),
-        // so these tests exercise the requester/board-access gate rather than op-shape rejection.
+        // A board-scoped Applied proposal carrying one benign update-board operation. The terminal
+        // stored-preview read gates ONLY on requester/board access (ValidateBoardAccessAsync) —
+        // operations are never re-validated against live board state — so the op shape here is
+        // representative rather than load-bearing.
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
             requesterId,
@@ -2439,8 +2440,9 @@ public class AutomationProposalServiceTests
     private static AutomationProposal BuildZeroOperationTerminalProposal(Guid requesterId, Guid boardId, string preview)
     {
         // CreateProposalAsync enforces no minimum operation count, so a board-scoped proposal can
-        // carry zero operations and still be decided (here: Rejected). This is the shape that would
-        // slip past ValidatePermissionsAsync's empty-operations short-circuit without the guard.
+        // carry zero operations and still be decided (here: Rejected). ValidatePermissionsAsync's
+        // empty-operations short-circuit skips its board half for this shape — the terminal read
+        // calls ValidateBoardAccessAsync directly so the board gate holds uniformly.
         var proposal = new AutomationProposal(
             ProposalSourceType.Chat,
             requesterId,
@@ -2458,7 +2460,8 @@ public class AutomationProposalServiceTests
     {
         // #1415 regression guard: a board-scoped decided proposal with NO operations must still be
         // denied to a requester who lost board access — ValidatePermissionsAsync short-circuits on
-        // the empty op list before its board gate, so the explicit fallback must fail it closed.
+        // the empty op list before its board half, so the terminal read's direct
+        // ValidateBoardAccessAsync call must fail it closed.
         var proposalId = Guid.NewGuid();
         var boardId = Guid.NewGuid();
         var requesterId = Guid.NewGuid();
@@ -2510,6 +2513,102 @@ public class AutomationProposalServiceTests
 
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().Be("empty-but-visible");
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldServeStoredPreview_WhenAppliedMoveCardReferencesDeletedCard()
+    {
+        // #1425 MEDIUM regression pin (over-gating): an Applied move-card proposal whose referenced
+        // card was deleted AFTER apply must still serve its stored historical preview to a requester
+        // with intact access. The terminal read must NOT run the operation-contract validator — that
+        // validator checks references against LIVE board state (ValidateCardBoardAsync) and would
+        // wrongly deny the historical preview with a misleading scope/NotFound error.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var cardId = Guid.NewGuid();
+
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat, requesterId, "Move card", RiskLevel.Medium,
+            Guid.NewGuid().ToString(), boardId);
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId, cardId, columnId = Guid.NewGuid() });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "move", "card", parameters, Guid.NewGuid().ToString(),
+            targetId: cardId.ToString()));
+        proposal.SetDiffPreview("historical: moved card to Done");
+        proposal.Approve(Guid.NewGuid());
+        proposal.MarkAsApplied();
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // The referenced card no longer exists (deleted post-apply).
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByIdAsync(cardId, It.IsAny<CancellationToken>())).ReturnsAsync((Card?)null);
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Be("historical: moved card to Done");
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldServeStoredPreview_WhenAppliedCreateCardTargetIdNowResolves()
+    {
+        // #1425 MEDIUM regression pin (the always-fires case): an Applied create-card proposal's
+        // TargetId resolves to the card Apply created — the operation-contract validator's
+        // new-card-id collision check (ValidateNewCardIdAsync) would ALWAYS reject it with
+        // Conflict. The terminal read must serve the stored preview immediately instead.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var createdCardId = Guid.NewGuid();
+        var columnId = Guid.NewGuid();
+
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat, requesterId, "Create card", RiskLevel.Low,
+            Guid.NewGuid().ToString(), boardId);
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId, title = "Task", columnId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "card", parameters, Guid.NewGuid().ToString(),
+            targetId: createdCardId.ToString()));
+        proposal.SetDiffPreview("historical: created card \"Task\"");
+        proposal.Approve(Guid.NewGuid());
+        proposal.MarkAsApplied();
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // The created card EXISTS now — exactly what the live new-card-id check would reject.
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock
+            .Setup(r => r.GetByIdAsync(createdCardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TestDataBuilder.CreateCard(boardId, columnId, "Task"));
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Be("historical: created card \"Task\"");
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnNullPreview_WhenNoPreviewWasStored()
+    {
+        // #1425 LOW-2 pin: a decided proposal that never had a preview stored returns null (not ""),
+        // so MCP clients can distinguish never-stored from stored-but-empty — matching how the raw
+        // field serialized before the gating.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat, requesterId, "Never previewed", RiskLevel.Low,
+            Guid.NewGuid().ToString(), boardId);
+        proposal.Approve(Guid.NewGuid());
+        proposal.MarkAsApplied();
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().BeNull();
     }
 
     #endregion

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -2436,6 +2436,82 @@ public class AutomationProposalServiceTests
         result.Value.Should().Be("expired-but-historical");
     }
 
+    private static AutomationProposal BuildZeroOperationTerminalProposal(Guid requesterId, Guid boardId, string preview)
+    {
+        // CreateProposalAsync enforces no minimum operation count, so a board-scoped proposal can
+        // carry zero operations and still be decided (here: Rejected). This is the shape that would
+        // slip past ValidatePermissionsAsync's empty-operations short-circuit without the guard.
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            requesterId,
+            "Zero-op proposal",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        proposal.SetDiffPreview(preview);
+        proposal.Reject(Guid.NewGuid(), "not needed");
+        return proposal;
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnForbidden_WhenZeroOpBoardScopedProposalLostAccess()
+    {
+        // #1415 regression guard: a board-scoped decided proposal with NO operations must still be
+        // denied to a requester who lost board access — ValidatePermissionsAsync short-circuits on
+        // the empty op list before its board gate, so the explicit fallback must fail it closed.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildZeroOperationTerminalProposal(requesterId, boardId, "leaked-empty-preview");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnNotFound_WhenZeroOpBoardScopedProposalBoardDeleted()
+    {
+        // #1415 regression guard: the board-exists half of the gate must also run for a zero-op
+        // board-scoped decided proposal.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildZeroOperationTerminalProposal(requesterId, boardId, "orphan-empty-preview");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _boardRepoMock
+            .Setup(r => r.GetByIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Board?)null);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnStoredPreview_WhenZeroOpBoardScopedProposalRetainsAccess()
+    {
+        // The guard denies only revoked/deleted access — a zero-op board-scoped proposal whose
+        // requester still has access serves its stored preview normally.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var proposal = BuildZeroOperationTerminalProposal(requesterId, boardId, "empty-but-visible");
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be("empty-but-visible");
+    }
+
     #endregion
 
     #region GetProposalsAsync Tests


### PR DESCRIPTION
## Summary

The MCP `proposal_detail` resource served the stored `DiffPreview` field directly (`ProposalResources.cs` ~line 104), never running the gates the HTTP diff endpoint runs. This left the preview==apply trust-violation class — the one #1370→#1374, #1376→#1395, #1398→#1413 closed on the HTTP surface — alive on the MCP surface: an MCP client that is the proposal's requester (`RequestedByUserId == userId` still passed) but has since **lost board access**, or whose board was deleted, still received the stale stored preview while the corresponding apply would 403/404.

This closes that asymmetry. `proposal_detail` no longer emits the raw stored field.

## Gates now enforced

- **Open proposals (PendingReview / Approved)** route through `AutomationProposalService.GetProposalDiffAsync` — the single source of truth for the live, fully-gated diff (structure + expiry from #1376/#1395; requester-exists → 404, board-exists → 404, board-access → 403 from #1398/#1413). No gate logic is duplicated in the resource.
- **Decided (terminal) proposals (Applied / Rejected / Failed / Expired / Dismissed)** serve the **stored** preview (a live rebuild would describe a board that has since moved — the #1397 frontend decision) but still re-check the requester/board-access gate via a new minimal service seam, `GetTerminalProposalStoredPreviewAsync`. It calls the same `AutomationPolicyEngine.ValidatePermissionsAsync` the diff path uses, so a reviewer who lost board access — or whose board/requester was deleted — is denied the stored preview instead of reading stale board contents through it. The pre-decision structure/expiry gates are deliberately **not** run on a decided proposal (the sole intended divergence from the live path); this matches the pinned semantics of `GetProposalDiffAsync_ShouldRejectRevokedAccess_ForTerminalAppliedProposal` (revoked terminal access → Forbidden, stored preview not surfaced).

## Terminal-status read semantics

The payload gains an explicit provenance marker `diffPreviewSource`: `"live"` for a freshly gated open-proposal diff, `"stored"` for a decided proposal's historical preview. The existing `status` field continues to report the proposal status.

## MCP error-shape conventions

Gate denials are surfaced by throwing `InvalidOperationException` carrying the service's own `result.ErrorMessage`, exactly as the sibling `GetProposalByIdAsync` failure already does in this resource and as the MCP write tools do (`WriteTools`/`ProposalTools` raise `result.ErrorMessage` verbatim). No new MCP error shape is invented; the resource's established throw-based failure convention is preserved.

## Scope

No change to the HTTP surface, the service's existing gate logic (`GetProposalDiffAsync` / `ValidatePermissionsAsync` / `ValidatePolicy` are untouched), or any write tool. The only new production seam is the additive `GetTerminalProposalStoredPreviewAsync` service method.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release -m:1` — clean (0 errors).
- `dotnet test` Application.Tests `FullyQualifiedName~AutomationProposalServiceTests` — **71 passed** (6 new `GetTerminalProposalStoredPreviewAsync_*` tests: stored-preview with access, Forbidden on revoked access, NotFound on deleted board, NotFound on deleted requester, NotFound on missing proposal, expiry-gate-skip serving stored preview when expired-but-access-retained).
- `dotnet test` Api.Tests `FullyQualifiedName~Mcp` — **151 passed**, including 10 `McpResourcesTests` (4 new: non-terminal live gated diff, terminal stored-preview + `stored` marker, terminal revoked-access denial not leaking the stored text, non-terminal revoked-access denial; plus the existing `ReturnsOperations` test updated to a gate-passing operation shape).

Closes #1415
