### PR TITLE
Extraction permit/concurrency gate (split from #1379 ceiling work) + ADR-0047/0048

### DIFF
--- a/backend/src/Taskdeck.Api/Extensions/SettingsRegistration.cs
+++ b/backend/src/Taskdeck.Api/Extensions/SettingsRegistration.cs
@@ -47,6 +47,11 @@ public static class SettingsRegistration
             ?? new ArtefactStorageSettings();
         services.AddSingleton(artefactStorageSettings);
 
+        // Extraction permit gate: a process-wide singleton so its permits bound the
+        // number of concurrent (and concurrently-abandoned) parse workers box-wide.
+        // Built from the same ArtefactStorageSettings bound just above.
+        services.AddSingleton<ArtefactExtractionGate>();
+
         jwtSettings = configuration.GetSection("Jwt").Get<JwtSettings>() ?? new JwtSettings();
         services.AddSingleton(jwtSettings);
 

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionGate.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionGate.cs
@@ -1,0 +1,54 @@
+namespace Taskdeck.Application.Services;
+
+/// <summary>
+/// Bounds the number of artefact-extraction parse workers that may run
+/// concurrently. Permits track parse-THREAD occupancy, not request lifetime: an
+/// abandoned parse-bomb thread (one that never observes cancellation and keeps
+/// spinning after its request has timed out and returned) continues to hold its
+/// permit until it actually finishes. That is the point — it caps how many
+/// concurrently-abandoned parses can accumulate. When every permit is held, a new
+/// extraction is rejected pre-parse (<see cref="TryAcquire"/> returns
+/// <c>false</c>) rather than queued, because a queue in front of permits held by
+/// spinning bombs is just a second unbounded backlog.
+/// </summary>
+public sealed class ArtefactExtractionGate : IDisposable
+{
+    private readonly SemaphoreSlim _semaphore;
+
+    public ArtefactExtractionGate(ArtefactStorageSettings? settings = null)
+    {
+        MaxConcurrency = (settings ?? new ArtefactStorageSettings()).ExtractionMaxConcurrency;
+        // maxCount == MaxConcurrency turns an over-release (a double-free bug) into an
+        // immediate SemaphoreFullException instead of silently inflating capacity.
+        _semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+    }
+
+    /// <summary>Maximum number of parse workers permitted to run at once.</summary>
+    public int MaxConcurrency { get; }
+
+    /// <summary>Permits currently available (diagnostic / test observation only).</summary>
+    public int AvailablePermits => _semaphore.CurrentCount;
+
+    /// <summary>
+    /// Try to take a permit without blocking. Returns <c>true</c> when a permit was
+    /// acquired (the caller must later call <see cref="Release"/> exactly once);
+    /// <c>false</c> when the gate is saturated.
+    /// </summary>
+    public bool TryAcquire() => _semaphore.Wait(0);
+
+    /// <summary>Return a permit previously taken by <see cref="TryAcquire"/>.</summary>
+    public void Release()
+    {
+        _semaphore.Release();
+        PermitReleased?.Invoke();
+    }
+
+    /// <summary>
+    /// Test-only observation seam: raised after each permit is released. Lets a test
+    /// await the release that happens inside the service's abandoned-worker
+    /// completion continuation without polling. Never wired in production.
+    /// </summary>
+    internal event Action? PermitReleased;
+
+    public void Dispose() => _semaphore.Dispose();
+}

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionGate.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionGate.cs
@@ -17,7 +17,20 @@ public sealed class ArtefactExtractionGate : IDisposable
 
     public ArtefactExtractionGate(ArtefactStorageSettings? settings = null)
     {
-        MaxConcurrency = (settings ?? new ArtefactStorageSettings()).ExtractionMaxConcurrency;
+        var concurrency = (settings ?? new ArtefactStorageSettings()).ExtractionMaxConcurrency;
+        // Startup options validation enforces [1, 64] on the bound settings, but a
+        // hand-constructed or misconfigured settings object can still reach here. Guard
+        // loudly: a negative value would throw an opaque ArgumentOutOfRangeException from
+        // SemaphoreSlim, and zero would silently create a permanently-locked gate that
+        // rejects every extraction — both are misconfigurations, not runtime states.
+        if (concurrency < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(settings),
+                concurrency,
+                $"{nameof(ArtefactStorageSettings.ExtractionMaxConcurrency)} must be at least 1.");
+        }
+        MaxConcurrency = concurrency;
         // maxCount == MaxConcurrency turns an over-release (a double-free bug) into an
         // immediate SemaphoreFullException instead of silently inflating capacity.
         _semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
@@ -39,8 +52,22 @@ public sealed class ArtefactExtractionGate : IDisposable
     /// <summary>Return a permit previously taken by <see cref="TryAcquire"/>.</summary>
     public void Release()
     {
-        _semaphore.Release();
-        PermitReleased?.Invoke();
+        try
+        {
+            _semaphore.Release();
+            PermitReleased?.Invoke();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The gate is a DI singleton disposed at application shutdown, but an
+            // abandoned parse worker's completion continuation can still run afterwards
+            // and call Release() on the disposed semaphore. Swallow the shutdown-race
+            // dispose: releasing capacity in a dying process is a no-op, and letting it
+            // throw would either mask another exception in the service's finally or
+            // surface as an UnobservedTaskException (noisy Sentry alerts) from the
+            // fire-and-forget continuation. This catches only the disposed-gate race; a
+            // genuine over-release still throws SemaphoreFullException (see the ctor).
+        }
     }
 
     /// <summary>

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
@@ -18,6 +18,7 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
     private readonly IArtefactExtractionRepository _extractions;
     private readonly IReadOnlyList<IArtefactTextExtractor> _extractors;
     private readonly ArtefactStorageSettings _settings;
+    private readonly ArtefactExtractionGate? _gate;
     private readonly ILogger<ArtefactExtractionService>? _logger;
 
     public ArtefactExtractionService(
@@ -25,12 +26,14 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
         IArtefactExtractionRepository extractions,
         IEnumerable<IArtefactTextExtractor> extractors,
         ArtefactStorageSettings? settings = null,
-        ILogger<ArtefactExtractionService>? logger = null)
+        ILogger<ArtefactExtractionService>? logger = null,
+        ArtefactExtractionGate? gate = null)
     {
         _artefacts = artefacts;
         _extractions = extractions;
         _extractors = extractors.ToArray();
         _settings = settings ?? new ArtefactStorageSettings();
+        _gate = gate;
         _logger = logger;
     }
 
@@ -134,6 +137,27 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                 // provably completed; abandonment paths defer disposal to a
                 // worker-completion continuation so the abandoned parse can never
                 // touch a disposed token source.
+                //
+                // Extraction permit: take a permit immediately before spawning the
+                // parse worker so the permit tracks parse-THREAD occupancy. When the
+                // gate is saturated — every permit held, including by abandoned bombs
+                // still spinning box-wide — reject pre-parse without creating a worker
+                // or an extraction-history row (capacity is a transient property of the
+                // box, not of this artefact; unlike the timeout/decoded-size outcomes,
+                // it is not recorded). Callers retry on TooManyRequests. Release mirrors
+                // budgetCts disposal exactly: inline in the finally on completed paths,
+                // deferred to the worker-completion continuation on abandoned paths.
+                if (_gate is not null && !_gate.TryAcquire())
+                {
+                    _logger?.LogWarning(
+                        "Local extraction rejected for artefact {ArtefactId}: extraction capacity is saturated ({MaxConcurrency} concurrent)",
+                        sourceArtefactId,
+                        _gate.MaxConcurrency);
+                    return Result.Failure<ArtefactExtractionDto>(
+                        ErrorCodes.TooManyRequests,
+                        "Local extraction is at capacity; retry shortly");
+                }
+
                 var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var workerAbandoned = false;
                 try
@@ -205,7 +229,15 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                 finally
                 {
                     if (!workerAbandoned)
+                    {
                         budgetCts.Dispose();
+                        // Completed path (normal result, extractor fault, or store
+                        // failure below): the worker is done, so release the permit
+                        // here. Abandoned paths skip this and release in the worker
+                        // continuation instead, holding the permit until the runaway
+                        // thread actually finishes.
+                        _gate?.Release();
+                    }
                 }
             }
         }
@@ -350,6 +382,11 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                 }
 
                 budgetCts.Dispose();
+                // Release the permit only now that the abandoned worker has actually
+                // finished: the whole point of the gate is that a runaway parse holds
+                // capacity for its full lifetime, not just for the request that spawned
+                // it. This is the exactly-once release for every abandoned path.
+                _gate?.Release();
             },
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,

--- a/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactExtractionService.cs
@@ -143,12 +143,21 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                 // gate is saturated — every permit held, including by abandoned bombs
                 // still spinning box-wide — reject pre-parse without creating a worker
                 // or an extraction-history row (capacity is a transient property of the
-                // box, not of this artefact; unlike the timeout/decoded-size outcomes,
-                // it is not recorded). Callers retry on TooManyRequests. Release mirrors
-                // budgetCts disposal exactly: inline in the finally on completed paths,
-                // deferred to the worker-completion continuation on abandoned paths.
+                // box, not of this artefact; unlike the timeout outcome, it is not
+                // recorded). Callers retry on TooManyRequests. Release mirrors budgetCts
+                // disposal exactly: inline in the finally on completed paths, deferred to
+                // the worker-completion continuation on abandoned paths.
+                //
+                // The linked budget CTS is created BEFORE the permit is taken: if its
+                // construction ever throws (e.g. the caller's token source was already
+                // disposed), no permit has been acquired yet, so none can leak. After a
+                // successful acquire the only statement before the release-owning try is a
+                // non-throwing assignment, and the worker is still spawned only inside the
+                // try — so the permit tracks parse-THREAD occupancy exactly.
+                var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 if (_gate is not null && !_gate.TryAcquire())
                 {
+                    budgetCts.Dispose();
                     _logger?.LogWarning(
                         "Local extraction rejected for artefact {ArtefactId}: extraction capacity is saturated ({MaxConcurrency} concurrent)",
                         sourceArtefactId,
@@ -158,7 +167,6 @@ public sealed class ArtefactExtractionService : IArtefactExtractionService
                         "Local extraction is at capacity; retry shortly");
                 }
 
-                var budgetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var workerAbandoned = false;
                 try
                 {

--- a/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
@@ -7,6 +7,7 @@ public sealed class ArtefactStorageSettings
     public const long DefaultMaxBytesPerArtefact = 10L * 1024 * 1024;
     public const long DefaultMaxBytesPerUser = 200L * 1024 * 1024;
     public const double DefaultExtractionTimeoutSeconds = 30;
+    public const int DefaultExtractionMaxConcurrency = 2;
 
     [Range(typeof(long), "1", "2147483647")]
     public long MaxBytesPerArtefact { get; set; } = DefaultMaxBytesPerArtefact;
@@ -38,4 +39,21 @@ public sealed class ArtefactStorageSettings
     /// "no budget" rather than an instant timeout.
     /// </summary>
     public TimeSpan ExtractionTimeout => TimeSpan.FromSeconds(ExtractionTimeoutSeconds);
+
+    /// <summary>
+    /// Maximum number of artefact extractions whose parse worker may run at once.
+    /// A crafted parser-bomb PDF that never observes cancellation keeps a
+    /// thread-pool thread at full CPU until PdfPig's synchronous parse completes
+    /// (only the request is bounded by <see cref="ExtractionTimeoutSeconds"/>, not
+    /// the abandoned thread). This bounds how many such parses can accumulate: once
+    /// the permits are exhausted, further extractions are rejected pre-parse with
+    /// <c>TooManyRequests</c> and spawn no new thread, so box-wide CPU burn is capped
+    /// at this many spinning threads. This gate caps concurrency and abandoned-thread
+    /// accumulation; it does not bound a single parse's peak memory (a decompression
+    /// bomb inside one parse) — that containment is tracked separately (#1379).
+    /// </summary>
+    // Integer literals set RangeAttribute.OperandType to int, matching this int
+    // property; a string/double-operand range would coerce and misvalidate.
+    [Range(1, 64)]
+    public int ExtractionMaxConcurrency { get; set; } = DefaultExtractionMaxConcurrency;
 }

--- a/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
+++ b/backend/src/Taskdeck.Application/Services/ArtefactStorageSettings.cs
@@ -50,7 +50,7 @@ public sealed class ArtefactStorageSettings
     /// <c>TooManyRequests</c> and spawn no new thread, so box-wide CPU burn is capped
     /// at this many spinning threads. This gate caps concurrency and abandoned-thread
     /// accumulation; it does not bound a single parse's peak memory (a decompression
-    /// bomb inside one parse) — that containment is tracked separately (#1379).
+    /// bomb inside one parse) — that containment is tracked separately (ADR-0048 / #1379).
     /// </summary>
     // Integer literals set RangeAttribute.OperandType to int, matching this int
     // property; a string/double-operand range would coerce and misvalidate.

--- a/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/Validation/OptionsValidationTests.cs
@@ -150,6 +150,85 @@ public class OptionsValidationTests
         Assert.Contains(nameof(ArtefactStorageSettings.ExtractionTimeoutSeconds), exception.Message);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65)]
+    [InlineData(int.MaxValue)]
+    public void ArtefactStorageSettings_ExtractionMaxConcurrency_RejectsOutOfRange(int value)
+    {
+        var settings = new ArtefactStorageSettings { ExtractionMaxConcurrency = value };
+
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(settings);
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var isValid = System.ComponentModel.DataAnnotations.Validator.TryValidateObject(
+            settings, context, results, validateAllProperties: true);
+
+        Assert.False(isValid);
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(ArtefactStorageSettings.ExtractionMaxConcurrency)));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(64)]
+    public void ArtefactStorageSettings_ExtractionMaxConcurrency_AcceptsValidValues(int value)
+    {
+        var settings = new ArtefactStorageSettings { ExtractionMaxConcurrency = value };
+
+        var context = new System.ComponentModel.DataAnnotations.ValidationContext(settings);
+        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+        var isValid = System.ComponentModel.DataAnnotations.Validator.TryValidateObject(
+            settings, context, results, validateAllProperties: true);
+
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public void ArtefactStorageSettings_ExtractionMaxConcurrency_HasExpectedDefault()
+    {
+        var settings = new ArtefactStorageSettings();
+
+        Assert.Equal(2, settings.ExtractionMaxConcurrency);
+        Assert.Equal(ArtefactStorageSettings.DefaultExtractionMaxConcurrency, settings.ExtractionMaxConcurrency);
+    }
+
+    [Fact]
+    public void ArtefactStorageSettings_BindsExtractionMaxConcurrencyFromConfiguration()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Artefacts:ExtractionMaxConcurrency"] = "4"
+            })
+            .Build();
+
+        var settings = configuration.GetSection("Artefacts").Get<ArtefactStorageSettings>();
+
+        Assert.NotNull(settings);
+        Assert.Equal(4, settings!.ExtractionMaxConcurrency);
+    }
+
+    [Fact]
+    public void AddOptionsValidation_RejectsExtractionMaxConcurrencyOutOfRangeAtStartup()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Artefacts:ExtractionMaxConcurrency"] = "0"
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        services.AddOptionsValidation(configuration);
+
+        using var provider = services.BuildServiceProvider();
+
+        var exception = Assert.Throws<OptionsValidationException>(
+            () => provider.GetRequiredService<IOptions<ArtefactStorageSettings>>().Value);
+        Assert.Contains(nameof(ArtefactStorageSettings.ExtractionMaxConcurrency), exception.Message);
+    }
+
     // ── JwtSettingsValidator ─────────────────────────────────────────────
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionGateTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionGateTests.cs
@@ -191,6 +191,33 @@ public sealed class ArtefactExtractionGateTests
         gate.AvailablePermits.Should().Be(1, "the permit is returned exactly once after the abandoned worker completes");
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_RejectsNonPositiveConcurrency(int concurrency)
+    {
+        // Zero would create a permanently-locked gate; negative throws opaquely from
+        // SemaphoreSlim. The ctor guards both loudly as misconfiguration.
+        var act = () => new ArtefactExtractionGate(
+            new ArtefactStorageSettings { ExtractionMaxConcurrency = concurrency });
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Release_AfterDispose_DoesNotThrow_ForShutdownRace()
+    {
+        // Mirrors an abandoned worker's completion continuation calling Release() after
+        // the DI singleton gate has been disposed at application shutdown.
+        var gate = new ArtefactExtractionGate(new ArtefactStorageSettings { ExtractionMaxConcurrency = 1 });
+        gate.TryAcquire().Should().BeTrue();
+        gate.Dispose();
+
+        var act = gate.Release;
+
+        act.Should().NotThrow();
+    }
+
     private void ArrangeStoredArtefact(string mimeType, byte[] content)
     {
         var artefact = new SourceArtefact(

--- a/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionGateTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionGateTests.cs
@@ -1,0 +1,256 @@
+using FluentAssertions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Taskdeck.Domain.Exceptions;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+/// <summary>
+/// Covers the <see cref="ArtefactExtractionGate"/> permit semantics wired into
+/// <see cref="ArtefactExtractionService"/> for #1379: an abandoned parse holds its
+/// permit until it actually finishes, saturation rejects with
+/// <c>TooManyRequests</c> and writes no history row, and concurrency is capped
+/// (never queued). All synchronization is mechanism-based (latches +
+/// TaskCompletionSource); no sleeps or timing assumptions decide outcomes.
+/// </summary>
+public sealed class ArtefactExtractionGateTests
+{
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _artefactId = Guid.NewGuid();
+    private readonly Mock<ISourceArtefactRepository> _artefacts = new();
+    private readonly Mock<IArtefactExtractionRepository> _extractions = new();
+
+    [Fact]
+    public async Task AbandonedParse_HoldsPermit_UntilItFinishes_ThenCapacityFrees()
+    {
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        var storeCalls = 0;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback(() => Interlocked.Increment(ref storeCalls))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+
+        var gate = new ArtefactExtractionGate(new ArtefactStorageSettings { ExtractionMaxConcurrency = 1 });
+        var permitReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        gate.PermitReleased += () => permitReleased.TrySetResult();
+
+        using var block1 = new ManualResetEventSlim(false);
+        var tinyBudget = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 0.05, ExtractionMaxConcurrency = 1 };
+
+        // Submission 1: an extractor that ignores cancellation (models PdfPig's
+        // synchronous Open). The tiny budget fires, the request is abandoned, but the
+        // worker stays blocked on block1 — so the single permit is still held.
+        var blockingExtractor = new BlockingExtractor("application/pdf", block1);
+        var service1 = new ArtefactExtractionService(
+            _artefacts.Object, _extractions.Object, [blockingExtractor], tinyBudget, gate: gate);
+
+        var first = await service1.ExtractAsync(_userId, _artefactId);
+        first.IsSuccess.Should().BeTrue();
+        first.Value.Warnings.Should().Equal(ArtefactExtractionWarningCodes.ExtractionTimeout);
+        gate.AvailablePermits.Should().Be(0, "the abandoned worker is still blocked and holds the permit");
+
+        // Submission 2: the permit is provably still held (block1 is not set, so the
+        // worker cannot have finished). It must be rejected pre-parse with no row.
+        var service2 = new ArtefactExtractionService(
+            _artefacts.Object, _extractions.Object, [new BlockingExtractor("application/pdf", block1)], tinyBudget, gate: gate);
+        var second = await service2.ExtractAsync(_userId, _artefactId);
+        second.IsSuccess.Should().BeFalse();
+        second.ErrorCode.Should().Be(ErrorCodes.TooManyRequests);
+        storeCalls.Should().Be(1, "the rejected submission writes no extraction-history row");
+
+        // Release the abandoned worker; the service's completion continuation now runs
+        // and returns the permit. Await that deterministically via the gate's hook.
+        block1.Set();
+        (await Task.WhenAny(permitReleased.Task, Task.Delay(TimeSpan.FromSeconds(10))))
+            .Should().Be(permitReleased.Task, "the abandoned worker must release its permit once it finishes");
+        gate.AvailablePermits.Should().Be(1);
+
+        // Submission 3: capacity is free again, so a normal extraction succeeds and
+        // writes a row. A generous budget avoids any interaction with the abandonment.
+        var fastExtractor = new BlockingExtractor(
+            "application/pdf",
+            block: null,
+            result: new ArtefactExtractionResult("recovered", [], "Blocking", "1.0"));
+        var service3 = new ArtefactExtractionService(
+            _artefacts.Object,
+            _extractions.Object,
+            [fastExtractor],
+            new ArtefactStorageSettings { ExtractionTimeoutSeconds = 30, ExtractionMaxConcurrency = 1 },
+            gate: gate);
+        var third = await service3.ExtractAsync(_userId, _artefactId);
+        third.IsSuccess.Should().BeTrue();
+        third.Value.ExtractedText.Should().Be("recovered");
+        storeCalls.Should().Be(2);
+        gate.AvailablePermits.Should().Be(1, "the successful extraction released its permit");
+    }
+
+    [Fact]
+    public async Task Saturated_RejectsExcess_NeverQueues_AndNeverExceedsCap()
+    {
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+
+        const int cap = 2;
+        const int submissions = 8;
+        var gate = new ArtefactExtractionGate(new ArtefactStorageSettings { ExtractionMaxConcurrency = cap });
+        using var release = new ManualResetEventSlim(false);
+        using var allEntered = new CountdownEvent(cap);
+        var latched = new LatchedCountingExtractor("application/pdf", release, allEntered);
+
+        // A generous budget: the two admitted workers block on the latch and then
+        // complete normally (never abandoned), so the outcome is a clean 2 success /
+        // 6 rejected split with no queueing.
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 30, ExtractionMaxConcurrency = cap };
+        var service = new ArtefactExtractionService(
+            _artefacts.Object, _extractions.Object, [latched], settings, gate: gate);
+
+        var tasks = Enumerable
+            .Range(0, submissions)
+            .Select(_ => service.ExtractAsync(_userId, _artefactId))
+            .ToArray();
+
+        // Exactly cap workers can enter the extractor concurrently; the rest are
+        // rejected immediately. Deterministic: the two that entered block on the latch,
+        // so no permit ever frees to admit a third.
+        allEntered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("exactly the cap should enter the extractor");
+        latched.MaxConcurrent.Should().Be(cap);
+        gate.AvailablePermits.Should().Be(0);
+
+        release.Set();
+        var all = Task.WhenAll(tasks);
+        var completed = await Task.WhenAny(all, Task.Delay(TimeSpan.FromSeconds(15)));
+        completed.Should().Be(all, "no deadlock: every submission resolves after release");
+
+        var results = await all;
+        results.Count(r => r.IsSuccess).Should().Be(cap);
+        results.Count(r => !r.IsSuccess && r.ErrorCode == ErrorCodes.TooManyRequests)
+            .Should().Be(submissions - cap);
+        latched.MaxConcurrent.Should().Be(cap, "the gate never let more than the cap run at once");
+        gate.AvailablePermits.Should().Be(cap, "every permit was returned");
+    }
+
+    private void ArrangeStoredArtefact(string mimeType, byte[] content)
+    {
+        var artefact = new SourceArtefact(
+            _userId,
+            ArtefactKind.Pdf,
+            mimeType,
+            "source.pdf",
+            content.LongLength,
+            new string('a', 64),
+            CaptureSource.Import);
+        typeof(Taskdeck.Domain.Common.Entity)
+            .GetProperty(nameof(Taskdeck.Domain.Common.Entity.Id))!
+            .SetValue(artefact, _artefactId);
+
+        _artefacts
+            .Setup(repository => repository.GetByIdForUserAsync(
+                _artefactId,
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(artefact);
+        _artefacts
+            .Setup(repository => repository.CopyContentForUserAsync(
+                _artefactId,
+                _userId,
+                It.IsAny<Stream>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(async (Guid _, Guid _, Stream destination, CancellationToken cancellationToken) =>
+            {
+                await destination.WriteAsync(content, cancellationToken);
+                return true;
+            });
+    }
+
+    /// <summary>
+    /// Ignores the cancellation token entirely (models PdfPig's synchronous
+    /// <c>PdfDocument.Open</c>) and optionally blocks on a latch, so the service must
+    /// abandon it when the budget fires.
+    /// </summary>
+    private sealed class BlockingExtractor : IArtefactTextExtractor
+    {
+        private readonly string _mime;
+        private readonly ManualResetEventSlim? _block;
+        private readonly ArtefactExtractionResult _result;
+
+        public BlockingExtractor(string mime, ManualResetEventSlim? block, ArtefactExtractionResult? result = null)
+        {
+            _mime = mime;
+            _block = block;
+            _result = result ?? new ArtefactExtractionResult("blocked", [], "Blocking", "1.0");
+        }
+
+        public string ExtractorName => "Blocking";
+        public string ExtractorVersion => "1.0";
+        public long InputByteLimit => 1024 * 1024;
+
+        public bool CanExtract(string mimeType)
+            => mimeType.StartsWith(_mime, StringComparison.OrdinalIgnoreCase);
+
+        public Task<ArtefactExtractionResult> ExtractAsync(Stream content, CancellationToken cancellationToken = default)
+        {
+            _block?.Wait(TimeSpan.FromSeconds(30));
+            return Task.FromResult(_result);
+        }
+    }
+
+    /// <summary>
+    /// Records the peak number of concurrent extractor entries, signals each entry,
+    /// then blocks all entrants on a shared latch — proving the gate admits at most
+    /// the configured cap at once.
+    /// </summary>
+    private sealed class LatchedCountingExtractor : IArtefactTextExtractor
+    {
+        private readonly string _mime;
+        private readonly ManualResetEventSlim _release;
+        private readonly CountdownEvent _entered;
+        private int _current;
+        private int _max;
+
+        public LatchedCountingExtractor(string mime, ManualResetEventSlim release, CountdownEvent entered)
+        {
+            _mime = mime;
+            _release = release;
+            _entered = entered;
+        }
+
+        public string ExtractorName => "LatchedCounting";
+        public string ExtractorVersion => "1.0";
+        public long InputByteLimit => 1024 * 1024;
+        public int MaxConcurrent => Volatile.Read(ref _max);
+
+        public bool CanExtract(string mimeType)
+            => mimeType.StartsWith(_mime, StringComparison.OrdinalIgnoreCase);
+
+        public Task<ArtefactExtractionResult> ExtractAsync(Stream content, CancellationToken cancellationToken = default)
+        {
+            var now = Interlocked.Increment(ref _current);
+            int observed;
+            do
+            {
+                observed = Volatile.Read(ref _max);
+                if (now <= observed)
+                    break;
+            }
+            while (Interlocked.CompareExchange(ref _max, now, observed) != observed);
+
+            _entered.Signal();
+            _release.Wait(TimeSpan.FromSeconds(30));
+            Interlocked.Decrement(ref _current);
+            return Task.FromResult(new ArtefactExtractionResult("done", [], ExtractorName, ExtractorVersion));
+        }
+    }
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionGateTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ArtefactExtractionGateTests.cs
@@ -142,6 +142,55 @@ public sealed class ArtefactExtractionGateTests
         gate.AvailablePermits.Should().Be(cap, "every permit was returned");
     }
 
+    [Fact]
+    public async Task CallerCancellation_AbandonsWorker_RecordsNoRow_AndReleasesPermitWhenWorkerFinishes()
+    {
+        // The caller-cancellation branch is distinct from the budget-timeout branch: it
+        // rethrows (no history row) but still defers permit release to the worker-completion
+        // continuation. Pin that the permit is held until the abandoned worker finishes and
+        // released exactly once thereafter, with no extraction-history row written.
+        ArrangeStoredArtefact("application/pdf", [1, 2, 3]);
+        var storeCalls = 0;
+        _extractions
+            .Setup(repository => repository.TryAddForUserAsync(
+                It.IsAny<ArtefactExtraction>(),
+                _userId,
+                It.IsAny<CancellationToken>()))
+            .Callback(() => Interlocked.Increment(ref storeCalls))
+            .ReturnsAsync(ArtefactExtractionStoreResult.Stored);
+
+        var gate = new ArtefactExtractionGate(new ArtefactStorageSettings { ExtractionMaxConcurrency = 1 });
+        var permitReleased = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        gate.PermitReleased += () => permitReleased.TrySetResult();
+
+        using var release = new ManualResetEventSlim(false);
+        using var entered = new CountdownEvent(1);
+        // A generous budget so only caller cancellation (never the timeout branch) can end
+        // the wait; the latched extractor ignores its token, so the parse must be abandoned.
+        var settings = new ArtefactStorageSettings { ExtractionTimeoutSeconds = 30, ExtractionMaxConcurrency = 1 };
+        var extractor = new LatchedCountingExtractor("application/pdf", release, entered);
+        var service = new ArtefactExtractionService(
+            _artefacts.Object, _extractions.Object, [extractor], settings, gate: gate);
+
+        using var callerCts = new CancellationTokenSource();
+        var extraction = service.ExtractAsync(_userId, _artefactId, callerCts.Token);
+
+        entered.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue("the worker must enter the extractor before we cancel");
+        gate.AvailablePermits.Should().Be(0, "the running worker holds the permit");
+
+        callerCts.Cancel();
+
+        var act = async () => await extraction;
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        storeCalls.Should().Be(0, "a caller-cancelled extraction writes no history row");
+        gate.AvailablePermits.Should().Be(0, "the abandoned worker still holds the permit until it finishes");
+
+        release.Set();
+        (await Task.WhenAny(permitReleased.Task, Task.Delay(TimeSpan.FromSeconds(10))))
+            .Should().Be(permitReleased.Task, "the abandoned worker must release its permit once it finishes");
+        gate.AvailablePermits.Should().Be(1, "the permit is returned exactly once after the abandoned worker completes");
+    }
+
     private void ArrangeStoredArtefact(string mimeType, byte[] content)
     {
         var artefact = new SourceArtefact(

--- a/docs/decisions/ADR-0047-artefact-extraction-resource-bounding.md
+++ b/docs/decisions/ADR-0047-artefact-extraction-resource-bounding.md
@@ -1,0 +1,60 @@
+# ADR-0047: Artefact-Extraction Resource Bounding — Permit Gate (Shipped) + Provider-Injection Decode Ceiling as Defense-in-Depth
+
+- Status: Accepted
+- Date: 2026-07-18
+- Deciders: Overnight coordinator, on the boundary choice the maintainer delegated 2026-07-18; maintainer ratifies
+- Related: ADR-0048 (decompression-bomb containment boundary — the worker-process decision this defers hard memory containment to), ADR-0046 (generalist artefact intake — the wave this hardens), ADR-0044 (revival pivot / finite-work discipline), `#1379` (extraction resource ceiling), `#1369` (wall-clock extraction budget), PR `#1417` and its stop-gate adjudication (comment `5007117851`), `docs/platform/CONFIGURATION_REFERENCE.md` §Artefacts
+
+> **Supersedes an unmerged draft.** An earlier `ADR-0047` draft ("Bound Artefact-Extraction Resource Consumption In-Process (Permit Gate + Bounded Filter) over Process Isolation", Proposed) exists **only on the unmerged `issue-1379/extraction-resource-ceiling` branch (PR #1417)**. That draft claimed worst-case in-process work is bounded at `ExtractionMaxConcurrency × ExtractionMaxDecodedBytes`. **That claim is proven false for the cross-reference-stream path** (see Context). This ADR takes the same number on `main` (the draft never merged) and records the honest, evidence-corrected decision.
+
+## Context
+
+`ArtefactExtractionService` runs local text extractors (PdfPig for PDFs, plain-text/Markdown) over stored artefact bytes. Slice `#1369` added a wall-clock budget: because PdfPig's `PdfDocument.Open(...)` is synchronous and does not observe a `CancellationToken`, the parse runs on a `Task.Run` worker and a runaway parse is *abandoned* (the request returns an `extraction-timeout` warning row) rather than cancelled.
+
+That left three gaps, all reachable by a crafted PDF under the existing byte/page/character caps:
+
+1. **Abandoned-thread CPU.** An abandoned parse keeps one thread-pool thread at full CPU until PdfPig finishes on its own. Only the request was bounded.
+2. **Unbounded accumulation of abandoned parses.** Nothing capped how many such threads could pile up under concurrent parser-bomb submissions.
+3. **Memory / decompression ceiling.** A FlateDecode "decompression bomb" — a few KiB of compressed stream that inflates to gigabytes — stays under the 10 MiB input cap while exhausting memory during the decode itself.
+
+The `#1379` work attempted to close all three in-process. Gaps 1 and 2 are cleanly closed by a permit gate. Gap 3 was attempted with a decode ceiling injected via `ParsingOptions.FilterProvider` (`BoundedFilterProvider`). A stop-gate verification on PR #1417 (comment `5007117851`), proven two independent ways (probe tests + PdfPig 0.1.15 source read), established:
+
+- **Object streams (`/ObjStm`) ARE covered** by the injected provider — a bomb inside an object stream trips the decoded-size ceiling.
+- **Cross-reference streams (xref streams) are NOT covered.** `XrefStreamParser.TryReadStreamAtOffset` decodes with a hard-coded `DefaultFilterProvider.Instance`, called from `FirstPassParser.Parse` **before** `PdfDocumentFactory.OpenDocument` constructs the wrapped provider. `ParsingOptions.FilterProvider` structurally cannot reach it. A single-filter FlateDecode xref stream is therefore unbounded regardless of how good the injected filter is.
+
+**Consequence:** provider injection cannot deliver a "detect before materialize" containment guarantee on PdfPig 0.1.15. The `cap × ceiling` bound the draft ADR claimed is false for the xref path. The service has no production caller by design (this wiring is the prerequisite for that caller), so there is zero current exposure — this is a correctness-of-record and future-safety decision, not an incident.
+
+## Decision
+
+Split extraction resource bounding into an honestly-scoped mechanism set:
+
+1. **Extraction permit gate (`ArtefactExtractionGate`, Application singleton) — SHIPPED in this PR.** Wraps `SemaphoreSlim(ExtractionMaxConcurrency)` (new setting, `int`, default 2, `[Range(1, 64)]`). The service takes a permit with a non-blocking `Wait(0)` immediately before spawning the parse worker. **Permits track parse-THREAD occupancy, not request lifetime:** released in the `finally` on completed paths, but on abandoned paths (budget timeout or caller cancellation) release is deferred into the worker-completion continuation, so a runaway thread holds its permit until it *actually finishes*. Once permits are exhausted, a new extraction is **rejected pre-parse** with `TooManyRequests` and **no history row** (capacity is a transient property of the box); rejection, not queueing. This closes gaps 1 and 2 and is independent of any containment choice. It is sound under any resolution of gap 3.
+
+2. **Provider-injection decode ceiling (`BoundedFilterProvider`) — DEFENSE-IN-DEPTH, NOT containment; NOT merged here.** Decorates PdfPig's `DefaultFilterProvider` via `ParsingOptions.FilterProvider`, capping cumulative decoded bytes at `ExtractionMaxDecodedBytes`. It **provably covers the object-stream (`/ObjStm`) path** and is retained as a depth layer for the paths it can see. It **does not cover the xref-stream path** (see Context) and must never be relied upon as the containment boundary. It carries open review findings (Flate corrupt-header bypass, LZW under-admission, unguarded RunLength) and is coupled to the containment redesign, so it lands **with** the ADR-0048 worker-process work on `#1379`, not in this permit-only PR. Its ObjStm coverage and the xref gap are pinned by the probe tests that remain on PR #1417 as evidence.
+
+3. **Containment boundary — deferred to ADR-0048.** The only mechanism that hard-bounds a single parse's peak memory across paths the process cannot see (xref streams included) is a process-level memory cap on a dedicated extraction worker. That is decided in ADR-0048.
+
+## Alternatives Considered
+
+- **Keep the draft's in-process `cap × ceiling` as the containment story.** Rejected: proven false for xref streams (Context). Shipping it as containment would be a dishonest guarantee.
+- **Raw-bytes bounded pre-inflate before `PdfDocument.Open`.** Rejected as *primary* containment (see ADR-0048): the tokenizer becomes a second PDF parser and is blocklist-shaped / tokenizer-evasion bypassable.
+- **Drop the provider ceiling entirely.** Rejected: it provably covers the ObjStm path at low cost and is worth keeping as depth once the real boundary (ADR-0048) exists. Dropping it would discard a working layer.
+- **Ship the permit gate and the decode ceiling together now.** Rejected: the decode ceiling has open HIGH findings and depends on the containment redesign; bundling would import unfixed findings into an otherwise-sound permit PR and block the sound half behind the parked half.
+
+## Consequences
+
+- The permit gate ships now: box-wide extraction CPU burn under a bomb flood is capped at `ExtractionMaxConcurrency` spinning threads, and abandoned-parse accumulation is bounded. `TooManyRequests` becomes a retryable outcome the future upload/worker caller must handle. `ExtractionMaxConcurrency` is a new startup-validated `Artefacts` setting.
+- **No decode-ceiling code, no `ExtractionMaxDecodedBytes` setting, and no `decoded-size-limit` warning code ship in this PR.** They land with ADR-0048's worker-process work. The `#1379` hard gate (no request/worker wiring until a real memory-containment boundary exists) still stands.
+- The record no longer claims a false containment bound. Future contributors reading this ADR learn the xref gap and where the evidence lives (PR #1417, comment `5007117851`) rather than inheriting the overclaim.
+- The permit gate is a process-wide singleton, so its bound is per-process; a multi-process deployment bounds each process independently — acceptable at current scale.
+- Ratification: ships **Accepted** on the coordinator's delegated authority (maintainer delegated the boundary choice 2026-07-18); the maintainer may revise.
+
+## References
+
+- PR `#1417` — the parked extraction-ceiling work; stop-gate adjudication comment `5007117851` (ObjStm-covered / xref-gap proof); the overclaiming draft `ADR-0047` lives only on its branch
+- Issue `#1379` — extraction resource ceiling (stays open for the containment work)
+- `#1369` — the wall-clock extraction budget this builds on
+- ADR-0048 — decompression-bomb containment boundary (memory-capped worker process)
+- ADR-0046 — the generalist artefact-intake wave whose extraction lane this hardens
+- PdfPig 0.1.15 `XrefStreamParser.TryReadStreamAtOffset`, `FirstPassParser.Parse`, `DefaultFilterProvider.Instance`, `ParsingOptions.FilterProvider`
+- `docs/platform/CONFIGURATION_REFERENCE.md` §Artefacts — `ExtractionMaxConcurrency`

--- a/docs/decisions/ADR-0047-artefact-extraction-resource-bounding.md
+++ b/docs/decisions/ADR-0047-artefact-extraction-resource-bounding.md
@@ -1,6 +1,6 @@
 # ADR-0047: Artefact-Extraction Resource Bounding — Permit Gate (Shipped) + Provider-Injection Decode Ceiling as Defense-in-Depth
 
-- Status: Accepted
+- Status: Accepted (under authority the maintainer delegated 2026-07-18; open to maintainer revision)
 - Date: 2026-07-18
 - Deciders: Overnight coordinator, on the boundary choice the maintainer delegated 2026-07-18; maintainer ratifies
 - Related: ADR-0048 (decompression-bomb containment boundary — the worker-process decision this defers hard memory containment to), ADR-0046 (generalist artefact intake — the wave this hardens), ADR-0044 (revival pivot / finite-work discipline), `#1379` (extraction resource ceiling), `#1369` (wall-clock extraction budget), PR `#1417` and its stop-gate adjudication (comment `5007117851`), `docs/platform/CONFIGURATION_REFERENCE.md` §Artefacts

--- a/docs/decisions/ADR-0048-decompression-bomb-containment-worker-process.md
+++ b/docs/decisions/ADR-0048-decompression-bomb-containment-worker-process.md
@@ -1,6 +1,6 @@
 # ADR-0048: Decompression-Bomb Containment Boundary — Memory-Capped Extraction Worker Process
 
-- Status: Accepted
+- Status: Accepted (under authority the maintainer delegated 2026-07-18; the reversal below remains open to maintainer revision)
 - Date: 2026-07-18
 - Deciders: Overnight coordinator, on the containment-boundary choice the maintainer explicitly delegated in the 2026-07-18 launch directive; the reversal below remains open to the maintainer
 - Related: ADR-0047 (artefact-extraction resource bounding — permit gate + provider-injection depth; this ADR is its deferred containment boundary), ADR-0046 (generalist artefact intake), ADR-0044 (revival pivot / finite-work discipline), `#1379` (extraction resource ceiling — stays open for this work), PR `#1417` stop-gate adjudication (comment `5007117851`)
@@ -28,6 +28,8 @@ The kill/timeout semantics reuse the existing abandonment vocabulary: a killed w
 
 ## Alternatives Considered
 
+The (a)/(c) letters track the option labels in the PR #1417 stop-gate adjudication (comment `5007117851`); **(b) — the memory-capped worker process — is the chosen option, recorded in the Decision above**, which is why it is not repeated as a rejected alternative here.
+
 - **(a) Raw-bytes bounded pre-inflate scan before `PdfDocument.Open`.** REJECTED as the primary boundary. To bound decode you must locate every stream and its filter chain, which means tokenizing PDF structure ahead of the real parser — a second, partial PDF parser. It is blocklist-shaped (enumerate known bomb vectors) and defeatable by tokenizer evasion (object-stream indirection, malformed-but-tolerated structure, filter aliasing) where the pre-scan and PdfPig disagree on what a stream is. Retained at most as an optional cheap in-process pre-filter, never as the guarantee.
 - **(c) Upstream PdfPig fix/fork** threading `ParsingOptions.FilterProvider` through `FirstPassParser`/`XrefStreamParser`. This is the cleanest long-term exit and is **pursued as the long-term fix**, but it is externally timed (upstream release cadence) and cannot gate this work. **The public disclosure/upstream-filing step is HUMAN-OWNED** — no upstream issue or PR is filed by an agent.
 - **In-process only (accept the xref gap).** Rejected: it would ship a known-unbounded memory path as if contained, exactly the overclaim ADR-0047 corrects.
@@ -39,7 +41,7 @@ The kill/timeout semantics reuse the existing abandonment vocabulary: a killed w
 - **Cost:** a process host (spawn, lifecycle/health/restart supervision, IPC contract for artefact bytes in and extraction result/warnings out) and cross-platform cap wiring across the desktop-exe and container run paths — the standing operational surface the draft wanted to avoid, now justified by the proven gap.
 - **Spawn latency:** each extraction pays worker start-up (or warm-pool checkout) cost; acceptable because extraction is already off the interactive path and rate-bounded by the permit gate.
 - **True hard memory guarantee:** the OS enforces the cap regardless of what the parser does internally, so a bomb on any path (xref included) is contained rather than merely detected.
-- **Delivery:** implementation is tracked as a `#1379` follow-up (see the seeded implementation issue). Config keys ship default-OFF; the acceptance bar includes a bomb-fixture test proving the cap kills the worker on both the Job Object and cgroup paths. The provider ceiling (ADR-0047 §2) and this boundary land together; the permit gate (ADR-0047 §1) is already independently merged.
+- **Delivery:** implementation is tracked as issue `#1429` (the seeded `#1379` follow-up). Config keys ship default-OFF; the acceptance bar includes a bomb-fixture test proving the cap kills the worker on both the Job Object and cgroup paths. The provider ceiling (ADR-0047 §2) and this boundary land together; the permit gate (ADR-0047 §1) is already independently merged.
 - **Ratification:** ships **Accepted** on the coordinator's delegated authority; the reversal and the boundary choice are surfaced for maintainer confirmation.
 
 ## References
@@ -47,5 +49,6 @@ The kill/timeout semantics reuse the existing abandonment vocabulary: a killed w
 - PR `#1417` stop-gate adjudication — comment `5007117851` (the `DefaultFilterProvider.Instance` proof; ObjStm-covered / xref-gapped)
 - ADR-0047 — permit gate (shipped) + provider-injection ceiling (depth); this ADR is its deferred containment boundary
 - Issue `#1379` — extraction resource ceiling (stays open); the memory-capped-worker implementation issue links here
+- Issue `#1429` — memory-capped extraction-worker implementation (the seeded `#1379` follow-up that delivers this decision)
 - PdfPig 0.1.15 `XrefStreamParser.TryReadStreamAtOffset`, `FirstPassParser.Parse`, `DefaultFilterProvider.Instance`
 - Windows Job Objects (`JOB_OBJECT_LIMIT_JOB_MEMORY`); Linux cgroup / container memory limits

--- a/docs/decisions/ADR-0048-decompression-bomb-containment-worker-process.md
+++ b/docs/decisions/ADR-0048-decompression-bomb-containment-worker-process.md
@@ -1,0 +1,51 @@
+# ADR-0048: Decompression-Bomb Containment Boundary — Memory-Capped Extraction Worker Process
+
+- Status: Accepted
+- Date: 2026-07-18
+- Deciders: Overnight coordinator, on the containment-boundary choice the maintainer explicitly delegated in the 2026-07-18 launch directive; the reversal below remains open to the maintainer
+- Related: ADR-0047 (artefact-extraction resource bounding — permit gate + provider-injection depth; this ADR is its deferred containment boundary), ADR-0046 (generalist artefact intake), ADR-0044 (revival pivot / finite-work discipline), `#1379` (extraction resource ceiling — stays open for this work), PR `#1417` stop-gate adjudication (comment `5007117851`)
+
+## Context
+
+Artefact text extraction must survive a decompression bomb — a PDF whose compressed streams (a few KiB) inflate to gigabytes during decode, exhausting host memory while staying under every input-byte cap.
+
+The `#1379` attempt to contain this in-process, by injecting a decoded-byte ceiling through PdfPig's `ParsingOptions.FilterProvider` (`BoundedFilterProvider`), was proven insufficient (PR #1417 stop-gate, comment `5007117851`, established two independent ways):
+
+- **Object streams (`/ObjStm`) are covered** by the injected provider.
+- **Cross-reference streams are NOT.** PdfPig 0.1.15's `XrefStreamParser.TryReadStreamAtOffset` decodes with a **hard-coded `DefaultFilterProvider.Instance`**, invoked from `FirstPassParser.Parse` **before** the wrapped provider is ever constructed. The injected ceiling structurally cannot reach that decode, so a single-filter FlateDecode xref stream inflates unbounded.
+
+No amount of filter cleverness closes a path the injection point cannot see. A hard, path-independent guarantee therefore cannot be delivered in-process on the pinned parser. Because the extraction service has no production caller yet (this is the wiring prerequisite), there is no current exposure — this decision fixes the boundary before wiring, not in response to an incident.
+
+## Decision
+
+**The containment boundary for decompression bombs is a process-level memory cap on a dedicated extraction worker process.** A parse that exceeds the cap is killed by the OS/runtime and reported as a content-free warning outcome (the same shape as the existing `extraction-timeout` row), never a host-wide OOM.
+
+- **Per-platform cap mechanism:** a Windows **Job Object** with `JOB_OBJECT_LIMIT_JOB_MEMORY` for the desktop/native run path; a **container/cgroup memory limit** for the Docker run path. The cap governs the whole worker process, which hosts exactly one parse at a time, so "process cap" equals "per-parse cap" by construction — covering xref streams and every other path the in-process ceiling cannot see.
+- **Provider-injection ceiling (ADR-0047 §2) is retained as defense-in-depth** for the paths it provably covers (ObjStm), giving an in-process early abort with a precise warning before the coarse process cap fires. It is not the boundary.
+- **The permit gate (ADR-0047 §1) is independent and already shipped.** It bounds concurrency and abandoned-thread accumulation; it composes with, but does not depend on, this boundary.
+
+The kill/timeout semantics reuse the existing abandonment vocabulary: a killed worker yields one immutable warning-bearing history row, no HTTP 500, artefact stays stored. Configuration keys for the worker path ship **default-OFF** until the mechanism is proven on both run paths.
+
+## Alternatives Considered
+
+- **(a) Raw-bytes bounded pre-inflate scan before `PdfDocument.Open`.** REJECTED as the primary boundary. To bound decode you must locate every stream and its filter chain, which means tokenizing PDF structure ahead of the real parser — a second, partial PDF parser. It is blocklist-shaped (enumerate known bomb vectors) and defeatable by tokenizer evasion (object-stream indirection, malformed-but-tolerated structure, filter aliasing) where the pre-scan and PdfPig disagree on what a stream is. Retained at most as an optional cheap in-process pre-filter, never as the guarantee.
+- **(c) Upstream PdfPig fix/fork** threading `ParsingOptions.FilterProvider` through `FirstPassParser`/`XrefStreamParser`. This is the cleanest long-term exit and is **pursued as the long-term fix**, but it is externally timed (upstream release cadence) and cannot gate this work. **The public disclosure/upstream-filing step is HUMAN-OWNED** — no upstream issue or PR is filed by an agent.
+- **In-process only (accept the xref gap).** Rejected: it would ship a known-unbounded memory path as if contained, exactly the overclaim ADR-0047 corrects.
+- **OS `ulimit`-style whole-host limit.** Rejected: coarse and host-wide — it cannot distinguish one bomb from legitimate concurrent load and would take the host down rather than record an honest per-artefact warning. A per-worker Job Object / cgroup scopes the cap to the single parse.
+
+## Consequences
+
+- **This explicitly REVERSES the earlier rejection of process isolation** (the unmerged ADR-0047 draft rejected an out-of-process parse "sidecar" as disproportionate for a local-first single-file app). The reversal is on **new evidence**: the hard-coded `DefaultFilterProvider.Instance` proof showed the in-process bound the draft relied on does not hold, removing the premise that made the sidecar unnecessary. Stating the reversal openly per ADR discipline. **The reversal remains open to the maintainer** — if the maintainer prefers to accept the xref gap or wait for the upstream fix instead, this ADR is revised.
+- **Cost:** a process host (spawn, lifecycle/health/restart supervision, IPC contract for artefact bytes in and extraction result/warnings out) and cross-platform cap wiring across the desktop-exe and container run paths — the standing operational surface the draft wanted to avoid, now justified by the proven gap.
+- **Spawn latency:** each extraction pays worker start-up (or warm-pool checkout) cost; acceptable because extraction is already off the interactive path and rate-bounded by the permit gate.
+- **True hard memory guarantee:** the OS enforces the cap regardless of what the parser does internally, so a bomb on any path (xref included) is contained rather than merely detected.
+- **Delivery:** implementation is tracked as a `#1379` follow-up (see the seeded implementation issue). Config keys ship default-OFF; the acceptance bar includes a bomb-fixture test proving the cap kills the worker on both the Job Object and cgroup paths. The provider ceiling (ADR-0047 §2) and this boundary land together; the permit gate (ADR-0047 §1) is already independently merged.
+- **Ratification:** ships **Accepted** on the coordinator's delegated authority; the reversal and the boundary choice are surfaced for maintainer confirmation.
+
+## References
+
+- PR `#1417` stop-gate adjudication — comment `5007117851` (the `DefaultFilterProvider.Instance` proof; ObjStm-covered / xref-gapped)
+- ADR-0047 — permit gate (shipped) + provider-injection ceiling (depth); this ADR is its deferred containment boundary
+- Issue `#1379` — extraction resource ceiling (stays open); the memory-capped-worker implementation issue links here
+- PdfPig 0.1.15 `XrefStreamParser.TryReadStreamAtOffset`, `FirstPassParser.Parse`, `DefaultFilterProvider.Instance`
+- Windows Job Objects (`JOB_OBJECT_LIMIT_JOB_MEMORY`); Linux cgroup / container memory limits

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -48,3 +48,5 @@
 | [0044](ADR-0044-revival-pivot-open-beta.md) | Revival Pivot — Open-Beta Distribution with a Commercial Horizon (Supersedes the Archive Pivot) | Accepted | 2026-07-10 |
 | [0045](ADR-0045-llm-transcript-triage-engine.md) | LLM Transcript Triage — Dedicated Worker Lane, Strategy-with-Fallback, Honest Provenance | Accepted | 2026-07-11 |
 | [0046](ADR-0046-generalist-expansion-single-app.md) | Generalist Expansion — Artefact Intake and Dossiers in the Single App (No Twin Fork) | Accepted | 2026-07-13 |
+| [0047](ADR-0047-artefact-extraction-resource-bounding.md) | Artefact-Extraction Resource Bounding — Permit Gate (Shipped) + Provider-Injection Decode Ceiling as Defense-in-Depth | Accepted | 2026-07-18 |
+| [0048](ADR-0048-decompression-bomb-containment-worker-process.md) | Decompression-Bomb Containment Boundary — Memory-Capped Extraction Worker Process | Accepted | 2026-07-18 |

--- a/docs/platform/CONFIGURATION_REFERENCE.md
+++ b/docs/platform/CONFIGURATION_REFERENCE.md
@@ -600,13 +600,20 @@ the blob table is queried only for explicit content retrieval and GDPR export.
 The storage limits are enforced from server configuration, never from multipart
 form fields. Concurrent uploads serialize the quota check with the SQLite write.
 `ExtractionTimeoutSeconds` additionally bounds the local text-extraction path so
-a crafted parser-bomb artefact cannot spin the parse thread indefinitely.
+a crafted parser-bomb artefact cannot spin the parse thread indefinitely, and
+`ExtractionMaxConcurrency` caps how many extraction parse workers (including
+runaway, already-abandoned ones) may run at once so box-wide CPU burn cannot
+accumulate without bound (see ADR-0047). Note: this permit gate bounds
+concurrency and abandoned-thread accumulation, not a single parse's peak memory;
+the decompression-bomb containment boundary for one parse is tracked separately
+(ADR-0048 / #1379).
 
 | Key | Type | Default | Description | Required? |
 | --- | --- | --- | --- | --- |
 | `Artefacts:MaxBytesPerArtefact` | `long` | `10485760` (10 MiB) | Maximum bytes accepted for one PNG, JPEG, WebP, PDF, TXT, or Markdown artefact. The upload stream stops and returns HTTP 413 once this bound is crossed. The API raises Kestrel's request-body ceiling to this value plus 128 KiB of bounded multipart overhead. This setting is capped at `int.MaxValue` because upload validation materializes one accepted artefact as a `byte[]` before the atomic SQLite write. Environment variable: `Artefacts__MaxBytesPerArtefact`. | No |
 | `Artefacts:MaxBytesPerUser` | `long` | `209715200` (200 MiB) | Aggregate source-artefact quota for one user, including blob bytes. Uploads that would cross it return HTTP 413. Environment variable: `Artefacts__MaxBytesPerUser`. | No |
 | `Artefacts:ExtractionTimeoutSeconds` | `double` | `30` | Wall-clock budget for a single local text extraction (PdfPig / plain-text / Markdown). The byte, page, and character caps bound the input and persisted output but not the parser's in-memory work; a crafted PDF (deeply nested object streams, decompression bombs) that stays under those caps can still spin PdfPig's synchronous `PdfDocument.Open(...)` arbitrarily long. When the budget is exceeded the extraction is abandoned and recorded as an immutable extraction-history row carrying the `extraction-timeout` warning (no HTTP 500; the artefact stays stored). Bounded to `[1, 3600]`; raise it toward the ceiling to effectively disable the budget. Environment variable: `Artefacts__ExtractionTimeoutSeconds`. | No |
+| `Artefacts:ExtractionMaxConcurrency` | `int` | `2` | Maximum number of extraction parse workers permitted to run at once, enforced by a process-wide permit gate (`ArtefactExtractionGate`). A parser-bomb PDF that never observes cancellation keeps a thread-pool thread at full CPU until PdfPig's synchronous parse finishes — only the request is bounded by `ExtractionTimeoutSeconds`, not the abandoned thread — and the permit is held for that thread's full lifetime, not just the request's. Once the permits are exhausted (including by abandoned bombs still spinning), further extractions are rejected pre-parse with `TooManyRequests` and write no extraction-history row, so box-wide CPU burn is capped at this many spinning threads. Rejection, not queueing: a queue in front of held permits would be a second unbounded backlog. This bounds concurrency and abandoned-thread accumulation; it does not bound one parse's peak decoded memory (ADR-0048 / #1379). Bounded to `[1, 64]`. Environment variable: `Artefacts__ExtractionMaxConcurrency`. | No |
 
 ### `FirstRun`
 


### PR DESCRIPTION
## What

Splits the **verified-sound permit/concurrency half** out of the parked #1417 (`issue-1379/extraction-resource-ceiling`) into its own PR so the safe half can land while the decompression-bomb containment work is redesigned.

Refs #1379 (stays open — this carries only the concurrency half; the containment work continues under #1429). Does **not** close #1379.

## Why (the split)

#1417 mixed two things:

1. A **permit/concurrency gate** — sound, verified by two independent review lenses (exactly-once release across completed/abandoned paths, gate singleton + settings parity, `TooManyRequests` rejection with no history row). Orthogonal to any containment choice.
2. A **provider-injection decode ceiling** for decompression bombs — proven insufficient: PdfPig 0.1.15's `XrefStreamParser.TryReadStreamAtOffset` decodes with a hard-coded `DefaultFilterProvider.Instance` before any injected `ParsingOptions.FilterProvider` exists, so xref-stream bombs bypass the ceiling entirely (PR #1417 stop-gate, comment 5007117851; proven by probe tests + source read).

This PR takes **only (1)**, plus two ADRs that record the honest picture and the containment boundary decision.

## What ships here

- **`ArtefactExtractionGate`** (Application singleton) + service wiring: a non-blocking permit taken before the parse worker spawns; released in the `finally` on completed paths and in the worker-completion continuation on abandoned paths, so a runaway parse holds its permit for its full lifetime. Saturation ⇒ pre-parse `TooManyRequests`, no history row, no new thread.
- **`ExtractionMaxConcurrency`** setting (`int`, default 2, `[Range(1, 64)]`), startup-validated, registered as a process-wide singleton, documented in `CONFIGURATION_REFERENCE.md`.
- **Tests:** `ArtefactExtractionGateTests` (2 mechanism-based concurrency tests — abandoned-permit-hold + saturation cap, no sleeps) and `ExtractionMaxConcurrency` validation cases in `OptionsValidationTests`.
- **ADR-0047** — Artefact-Extraction Resource Bounding: permit gate (shipped here) + provider-injection ceiling as ObjStm-covering **defense-in-depth** with the documented xref gap and evidence pointer. Supersedes the overclaiming ADR-0047 draft that lives only on the #1417 branch (took the same number since that draft never merged).
- **ADR-0048** — Decompression-Bomb Containment Boundary: **memory-capped extraction worker process** (Job Object on Windows / cgroup under Docker). Explicitly reverses the earlier sidecar rejection on the new hard-coded-provider evidence (reversal open to the maintainer). Accepted on the coordinator's delegated authority (maintainer delegated the boundary choice 2026-07-18).

## What is deliberately NOT here

- `BoundedFilterProvider`, `ExtractionMaxDecodedBytes`, the `decoded-size-limit` warning code, and the decompression bomb tests — they carry open HIGH findings and depend on the containment redesign; they land with the worker-process work (#1429).
- The xref-bypass **probe evidence tests** stay on #1417 as the proof record.

## Verification

- `dotnet build backend/Taskdeck.sln -c Release` — clean.
- `ArtefactExtractionGateTests` — 2/2 passed.
- `OptionsValidationTests` + `ArtefactExtraction*` (Api.Tests) — 141/141 passed.
- No decompression/containment references leaked into the diff (grep-verified: no `ExtractionMaxDecodedBytes` / `DecodedSizeLimit` / `BoundedFilterProvider`).

## Follow-up

- #1429 — memory-capped extraction worker process (the ADR-0048 containment boundary; carries the provider depth ceiling with its findings fixed).

## Links

- #1379 (open) · #1417 (parked, adjudication 5007117851) · #1429 (containment follow-up) · ADR-0047 · ADR-0048
