### PR TITLE
docs: promote the two-run-proven frugality overlay into the Fable overnight manual

### DIFF
--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -149,15 +149,18 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
   the exact command, the expected-green shape, the known flakes carved out BY NAME with issue
   numbers, and "any other red → stop, report the failing names + excerpts, no reruns, no
   diagnosis".
-- **Spot-check one load-bearing claim per returned OPS/MECHANICS packet** (re-query the
-  unresolved-thread count, re-read one changed hunk, re-run one count) instead of
-  re-verifying everything — trust but sample; a packet that fails its spot-check is
-  re-verified in full. Two packet classes are NEVER sampled: (1) reviewer packets — every
-  returned finding is read and adjudicated individually per base §4 and the repo Review
-  Policy, at every severity; (2) the merge gate — the coordinator still performs the full
-  base §5 feedback-by-content sweep (unresolved threads AND top-level comments AND
-  review-summary bodies since the final push) and still owns the suite/CI verdict. Sampling
-  is a mechanics-lane shortcut, not a review or gate shortcut.
+- **Sampling is allowlisted, not default.** Spot-check one load-bearing claim per returned
+  packet (re-run one count, re-read one changed hunk) ONLY for pure mechanics packets whose
+  content feeds no review, settlement, or gate decision: suite/determinism runs, CI polls,
+  branch freshening, push confirmations. A packet that fails its spot-check is re-verified
+  in full. Everything decision-bearing is verified in full, never sampled — in particular:
+  reviewer packets (every returned finding read and adjudicated individually per base §4
+  and the repo Review Policy, at every severity); settlement packets (the coordinator
+  verifies each settled thread carries its reply and its finding→commit fix-evidence
+  mapping, not just the unresolved count — a thread resolved without evidence is unsettled);
+  and the merge gate (the full base §5 feedback-by-content sweep — unresolved threads AND
+  top-level comments AND review-summary bodies since the final push — plus the suite/CI
+  verdict, all coordinator-owned). Sampling is a mechanics-lane shortcut, nothing else.
 - **Flake adjudication stays evidence-priced:** full-suite red → ops STOPs per its decision
   rule → isolated reruns (4–6×, branch AND main) → root-cause read → ruled flaky ⇒ tracked
   issue/evidence comment, and the gate proceeds with the flake carved out BY NAME in the next

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -115,6 +115,33 @@ an orchestrator that thinks, decides, and gates — not the typist.
   unsure). While workers run in the background, use your foreground turn for the next wave's
   planning or adjudication — don't idle, and don't poll what will notify you.
 
+## FRUGALITY MODE (proven overlay — survived two full runs, a model switch, and a mid-run usage-limit pause)
+
+Engage when the usage window is tight, a reset boundary is near, or the maintainer asks for a
+frugal run. It tightens the standard division of labor; everything else in this manual still
+applies (the gate is never thinned to save tokens — degrade by stopping, not by improvising).
+
+- **Coordinator turns = adjudication and gates only.** No inline reading a subagent could
+  summarize, no sitting through suites, no drafting mechanics a cheaper lane can execute from
+  your finalized text.
+- **Opus gate-marshals per lane:** one worker owns a PR's whole fix→verify→settle cycle
+  end-to-end, continued via `SendMessage` round after round — never respawned per round, so
+  context (the PR's history, reviewers' phrasing, prior verdicts) is paid for once.
+- **ONE long-lived Sonnet ops agent all night** (SendMessage-continued; 6+ task cycles proven):
+  full-suite runs with an explicit STOP-on-red decision rule, pushes with explicit refspec,
+  thread settlement (reply + `resolveReviewThread` + report `unresolved == 0`), determinism
+  reruns, CI polling with exact verdict + failing-job excerpts. It executes decided work; it
+  never decides — anything ambiguous bounces back with a report.
+- **Spot-check one load-bearing claim per returned packet** (re-query the unresolved-thread
+  count, re-read one changed hunk, re-run one count) instead of re-verifying everything —
+  trust but sample. A packet that fails its spot-check is re-verified in full.
+- **Flake adjudication stays evidence-priced:** full-suite red → ops STOPs per its decision
+  rule → isolated reruns (4–6×, branch AND main) → root-cause read → ruled flaky ⇒ tracked
+  issue/evidence comment, and the gate proceeds with the flake carved out BY NAME in the ops
+  decision rule.
+- **Near a usage-reset boundary, sequence reviewer fan-outs after it.** A reviewer killed by
+  a limit produces an untrustworthy partial verdict — rerun it, never salvage it.
+
 ## PER-PR GATE SEQUENCE (proven across 20+ merges; run it every time)
 
 worker round → 2 read-only reviewers (distinct lenses) → coordinator adjudication → ONE

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -150,10 +150,15 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
   numbers, and "any other red → stop, report the failing names + excerpts, no reruns, no
   diagnosis".
 - **Sampling is allowlisted, not default.** Spot-check one load-bearing claim per returned
-  packet (re-run one count, re-read one changed hunk) ONLY for pure mechanics packets whose
-  content feeds no review, settlement, or gate decision: suite/determinism runs, CI polls,
-  branch freshening, push confirmations. A packet that fails its spot-check is re-verified
-  in full. Everything decision-bearing is verified in full, never sampled — in particular:
+  packet (re-run one count, re-read one changed hunk) ONLY for pure motion packets whose
+  content feeds no review, settlement, or gate decision: branch freshening, push
+  confirmations, intermediate progress polls. Suite/determinism runs and CI checks are
+  mechanics to EXECUTE in the ops lane, but their returned verdicts are gate inputs: the
+  coordinator reads the full returned report (exact counts, every failing job/test name,
+  the excerpts) for the exact head — never a sampled slice of it (branch protection is
+  lenient, so a misreported red has no other backstop). A packet that fails its spot-check
+  is re-verified in full. Everything decision-bearing is verified in full, never sampled
+  — in particular:
   reviewer packets (every returned finding read and adjudicated individually per base §4
   and the repo Review Policy, at every severity); settlement packets (the coordinator
   verifies each settled thread carries its reply and its finding→commit fix-evidence

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -126,17 +126,24 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
   summarize, no sitting through suites, no drafting mechanics a cheaper lane can execute from
   your finalized text.
 - **Opus gate-marshals per lane:** one worker owns a PR's whole fix→verify→settle cycle
-  end-to-end, continued via `SendMessage` round after round — never respawned per round, so
-  context (the PR's history, reviewers' phrasing, prior verdicts) is paid for once. Thread
-  settlement (reply + `resolveReviewThread` + report `unresolved == 0`) is owned by exactly
-  ONE lane per PR — default the gate-marshal, per the gate sequence below; the coordinator may
-  reassign a PR's settlement to the ops agent in that packet explicitly (e.g. the marshal is
-  retired), but never lets both act on the same PR's threads.
+  end-to-end — "verify" meaning the worker's TARGETED runs; full-suite verdicts stay with the
+  ops lane + coordinator per BUDGET & CADENCE — continued via `SendMessage` round after round,
+  never respawned per round, so context (the PR's history, reviewers' phrasing, prior
+  verdicts) is paid for once. Thread settlement (reply + `resolveReviewThread` + report
+  `unresolved == 0`) is owned by exactly ONE lane per PR — default the gate-marshal; the
+  coordinator may reassign a PR's settlement to the ops agent in that packet explicitly
+  (e.g. the marshal is retired), but never lets both act on the same PR's threads. (Honest
+  provenance: the two proving runs actually ran settlement in the ops lane as a standing
+  cycle; the marshal default here is a deliberate alignment with the gate sequence below,
+  which the single-owner rule preserves either way.)
 - **The Cheap-ops-lane Sonnet agent (the SAME single agent, not a second one) takes on an
   extended remit** in addition to its standing tasks: full-suite runs under a STOP-on-red
   decision rule, determinism reruns, and any settlement packet reassigned per the bullet
-  above. The lane's standing rule (executes decided work, never decides) is unchanged. The
-  STOP-on-red decision rule is authored by the coordinator inside the task packet itself:
+  above (reply texts in a settlement packet are always coordinator-authored — the lane posts
+  finalized text, consistent with its standing remit). The lane's standing rule (executes
+  decided work, never decides) is unchanged. A "packet" throughout this section = one
+  `SendMessage` task assignment plus its returned report. The STOP-on-red decision rule is
+  authored by the coordinator inside the task packet itself:
   the exact command, the expected-green shape, the known flakes carved out BY NAME with issue
   numbers, and "any other red → stop, report the failing names + excerpts, no reruns, no
   diagnosis".
@@ -170,7 +177,8 @@ merge → pull `main` → prune worktree+branch (cd out of a worktree before rem
   review-summary bodies since the final push — bots put findings in all three places, and a
   "review" entry with no findings looks identical to one with two P2s until you read it. This applies to docs-only PRs too (a docs sweep has been merged
   over two valid unresolved P2s before; the fix cost a follow-up PR).
-- **Review-loop discipline**: batch fixes into ONE push per round; every worker replies AND
+- **Review-loop discipline**: batch fixes into ONE push per round; every worker — or the PR's
+  designated settlement lane, when FRUGALITY MODE has reassigned it — replies AND
   resolves threads via GraphQL `resolveReviewThread` and reports `unresolved == 0`; new bot
   findings on a final head are reported to the coordinator, never cycled unilaterally. When
   bot rounds keep finding new interleavings in one seam, issue ONE structural redesign

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -124,7 +124,9 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
 - **Coordinator turns go to the Fable lane's never-delegated work** (wave planning, task
   selection, adjudication, the gates) **and nothing else.** No inline reading a subagent could
   summarize, no sitting through suites, no drafting mechanics a cheaper lane can execute from
-  your finalized text.
+  your finalized text. Required orientation and gate reads are never delegated to save
+  tokens: the coordinator still reads the source-of-truth docs (base §1 — STATUS,
+  OUTSTANDING_TASKS, the handoff) and every gate input itself.
 - **Opus gate-marshals per lane:** one worker owns a PR's whole fix→verify→settle cycle
   end-to-end — "verify" meaning the worker's TARGETED runs; full-suite verdicts stay with the
   ops lane + coordinator per BUDGET & CADENCE — continued via `SendMessage` round after round,
@@ -147,13 +149,15 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
   the exact command, the expected-green shape, the known flakes carved out BY NAME with issue
   numbers, and "any other red → stop, report the failing names + excerpts, no reruns, no
   diagnosis".
-- **Spot-check one load-bearing claim per returned packet** (re-query the unresolved-thread
-  count, re-read one changed hunk, re-run one count) instead of re-verifying everything —
-  trust but sample; a packet that fails its spot-check is re-verified in full. This sampling
-  NEVER substitutes for the base §5 gate checks: at gate time the coordinator still performs
-  the full feedback-by-content sweep (unresolved threads AND top-level comments AND
-  review-summary bodies since the final push) and still owns the suite/CI verdict — sampling
-  applies to intermediate packets, not to the merge gate.
+- **Spot-check one load-bearing claim per returned OPS/MECHANICS packet** (re-query the
+  unresolved-thread count, re-read one changed hunk, re-run one count) instead of
+  re-verifying everything — trust but sample; a packet that fails its spot-check is
+  re-verified in full. Two packet classes are NEVER sampled: (1) reviewer packets — every
+  returned finding is read and adjudicated individually per base §4 and the repo Review
+  Policy, at every severity; (2) the merge gate — the coordinator still performs the full
+  base §5 feedback-by-content sweep (unresolved threads AND top-level comments AND
+  review-summary bodies since the final push) and still owns the suite/CI verdict. Sampling
+  is a mechanics-lane shortcut, not a review or gate shortcut.
 - **Flake adjudication stays evidence-priced:** full-suite red → ops STOPs per its decision
   rule → isolated reruns (4–6×, branch AND main) → root-cause read → ruled flaky ⇒ tracked
   issue/evidence comment, and the gate proceeds with the flake carved out BY NAME in the next

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -119,26 +119,38 @@ an orchestrator that thinks, decides, and gates — not the typist.
 
 Engage when the usage window is tight, a reset boundary is near, or the maintainer asks for a
 frugal run. It tightens the standard division of labor; everything else in this manual still
-applies (the gate is never thinned to save tokens — degrade by stopping, not by improvising).
+applies — the gate is never thinned to save tokens (see STOP CONDITIONS for how to degrade).
 
-- **Coordinator turns = adjudication and gates only.** No inline reading a subagent could
+- **Coordinator turns go to the Fable lane's never-delegated work** (wave planning, task
+  selection, adjudication, the gates) **and nothing else.** No inline reading a subagent could
   summarize, no sitting through suites, no drafting mechanics a cheaper lane can execute from
   your finalized text.
 - **Opus gate-marshals per lane:** one worker owns a PR's whole fix→verify→settle cycle
   end-to-end, continued via `SendMessage` round after round — never respawned per round, so
-  context (the PR's history, reviewers' phrasing, prior verdicts) is paid for once.
-- **ONE long-lived Sonnet ops agent all night** (SendMessage-continued; 6+ task cycles proven):
-  full-suite runs with an explicit STOP-on-red decision rule, pushes with explicit refspec,
-  thread settlement (reply + `resolveReviewThread` + report `unresolved == 0`), determinism
-  reruns, CI polling with exact verdict + failing-job excerpts. It executes decided work; it
-  never decides — anything ambiguous bounces back with a report.
+  context (the PR's history, reviewers' phrasing, prior verdicts) is paid for once. Thread
+  settlement (reply + `resolveReviewThread` + report `unresolved == 0`) is owned by exactly
+  ONE lane per PR — default the gate-marshal, per the gate sequence below; the coordinator may
+  reassign a PR's settlement to the ops agent in that packet explicitly (e.g. the marshal is
+  retired), but never lets both act on the same PR's threads.
+- **The Cheap-ops-lane Sonnet agent (the SAME single agent, not a second one) takes on an
+  extended remit** in addition to its standing tasks: full-suite runs under a STOP-on-red
+  decision rule, determinism reruns, and any settlement packet reassigned per the bullet
+  above. The lane's standing rule (executes decided work, never decides) is unchanged. The
+  STOP-on-red decision rule is authored by the coordinator inside the task packet itself:
+  the exact command, the expected-green shape, the known flakes carved out BY NAME with issue
+  numbers, and "any other red → stop, report the failing names + excerpts, no reruns, no
+  diagnosis".
 - **Spot-check one load-bearing claim per returned packet** (re-query the unresolved-thread
   count, re-read one changed hunk, re-run one count) instead of re-verifying everything —
-  trust but sample. A packet that fails its spot-check is re-verified in full.
+  trust but sample; a packet that fails its spot-check is re-verified in full. This sampling
+  NEVER substitutes for the base §5 gate checks: at gate time the coordinator still performs
+  the full feedback-by-content sweep (unresolved threads AND top-level comments AND
+  review-summary bodies since the final push) and still owns the suite/CI verdict — sampling
+  applies to intermediate packets, not to the merge gate.
 - **Flake adjudication stays evidence-priced:** full-suite red → ops STOPs per its decision
   rule → isolated reruns (4–6×, branch AND main) → root-cause read → ruled flaky ⇒ tracked
-  issue/evidence comment, and the gate proceeds with the flake carved out BY NAME in the ops
-  decision rule.
+  issue/evidence comment, and the gate proceeds with the flake carved out BY NAME in the next
+  packet's decision rule.
 - **Near a usage-reset boundary, sequence reviewer fan-outs after it.** A reviewer killed by
   a limit produces an untrustworthy partial verdict — rerun it, never salvage it.
 


### PR DESCRIPTION
## Summary

Promotes the "frugality overlay" from launch-prompt folklore into `docs/agentic/OVERNIGHT_LOOP.fable.md` as a named **FRUGALITY MODE** section, per the enforcement-ladder rule the manual itself states ("anything that survives two runs belongs in these manuals, not the launch prompt").

The pattern has now survived its two qualifying runs (both 2026-07-18 sessions), including a model switch and a mid-run usage-limit pause — the 2026-07-18 "/loop" handoff explicitly scheduled this promotion as next-session backlog item 3.

Content captured (from the proven practice, not invented): coordinator turns restricted to adjudication/gates; per-lane Opus gate-marshals continued via SendMessage instead of respawned; one long-lived Sonnet ops agent executing decided mechanics with STOP-on-red decision rules; the one-load-bearing-claim spot-check discipline; evidence-priced flake adjudication; sequencing reviewer fan-outs after a usage-reset boundary.

## Verification

- Docs-only, agentic-manual lane (not STATUS/GOLDEN governance surface); `node scripts/check-docs-governance.mjs` and `check-golden-principles.mjs` both pass on the branch.
- No behavior/code paths touched.
