### PR TITLE
Pin the approved revision at approve time; Apply executes exactly it (#1428, #1424)

### DIFF
--- a/backend/src/Taskdeck.Application/DTOs/AutomationProposalDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/AutomationProposalDtos.cs
@@ -40,8 +40,13 @@ public record ProposalDto(
 
     /// <summary>
     /// The revision pinned at approve time that Apply will materialize (#1428), or <c>null</c>
-    /// when the proposal was approved from its original operations (or is not yet decided). When
-    /// set, <see cref="Operations"/> reflects that pinned revision's effective operation set.
+    /// when the proposal was approved from its original operations (or is not yet decided).
+    /// On SINGLE-proposal responses (get by id, approve, reject), a set pin also means
+    /// <see cref="Operations"/> and <see cref="Presentation"/> carry that pinned revision's
+    /// effective operation set. LIST items expose the pin but deliberately map the ORIGINAL
+    /// operations (no per-item revision lookup, avoiding an N+1 query); clients needing the
+    /// effective set for a listed proposal should use the single-proposal read or the diff
+    /// endpoint.
     /// </summary>
     public Guid? ApprovedRevisionId { get; init; }
 }

--- a/backend/src/Taskdeck.Application/DTOs/AutomationProposalDtos.cs
+++ b/backend/src/Taskdeck.Application/DTOs/AutomationProposalDtos.cs
@@ -37,6 +37,13 @@ public record ProposalDto(
     /// client clock can resurface it in-session and a re-snooze toast can confirm the new window.
     /// </summary>
     public DateTime? DeferredUntil { get; init; }
+
+    /// <summary>
+    /// The revision pinned at approve time that Apply will materialize (#1428), or <c>null</c>
+    /// when the proposal was approved from its original operations (or is not yet decided). When
+    /// set, <see cref="Operations"/> reflects that pinned revision's effective operation set.
+    /// </summary>
+    public Guid? ApprovedRevisionId { get; init; }
 }
 
 public record ProposalPresentationDto(

--- a/backend/src/Taskdeck.Application/Services/AutomationExecutorService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationExecutorService.cs
@@ -242,15 +242,29 @@ public class AutomationExecutorService : IAutomationExecutorService
         ProposalDto proposal,
         CancellationToken cancellationToken)
     {
-        var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(
-            proposal.Id,
-            cancellationToken);
-        if (latestRevision is null)
+        // Apply materializes exactly the revision pinned at approve time (#1428), NOT the latest
+        // one. A null pin means the proposal was approved from its original operations, so a
+        // revision saved after approval — including one that landed in the race window between
+        // approve's validation read and its commit — cannot change what Apply executes.
+        if (proposal.ApprovedRevisionId is not Guid approvedRevisionId)
             return Result.Success(proposal);
+
+        var pinnedRevision = await _unitOfWork.ProposalRevisions.GetByIdAsync(
+            approvedRevisionId,
+            cancellationToken);
+        if (pinnedRevision is null)
+        {
+            // The pinned revision is cascade-owned by the proposal, so it can only vanish together
+            // with the proposal itself — this branch is unreachable in practice. Refuse to apply
+            // rather than silently fall back to the (unapproved) original operations.
+            return Result.Failure<ProposalDto>(
+                ErrorCodes.NotFound,
+                $"Approved revision {approvedRevisionId} for proposal {proposal.Id} was not found");
+        }
 
         if (!ProposalRevisionPayload.TryParseOperations(
                 proposal.Id,
-                latestRevision.RevisedPayload,
+                pinnedRevision.RevisedPayload,
                 out var revisedOperations,
                 out var errorMessage))
         {

--- a/backend/src/Taskdeck.Application/Services/AutomationExecutorService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationExecutorService.cs
@@ -256,10 +256,13 @@ public class AutomationExecutorService : IAutomationExecutorService
         {
             // The pinned revision is cascade-owned by the proposal, so it can only vanish together
             // with the proposal itself — this branch is unreachable in practice. Refuse to apply
-            // rather than silently fall back to the (unapproved) original operations.
+            // rather than silently fall back to the (unapproved) original operations. Shaped as
+            // InvalidOperation (server invariant violation), NOT NotFound: the proposal being
+            // executed exists, and a NotFound here would misread as "proposal not found".
             return Result.Failure<ProposalDto>(
-                ErrorCodes.NotFound,
-                $"Approved revision {approvedRevisionId} for proposal {proposal.Id} was not found");
+                ErrorCodes.InvalidOperation,
+                $"Server invariant violation: proposal {proposal.Id} pins approved revision " +
+                $"{approvedRevisionId}, but that revision no longer exists; refusing to apply");
         }
 
         if (!ProposalRevisionPayload.TryParseOperations(

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -263,6 +263,11 @@ public class AutomationProposalService : IAutomationProposalService
             // approve proposal in status X"), which this slice leaves untouched — running these
             // gates on a terminal proposal would wrongly report a 400/403/404 in place of that 409.
             Guid? approvedRevisionId = null;
+            // Hoisted so the success-path DTO build can reuse the exact revision read here (the
+            // pinned one) instead of re-querying it (Gemini review, #1439). Null when the proposal
+            // is not PendingReview — but the domain guard in Approve throws for any other status
+            // before that DTO is built, so the reused value is always the pinned revision.
+            ProposalRevision? latestRevision = null;
             if (proposal.Status == ProposalStatus.PendingReview)
             {
                 // Read the latest revision NOW and pin its id onto the proposal (#1428): approve
@@ -270,7 +275,7 @@ public class AutomationProposalService : IAutomationProposalService
                 // later — even one landing in the race window between this read and approve's
                 // commit — can no longer change what Apply executes. A null id approves the
                 // original operations, and Apply then ignores any post-approval revision entirely.
-                var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
+                latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
                 approvedRevisionId = latestRevision?.Id;
 
                 var effectiveOperations = ResolveEffectiveGateOperations(proposal, latestRevision);
@@ -301,7 +306,9 @@ public class AutomationProposalService : IAutomationProposalService
                 return Result.Failure<ProposalDto>(notifyResult.ErrorCode, notifyResult.ErrorMessage);
 
             // Echo the effective (pinned) operations Apply will run, not the stale originals (#1424).
-            return await BuildEffectiveProposalDtoAsync(proposal, cancellationToken);
+            // latestRevision IS the pinned revision (its id was stored as ApprovedRevisionId), so map
+            // the DTO from it directly rather than re-reading it via GetEffectiveRevisionAsync.
+            return BuildEffectiveProposalDto(proposal, latestRevision);
         }
         catch (DomainException ex)
         {
@@ -349,12 +356,15 @@ public class AutomationProposalService : IAutomationProposalService
     /// <summary>
     /// Resolves the revision whose operations are the EFFECTIVE set for a proposal — the one Apply
     /// will materialize — so the diff preview and the decided-proposal response DTOs agree with
-    /// Apply (preview == apply / approve == apply). A decided proposal returns its pinned
-    /// <see cref="AutomationProposal.ApprovedRevisionId"/> revision (#1428); a proposal approved
-    /// from its original operations (null pin) returns null so the original set is used, ignoring
-    /// any revision that raced in after approval; a still-pending or rejected proposal returns the
-    /// latest saved revision (what the reviewer sees, and what approve would pin). Returns null
-    /// when no revision applies, meaning "use the proposal's original operations".
+    /// Apply (preview == apply / approve == apply). A decided proposal with a pinned
+    /// <see cref="AutomationProposal.ApprovedRevisionId"/> returns that revision (#1428); an
+    /// Approved proposal with a null pin returns null so the original set is used, ignoring any
+    /// revision that raced in after approval. A still-pending proposal returns the unconditional
+    /// latest saved revision (what the reviewer sees, and what approve would pin). A Rejected
+    /// proposal is FROZEN at its decision time: it returns the latest revision saved at or before
+    /// <see cref="AutomationProposal.DecidedAt"/>, so a revision that raced in AFTER rejection can
+    /// never surface in the reject/GET/diff response (Codex review, #1439). Returns null when no
+    /// revision applies, meaning "use the proposal's original operations".
     /// </summary>
     private async Task<ProposalRevision?> GetEffectiveRevisionAsync(
         AutomationProposal proposal,
@@ -363,8 +373,26 @@ public class AutomationProposalService : IAutomationProposalService
         if (proposal.ApprovedRevisionId is Guid approvedRevisionId)
             return await _unitOfWork.ProposalRevisions.GetByIdAsync(approvedRevisionId, cancellationToken);
 
-        if (proposal.Status is ProposalStatus.PendingReview or ProposalStatus.Rejected)
+        if (proposal.Status is ProposalStatus.PendingReview)
             return await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
+
+        if (proposal.Status is ProposalStatus.Rejected)
+        {
+            // Freeze the rejected proposal at decision time. DecidedAt is always set by Reject, but
+            // treat a null defensively as "no cutoff" and fall back to the unconditional latest.
+            if (proposal.DecidedAt is not DateTime decidedAt)
+                return await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
+
+            // Filter in memory (revision lists are small) rather than relying on EF's SQLite
+            // provider to translate a DateTimeOffset-vs-DateTime comparison. RevisedAt is a
+            // DateTimeOffset in UTC; compare its UtcDateTime against the UTC DecidedAt.
+            var revisions = await _unitOfWork.ProposalRevisions.GetByProposalIdAsync(proposal.Id, cancellationToken);
+            return revisions
+                .Where(r => r.RevisedAt.UtcDateTime <= decidedAt)
+                .OrderByDescending(r => r.RevisedAt)
+                .ThenByDescending(r => r.RevisionNumber)
+                .FirstOrDefault();
+        }
 
         return null;
     }
@@ -384,9 +412,25 @@ public class AutomationProposalService : IAutomationProposalService
         AutomationProposal proposal,
         CancellationToken cancellationToken)
     {
+        var effectiveRevision = await GetEffectiveRevisionAsync(proposal, cancellationToken);
+        return BuildEffectiveProposalDto(proposal, effectiveRevision);
+    }
+
+    /// <summary>
+    /// Synchronous core of <see cref="BuildEffectiveProposalDtoAsync"/>: maps the proposal to its
+    /// response DTO, rebuilding <see cref="ProposalDto.Operations"/> and
+    /// <see cref="ProposalDto.Presentation"/> together from the supplied EFFECTIVE revision (or the
+    /// originals when it is null). Split out so callers that have ALREADY read the effective
+    /// revision — <see cref="ApproveProposalAsync"/> passes the latest revision it read to pin as
+    /// <see cref="AutomationProposal.ApprovedRevisionId"/> — can build the DTO without a redundant
+    /// re-query (Gemini review, #1439).
+    /// </summary>
+    private static Result<ProposalDto> BuildEffectiveProposalDto(
+        AutomationProposal proposal,
+        ProposalRevision? effectiveRevision)
+    {
         var dto = MapToDto(proposal);
 
-        var effectiveRevision = await GetEffectiveRevisionAsync(proposal, cancellationToken);
         if (effectiveRevision is null)
             return Result.Success(dto);
 
@@ -690,6 +734,19 @@ public class AutomationProposalService : IAutomationProposalService
             cancellationToken);
         if (!accessValidation.IsSuccess)
             return Result.Failure<string>(accessValidation.ErrorCode, accessValidation.ErrorMessage);
+
+        // Suppress the stored preview when an effective revision applies to this proposal (a pinned
+        // ApprovedRevisionId, or the decision-time-frozen revision for a rejected one). The stored
+        // DiffPreview is built from the proposal's ORIGINAL operations, so serving it next to a
+        // revision-derived operation set would let a single MCP proposal_detail payload carry two
+        // disagreeing views of the same change (Codex review, #1439). Returning null omits the
+        // field, matching the never-stored shape. Production never persists DiffPreview today (the
+        // V1 generator that wrote it was removed in #1214), so this is a consistency guard for
+        // legacy/test data; a terminal proposal WITHOUT a revision still serves its stored preview
+        // exactly as before (the #1397 decision is unchanged).
+        var effectiveRevision = await GetEffectiveRevisionAsync(proposal, cancellationToken);
+        if (effectiveRevision is not null)
+            return Result.Success<string>(null!);
 
         // A never-stored preview passes through as null (never coerced to ""), so callers can
         // distinguish never-stored from stored-but-empty. Under the MCP resource serializer's

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -174,7 +174,9 @@ public class AutomationProposalService : IAutomationProposalService
         if (proposal == null)
             return Result.Failure<ProposalDto>(ErrorCodes.NotFound, $"Proposal with ID {id} not found");
 
-        return Result.Success(MapToDto(proposal));
+        // Surface the EFFECTIVE operation set (pinned/latest revision when one applies, else the
+        // originals) so a revised proposal no longer echoes stale original operations (#1424).
+        return await BuildEffectiveProposalDtoAsync(proposal, cancellationToken);
     }
 
     public async Task<Result<IEnumerable<ProposalDto>>> GetProposalsAsync(ProposalFilterDto? filter = null, CancellationToken cancellationToken = default)
@@ -260,9 +262,18 @@ public class AutomationProposalService : IAutomationProposalService
             // domain transition's terminal-status short-circuit owns the response (409 "Cannot
             // approve proposal in status X"), which this slice leaves untouched — running these
             // gates on a terminal proposal would wrongly report a 400/403/404 in place of that 409.
+            Guid? approvedRevisionId = null;
             if (proposal.Status == ProposalStatus.PendingReview)
             {
-                var effectiveOperations = await ResolveEffectiveOperationsAsync(proposal, cancellationToken);
+                // Read the latest revision NOW and pin its id onto the proposal (#1428): approve
+                // validates this exact revision and Apply materializes it, so a revision saved
+                // later — even one landing in the race window between this read and approve's
+                // commit — can no longer change what Apply executes. A null id approves the
+                // original operations, and Apply then ignores any post-approval revision entirely.
+                var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
+                approvedRevisionId = latestRevision?.Id;
+
+                var effectiveOperations = ResolveEffectiveGateOperations(proposal, latestRevision);
                 if (!effectiveOperations.IsSuccess)
                     return Result.Failure<ProposalDto>(effectiveOperations.ErrorCode, effectiveOperations.ErrorMessage);
 
@@ -282,14 +293,15 @@ public class AutomationProposalService : IAutomationProposalService
                 }
             }
 
-            proposal.Approve(decidedByUserId);
+            proposal.Approve(decidedByUserId, approvedRevisionId);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
 
             var notifyResult = await PublishProposalOutcomeNotificationAsync(proposal, "approved", cancellationToken);
             if (!notifyResult.IsSuccess)
                 return Result.Failure<ProposalDto>(notifyResult.ErrorCode, notifyResult.ErrorMessage);
 
-            return Result.Success(MapToDto(proposal));
+            // Echo the effective (pinned) operations Apply will run, not the stale originals (#1424).
+            return await BuildEffectiveProposalDtoAsync(proposal, cancellationToken);
         }
         catch (DomainException ex)
         {
@@ -299,19 +311,20 @@ public class AutomationProposalService : IAutomationProposalService
 
     /// <summary>
     /// Resolves the effective operation set Apply will execute, for the approve-time structure
-    /// and permission/contract gates — the latest saved <see cref="ProposalRevision"/> when one exists (mirroring
-    /// <c>AutomationExecutorService.MaterializeEffectiveProposalAsync</c> and the revision-aware
-    /// <see cref="GetProposalDiffAsync"/> path), otherwise the proposal's original operations —
-    /// so approve validates exactly what Apply will run (#1416 approve == apply). A revision is
-    /// structure-validated at save time, so the parse-failure branch is defensive: if the
-    /// effective payload cannot be materialized, Apply would fail the same way, so surface the
-    /// identical <see cref="ErrorCodes.ValidationError"/>.
+    /// and permission/contract gates — the supplied latest saved <see cref="ProposalRevision"/>
+    /// when one exists (mirroring <c>AutomationExecutorService.MaterializeEffectiveProposalAsync</c>
+    /// and the revision-aware <see cref="GetProposalDiffAsync"/> path), otherwise the proposal's
+    /// original operations — so approve validates exactly what Apply will run (#1416 approve ==
+    /// apply). The revision is passed in (already read in <see cref="ApproveProposalAsync"/> so its
+    /// id can be pinned as <see cref="AutomationProposal.ApprovedRevisionId"/>) to avoid a second
+    /// query. A revision is structure-validated at save time, so the parse-failure branch is
+    /// defensive: if the effective payload cannot be materialized, Apply would fail the same way,
+    /// so surface the identical <see cref="ErrorCodes.ValidationError"/>.
     /// </summary>
-    private async Task<Result<IReadOnlyCollection<ProposalOperationDto>>> ResolveEffectiveOperationsAsync(
+    private Result<IReadOnlyCollection<ProposalOperationDto>> ResolveEffectiveGateOperations(
         AutomationProposal proposal,
-        CancellationToken cancellationToken)
+        ProposalRevision? latestRevision)
     {
-        var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
         if (latestRevision is not null)
         {
             if (!ProposalRevisionPayload.TryParseOperations(
@@ -333,6 +346,61 @@ public class AutomationProposalService : IAutomationProposalService
         return Result.Success<IReadOnlyCollection<ProposalOperationDto>>(originalOperations);
     }
 
+    /// <summary>
+    /// Resolves the revision whose operations are the EFFECTIVE set for a proposal — the one Apply
+    /// will materialize — so the diff preview and the decided-proposal response DTOs agree with
+    /// Apply (preview == apply / approve == apply). A decided proposal returns its pinned
+    /// <see cref="AutomationProposal.ApprovedRevisionId"/> revision (#1428); a proposal approved
+    /// from its original operations (null pin) returns null so the original set is used, ignoring
+    /// any revision that raced in after approval; a still-pending or rejected proposal returns the
+    /// latest saved revision (what the reviewer sees, and what approve would pin). Returns null
+    /// when no revision applies, meaning "use the proposal's original operations".
+    /// </summary>
+    private async Task<ProposalRevision?> GetEffectiveRevisionAsync(
+        AutomationProposal proposal,
+        CancellationToken cancellationToken)
+    {
+        if (proposal.ApprovedRevisionId is Guid approvedRevisionId)
+            return await _unitOfWork.ProposalRevisions.GetByIdAsync(approvedRevisionId, cancellationToken);
+
+        if (proposal.Status is ProposalStatus.PendingReview or ProposalStatus.Rejected)
+            return await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(proposal.Id, cancellationToken);
+
+        return null;
+    }
+
+    /// <summary>
+    /// Maps a proposal to its response DTO with <see cref="ProposalDto.Operations"/> materialized
+    /// to the EFFECTIVE operation set (the pinned/latest revision when one applies, else the
+    /// originals), so approve/reject/get responses no longer echo stale original operations for a
+    /// revised proposal (#1424). The presentation block still derives from the persisted original
+    /// operations; only the Operations collection is swapped to the effective set.
+    /// </summary>
+    private async Task<Result<ProposalDto>> BuildEffectiveProposalDtoAsync(
+        AutomationProposal proposal,
+        CancellationToken cancellationToken)
+    {
+        var dto = MapToDto(proposal);
+
+        var effectiveRevision = await GetEffectiveRevisionAsync(proposal, cancellationToken);
+        if (effectiveRevision is null)
+            return Result.Success(dto);
+
+        if (!ProposalRevisionPayload.TryParseOperations(
+                proposal.Id,
+                effectiveRevision.RevisedPayload,
+                out var revisedOperations,
+                out _))
+        {
+            // A saved revision is structure-validated at creation, so an unparseable payload is a
+            // defensive impossibility. A read must not fail on it — the diff/approve/apply gates
+            // own surfacing that error — so fall back to the persisted original operations.
+            return Result.Success(dto);
+        }
+
+        return Result.Success(dto with { Operations = revisedOperations });
+    }
+
     public async Task<Result<ProposalDto>> RejectProposalAsync(Guid id, Guid decidedByUserId, UpdateProposalStatusDto dto, CancellationToken cancellationToken = default)
     {
         try
@@ -348,7 +416,9 @@ public class AutomationProposalService : IAutomationProposalService
             if (!notifyResult.IsSuccess)
                 return Result.Failure<ProposalDto>(notifyResult.ErrorCode, notifyResult.ErrorMessage);
 
-            return Result.Success(MapToDto(proposal));
+            // Echo the effective (latest-revision) operations the reviewer decided on, not the
+            // stale originals, when the rejected proposal carried a saved revision (#1424).
+            return await BuildEffectiveProposalDtoAsync(proposal, cancellationToken);
         }
         catch (DomainException ex)
         {
@@ -470,19 +540,20 @@ public class AutomationProposalService : IAutomationProposalService
         if (proposal == null)
             return Result.Failure<string>(ErrorCodes.NotFound, $"Proposal with ID {id} not found");
 
-        // When a reviewer has saved a revision, Apply executes THAT payload — the
-        // executor materializes the latest ProposalRevision via
-        // AutomationExecutorService.MaterializeEffectiveProposalAsync, not the
-        // original operations. Build the diff from the same effective operations so
-        // the approval-gate preview equals what Apply will run (#1235). The stored
-        // DiffPreview is deliberately bypassed on this path because it describes the
+        // When a reviewer has saved a revision, Apply executes THAT payload — the executor
+        // materializes the EFFECTIVE ProposalRevision (the pinned one once approved, the latest
+        // while pending) via AutomationExecutorService.MaterializeEffectiveProposalAsync, not the
+        // original operations. Build the diff from the same effective revision so the preview
+        // equals what Apply will run (#1235) — and, once a proposal is approved, so a revision that
+        // raced in after approval cannot make the diff diverge from the pinned apply set (#1428).
+        // The stored DiffPreview is deliberately bypassed on this path because it describes the
         // original proposal, which is exactly the stale-preview bug we are fixing.
-        var latestRevision = await _unitOfWork.ProposalRevisions.GetLatestByProposalIdAsync(id, cancellationToken);
-        if (latestRevision is not null)
+        var effectiveRevision = await GetEffectiveRevisionAsync(proposal, cancellationToken);
+        if (effectiveRevision is not null)
         {
             if (!ProposalRevisionPayload.TryParseOperations(
                     id,
-                    latestRevision.RevisedPayload,
+                    effectiveRevision.RevisedPayload,
                     out var revisedOperations,
                     out var errorMessage))
             {
@@ -727,7 +798,8 @@ public class AutomationProposalService : IAutomationProposalService
         {
             Presentation = BuildPresentation(proposal),
             IsExpired = proposal.IsExpired,
-            DeferredUntil = proposal.DeferredUntil
+            DeferredUntil = proposal.DeferredUntil,
+            ApprovedRevisionId = proposal.ApprovedRevisionId
         };
     }
 

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -370,11 +370,15 @@ public class AutomationProposalService : IAutomationProposalService
     }
 
     /// <summary>
-    /// Maps a proposal to its response DTO with <see cref="ProposalDto.Operations"/> materialized
-    /// to the EFFECTIVE operation set (the pinned/latest revision when one applies, else the
-    /// originals), so approve/reject/get responses no longer echo stale original operations for a
-    /// revised proposal (#1424). The presentation block still derives from the persisted original
-    /// operations; only the Operations collection is swapped to the effective set.
+    /// Maps a proposal to its response DTO with <see cref="ProposalDto.Operations"/> AND
+    /// <see cref="ProposalDto.Presentation"/> materialized together from the EFFECTIVE operation
+    /// set (the pinned/latest revision when one applies, else the originals), so approve/reject/get
+    /// responses no longer echo stale original operations for a revised proposal (#1424) and the
+    /// presentation block can never contradict the operations it accompanies. Deliberate scope
+    /// boundary: only the single-proposal read/decide paths use this builder — the list endpoint
+    /// (<see cref="GetProposalsAsync"/>) maps original operations without a per-proposal revision
+    /// lookup (avoiding an N+1 query); its items still expose
+    /// <see cref="ProposalDto.ApprovedRevisionId"/> so clients can detect a pinned revision.
     /// </summary>
     private async Task<Result<ProposalDto>> BuildEffectiveProposalDtoAsync(
         AutomationProposal proposal,
@@ -398,7 +402,15 @@ public class AutomationProposalService : IAutomationProposalService
             return Result.Success(dto);
         }
 
-        return Result.Success(dto with { Operations = revisedOperations });
+        return Result.Success(dto with
+        {
+            Operations = revisedOperations,
+            Presentation = BuildPresentation(
+                proposal.Summary,
+                proposal.RiskLevel,
+                proposal.SourceType,
+                revisedOperations)
+        });
     }
 
     public async Task<Result<ProposalDto>> RejectProposalAsync(Guid id, Guid decidedByUserId, UpdateProposalStatusDto dto, CancellationToken cancellationToken = default)
@@ -774,6 +786,8 @@ public class AutomationProposalService : IAutomationProposalService
 
     private static ProposalDto MapToDto(AutomationProposal proposal)
     {
+        var operationDtos = proposal.Operations.Select(MapOperationToDto).ToList();
+
         return new ProposalDto(
             proposal.Id,
             proposal.SourceType,
@@ -793,10 +807,13 @@ public class AutomationProposalService : IAutomationProposalService
             proposal.AppliedAt,
             proposal.FailureReason,
             proposal.CorrelationId,
-            proposal.Operations.Select(MapOperationToDto).ToList()
+            operationDtos
         )
         {
-            Presentation = BuildPresentation(proposal),
+            // Presentation is built from the SAME list assigned to Operations, so a ProposalDto
+            // can never describe one operation set while presenting another (#1424 split-brain
+            // guard). Effective-DTO callers rebuild both together from the revised set.
+            Presentation = BuildPresentation(proposal.Summary, proposal.RiskLevel, proposal.SourceType, operationDtos),
             IsExpired = proposal.IsExpired,
             DeferredUntil = proposal.DeferredUntil,
             ApprovedRevisionId = proposal.ApprovedRevisionId
@@ -841,9 +858,19 @@ public class AutomationProposalService : IAutomationProposalService
         return Result.Success();
     }
 
-    private static ProposalPresentationDto BuildPresentation(AutomationProposal proposal)
+    /// <summary>
+    /// Builds the human-readable presentation block from an explicit operation-DTO list rather
+    /// than the entity's persisted operations, so callers rendering a revision's EFFECTIVE set
+    /// (#1424) produce a presentation that matches the operations they return — the DTO can
+    /// never present one operation set while carrying another.
+    /// </summary>
+    private static ProposalPresentationDto BuildPresentation(
+        string summary,
+        RiskLevel riskLevel,
+        ProposalSourceType sourceType,
+        IReadOnlyList<ProposalOperationDto> operations)
     {
-        var orderedOperations = proposal.Operations
+        var orderedOperations = operations
             .OrderBy(operation => operation.Sequence)
             .ToList();
 
@@ -867,13 +894,13 @@ public class AutomationProposalService : IAutomationProposalService
             .Select(DescribeOperation)
             .ToList();
 
-        var isCaptureTaskBatch = IsCaptureTaskBatch(proposal.SourceType, orderedOperations);
+        var isCaptureTaskBatch = IsCaptureTaskBatch(sourceType, orderedOperations);
 
         return new ProposalPresentationDto(
-            BuildPlainSummary(proposal.Summary, isCaptureTaskBatch, orderedOperations, affectedEntities),
+            BuildPlainSummary(summary, isCaptureTaskBatch, orderedOperations, affectedEntities),
             BuildImpactSummary(orderedOperations.Count, affectedEntities, isCaptureTaskBatch),
-            BuildRiskCue(proposal.RiskLevel),
-            BuildSourceCue(proposal.SourceType),
+            BuildRiskCue(riskLevel),
+            BuildSourceCue(sourceType),
             operationHeadlines,
             affectedEntities);
     }
@@ -881,7 +908,7 @@ public class AutomationProposalService : IAutomationProposalService
     private static string BuildPlainSummary(
         string summary,
         bool isCaptureTaskBatch,
-        IReadOnlyList<AutomationProposalOperation> orderedOperations,
+        IReadOnlyList<ProposalOperationDto> orderedOperations,
         IReadOnlyList<ProposalAffectedEntityDto> affectedEntities)
     {
         if (orderedOperations.Count == 0)
@@ -955,7 +982,7 @@ public class AutomationProposalService : IAutomationProposalService
         };
     }
 
-    private static string DescribeOperation(AutomationProposalOperation operation)
+    private static string DescribeOperation(ProposalOperationDto operation)
     {
         var verb = HumanizeActionVerb(operation.ActionType);
         var target = HumanizeTargetType(operation.TargetType).ToLowerInvariant();
@@ -1340,7 +1367,7 @@ public class AutomationProposalService : IAutomationProposalService
         return buffer.ToString();
     }
 
-    private static bool IsCaptureTaskBatch(ProposalSourceType sourceType, IReadOnlyList<AutomationProposalOperation> orderedOperations)
+    private static bool IsCaptureTaskBatch(ProposalSourceType sourceType, IReadOnlyList<ProposalOperationDto> orderedOperations)
     {
         if (sourceType != ProposalSourceType.Queue)
         {

--- a/backend/src/Taskdeck.Domain/Entities/AutomationProposal.cs
+++ b/backend/src/Taskdeck.Domain/Entities/AutomationProposal.cs
@@ -35,6 +35,17 @@ public class AutomationProposal : Entity
     public string? FailureReason { get; private set; }
     public string CorrelationId { get; private set; } = string.Empty;
 
+    /// <summary>
+    /// The <see cref="ProposalRevision"/> that was validated and pinned at approve time, or
+    /// <c>null</c> when the proposal was approved from its original operations (no revision
+    /// existed). Apply materializes exactly this revision (#1428): a revision saved AFTER
+    /// approval — even a valid one landing in the race window between approve's validation read
+    /// and its commit — cannot change what Apply executes, so approved-content == applied-content.
+    /// Modelled as a plain scalar pointer (not an EF foreign key) to avoid a cyclic
+    /// Proposal ↔ ProposalRevision constraint; the revision is cascade-owned by the proposal.
+    /// </summary>
+    public Guid? ApprovedRevisionId { get; private set; }
+
     private readonly List<AutomationProposalOperation> _operations = new();
     public IReadOnlyList<AutomationProposalOperation> Operations => _operations.AsReadOnly();
 
@@ -87,7 +98,12 @@ public class AutomationProposal : Entity
         Touch();
     }
 
-    public void Approve(Guid decidedByUserId)
+    /// <summary>
+    /// Transitions a pending proposal to Approved, pinning <paramref name="approvedRevisionId"/>
+    /// as the exact revision Apply must materialize (#1428). Pass the id of the latest saved
+    /// revision validated at approve time, or <c>null</c> when approving the original operations.
+    /// </summary>
+    public void Approve(Guid decidedByUserId, Guid? approvedRevisionId = null)
     {
         if (decidedByUserId == Guid.Empty)
             throw new DomainException(ErrorCodes.ValidationError, "DecidedByUserId cannot be empty");
@@ -99,6 +115,8 @@ public class AutomationProposal : Entity
         Status = ProposalStatus.Approved;
         DecidedByUserId = decidedByUserId;
         DecidedAt = DateTime.UtcNow;
+        // Pin the exact revision the reviewer approved so Apply cannot execute a later one (#1428).
+        ApprovedRevisionId = approvedRevisionId;
         // A decided proposal must never carry a stale snooze that would hide it from list reads.
         DeferredUntil = null;
         Touch();

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.Designer.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Taskdeck.Infrastructure.Persistence;
 
@@ -10,9 +11,11 @@ using Taskdeck.Infrastructure.Persistence;
 namespace Taskdeck.Infrastructure.Migrations
 {
     [DbContext(typeof(TaskdeckDbContext))]
-    partial class TaskdeckDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718131220_AddApprovedRevisionIdToAutomationProposal")]
+    partial class AddApprovedRevisionIdToAutomationProposal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.28");

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.cs
@@ -20,11 +20,29 @@ namespace Taskdeck.Infrastructure.Migrations
             // Backfill (#1428 Apply parity for in-flight proposals): before this migration, Apply
             // materialized the LATEST revision for an Approved proposal. A null pin now means
             // "apply the ORIGINAL operations", so proposals already Approved with saved revisions
-            // must be pinned to their latest revision — otherwise this deploy would silently
-            // re-introduce operations a reviewer edited out. Status = 1 is ProposalStatus.Approved
-            // (persisted via HasConversion<int>; enum order PendingReview=0, Approved=1, ...).
-            // PendingReview proposals are deliberately NOT backfilled (approve pins them from now
-            // on) and terminal statuses never reach the executor's materialization.
+            // must be pinned — otherwise this deploy would silently re-introduce operations a
+            // reviewer edited out. Status = 1 is ProposalStatus.Approved (persisted via
+            // HasConversion<int>; enum order PendingReview=0, Approved=1, ...). PendingReview
+            // proposals are deliberately NOT backfilled (approve pins them from now on) and
+            // terminal statuses never reach the executor's materialization.
+            //
+            // Pin the latest revision saved AT OR BEFORE the proposal's decision time
+            // (RevisedAt <= DecidedAt), NOT the unconditional latest. This PR's invariant is that
+            // Apply executes exactly what the approver saw/approved; an Approved proposal with a
+            // revision saved AFTER DecidedAt is precisely the race this PR closes, so backfilling
+            // that later revision would execute content the reviewer never approved. When no
+            // qualifying pre-decision revision exists the pin stays NULL and Apply runs the
+            // original operations — again, what the approver saw.
+            //
+            // Timestamp formats differ and must not be compared lexicographically as-is: EF stores
+            // DecidedAt (DateTime) as TEXT "yyyy-MM-dd HH:mm:ss.FFFFFFF" and RevisedAt
+            // (DateTimeOffset) as "yyyy-MM-dd HH:mm:ss.FFFFFFF+00:00". Both are UTC, so appending
+            // '+00:00' to DecidedAt yields an identically-shaped string; the fractional-second
+            // parts then compare correctly digit-by-digit because the shorter fraction's next
+            // character ('+') sorts below any digit. A NULL DecidedAt (never expected for an
+            // Approved row) concatenates to NULL, the comparison yields NULL, no revision
+            // qualifies, and the pin stays NULL. Proven empirically by
+            // MigrationBootstrapTests.AddApprovedRevisionId_* (before/after/straddle cases).
             migrationBuilder.Sql(
                 """
                 UPDATE AutomationProposals
@@ -32,13 +50,15 @@ namespace Taskdeck.Infrastructure.Migrations
                     SELECT pr.Id
                     FROM ProposalRevisions pr
                     WHERE pr.ProposalId = AutomationProposals.Id
-                    ORDER BY pr.RevisionNumber DESC
+                      AND pr.RevisedAt <= (AutomationProposals.DecidedAt || '+00:00')
+                    ORDER BY pr.RevisedAt DESC, pr.RevisionNumber DESC
                     LIMIT 1)
                 WHERE Status = 1
                   AND EXISTS (
                     SELECT 1
                     FROM ProposalRevisions pr2
-                    WHERE pr2.ProposalId = AutomationProposals.Id);
+                    WHERE pr2.ProposalId = AutomationProposals.Id
+                      AND pr2.RevisedAt <= (AutomationProposals.DecidedAt || '+00:00'));
                 """);
         }
 

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.cs
@@ -16,6 +16,30 @@ namespace Taskdeck.Infrastructure.Migrations
                 table: "AutomationProposals",
                 type: "TEXT",
                 nullable: true);
+
+            // Backfill (#1428 Apply parity for in-flight proposals): before this migration, Apply
+            // materialized the LATEST revision for an Approved proposal. A null pin now means
+            // "apply the ORIGINAL operations", so proposals already Approved with saved revisions
+            // must be pinned to their latest revision — otherwise this deploy would silently
+            // re-introduce operations a reviewer edited out. Status = 1 is ProposalStatus.Approved
+            // (persisted via HasConversion<int>; enum order PendingReview=0, Approved=1, ...).
+            // PendingReview proposals are deliberately NOT backfilled (approve pins them from now
+            // on) and terminal statuses never reach the executor's materialization.
+            migrationBuilder.Sql(
+                """
+                UPDATE AutomationProposals
+                SET ApprovedRevisionId = (
+                    SELECT pr.Id
+                    FROM ProposalRevisions pr
+                    WHERE pr.ProposalId = AutomationProposals.Id
+                    ORDER BY pr.RevisionNumber DESC
+                    LIMIT 1)
+                WHERE Status = 1
+                  AND EXISTS (
+                    SELECT 1
+                    FROM ProposalRevisions pr2
+                    WHERE pr2.ProposalId = AutomationProposals.Id);
+                """);
         }
 
         /// <inheritdoc />

--- a/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.cs
+++ b/backend/src/Taskdeck.Infrastructure/Migrations/20260718131220_AddApprovedRevisionIdToAutomationProposal.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Taskdeck.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApprovedRevisionIdToAutomationProposal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ApprovedRevisionId",
+                table: "AutomationProposals",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApprovedRevisionId",
+                table: "AutomationProposals");
+        }
+    }
+}

--- a/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/AutomationProposalConfiguration.cs
+++ b/backend/src/Taskdeck.Infrastructure/Persistence/Configurations/AutomationProposalConfiguration.cs
@@ -60,6 +60,13 @@ public class AutomationProposalConfiguration : IEntityTypeConfiguration<Automati
 
         builder.Property(ap => ap.AppliedAt);
 
+        // The revision pinned at approve time (#1428). A plain nullable scalar, NOT an EF foreign
+        // key: a real FK from AutomationProposals -> ProposalRevisions would form a cycle with the
+        // existing ProposalRevisions.ProposalId -> AutomationProposals FK, complicating SQLite
+        // insert ordering. The revision it points at is cascade-owned by the proposal, so no
+        // dangling-pointer risk. No index: it is only ever read for an already-loaded proposal.
+        builder.Property(ap => ap.ApprovedRevisionId);
+
         builder.Property(ap => ap.FailureReason)
             .HasMaxLength(1000);
 

--- a/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
@@ -288,6 +288,100 @@ public class MigrationBootstrapTests : IDisposable
         }
     }
 
+    [Fact]
+    public void AddApprovedRevisionId_backfills_latest_revision_pin_for_preexisting_approved_proposals()
+    {
+        // #1428 backfill: before the pinning migration, Apply materialized the LATEST revision for
+        // an Approved proposal; after it, a null pin means "apply the ORIGINAL operations". The
+        // migration must therefore pin already-Approved proposals with revisions to their latest
+        // revision, or the deploy would silently revert them to content a reviewer edited out.
+        // Arrange — stop just before the pinning migration and seed the pre-migration shape.
+        _context.GetService<IMigrator>()
+            .Migrate("20260713054422_AddArtefactExtractions");
+
+        var approvedWithRevisions = Guid.NewGuid();
+        var approvedWithoutRevisions = Guid.NewGuid();
+        var pendingWithRevision = Guid.NewGuid();
+        var latestRevisionId = Guid.NewGuid();
+
+        InsertPreMigrationProposal(approvedWithRevisions, status: 1);    // Approved
+        InsertPreMigrationProposal(approvedWithoutRevisions, status: 1); // Approved, no revisions
+        InsertPreMigrationProposal(pendingWithRevision, status: 0);      // PendingReview
+
+        InsertPreMigrationRevision(Guid.NewGuid(), approvedWithRevisions, revisionNumber: 1);
+        InsertPreMigrationRevision(latestRevisionId, approvedWithRevisions, revisionNumber: 2);
+        InsertPreMigrationRevision(Guid.NewGuid(), pendingWithRevision, revisionNumber: 1);
+
+        // Act — apply the pinning migration (and any remainder of the chain).
+        _context.Database.Migrate();
+
+        // Assert — the approved-with-revisions proposal is pinned to its LATEST revision; the
+        // revisionless approved proposal and the pending proposal stay unpinned (null pin =
+        // original operations for the former; approve pins the latter going forward).
+        GetApprovedRevisionId(approvedWithRevisions).Should().Be(latestRevisionId,
+            "an already-approved proposal with revisions must be pinned to its latest revision " +
+            "to preserve pre-migration Apply behavior");
+        GetApprovedRevisionId(approvedWithoutRevisions).Should().BeNull(
+            "an approved proposal without revisions applies its original operations");
+        GetApprovedRevisionId(pendingWithRevision).Should().BeNull(
+            "pending proposals are pinned at approve time, not by the backfill");
+    }
+
+    private void InsertPreMigrationProposal(Guid id, int status)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var expiresAt = DateTime.UtcNow.AddDays(1);
+
+        _context.Database.ExecuteSqlInterpolated($"""
+            INSERT INTO AutomationProposals
+                (Id, SourceType, SourceReferenceId, BoardId, RequestedByUserId, Status, RiskLevel, Summary,
+                 DiffPreview, ValidationIssues, ExpiresAt, DecidedAt, DecidedByUserId, AppliedAt,
+                 FailureReason, CorrelationId, CreatedAt, UpdatedAt)
+            VALUES
+                ({id}, 1, NULL, NULL, {Guid.NewGuid()}, {status}, 0, 'Pre-migration proposal',
+                 NULL, NULL, {expiresAt}, NULL, NULL, NULL,
+                 NULL, {Guid.NewGuid().ToString("N")}, {now}, {now})
+            """);
+    }
+
+    private void InsertPreMigrationRevision(Guid id, Guid proposalId, int revisionNumber)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        // The payload body is opaque to the backfill (it copies revision IDs, never parses
+        // payloads), so a plain placeholder keeps the seed simple.
+        _context.Database.ExecuteSqlInterpolated($"""
+            INSERT INTO ProposalRevisions
+                (Id, ProposalId, RevisionNumber, EditorUserId, RevisedPayload, RevisedAt, Reason,
+                 CreatedAt, UpdatedAt)
+            VALUES
+                ({id}, {proposalId}, {revisionNumber}, {Guid.NewGuid()}, 'pre-migration payload', {now},
+                 'pre-migration revision', {now}, {now})
+            """);
+    }
+
+    private Guid? GetApprovedRevisionId(Guid proposalId)
+    {
+        var connection = _context.Database.GetDbConnection();
+        _context.Database.OpenConnection();
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT ApprovedRevisionId FROM AutomationProposals WHERE Id = $id";
+            var parameter = cmd.CreateParameter();
+            parameter.ParameterName = "$id";
+            parameter.Value = proposalId;
+            cmd.Parameters.Add(parameter);
+
+            var value = cmd.ExecuteScalar();
+            return value is null or DBNull ? null : Guid.Parse((string)value);
+        }
+        finally
+        {
+            _context.Database.CloseConnection();
+        }
+    }
+
     private void InsertLegacyProposalOutcome(Guid id, OutcomeType outcomeType)
     {
         var proposalId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
@@ -302,22 +302,26 @@ public class MigrationBootstrapTests : IDisposable
         var approvedWithRevisions = Guid.NewGuid();
         var approvedWithoutRevisions = Guid.NewGuid();
         var pendingWithRevision = Guid.NewGuid();
+        var appliedWithRevision = Guid.NewGuid();
         var latestRevisionId = Guid.NewGuid();
 
         InsertPreMigrationProposal(approvedWithRevisions, status: 1);    // Approved
         InsertPreMigrationProposal(approvedWithoutRevisions, status: 1); // Approved, no revisions
         InsertPreMigrationProposal(pendingWithRevision, status: 0);      // PendingReview
+        InsertPreMigrationProposal(appliedWithRevision, status: 3);      // Applied (terminal)
 
         InsertPreMigrationRevision(Guid.NewGuid(), approvedWithRevisions, revisionNumber: 1);
         InsertPreMigrationRevision(latestRevisionId, approvedWithRevisions, revisionNumber: 2);
         InsertPreMigrationRevision(Guid.NewGuid(), pendingWithRevision, revisionNumber: 1);
+        InsertPreMigrationRevision(Guid.NewGuid(), appliedWithRevision, revisionNumber: 1);
 
         // Act — apply the pinning migration (and any remainder of the chain).
         _context.Database.Migrate();
 
         // Assert — the approved-with-revisions proposal is pinned to its LATEST revision; the
-        // revisionless approved proposal and the pending proposal stay unpinned (null pin =
-        // original operations for the former; approve pins the latter going forward).
+        // revisionless approved proposal, the pending proposal, and the terminal proposal all
+        // stay unpinned (null pin = original operations for the first; approve pins the second
+        // going forward; the third never reaches the executor's materialization again).
         GetApprovedRevisionId(approvedWithRevisions).Should().Be(latestRevisionId,
             "an already-approved proposal with revisions must be pinned to its latest revision " +
             "to preserve pre-migration Apply behavior");
@@ -325,6 +329,9 @@ public class MigrationBootstrapTests : IDisposable
             "an approved proposal without revisions applies its original operations");
         GetApprovedRevisionId(pendingWithRevision).Should().BeNull(
             "pending proposals are pinned at approve time, not by the backfill");
+        GetApprovedRevisionId(appliedWithRevision).Should().BeNull(
+            "the backfill targets Status = 1 (Approved) only; terminal proposals are already " +
+            "executed and must not be retroactively pinned");
     }
 
     private void InsertPreMigrationProposal(Guid id, int status)

--- a/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
@@ -289,52 +289,86 @@ public class MigrationBootstrapTests : IDisposable
     }
 
     [Fact]
-    public void AddApprovedRevisionId_backfills_latest_revision_pin_for_preexisting_approved_proposals()
+    public void AddApprovedRevisionId_backfills_pre_decision_revision_pin_for_preexisting_approved_proposals()
     {
         // #1428 backfill: before the pinning migration, Apply materialized the LATEST revision for
         // an Approved proposal; after it, a null pin means "apply the ORIGINAL operations". The
-        // migration must therefore pin already-Approved proposals with revisions to their latest
-        // revision, or the deploy would silently revert them to content a reviewer edited out.
+        // migration must therefore pin already-Approved proposals — but only to the latest revision
+        // saved AT OR BEFORE the proposal's decision time (RevisedAt <= DecidedAt). This PR's
+        // invariant is that Apply executes exactly what the approver saw; a revision saved AFTER
+        // DecidedAt is precisely the race this PR closes, so it must NOT be backfilled. When only
+        // post-decision revisions exist the pin stays NULL and Apply runs the original operations.
         // Arrange — stop just before the pinning migration and seed the pre-migration shape.
         _context.GetService<IMigrator>()
             .Migrate("20260713054422_AddArtefactExtractions");
 
-        var approvedWithRevisions = Guid.NewGuid();
+        // A fixed, whole-second decision time so the seed timestamps are unambiguous. RevisedAt is
+        // stored with a UTC offset ("+00:00") and DecidedAt without one; the migration appends
+        // '+00:00' to DecidedAt so the comparison is apples-to-apples (both UTC).
+        var decision = new DateTime(2026, 7, 18, 13, 0, 0, DateTimeKind.Utc);
+        var oneHourBefore = new DateTimeOffset(decision.AddHours(-1), TimeSpan.Zero);
+        var twoHoursBefore = new DateTimeOffset(decision.AddHours(-2), TimeSpan.Zero);
+        var oneHourAfter = new DateTimeOffset(decision.AddHours(1), TimeSpan.Zero);
+
+        var approvedStraddle = Guid.NewGuid();       // (c) revisions straddling the decision time
+        var approvedOnlyBefore = Guid.NewGuid();     // (a) revisions all before the decision time
+        var approvedOnlyAfter = Guid.NewGuid();      // (b) only a post-decision revision
         var approvedWithoutRevisions = Guid.NewGuid();
         var pendingWithRevision = Guid.NewGuid();
-        var appliedWithRevision = Guid.NewGuid();
-        var latestRevisionId = Guid.NewGuid();
+        var appliedWithPreDecisionRevision = Guid.NewGuid();
 
-        InsertPreMigrationProposal(approvedWithRevisions, status: 1);    // Approved
-        InsertPreMigrationProposal(approvedWithoutRevisions, status: 1); // Approved, no revisions
-        InsertPreMigrationProposal(pendingWithRevision, status: 0);      // PendingReview
-        InsertPreMigrationProposal(appliedWithRevision, status: 3);      // Applied (terminal)
+        var straddlePreDecisionRevisionId = Guid.NewGuid();
+        var latestBeforeRevisionId = Guid.NewGuid();
 
-        InsertPreMigrationRevision(Guid.NewGuid(), approvedWithRevisions, revisionNumber: 1);
-        InsertPreMigrationRevision(latestRevisionId, approvedWithRevisions, revisionNumber: 2);
-        InsertPreMigrationRevision(Guid.NewGuid(), pendingWithRevision, revisionNumber: 1);
-        InsertPreMigrationRevision(Guid.NewGuid(), appliedWithRevision, revisionNumber: 1);
+        InsertPreMigrationProposal(approvedStraddle, status: 1, decidedAt: decision);
+        InsertPreMigrationProposal(approvedOnlyBefore, status: 1, decidedAt: decision);
+        InsertPreMigrationProposal(approvedOnlyAfter, status: 1, decidedAt: decision);
+        InsertPreMigrationProposal(approvedWithoutRevisions, status: 1, decidedAt: decision);
+        InsertPreMigrationProposal(pendingWithRevision, status: 0);                            // PendingReview, undecided
+        InsertPreMigrationProposal(appliedWithPreDecisionRevision, status: 3, decidedAt: decision); // Applied (terminal)
+
+        // (c) straddle: the pre-decision revision has the LOWER revision number, the post-decision
+        // one the higher — the pin must still choose the pre-decision revision, not the latest.
+        InsertPreMigrationRevision(straddlePreDecisionRevisionId, approvedStraddle, revisionNumber: 1, revisedAt: oneHourBefore);
+        InsertPreMigrationRevision(Guid.NewGuid(), approvedStraddle, revisionNumber: 2, revisedAt: oneHourAfter);
+
+        // (a) all before: pin the latest one that is still at or before the decision time.
+        InsertPreMigrationRevision(Guid.NewGuid(), approvedOnlyBefore, revisionNumber: 1, revisedAt: twoHoursBefore);
+        InsertPreMigrationRevision(latestBeforeRevisionId, approvedOnlyBefore, revisionNumber: 2, revisedAt: oneHourBefore);
+
+        // (b) only after: no qualifying pre-decision revision → pin stays NULL.
+        InsertPreMigrationRevision(Guid.NewGuid(), approvedOnlyAfter, revisionNumber: 1, revisedAt: oneHourAfter);
+
+        InsertPreMigrationRevision(Guid.NewGuid(), pendingWithRevision, revisionNumber: 1, revisedAt: oneHourBefore);
+        // A pre-decision revision that WOULD qualify — proving the Status = 1 filter, not the
+        // timestamp filter, is what excludes this terminal proposal.
+        InsertPreMigrationRevision(Guid.NewGuid(), appliedWithPreDecisionRevision, revisionNumber: 1, revisedAt: oneHourBefore);
 
         // Act — apply the pinning migration (and any remainder of the chain).
         _context.Database.Migrate();
 
-        // Assert — the approved-with-revisions proposal is pinned to its LATEST revision; the
-        // revisionless approved proposal, the pending proposal, and the terminal proposal all
-        // stay unpinned (null pin = original operations for the first; approve pins the second
-        // going forward; the third never reaches the executor's materialization again).
-        GetApprovedRevisionId(approvedWithRevisions).Should().Be(latestRevisionId,
-            "an already-approved proposal with revisions must be pinned to its latest revision " +
-            "to preserve pre-migration Apply behavior");
+        // Assert — (c) the straddling proposal pins its PRE-decision revision even though a later
+        // one with a higher revision number exists.
+        GetApprovedRevisionId(approvedStraddle).Should().Be(straddlePreDecisionRevisionId,
+            "the backfill must pin the latest revision saved at or before DecidedAt, never a " +
+            "revision that raced in after the decision — even when the later one has a higher number");
+        // (a) the all-before proposal pins its latest pre-decision revision.
+        GetApprovedRevisionId(approvedOnlyBefore).Should().Be(latestBeforeRevisionId,
+            "an approved proposal whose revisions are all pre-decision pins the latest of them");
+        // (b) the only-after proposal stays unpinned — Apply then runs its original operations.
+        GetApprovedRevisionId(approvedOnlyAfter).Should().BeNull(
+            "an approved proposal with only a post-decision revision must not backfill that " +
+            "revision; a null pin means Apply runs the original operations the approver saw");
         GetApprovedRevisionId(approvedWithoutRevisions).Should().BeNull(
             "an approved proposal without revisions applies its original operations");
         GetApprovedRevisionId(pendingWithRevision).Should().BeNull(
             "pending proposals are pinned at approve time, not by the backfill");
-        GetApprovedRevisionId(appliedWithRevision).Should().BeNull(
+        GetApprovedRevisionId(appliedWithPreDecisionRevision).Should().BeNull(
             "the backfill targets Status = 1 (Approved) only; terminal proposals are already " +
-            "executed and must not be retroactively pinned");
+            "executed and must not be retroactively pinned, even with a qualifying revision");
     }
 
-    private void InsertPreMigrationProposal(Guid id, int status)
+    private void InsertPreMigrationProposal(Guid id, int status, DateTime? decidedAt = null)
     {
         var now = DateTimeOffset.UtcNow;
         var expiresAt = DateTime.UtcNow.AddDays(1);
@@ -346,23 +380,24 @@ public class MigrationBootstrapTests : IDisposable
                  FailureReason, CorrelationId, CreatedAt, UpdatedAt)
             VALUES
                 ({id}, 1, NULL, NULL, {Guid.NewGuid()}, {status}, 0, 'Pre-migration proposal',
-                 NULL, NULL, {expiresAt}, NULL, NULL, NULL,
+                 NULL, NULL, {expiresAt}, {decidedAt}, NULL, NULL,
                  NULL, {Guid.NewGuid().ToString("N")}, {now}, {now})
             """);
     }
 
-    private void InsertPreMigrationRevision(Guid id, Guid proposalId, int revisionNumber)
+    private void InsertPreMigrationRevision(Guid id, Guid proposalId, int revisionNumber, DateTimeOffset revisedAt)
     {
         var now = DateTimeOffset.UtcNow;
 
         // The payload body is opaque to the backfill (it copies revision IDs, never parses
-        // payloads), so a plain placeholder keeps the seed simple.
+        // payloads), so a plain placeholder keeps the seed simple. RevisedAt is the load-bearing
+        // field — the backfill filters on it against the proposal's DecidedAt.
         _context.Database.ExecuteSqlInterpolated($"""
             INSERT INTO ProposalRevisions
                 (Id, ProposalId, RevisionNumber, EditorUserId, RevisedPayload, RevisedAt, Reason,
                  CreatedAt, UpdatedAt)
             VALUES
-                ({id}, {proposalId}, {revisionNumber}, {Guid.NewGuid()}, 'pre-migration payload', {now},
+                ({id}, {proposalId}, {revisionNumber}, {Guid.NewGuid()}, 'pre-migration payload', {revisedAt},
                  'pre-migration revision', {now}, {now})
             """);
     }

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -902,6 +902,10 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         approved.Operations.Should().ContainSingle();
         approved.Operations[0].Parameters.Should().Contain("Effective Edit");
         approved.Operations[0].Parameters.Should().NotContain("Original Card");
+        // Split-brain guard: the presentation block must describe the SAME effective operations
+        // the response carries, never the stale originals.
+        approved.Presentation.OperationHeadlines.Should().ContainSingle(h => h.Contains("Effective Edit"));
+        approved.Presentation.OperationHeadlines.Should().NotContain(h => h.Contains("Original Card"));
 
         // GET reflects the same effective (pinned) operations.
         var getResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}");
@@ -911,6 +915,8 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
         fetched.Operations.Should().ContainSingle();
         fetched.Operations[0].Parameters.Should().Contain("Effective Edit");
         fetched.Operations[0].Parameters.Should().NotContain("Original Card");
+        fetched.Presentation.OperationHeadlines.Should().ContainSingle(h => h.Contains("Effective Edit"));
+        fetched.Presentation.OperationHeadlines.Should().NotContain(h => h.Contains("Original Card"));
     }
 
     private async Task InsertRevisionDirectlyAsync(

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionApiTests.cs
@@ -2,10 +2,12 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Enums;
+using Taskdeck.Infrastructure.Persistence;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -798,6 +800,130 @@ public class ProposalRevisionApiTests : IClassFixture<TestWebApplicationFactory>
 
         var victimCards = await ReadCardsAsync(victimClient, victimBoard.Id);
         victimCards.Should().NotContain(card => card.Title == "Cross-board column card");
+    }
+
+    [Fact]
+    public async Task ExecuteProposal_WithRacedRevisionSavedAfterApprove_AppliesPinnedRevision_NotLater()
+    {
+        // #1428 core: approve validates and PINS the latest revision at approve time; Apply must
+        // materialize THAT pinned revision, never a later one. This simulates the race where a
+        // revision-save whose PendingReview guard-read predated approve's commit lands a new
+        // revision (N+1) after approval — by inserting it straight into the store, bypassing the
+        // guard the normal API path enforces. Apply must still run the pinned revision N.
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-pin-later");
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-pin-later-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id, "Original Card");
+
+        // Revision 1 (the one the reviewer sees and approves).
+        var revisionResponse = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = BuildRevisionPayload("Pinned Edit", board.Id, column.Id), reason = "reviewed edit" });
+        revisionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Revision 2 races in AFTER approval, straight into the store (past the PendingReview guard).
+        await InsertRevisionDirectlyAsync(
+            proposal.Id,
+            revisionNumber: 2,
+            editorUserId: user.UserId,
+            revisedPayload: BuildRevisionPayload("Raced Edit", board.Id, column.Id),
+            reason: "raced edit after approval");
+
+        var executeRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/automation/proposals/{proposal.Id}/execute");
+        executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        var executeResponse = await client.SendAsync(executeRequest);
+        executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var cards = await ReadCardsAsync(client, board.Id);
+        cards.Should().ContainSingle(card => card.Title == "Pinned Edit");
+        cards.Should().NotContain(card => card.Title == "Raced Edit");
+        cards.Should().NotContain(card => card.Title == "Original Card");
+    }
+
+    [Fact]
+    public async Task ExecuteProposal_ApprovedFromOriginal_IgnoresRacedRevision()
+    {
+        // #1428, null-pin direction: a proposal approved with NO revision pins nothing, so Apply
+        // materializes the ORIGINAL operations. Before pinning, Apply materialized the LATEST
+        // revision, so a revision that raced in after approval would hijack the applied content.
+        // This pins that it no longer can.
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-pin-original");
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-pin-original-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id, "Original Card");
+
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var approved = await approveResponse.Content.ReadFromJsonAsync<ProposalDto>();
+        approved!.ApprovedRevisionId.Should().BeNull("approving from original operations pins no revision");
+
+        // A revision races in after approval, straight into the store.
+        await InsertRevisionDirectlyAsync(
+            proposal.Id,
+            revisionNumber: 1,
+            editorUserId: user.UserId,
+            revisedPayload: BuildRevisionPayload("Hijack Card", board.Id, column.Id),
+            reason: "raced revision on an original-approved proposal");
+
+        var executeRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/automation/proposals/{proposal.Id}/execute");
+        executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        var executeResponse = await client.SendAsync(executeRequest);
+        executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var cards = await ReadCardsAsync(client, board.Id);
+        cards.Should().ContainSingle(card => card.Title == "Original Card");
+        cards.Should().NotContain(card => card.Title == "Hijack Card");
+    }
+
+    [Fact]
+    public async Task ApproveAndGetResponses_ForRevisedProposal_ReflectEffectivePinnedOperations()
+    {
+        // #1424: approve/get response DTOs must surface the EFFECTIVE (pinned) operations Apply will
+        // run, not the stale original operations, and expose the pinned revision id.
+        var client = _factory.CreateClient();
+        var user = await ApiTestHarness.AuthenticateAsync(client, "rev-effective-dto");
+        var (board, column) = await CreateBoardWithColumnAsync(client, "rev-effective-dto-board");
+        var proposal = await CreateTestProposalAsync(client, user.UserId, board.Id, column.Id, "Original Card");
+
+        var revisionResponse = await client.PostAsJsonAsync(
+            $"/api/automation/proposals/{proposal.Id}/revisions",
+            new { revisedPayload = BuildRevisionPayload("Effective Edit", board.Id, column.Id), reason = "edit before approve" });
+        revisionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var revision = await revisionResponse.Content.ReadFromJsonAsync<ProposalRevisionDto>();
+
+        var approveResponse = await client.PostAsync($"/api/automation/proposals/{proposal.Id}/approve", null);
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var approved = await approveResponse.Content.ReadFromJsonAsync<ProposalDto>();
+
+        approved!.ApprovedRevisionId.Should().Be(revision!.Id);
+        approved.Operations.Should().ContainSingle();
+        approved.Operations[0].Parameters.Should().Contain("Effective Edit");
+        approved.Operations[0].Parameters.Should().NotContain("Original Card");
+
+        // GET reflects the same effective (pinned) operations.
+        var getResponse = await client.GetAsync($"/api/automation/proposals/{proposal.Id}");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var fetched = await getResponse.Content.ReadFromJsonAsync<ProposalDto>();
+        fetched!.ApprovedRevisionId.Should().Be(revision.Id);
+        fetched.Operations.Should().ContainSingle();
+        fetched.Operations[0].Parameters.Should().Contain("Effective Edit");
+        fetched.Operations[0].Parameters.Should().NotContain("Original Card");
+    }
+
+    private async Task InsertRevisionDirectlyAsync(
+        Guid proposalId,
+        int revisionNumber,
+        Guid editorUserId,
+        string revisedPayload,
+        string reason)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<TaskdeckDbContext>();
+        db.ProposalRevisions.Add(new ProposalRevision(proposalId, revisionNumber, editorUserId, revisedPayload, reason));
+        await db.SaveChangesAsync();
     }
 
     private static async Task<ProposalDto> CreateTestProposalAsync(

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationExecutorServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationExecutorServiceTests.cs
@@ -296,6 +296,112 @@ public class AutomationExecutorServiceTests
     }
 
     [Fact]
+    public async Task ExecuteProposal_ShouldMaterializePinnedRevision_NotLatest()
+    {
+        // #1428: Apply materializes the revision pinned at approve time (proposal.ApprovedRevisionId),
+        // looked up by id — NOT the latest revision. This pins that the executor no longer consults
+        // GetLatestByProposalIdAsync, so a later revision cannot hijack the applied operations.
+        var proposalId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = TestDataBuilder.CreateBoard();
+
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "update",
+                    targetType = "board",
+                    targetId = board.Id.ToString(),
+                    parameters = $$"""{"boardId":"{{board.Id}}","name":"Pinned Rename"}""",
+                    idempotencyKey = "pinned-key"
+                }
+            }
+        });
+        var pinnedRevision = new ProposalRevision(proposalId, 1, userId, revisedPayload, "pinned edit");
+
+        // The DTO carries the pin; its own Operations are irrelevant (materialization replaces them).
+        var proposal = CreateApprovedProposal(proposalId, userId, board.Id, new List<ProposalOperationDto>()) with
+        {
+            ApprovedRevisionId = pinnedRevision.Id
+        };
+        var proposalEntity = CreateApprovedProposalEntity(userId, board.Id);
+
+        _proposalServiceMock.Setup(s => s.GetProposalByIdAsync(proposalId, default))
+            .ReturnsAsync(Result.Success(proposal));
+        _proposalRevisionRepoMock.Setup(r => r.GetByIdAsync(pinnedRevision.Id, default))
+            .ReturnsAsync(pinnedRevision);
+        _policyEngineMock.Setup(e => e.ValidatePolicy(It.IsAny<ProposalDto>())).Returns(Result.Success());
+        _policyEngineMock.Setup(e => e.ValidatePermissionsAsync(
+                userId, board.Id, It.IsAny<IEnumerable<ProposalOperationDto>>(), default))
+            .ReturnsAsync(Result.Success());
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposalEntity);
+
+        // Act
+        var result = await _service.ExecuteProposalAsync(proposalId, "execution-key");
+
+        // Assert: succeeded by materializing the PINNED revision, never consulting the latest.
+        result.IsSuccess.Should().BeTrue();
+        _proposalRevisionRepoMock.Verify(r => r.GetByIdAsync(pinnedRevision.Id, default), Times.Once);
+        _proposalRevisionRepoMock.Verify(
+            r => r.GetLatestByProposalIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _auditLogRepoMock.Verify(r => r.AddAsync(
+            It.Is<AuditLog>(a => a.EntityType == "board" && a.EntityId == board.Id),
+            default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteProposal_WithNullPin_ShouldApplyOriginalOperations_IgnoringAnyRevision()
+    {
+        // #1428, null-pin direction: a proposal approved from its original operations pins nothing,
+        // so Apply runs the original operations and never looks up a revision at all.
+        var proposalId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = TestDataBuilder.CreateBoard();
+        var operations = new List<ProposalOperationDto>
+        {
+            new(
+                Guid.NewGuid(),
+                proposalId,
+                0,
+                "update",
+                "board",
+                board.Id.ToString(),
+                $$"""{"boardId":"{{board.Id}}","name":"Original Rename"}""",
+                "key1",
+                null)
+        };
+
+        // ApprovedRevisionId defaults to null on CreateApprovedProposal.
+        var proposal = CreateApprovedProposal(proposalId, userId, board.Id, operations);
+        var proposalEntity = CreateApprovedProposalEntity(userId, board.Id);
+
+        _proposalServiceMock.Setup(s => s.GetProposalByIdAsync(proposalId, default))
+            .ReturnsAsync(Result.Success(proposal));
+        _policyEngineMock.Setup(e => e.ValidatePolicy(proposal)).Returns(Result.Success());
+        _policyEngineMock.Setup(e => e.ValidatePermissionsAsync(userId, board.Id, operations, default))
+            .ReturnsAsync(Result.Success());
+        _boardRepoMock.Setup(r => r.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposalEntity);
+
+        // Act
+        var result = await _service.ExecuteProposalAsync(proposalId, "execution-key");
+
+        // Assert: applied the originals without any revision lookup.
+        result.IsSuccess.Should().BeTrue();
+        _proposalRevisionRepoMock.Verify(
+            r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _proposalRevisionRepoMock.Verify(
+            r => r.GetLatestByProposalIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteProposal_ShouldMarkLinkedCaptureAsConverted_WhenCaptureBackedProposalIsApplied()
     {
         var proposalId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationExecutorServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationExecutorServiceTests.cs
@@ -402,6 +402,40 @@ public class AutomationExecutorServiceTests
     }
 
     [Fact]
+    public async Task ExecuteProposal_WithDanglingPin_ShouldRefuseAsInvariantViolation_NotNotFound()
+    {
+        // #1428 defensive branch: a pinned revision is cascade-owned by its proposal, so a
+        // missing pinned revision is a server invariant violation, not a lookup miss. The
+        // executor must refuse with InvalidOperation — NotFound would misread as "proposal not
+        // found" for a proposal that plainly exists — and must never fall back to the
+        // unapproved original operations.
+        var proposalId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var board = TestDataBuilder.CreateBoard();
+        var danglingRevisionId = Guid.NewGuid();
+
+        var proposal = CreateApprovedProposal(proposalId, userId, board.Id, new List<ProposalOperationDto>()) with
+        {
+            ApprovedRevisionId = danglingRevisionId
+        };
+
+        _proposalServiceMock.Setup(s => s.GetProposalByIdAsync(proposalId, default))
+            .ReturnsAsync(Result.Success(proposal));
+        _proposalRevisionRepoMock.Setup(r => r.GetByIdAsync(danglingRevisionId, default))
+            .ReturnsAsync((ProposalRevision?)null);
+
+        // Act
+        var result = await _service.ExecuteProposalAsync(proposalId, "execution-key");
+
+        // Assert: refused as an invariant violation before any transaction begins.
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.InvalidOperation);
+        result.ErrorMessage.Should().Contain(danglingRevisionId.ToString());
+        result.ErrorMessage.Should().Contain("invariant");
+        _unitOfWorkMock.Verify(u => u.BeginTransactionAsync(default), Times.Never);
+    }
+
+    [Fact]
     public async Task ExecuteProposal_ShouldMarkLinkedCaptureAsConverted_WhenCaptureBackedProposalIsApplied()
     {
         var proposalId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -626,6 +626,10 @@ public class AutomationProposalServiceTests
         result.Value.Operations.Should().ContainSingle();
         result.Value.Operations[0].Parameters.Should().Contain("Revised name");
         result.Value.Operations[0].Parameters.Should().NotContain("Original name");
+        // Split-brain guard: the presentation block derives from the same effective set as
+        // Operations, so it must describe the revised content, not the stale original.
+        result.Value.Presentation.OperationHeadlines.Should().ContainSingle(h => h.Contains("Revised name"));
+        result.Value.Presentation.OperationHeadlines.Should().NotContain(h => h.Contains("Original name"));
     }
 
     [Fact]

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -570,6 +570,103 @@ public class AutomationProposalServiceTests
     }
 
     [Fact]
+    public async Task ApproveProposalAsync_ShouldPinLatestRevision_AndEchoEffectiveOperations()
+    {
+        // #1428 + #1424: approve stamps ApprovedRevisionId with the latest revision read at approve
+        // time (so Apply materializes exactly that one), and the approve response echoes the
+        // effective (revised) operations rather than the stale original ones.
+        var proposalId = Guid.NewGuid();
+        var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Revised then approved",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Original name" }),
+            Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "update",
+                    targetType = "board",
+                    targetId = boardId.ToString(),
+                    parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Revised name" }),
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposal.Id, 1, deciderId, revisedPayload, "Rename differently");
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default)).ReturnsAsync(revision);
+        _revisionRepoMock.Setup(r => r.GetByIdAsync(revision.Id, default)).ReturnsAsync(revision);
+
+        // Act
+        var result = await _service.ApproveProposalAsync(proposalId, deciderId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Status.Should().Be(ProposalStatus.Approved);
+        result.Value.ApprovedRevisionId.Should().Be(revision.Id);
+        proposal.ApprovedRevisionId.Should().Be(revision.Id);
+        result.Value.Operations.Should().ContainSingle();
+        result.Value.Operations[0].Parameters.Should().Contain("Revised name");
+        result.Value.Operations[0].Parameters.Should().NotContain("Original name");
+    }
+
+    [Fact]
+    public async Task ApproveProposalAsync_ShouldLeaveApprovedRevisionIdNull_WhenNoRevisionExists()
+    {
+        // #1428: approving a proposal that has no saved revision pins nothing (null), so Apply
+        // materializes the original operations and later revisions cannot change what it runs.
+        var proposalId = Guid.NewGuid();
+        var deciderId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Approved from original",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id,
+            0,
+            "update",
+            "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Original name" }),
+            Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        // Default revision mock: GetLatestByProposalIdAsync returns null (no revision).
+
+        // Act
+        var result = await _service.ApproveProposalAsync(proposalId, deciderId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ApprovedRevisionId.Should().BeNull();
+        proposal.ApprovedRevisionId.Should().BeNull();
+        result.Value.Operations.Should().ContainSingle();
+        result.Value.Operations[0].Parameters.Should().Contain("Original name");
+    }
+
+    [Fact]
     public async Task ApproveProposalAsync_ShouldRejectRevokedBoardAccess_MatchingApplyPermissionGate()
     {
         // #1416 trust-class completion: Apply runs ValidatePermissionsAsync after the policy gate,
@@ -2231,7 +2328,7 @@ public class AutomationProposalServiceTests
             }
         });
         var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
-        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default))
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
             .ReturnsAsync(revision);
 
         var columnRepoMock = new Mock<IColumnRepository>();
@@ -2277,7 +2374,7 @@ public class AutomationProposalServiceTests
         // Non-empty payload that satisfies the entity ctor but carries no operations
         // array — TryParseOperations rejects it (mirrors the executor's behavior).
         var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), "{}", "Reviewer edit");
-        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default))
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
             .ReturnsAsync(revision);
 
         // Act
@@ -2333,7 +2430,7 @@ public class AutomationProposalServiceTests
             }
         });
         var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
-        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default))
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default))
             .ReturnsAsync(revision);
 
         // Act
@@ -2536,7 +2633,7 @@ public class AutomationProposalServiceTests
             }
         });
         var revision = new ProposalRevision(proposalId, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
-        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposalId, default)).ReturnsAsync(revision);
+        _revisionRepoMock.Setup(r => r.GetLatestByProposalIdAsync(proposal.Id, default)).ReturnsAsync(revision);
 
         _boardAccessRepoMock
             .Setup(r => r.HasAccessAsync(boardId, requesterId, It.IsAny<UserRole?>(), It.IsAny<CancellationToken>()))

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -45,6 +45,12 @@ public class AutomationProposalServiceTests
         _revisionRepoMock
             .Setup(r => r.GetLatestByProposalIdAsync(It.IsAny<Guid>(), default))
             .ReturnsAsync((ProposalRevision?)null);
+        // The rejected-proposal freeze path (#1439) loads all revisions and filters in memory;
+        // default to an empty list so tests that don't seed revisions don't NRE on the repository
+        // contract's non-null return.
+        _revisionRepoMock
+            .Setup(r => r.GetByProposalIdAsync(It.IsAny<Guid>(), default))
+            .ReturnsAsync(Array.Empty<ProposalRevision>());
         _notificationServiceMock
             .Setup(s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), default))
             .ReturnsAsync(Result.Success(true));
@@ -78,6 +84,26 @@ public class AutomationProposalServiceTests
             nameof(AutomationProposal.ExpiresAt),
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)!
             .SetValue(proposal, expiresAt);
+    }
+
+    // DecidedAt is stamped to UtcNow by Reject/Approve; force it to a fixed value so the rejected
+    // freeze tests can place revisions deterministically on either side of the decision cutoff.
+    private static void SetDecidedAt(AutomationProposal proposal, DateTime decidedAt)
+    {
+        typeof(AutomationProposal).GetProperty(
+            nameof(AutomationProposal.DecidedAt),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(proposal, decidedAt);
+    }
+
+    // RevisedAt is stamped to UtcNow in the ProposalRevision ctor; force it so a revision can be
+    // placed before or after a proposal's decision time in the rejected freeze tests.
+    private static void SetRevisedAt(ProposalRevision revision, DateTimeOffset revisedAt)
+    {
+        typeof(ProposalRevision).GetProperty(
+            nameof(ProposalRevision.RevisedAt),
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(revision, revisedAt);
     }
 
     #region CreateProposalAsync Tests
@@ -3086,6 +3112,122 @@ public class AutomationProposalServiceTests
 
         result.IsSuccess.Should().BeTrue(result.ErrorMessage);
         result.Value.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTerminalProposalStoredPreviewAsync_ShouldReturnNullPreview_WhenPinnedRevisionApplies()
+    {
+        // #1439: an Applied proposal that pinned a revision at approve time must NOT serve its
+        // stored DiffPreview — that preview describes the ORIGINAL operations, while proposal_detail
+        // also carries the revision-derived operation set, so serving both would let one MCP payload
+        // present two disagreeing views of the same change. When an effective revision applies the
+        // preview is suppressed (null).
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var revisionId = Guid.NewGuid();
+
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat, requesterId, "Rename board", RiskLevel.Low,
+            Guid.NewGuid().ToString(), boardId);
+        var parameters = System.Text.Json.JsonSerializer.Serialize(new { name = "Renamed board", boardId });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board", parameters, Guid.NewGuid().ToString(),
+            targetId: boardId.ToString()));
+        proposal.SetDiffPreview("historical: original operations");
+        proposal.Approve(Guid.NewGuid(), revisionId); // pins ApprovedRevisionId
+        proposal.MarkAsApplied();
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        var revision = new ProposalRevision(proposal.Id, 1, Guid.NewGuid(), "{}", "Reviewer edit");
+        _revisionRepoMock.Setup(r => r.GetByIdAsync(revisionId, default)).ReturnsAsync(revision);
+
+        var result = await _service.GetTerminalProposalStoredPreviewAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().BeNull(
+            "a pinned-revision terminal proposal suppresses its original-operations stored preview");
+    }
+
+    #endregion
+
+    #region GetEffectiveRevision freeze for rejected proposals (#1439)
+
+    // Builds an already-Rejected proposal carrying one original "update board" operation plus a
+    // saved revision, with DecidedAt and the revision's RevisedAt forced to fixed values so the
+    // decision-time cutoff is deterministic.
+    private (AutomationProposal Proposal, ProposalRevision Revision) BuildRejectedProposalWithRevision(
+        Guid proposalId,
+        DateTime decidedAt,
+        DateTimeOffset revisionRevisedAt)
+    {
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat, Guid.NewGuid(), "Rejected proposal", RiskLevel.Low,
+            Guid.NewGuid().ToString(), boardId);
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "update", "board",
+            System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Original name" }),
+            Guid.NewGuid().ToString(), targetId: boardId.ToString()));
+        proposal.Reject(Guid.NewGuid(), "not needed");
+        SetDecidedAt(proposal, decidedAt);
+
+        var revisedPayload = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            operations = new[]
+            {
+                new
+                {
+                    sequence = 0,
+                    actionType = "update",
+                    targetType = "board",
+                    targetId = boardId.ToString(),
+                    parameters = System.Text.Json.JsonSerializer.Serialize(new { boardId, name = "Revised name" }),
+                    idempotencyKey = Guid.NewGuid().ToString()
+                }
+            }
+        });
+        var revision = new ProposalRevision(proposal.Id, 1, Guid.NewGuid(), revisedPayload, "Reviewer edit");
+        SetRevisedAt(revision, revisionRevisedAt);
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default)).ReturnsAsync(proposal);
+        _revisionRepoMock.Setup(r => r.GetByProposalIdAsync(proposal.Id, default))
+            .ReturnsAsync(new[] { revision });
+        return (proposal, revision);
+    }
+
+    [Fact]
+    public async Task GetProposalByIdAsync_ShouldShowPreDecisionRevision_ForRejectedProposal()
+    {
+        // #1439: a rejected proposal is frozen at its decision time. A revision saved AT OR BEFORE
+        // DecidedAt is what the reviewer decided on, so the GET response surfaces its revised ops.
+        var proposalId = Guid.NewGuid();
+        var decision = new DateTime(2026, 7, 18, 13, 0, 0, DateTimeKind.Utc);
+        BuildRejectedProposalWithRevision(proposalId, decision, new DateTimeOffset(decision.AddHours(-1), TimeSpan.Zero));
+
+        var result = await _service.GetProposalByIdAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Operations.Should().ContainSingle();
+        result.Value.Operations[0].Parameters.Should().Contain("Revised name");
+        result.Value.Operations[0].Parameters.Should().NotContain("Original name");
+    }
+
+    [Fact]
+    public async Task GetProposalByIdAsync_ShouldShowOriginalOperations_ForRejectedProposalWithOnlyPostDecisionRevision()
+    {
+        // #1439: a revision that raced in AFTER rejection must never surface — the frozen response
+        // falls back to the original operations the reviewer actually rejected.
+        var proposalId = Guid.NewGuid();
+        var decision = new DateTime(2026, 7, 18, 13, 0, 0, DateTimeKind.Utc);
+        BuildRejectedProposalWithRevision(proposalId, decision, new DateTimeOffset(decision.AddHours(1), TimeSpan.Zero));
+
+        var result = await _service.GetProposalByIdAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Operations.Should().ContainSingle();
+        result.Value.Operations[0].Parameters.Should().Contain("Original name");
+        result.Value.Operations[0].Parameters.Should().NotContain("Revised name");
     }
 
     #endregion


### PR DESCRIPTION
Implements the maintainer's ruling on #1428: the revision approved is the revision applied. At approve time the proposal pins the exact revision that passed the approve-time gates (`ApprovedRevisionId`, nullable — null means approved-from-original); Apply/execute materializes the **pinned** revision, so a revision that lands after approval (past the existing `PendingReview` 409 guard, e.g. a raced insert) can never change what the executor runs. Mutual exclusion between revise and approve was considered and rejected in the ruling — no locking is introduced.

Also resolves #1424: approve/reject/get single-proposal responses now carry the **effective** operations (pinned for decided-with-pin, latest for pending, original otherwise) plus the `approvedRevisionId` field, instead of stale original ops. The diff path uses the same effective-revision resolver so preview == apply holds after approval too.

## Changes

- `AutomationProposal.ApprovedRevisionId` (nullable, plain scalar — no FK to avoid a Proposal↔Revision cycle); `Approve(..., approvedRevisionId)` with optional param (existing callers unaffected). Migration `20260718131220_AddApprovedRevisionIdToAutomationProposal` (+Down); `has-pending-model-changes` → "No changes"; `MigrationBootstrapTests` 10/10.
- `AutomationExecutorService.MaterializeEffectiveProposalAsync` reads the pinned revision; a missing pinned revision hard-fails (NotFound) rather than silently applying unapproved originals.
- `AutomationProposalService`: approve captures latest-at-approve revision id; new `GetEffectiveRevisionAsync` feeds effective-ops DTOs (approve/reject/get + diff).
- `ProposalDto.ApprovedRevisionId` (additive, ignorable by current clients).

## Behavior pinned by tests

- Approve pins revision N; a raced revision N+1 inserted after approve (direct DB insert simulating the race) → Apply executes **N** (`ExecuteProposal_WithRacedRevisionSavedAfterApprove_AppliesPinnedRevision_NotLater`); approved-from-original ignores raced revisions (`ExecuteProposal_ApprovedFromOriginal_IgnoresRacedRevision`).
- Revise-after-approve stays a 409 (pre-existing `CreateRevision_OnApprovedProposal_ShouldReturnConflict` — existing behavior pinned, not new rules).
- DTO effective-ops coverage in `ProposalRevisionApiTests` (+3), service tests (+2 each on proposal/executor suites).

## Scope notes (deliberate)

- List endpoint (`GetProposalsAsync`) still returns original ops (batch-materializing revisions would be an N+1; items expose `approvedRevisionId` from the entity). Follow-up candidate if effective-ops-in-list is wanted.
- ADR-0003 approve-then-execute untouched; this strengthens approve == apply / preview == apply.
- Backend-only; no frontend changes (additive response field).

## Verification (Release)

Build clean. Targeted: `ProposalRevisionApiTests` 36 passed (+3 new); `~ProposalRevision` Domain 25 / Application 7 / Api 38; `~AutomationProposalService` 100; `~AutomationExecutorService` 16; ecosystem sweep (`Proposal|Automation|Mcp|CaptureToBoard` 404, `Proposal|CaptureTriage` 420, `Workspace|ProposalHousekeeping|WorkerResilience|ProposalApprovalRace` 41, Domain `AutomationProposal` 117, provider-compat 23, migrations 10, Architecture 20) — 0 failures. Full suite + CI: this PR's gate.

Closes #1428. Closes #1424.
