### PR TITLE
Add pinned Codex deny-floor adapter

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -28,10 +28,17 @@ This `.codex/` layer is the Codex-facing control plane for Taskdeck. It routes a
 ## Canonical Vs Local
 
 - Canonical project docs: `docs/STATUS.md`, `docs/IMPLEMENTATION_MASTERPLAN.md`, `docs/TESTING_GUIDE.md`, `docs/MANUAL_TEST_CHECKLIST.md`, and `docs/GOLDEN_PRINCIPLES.md`.
-- Codex-local routing: `.codex/README.md`, `.codex/memories/00_ACTIVE.md`, `.codex/config.toml`, and `.codex/skills/*`.
+- Codex-local routing: `.codex/README.md`, `.codex/memories/00_ACTIVE.md`, `.codex/config.toml`, `.codex/hooks.json`, and `.codex/skills/*`.
 - Claude-local routing: `.claude/README.md`, `.claude/settings.json`, and `.claude/skills/*`.
 - Agentic operating layer: `docs/agentic/*`, `autodoc/AGENT_INDEX.md`, and `scripts/agent_hooks/*`.
 - Historical or research material: `docs/archive/` and `docs/InReview/`; use only when active docs point there or the task explicitly asks for reconciliation.
+
+## Deny Floor And Hook Trust
+
+- `.codex/hooks.json` is the single project adapter that binds Codex `Bash` calls to the shared global deny-floor dispatcher (`~/.claude/hooks/dispatch.py`); the dispatcher is not vendored here and must not be duplicated or modified from this repo.
+- Keep exactly one project adapter. Do not add additional hook groups or a second dispatcher path.
+- After any change to hook definitions, re-approve them via `/hooks` in a fresh Codex session — project trust is not hook trust, and previously granted trust does not carry over to changed definitions.
+- Static checks (JSON parse, pin assertions) do not prove live activation; only an in-session allowed-command pass plus a denied dangerous command (e.g. a non-writing force-push dry run) does.
 
 ## Development Loop
 

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -35,7 +35,9 @@ This `.codex/` layer is the Codex-facing control plane for Taskdeck. It routes a
 
 ## Deny Floor And Hook Trust
 
-- `.codex/hooks.json` is the single project adapter that binds Codex `Bash` calls to the shared global deny-floor dispatcher (`~/.claude/hooks/dispatch.py`); the dispatcher is not vendored here and must not be duplicated or modified from this repo.
+- `.codex/hooks.json` is the single project adapter that binds Codex `Bash` calls to the shared global Bash-command deny-floor dispatcher (`~/.claude/hooks/dispatch.py`); the dispatcher is not vendored here and must not be duplicated or modified from this repo.
+- Scope: this is a Bash-command deny floor only. Structured non-Bash write surfaces (file-edit tools, MCP writes) are outside this adapter/dispatcher contract and are tracked upstream at https://github.com/Chris0Jeky/agent-harness/issues/2; system and tool permissions remain the compensating controls for those surfaces.
+- The `expected` hash named in the adapter is an audit-time declaration checked by harness doctor against the installed dispatcher's normalized bytes; it is not runtime byte verification. Runtime enforcement design is tracked at https://github.com/Chris0Jeky/agent-harness/issues/18. Any global dispatcher change requires an adapter pin refresh, reviewed doctor/audit, and fresh `/hooks` trust.
 - Keep exactly one project adapter. Do not add additional hook groups or a second dispatcher path.
 - After any change to hook definitions, re-approve them via `/hooks` in a fresh Codex session — project trust is not hook trust, and previously granted trust does not carry over to changed definitions.
 - Static checks (JSON parse, pin assertions) do not prove live activation; only an in-session allowed-command pass plus a denied dangerous command (e.g. a non-writing force-push dry run) does.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "expected=9f38e906d49dd84de196bf22fc6388a5551494cf9b303610014ee6539783ebbb; python3 \"$HOME/.claude/hooks/dispatch.py\" --event pre --runtime codex",
-            "commandWindows": "$expected='9f38e906d49dd84de196bf22fc6388a5551494cf9b303610014ee6539783ebbb'; py -3 $env:USERPROFILE/.claude/hooks/dispatch.py --event pre --runtime codex",
+            "command": "expected=91088f9b8cf6a56a6eb6ef49903defe902da152e4ed835e83e59db66298f9a33; python3 \"$HOME/.claude/hooks/dispatch.py\" --event pre --runtime codex",
+            "commandWindows": "$expected='91088f9b8cf6a56a6eb6ef49903defe902da152e4ed835e83e59db66298f9a33'; py -3 $env:USERPROFILE/.claude/hooks/dispatch.py --event pre --runtime codex",
             "timeout": 5,
             "statusMessage": "Checking irreversible-command policy"
           }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "expected=9f38e906d49dd84de196bf22fc6388a5551494cf9b303610014ee6539783ebbb; python3 \"$HOME/.claude/hooks/dispatch.py\" --event pre --runtime codex",
+            "commandWindows": "$expected='9f38e906d49dd84de196bf22fc6388a5551494cf9b303610014ee6539783ebbb'; py -3 $env:USERPROFILE/.claude/hooks/dispatch.py --event pre --runtime codex",
+            "timeout": 5,
+            "statusMessage": "Checking irreversible-command policy"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -63,6 +63,7 @@ For docs/skill/hook-only agentic changes, use targeted checks rather than the fu
 ```powershell
 Get-Content -Raw .mcp.json | ConvertFrom-Json | Out-Null
 Get-Content -Raw .claude\settings.json | ConvertFrom-Json | Out-Null
+Get-Content -Raw .codex\hooks.json | ConvertFrom-Json | Out-Null
 python $env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\taskdeck-question-batch
 python $env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\taskdeck-failure-capture
 python $env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\taskdeck-interface-map
@@ -85,6 +86,19 @@ When `.claude/settings.json` changes outside the agentic smoke path, also parse 
 ```powershell
 Get-Content -Raw .claude\settings.json | ConvertFrom-Json | Out-Null
 ```
+
+### Codex Deny-Floor Adapter Checks
+
+`.codex/hooks.json` is the project adapter binding Codex to the shared global deny-floor dispatcher. When it changes, run the static checks from the reviewed agent-harness checkout (portable placeholder — substitute your local harness path):
+
+```powershell
+Get-Content -Raw .codex\hooks.json | ConvertFrom-Json | Out-Null
+python <agent-harness-root>\scripts\doctor.py
+python <agent-harness-root>\scripts\audit.py
+python "$env:USERPROFILE\.claude\hooks\smoke_test.py"   # installed-dispatcher smoke, if present
+```
+
+These static checks prove structure and pin integrity only — they are insufficient to prove the hook is live. Actual activation additionally requires, in a fresh Codex session: re-trusting the hook definitions via `/hooks`, then observing one allowed command pass and one dangerous command denied (use a non-writing force-push dry run such as `git push --dry-run --force`). Report activation as NOT verified unless that live check was performed in the current session.
 
 ## Paper Backend Gap Testing (2026-05-05, PRs `#1031`–`#1040`)
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -89,16 +89,20 @@ Get-Content -Raw .claude\settings.json | ConvertFrom-Json | Out-Null
 
 ### Codex Deny-Floor Adapter Checks
 
-`.codex/hooks.json` is the project adapter binding Codex to the shared global deny-floor dispatcher. When it changes, run the static checks from the reviewed agent-harness checkout (portable placeholder — substitute your local harness path):
+`.codex/hooks.json` is the project adapter binding Codex `Bash` calls to the shared global Bash-command deny-floor dispatcher. When it changes, run the static checks from the reviewed agent-harness worktree. The harness worktree must be detached at the reviewed canonical commit named by the active harness sync issue/PR — do not run these against an unreviewed harness head:
 
 ```powershell
 Get-Content -Raw .codex\hooks.json | ConvertFrom-Json | Out-Null
-python <agent-harness-root>\scripts\doctor.py
-python <agent-harness-root>\scripts\audit.py
-python "$env:USERPROFILE\.claude\hooks\smoke_test.py"   # installed-dispatcher smoke, if present
+$HarnessRoot = '<reviewed-agent-harness-worktree>'
+$TaskdeckRoot = (Resolve-Path .).Path
+py -3 "$HarnessRoot\harness.py" doctor --repo $TaskdeckRoot
+py -3 "$HarnessRoot\harness.py" audit --json $TaskdeckRoot
+py -3 "$env:USERPROFILE\.claude\hooks\smoke_test.py"
 ```
 
-These static checks prove structure and pin integrity only — they are insufficient to prove the hook is live. Actual activation additionally requires, in a fresh Codex session: re-trusting the hook definitions via `/hooks`, then observing one allowed command pass and one dangerous command denied (use a non-writing force-push dry run such as `git push --dry-run --force`). Report activation as NOT verified unless that live check was performed in the current session.
+Note on the pin: the `expected` hash named in the adapter is an audit-time declaration — harness doctor checks it against the installed dispatcher's normalized bytes. The hook performs no runtime byte verification of the dispatcher; runtime enforcement design is tracked at https://github.com/Chris0Jeky/agent-harness/issues/18. When the global dispatcher changes, refresh the adapter pin, re-run reviewed doctor/audit, and re-trust the hook via `/hooks`.
+
+These static checks prove structure and pin declaration only — they are insufficient to prove the hook is live. Actual activation additionally requires, in a fresh Codex session: re-trusting the hook definitions via `/hooks`, then observing one allowed command pass and one dangerous command denied (use a non-writing force-push dry run such as `git push --dry-run --force`). Report activation as NOT verified unless that live check was performed in the current session.
 
 ## Paper Backend Gap Testing (2026-05-05, PRs `#1031`–`#1040`)
 

--- a/docs/agentic/AGENT_TOOL_PARITY.md
+++ b/docs/agentic/AGENT_TOOL_PARITY.md
@@ -37,7 +37,7 @@ Both agents must preserve:
 | GitHub issues/PRs | GitHub MCP or `scripts/github/*` | GitHub MCP from `.mcp.json` or `gh` | `gh` CLI with explicit notes |
 | Containers/OpenAPI/SQLite docs | Docker MCP gateway | Docker MCP gateway from `.mcp.json` | `docker`/repo scripts |
 | High-autonomy issue work | Codex skills, configured agents/worktrees when runtime policy allows | Claude skills, hooks, worktree sessions | local coordinator flow |
-| Guardrails | system policy, `AGENTS.md`, `.codex/config.toml`, worktree guards | `.claude/settings.json`, hooks, skills, worktree guards | stop and ask for safety blockers |
+| Guardrails | shared deny-floor dispatcher via project `.codex/hooks.json`, system policy, `AGENTS.md`, worktree guards | shared deny-floor dispatcher via global Claude settings hooks, `.claude/settings.json`, skills, worktree guards | stop and ask for safety blockers |
 
 ## Codex Strengths To Use
 
@@ -72,7 +72,8 @@ Shared baseline servers:
 Known intentional difference:
 
 - Codex currently lists `ripgrep` MCP, but Taskdeck policy still prefers native `rg` on Windows.
-- Claude uses `.claude/settings.json` hooks for guardrails; Codex relies on system policy plus repo guard scripts and skills.
+
+Deny-floor parity: Claude and Codex run the same shared global dispatcher (`~/.claude/hooks/dispatch.py`) through one runtime-specific adapter each — Claude via global Claude settings hooks, Codex via the project `.codex/hooks.json` adapter. Neither runtime vendors the dispatcher.
 
 ## Verification
 
@@ -81,6 +82,7 @@ For parity-only changes, run:
 ```powershell
 Get-Content -Raw .mcp.json | ConvertFrom-Json | Out-Null
 Get-Content -Raw .claude\settings.json | ConvertFrom-Json | Out-Null
+Get-Content -Raw .codex\hooks.json | ConvertFrom-Json | Out-Null
 python $env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\taskdeck-question-batch
 python $env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\taskdeck-failure-capture
 python $env:USERPROFILE\.codex\skills\.system\skill-creator\scripts\quick_validate.py .codex\skills\taskdeck-interface-map
@@ -92,3 +94,5 @@ node scripts\check-golden-principles.mjs
 ```
 
 Use runtime MCP list commands when available, but do not claim remote MCP connectivity unless the current session actually verified it.
+
+For deny-floor adapter changes, the JSON parse above is only a static check. Actual activation proof requires a fresh Codex session that re-trusts the hook definitions via `/hooks`, then demonstrates one allowed command passing and one dangerous command denied (use a non-writing force-push dry run). Do not claim the hook is live from static checks alone.

--- a/docs/agentic/AGENT_TOOL_PARITY.md
+++ b/docs/agentic/AGENT_TOOL_PARITY.md
@@ -37,7 +37,7 @@ Both agents must preserve:
 | GitHub issues/PRs | GitHub MCP or `scripts/github/*` | GitHub MCP from `.mcp.json` or `gh` | `gh` CLI with explicit notes |
 | Containers/OpenAPI/SQLite docs | Docker MCP gateway | Docker MCP gateway from `.mcp.json` | `docker`/repo scripts |
 | High-autonomy issue work | Codex skills, configured agents/worktrees when runtime policy allows | Claude skills, hooks, worktree sessions | local coordinator flow |
-| Guardrails | shared deny-floor dispatcher via project `.codex/hooks.json`, system policy, `AGENTS.md`, worktree guards | shared deny-floor dispatcher via global Claude settings hooks, `.claude/settings.json`, skills, worktree guards | stop and ask for safety blockers |
+| Guardrails | shared Bash-command deny-floor dispatcher via project `.codex/hooks.json`, system policy, `AGENTS.md`, worktree guards | shared Bash-command deny-floor dispatcher via global Claude settings hooks, `.claude/settings.json`, skills, worktree guards | stop and ask for safety blockers |
 
 ## Codex Strengths To Use
 
@@ -73,7 +73,7 @@ Known intentional difference:
 
 - Codex currently lists `ripgrep` MCP, but Taskdeck policy still prefers native `rg` on Windows.
 
-Deny-floor parity: Claude and Codex run the same shared global dispatcher (`~/.claude/hooks/dispatch.py`) through one runtime-specific adapter each — Claude via global Claude settings hooks, Codex via the project `.codex/hooks.json` adapter. Neither runtime vendors the dispatcher.
+Deny-floor parity: Claude and Codex run the same shared global Bash-command deny-floor dispatcher (`~/.claude/hooks/dispatch.py`) through one runtime-specific adapter each — Claude via global Claude settings hooks, Codex via the project `.codex/hooks.json` adapter. Neither runtime vendors the dispatcher. This parity covers Bash commands only: structured non-Bash write surfaces (file-edit tools, MCP writes) are outside this adapter/dispatcher contract and are tracked upstream at https://github.com/Chris0Jeky/agent-harness/issues/2; system and tool permissions remain the compensating controls for those surfaces.
 
 ## Verification
 


### PR DESCRIPTION
## T4 gate

**Draft — exact-head CI and reviews are green, but do not merge until a maintainer has reviewed and trusted the project hook in a fresh interactive Codex `/hooks` session and recorded the real-engine allow/deny canaries.** This PR stages a security boundary; it does not self-ratify or self-merge it.

## Summary

- add Taskdeck&#39;s repo-local Codex `PreToolUse` adapter for `Bash`
- pin the reviewed canonical deny-floor v1.5.2 dispatcher declaration (`9f38e906d49dd84de196bf22fc6388a5551494cf9b303610014ee6539783ebbb`)
- document the exact fresh-session `/hooks` trust procedure
- state the boundary precisely: this is a Bash-command floor, not whole-tool containment, and the declared hash is audit-time metadata rather than a runtime byte check

No product behavior, API, database, frontend, `docs/STATUS.md`, or `docs/IMPLEMENTATION_MASTERPLAN.md` changes are included.

## Verification

For the reviewed harness commands below, `$TaskdeckRoot` means the absolute #1457 PR-worktree path.

- [x] `node scripts/check-docs-governance.mjs`
- [x] `node scripts/check-golden-principles.mjs`
- [x] `git diff --check origin/main...HEAD`
- [x] structural JSON assertion: exactly one `PreToolUse` entry, `^Bash$`, one command, timeout 5, no async/background, both platform commands contain the canonical pin and `--event pre --runtime codex`
- [x] `py -3 -B scripts\agent_hooks\smoke_test.py` with the real `py -3` interpreter directory prepended to `PATH`: hook behavior smoke matrix passed
- [x] reviewed agent-harness `72639b8781e41c4872e700291d865afbf2110f19`: installed canonical `smoke_test.py` reported **1604/1604 passed**
- [x] reviewed `harness.py doctor --repo $TaskdeckRoot`: project Codex floor reported one project handler, one candidate, one current pinned handler; overall command remained nonzero only for the pre-existing missing user-skills check
- [x] reviewed `harness.py audit --json $TaskdeckRoot`: no adapter finding; overall command remained nonzero for pre-existing repository hygiene tracked by #1138/#1291
- [ ] `dotnet test backend/Taskdeck.sln -c Release` — not run; no backend/product code changed
- [ ] frontend typecheck/build/Vitest — not run; no frontend code changed
- [ ] Playwright — not run; no UI or cross-surface behavior changed
- [ ] fresh interactive Codex `/hooks` review plus real-engine allow/deny canaries — maintainer gate
- [x] exact-head PR CI: run `30063860671` passed all 15 jobs (including E2E Smoke) and CodeQL run `30063859670` passed all 4 jobs on `a57b64aff4cf6f55057e163ba81c06dd5e4b31c8`

Two independent adversarial reviews examined the implementation. Their findings and resolutions are recorded in a PR comment; both re-reviewed exact head `a57b64aff4cf6f55057e163ba81c06dd5e4b31c8` after the documentation fix and reported no remaining findings. A fresh external Codex review then examined the same head and posted no inline thread or actionable finding.

## Documentation

- [ ] `docs/STATUS.md` updated — not applicable; shipped product reality did not change
- [ ] `docs/IMPLEMENTATION_MASTERPLAN.md` updated — not applicable; roadmap did not change
- [x] `docs/TESTING_GUIDE.md` updated for the new verification flow
- [x] `.codex/README.md` and `docs/agentic/AGENT_TOOL_PARITY.md` updated with trust boundaries

## Tracking

- [x] Closes #1456
- [x] linked issue project status is `Review`; PR/issue priorities are populated; priority audit scanned 1000 items with `needsUpdate: 0`

## CI Workflow Validation

- [x] no `.github/workflows/`, `deploy/`, `scripts/`, or `*.csproj` files changed; CI Extended path trigger is not expected
- [x] intended `ci-required.yml` run `30063860671` and CodeQL run `30063859670` are green on exact head `a57b64af`

## Risk Notes

- Security impact: introduces the reviewed canonical Bash deny-floor adapter, but activation/trust is deliberately left to a fresh human-reviewed Codex session.
- Behavior/regression risk: low for product behavior; the risk is security-posture overstatement, so the docs explicitly preserve the adapter&#39;s known limits.
- Follow-up tasks: agent-harness #2 tracks non-Bash mutation surfaces; agent-harness #17 tracks runtime-owned `GIT_CONFIG_GLOBAL` false denials; agent-harness #18 tracks enforceable-vs-audit-only hash semantics.