### PR TITLE
Harden ValidatePermissionsAsync empty-op short-circuit to always gate board access (#1426)

### DIFF
--- a/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
@@ -81,7 +81,8 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
 
     public async Task<Result> ValidatePermissionsAsync(Guid userId, Guid? boardId, IEnumerable<ProposalOperationDto> operations, CancellationToken cancellationToken = default)
     {
-        var opList = operations.ToList();
+        if (operations is null)
+            return Result.Failure(ErrorCodes.ValidationError, "Operations cannot be null");
 
         // The full requester/board access gate ALWAYS runs — including for an empty operation
         // list. Only the per-operation contract checks are operation-dependent; requester
@@ -101,6 +102,9 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
         if (!accessValidation.IsSuccess)
             return accessValidation;
 
+        // Materialize only after the access gate passes — the per-operation contract validator
+        // below is the sole consumer of the list, so a failed access check pays no allocation.
+        var opList = operations.ToList();
         if (opList.Count == 0)
             return Result.Success();
 

--- a/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationPolicyEngine.cs
@@ -83,14 +83,20 @@ public class AutomationPolicyEngine : IAutomationPolicyEngine
     {
         var opList = operations.ToList();
 
-        // The requester half of the shared access gate always runs; the board half applies only
-        // when the proposal carries operations, preserving the long-standing empty-operations
-        // short-circuit (empty → requester checks, then Success, board untouched). Callers that
-        // must gate board access for an operation-less proposal (the terminal stored-preview
-        // read, #1415) call ValidateBoardAccessAsync directly with the boardId.
+        // The full requester/board access gate ALWAYS runs — including for an empty operation
+        // list. Only the per-operation contract checks are operation-dependent; requester
+        // existence and board access are not, so an operation-less proposal must be gated on the
+        // board it targets exactly like an operation-bearing one. Emptiness itself is NOT rejected
+        // here: it is a legitimate transient shape (a proposal may be created empty and revised
+        // into validity, pinned by #1423), and the "nothing to apply" rejection belongs to the
+        // structure gate (ValidateOperationStructure / ProposalOperationStructureValidator), which
+        // runs BEFORE this method in every approve/apply/diff chain. Previously an empty list
+        // short-circuited to Success with the board half skipped (boardId forced to null), which
+        // silently treated an operation-less proposal as permitted and forced every new consumer
+        // to bolt on its own board-access fallback (the #1415/#1425 trap this hardens away, #1426).
         var accessValidation = await ValidateBoardAccessAsync(
             userId,
-            opList.Count > 0 ? boardId : null,
+            boardId,
             cancellationToken);
         if (!accessValidation.IsSuccess)
             return accessValidation;

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -597,9 +597,10 @@ public class AutomationProposalService : IAutomationProposalService
         // intentionally NOT run: they no longer apply to a completed proposal, and re-validating
         // a historical preview against LIVE board state would wrongly deny it whenever a
         // referenced card/column/label was later deleted — or always, for an Applied create-card
-        // whose TargetId now resolves. Calling ValidateBoardAccessAsync directly also covers
-        // operation-less proposals uniformly, which the full gate's empty-operations
-        // short-circuit would skip.
+        // whose TargetId now resolves. This path calls ValidateBoardAccessAsync directly (rather
+        // than ValidatePermissionsAsync) precisely to skip that operation-contract validation;
+        // both surface the identical access codes/messages for operation-less proposals now that
+        // ValidatePermissionsAsync no longer short-circuits the board half on an empty list (#1426).
         var accessValidation = await _policyEngine.ValidateBoardAccessAsync(
             proposal.RequestedByUserId,
             proposal.BoardId,

--- a/backend/src/Taskdeck.Application/Services/IAutomationPolicyEngine.cs
+++ b/backend/src/Taskdeck.Application/Services/IAutomationPolicyEngine.cs
@@ -20,6 +20,15 @@ public interface IAutomationPolicyEngine
     /// </summary>
     Task<Result> ValidateBoardAccessAsync(Guid requesterUserId, Guid? boardId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Composes <see cref="ValidateBoardAccessAsync"/> (requester + board access) with the
+    /// per-operation contract validator. The access gate runs for EVERY operation list, empty
+    /// or not — only the per-operation contract checks are skipped when there are no operations,
+    /// so an operation-less proposal is still board-access-gated (no empty-list short-circuit to
+    /// Success with the board half skipped, #1426). Emptiness is not rejected here; the "at least
+    /// one operation" structure gate (<see cref="ValidateOperationStructure"/>) owns that and runs
+    /// before this method in every approve/apply/diff chain.
+    /// </summary>
     Task<Result> ValidatePermissionsAsync(Guid userId, Guid? boardId, IEnumerable<ProposalOperationDto> operations, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationPolicyEngineTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationPolicyEngineTests.cs
@@ -336,6 +336,25 @@ public class AutomationPolicyEngineTests
     }
 
     [Fact]
+    public async Task ValidatePermissions_ShouldReturnNotFound_ForEmptyOperations_WhenRequesterMissing()
+    {
+        // Arrange: the requester-existence half of the gate must also run for an empty op list
+        // with a set boardId (the board-scoped path), not just the null-board path.
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var operations = new List<ProposalOperationDto>();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync((User?)null);
+
+        // Act
+        var result = await _engine.ValidatePermissionsAsync(userId, boardId, operations);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
     public async Task ValidatePermissions_ShouldReturnForbidden_ForEmptyOperations_WhenBoardAccessDenied()
     {
         // Arrange

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationPolicyEngineTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationPolicyEngineTests.cs
@@ -309,6 +309,80 @@ public class AutomationPolicyEngineTests
         result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
     }
 
+    // #1426: the empty-operations case must run the FULL requester/board access gate — only the
+    // per-operation contract checks are operation-dependent. The three tests below pin that an
+    // operation-less proposal is gated on board existence and board access exactly like an
+    // operation-bearing one; previously the empty-list short-circuit returned Success with the
+    // board half skipped (the trap that forced every new consumer to add a manual fallback).
+
+    [Fact]
+    public async Task ValidatePermissions_ShouldReturnNotFound_ForEmptyOperations_WhenBoardMissing()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", "hashedPassword");
+        var operations = new List<ProposalOperationDto>();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(user);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync((Board?)null);
+
+        // Act
+        var result = await _engine.ValidatePermissionsAsync(userId, boardId, operations);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.NotFound);
+    }
+
+    [Fact]
+    public async Task ValidatePermissions_ShouldReturnForbidden_ForEmptyOperations_WhenBoardAccessDenied()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", "hashedPassword");
+        var board = TestDataBuilder.CreateBoard();
+        var operations = new List<ProposalOperationDto>();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(user);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, userId, It.IsAny<Taskdeck.Domain.Enums.UserRole?>(), default))
+            .ReturnsAsync(false);
+
+        // Act
+        var result = await _engine.ValidatePermissionsAsync(userId, boardId, operations);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+    }
+
+    [Fact]
+    public async Task ValidatePermissions_ShouldReturnSuccess_ForEmptyOperations_WhenBoardAccessGranted()
+    {
+        // Arrange: empty op list with a board the requester can access — the access gate passes
+        // and the per-operation contract validator is (correctly) skipped, so the result is Success.
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var user = new User("testuser", "test@example.com", "hashedPassword");
+        var board = TestDataBuilder.CreateBoard();
+        var operations = new List<ProposalOperationDto>();
+
+        _userRepoMock.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(user);
+        _boardRepoMock.Setup(r => r.GetByIdAsync(boardId, default)).ReturnsAsync(board);
+        _boardAccessRepoMock
+            .Setup(r => r.HasAccessAsync(boardId, userId, It.IsAny<Taskdeck.Domain.Enums.UserRole?>(), default))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _engine.ValidatePermissionsAsync(userId, boardId, operations);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
     #endregion
 
     #region ValidatePolicy Tests

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationPolicyEngineTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationPolicyEngineTests.cs
@@ -336,6 +336,21 @@ public class AutomationPolicyEngineTests
     }
 
     [Fact]
+    public async Task ValidatePermissions_ShouldReturnValidationError_ForNullOperations()
+    {
+        // Arrange: a null operations argument is guarded before any work, returning the method's
+        // own ValidationError rather than throwing ArgumentNullException from ToList().
+        var userId = Guid.NewGuid();
+
+        // Act
+        var result = await _engine.ValidatePermissionsAsync(userId, null, null!);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+    }
+
+    [Fact]
     public async Task ValidatePermissions_ShouldReturnNotFound_ForEmptyOperations_WhenRequesterMissing()
     {
         // Arrange: the requester-existence half of the gate must also run for an empty op list


### PR DESCRIPTION
Closes #1426

## Decision context (maintainer Q3, final)

#1426 framed a choice for the root of the zero-op defense sprawl:

1. **Forbid zero-op proposals at create** — simplest invariant, but it forecloses the
   **create-empty-then-revise-into-validity** flow that merged PR #1423 explicitly pinned at
   approve time. Rejected: it would break a flow the revision system supports and the approve
   tests now pin.
2. **Harden `ValidatePermissionsAsync`'s empty-list short-circuit** so the requester/board access
   gate runs for every operation list — only the per-operation contract checks are
   operation-dependent. Chosen (this PR).

## What changed

`AutomationPolicyEngine.ValidatePermissionsAsync` previously short-circuited an empty operation
list to `Result.Success()` with the **board half of the access gate skipped** (`boardId` forced to
`null`). That silently treated an operation-less proposal as permitted and forced every new
consumer to bolt on its own board-access fallback — the #1415/#1425 trap (the MCP `proposal_detail`
surface had to add an explicit `ValidateBoardAccessAsync` call because of exactly this).

Now the full requester/board access gate always runs; only the per-operation contract validator is
skipped when the list is empty. **Emptiness itself is not rejected here by design** — it is a
legitimate transient shape (revise-into-validity, #1423). The "at least one operation" rejection
belongs to the structure gate (`ProposalOperationStructureValidator` / `ValidateOperationStructure`),
which runs **before** `ValidatePermissionsAsync` in every approve/apply/diff/executor chain.

## Why the approve==apply contract is unchanged

For a **non-empty** list the new `ValidateBoardAccessAsync(userId, boardId, …)` call is
byte-for-byte identical to the old `opList.Count > 0 ? boardId : null` (both yield `boardId`). For
an **empty** list, the structure gate rejects it (400 "at least one operation") before permissions
is ever reached in approve (`AutomationProposalService` line 269 → 275), both diff paths (499→514,
545→563), and the executor (`ValidatePolicy` → `ValidatePermissionsAsync`). So this hardening cannot
change what approve/apply/diff accept or reject — it only closes the trap for direct/future callers.
The terminal stored-preview path (#1415) still calls `ValidateBoardAccessAsync` directly (to skip
the op-contract validator); its comment is updated to reflect the removed short-circuit.

## Tests

- `AutomationPolicyEngineTests` (+4): empty ops + set board → {missing board → NotFound, missing
  requester → NotFound, access denied → Forbidden, access granted → Success}. These pin that an
  operation-less proposal is gated exactly like an operation-bearing one (previously all returned
  Success). Existing empty-ops + null-board → Success case is unchanged.
- Targeted: `AutomationPolicyEngineTests` 30/0, Application targeted (policy + proposal service +
  executor) 129/0, `Taskdeck.Api.Tests` `ProposalRevisionApiTests` + `AutomationProposal*` 99/0.

## Review

Two independent read-only reviewers (correctness vs approve==apply + revise-into-validity;
security/bypass + coverage). Correctness: zero findings, ordering claim verified at every caller.
Security: no CRITICAL/HIGH/MEDIUM, no bypass or new cross-user existence leak (the change is strictly
additive restriction — it can only turn a previously-Success empty-op result into a denial, never the
reverse). Two LOW coverage findings adjudicated: L2 (requester-existence permutation) fixed via the
added missing-requester test; L1 (caller-level end-to-end pin) addressed — the caller unit tests mock
`IAutomationPolicyEngine` so cannot exercise the gate; the hardening is pinned at the single engine
seam (the consolidation this issue is about) with caller propagation already covered by
`CaptureTriageServiceTests` line 408.
