### PR TITLE
Move AuditLogRepositoryIntegrationTests onto the workerless factory (#1438)

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/AuditLogRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuditLogRepositoryIntegrationTests.cs
@@ -13,12 +13,21 @@ namespace Taskdeck.Api.Tests;
 /// Integration tests for AuditLogRepository against real SQLite.
 /// Covers cross-user isolation, unknown level handling, board-scoped queries,
 /// time-range filtering, and entity-type case-insensitivity.
+///
+/// Runs on <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> (#1438, same family as
+/// #1391/#1383): several tests here (e.g. <c>GetByUserAsync_ShouldOrderByTimestampDesc</c>) seed
+/// <c>AuditLog</c> rows backdated well past the production <c>AuditRetentionWorker</c>'s 90-day
+/// cutoff. On the worker-enabled base factory, the worker's startup retention pass can delete
+/// those backdated rows between seed and assertion, intermittently failing lookups with a -1
+/// index. With the worker removed from this host, every seed/read here is deterministic. No test
+/// in this class exercises the retention worker itself, so there is no conflicting need to keep
+/// it live.
 /// </summary>
-public class AuditLogRepositoryIntegrationTests : IClassFixture<TestWebApplicationFactory>
+public class AuditLogRepositoryIntegrationTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {
-    private readonly TestWebApplicationFactory _factory;
+    private readonly HostedWorkerDisabledTestWebApplicationFactory _factory;
 
-    public AuditLogRepositoryIntegrationTests(TestWebApplicationFactory factory)
+    public AuditLogRepositoryIntegrationTests(HostedWorkerDisabledTestWebApplicationFactory factory)
     {
         _factory = factory;
     }

--- a/backend/tests/Taskdeck.Api.Tests/AuditLogRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/AuditLogRepositoryIntegrationTests.cs
@@ -15,13 +15,14 @@ namespace Taskdeck.Api.Tests;
 /// time-range filtering, and entity-type case-insensitivity.
 ///
 /// Runs on <see cref="HostedWorkerDisabledTestWebApplicationFactory"/> (#1438, same family as
-/// #1391/#1383): several tests here (e.g. <c>GetByUserAsync_ShouldOrderByTimestampDesc</c>) seed
+/// #1391/#1383): one test — <c>GetByUserAsync_ShouldOrderByTimestampDesc</c> — seeds
 /// <c>AuditLog</c> rows backdated well past the production <c>AuditRetentionWorker</c>'s 90-day
 /// cutoff. On the worker-enabled base factory, the worker's startup retention pass can delete
 /// those backdated rows between seed and assertion, intermittently failing lookups with a -1
-/// index. With the worker removed from this host, every seed/read here is deterministic. No test
-/// in this class exercises the retention worker itself, so there is no conflicting need to keep
-/// it live.
+/// index. With the worker removed from this host, every seed/read here is deterministic; the
+/// class-level swap (rather than isolating just that one test) matches the granularity of the
+/// other #1391-family adoptions. No test in this class exercises the retention worker itself,
+/// so there is no conflicting need to keep it live.
 /// </summary>
 public class AuditLogRepositoryIntegrationTests : IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>
 {


### PR DESCRIPTION
## Root cause

`AuditLogRepositoryIntegrationTests` used the plain `TestWebApplicationFactory`, which boots the app with all real hosted services — including `AuditRetentionWorker`. That worker runs a retention cleanup pass at host start with the default 90-day cutoff. Several tests in this class (notably `GetByUserAsync_ShouldOrderByTimestampDesc`) seed `AuditLog` rows backdated to `2024-01-01` — roughly 2.5 years past the cutoff. When the worker's retention pass interleaves between the test's seed `SaveChangesAsync` and its subsequent read, the backdated rows get deleted mid-test, and lookups by row `Id` return `-1` from `FindIndex`.

This is the same hosted-worker pre-emption family as #1383: a full-suite run on 2026-07-18 hit exactly this failure (7413 passed / 1 failed / 5 skipped on `31235fca`), while 6/6 isolated reruns passed cleanly — the signature of a suite-interaction race, not a real regression. Full details in #1438.

## Fix (mirrors the #1391 template)

#1391 already solved this exact race for the sibling `AuditRetention*` classes by migrating them onto `HostedWorkerDisabledTestWebApplicationFactory` (introduced in #1394), which boots the same app but strips app-assembly hosted services so no worker can pre-empt test-seeded state. That factory is also already in use by `LlmQueueRepositoryIntegrationTests`, `OutboundWebhookDeliveryRepositoryTests`, and `AutomationProposalRepositoryIntegrationTests`.

This PR mechanically applies the same migration to `AuditLogRepositoryIntegrationTests`:
- `IClassFixture<TestWebApplicationFactory>` -> `IClassFixture<HostedWorkerDisabledTestWebApplicationFactory>`
- constructor parameter and backing field type updated to match
- added a class-level doc comment (mirroring `AuditRetentionRepositoryIntegrationTests`'s) explaining why the workerless factory is required here

No test in this class exercises the retention worker itself (that behavior is already covered by `AuditRetentionRepositoryIntegrationTests`), so there was no conflicting requirement to keep any test on a live-worker host. No test assertions were changed.

## Verification

All commands run from the worktree, targeted only (no full-suite run, to avoid contending with another agent's full-suite slot):

- `dotnet build backend/Taskdeck.sln -c Release` -> **0 errors** (pre-existing warnings only, unrelated to this change).
- `AuditLogRepositoryIntegrationTests` run 6x consecutively:
  - Run 1: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
  - Run 2: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
  - Run 3: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
  - Run 4: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
  - Run 5: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
  - Run 6: `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10`
- Cross-impact check, `AuditRetentionRepositoryIntegrationTests` run once: `Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6` (confirms the sibling class the fix is modeled on is unaffected).

Not verified: full backend suite (`dotnet test backend/Taskdeck.sln -c Release -m:1`) — deliberately out of scope for this worker per the task's instructions, since another agent owns the box-wide full-suite slot concurrently. CI will run the full suite on this PR.

Closes #1438
