### PR TITLE
docs(agentic): the overnight manuals stop restating the model ladder (and the Codex manual stops authorizing squash merges)

### DIFF
--- a/docs/agentic/OVERNIGHT_LOOP.claude.md
+++ b/docs/agentic/OVERNIGHT_LOOP.claude.md
@@ -124,27 +124,54 @@ criteria), never idle. Leave `CODEX-*`-labelled trackers for Codex. The
   self-ratify a *strategic* ADR; that's a deferred question).
 - Keep the agent-facing maps current (**`taskdeck-interface-map`**) when you add/split a domain.
 
-### Compute routing — the calibrated ladder (invoke `model-effort-routing` when unsure)
+### Compute routing — the ladder lives in ONE place, and it is not this file
 
-Right-size **effort → model → agent count**, cheapest dial first. Don't reflexively fan out or
-crank the top model on trivia — that drains the run before the hard tasks land.
+**Do not restate the model/effort ladder here.** Its single source of truth is the
+**`model-effort-routing` skill** (`~/.claude/skills/model-effort-routing/SKILL.md`; the short form
+is the "Working style" bullet in `~/.claude/CLAUDE.md`). Invoke it at run start, route from it,
+and re-read it if a long run spans a change to it. **No model name, effort default, price, or
+fleet-size number belongs in this file, in `OVERNIGHT_LOOP.fable.md`, in a Taskdeck skill, or in a
+worker prompt** — a local copy is precisely how this section drifted: it went on routing mechanical
+work to a model the owner had banned outright, and naming a superseded model as the default reach,
+long after the canonical ladder had moved on. Writing the ladder down twice is what let one copy
+rot. If you find a Taskdeck doc restating it, delete the restatement and link the skill instead.
 
-- **Model ladder:** default reach is **Opus 4.8** at task-appropriate effort (prefer Opus
-  low/medium over Sonnet). **Fable 5** only for the hardest reasoning (security review, EF
-  migration-snapshot merges, race/concurrency analysis, architecture, ambiguous multi-file
-  debugging) if within its access window, else Opus 4.8 high. **Haiku 4.5** for mechanical work
-  (formatting, mass renames, dependency bumps, log/CI-log triage, doc-link fixes). **Sonnet 4.6
-  high** only for simple, fully-laid-out tasks; avoid Sonnet 5 as a default. Set the subagent's
-  `model` and `effort` explicitly per its job.
+Two constraints are repeated here only because they bound this run operationally rather than
+express a routing preference: **never Haiku** (standing owner directive, no exceptions), and
+**right-size effort → model → agent count, cheapest dial first** — don't reflexively fan out or
+crank the top model on trivia; that drains the run before the hard tasks land.
+
+What this file owns is the part the canonical skill cannot know: **which Taskdeck work is hard,
+which is genuinely mechanical, and how the lanes are shaped.**
+
+- **Judgment-heavy in this repo** — route to the ladder's top rungs, and escalate effort before
+  escalating model: EF migration-snapshot merges (proof is `dotnet ef migrations
+  has-pending-model-changes` → "No changes"), race/concurrency and permit-lifecycle analysis,
+  security and auth/permission review, Clean-Architecture boundary calls, ambiguous multi-file
+  debugging, adjudicating review findings, ADR drafting, and anything touching the deny floor or
+  the harness gates.
+- **Genuinely mechanical in this repo** — the cheap rung's only legitimate use here:
+  docs-governance `Last Updated` bumps, doc-link fixes, mass renames, dependency bumps, freshening
+  a stale branch via merge-from-main, opening a PR from a prepared branch with a body *you*
+  authored, posting review/fix-evidence text *you* finalised, reporting a CI verdict verbatim.
+  **"Mechanical" is a claim to check, not a default:** anything that decides what matters —
+  triaging a CI log, classifying a red, choosing which finding to fix — is judgment and goes up
+  the ladder.
+- **Set `model` and `effort` explicitly per subagent.** Silent inheritance of the session model is
+  how a trivial task gets the expensive agent and a hard task gets a cheap one. (The plain Agent
+  tool has no effort knob — it inherits the session; use Workflow `agent()` opts when the
+  distinction matters.)
 - **Fan out** only for genuinely disjoint regions, an independent review lens, or scope one
-  context can't hold. Right-size: **≤3–5 agents (≤8–12 for a broad sweep)**, never a reflexive
-  swarm. Start inline; escalate to subagents/the **Workflow** tool when the structure earns it
-  (parallel discovery, dimension-then-verify review pipelines, migrations across many sites).
+  context can't hold — **fleet sizing per the canonical skill.** Start inline; escalate to
+  subagents/the **Workflow** tool when the structure earns it (parallel discovery,
+  dimension-then-verify review pipelines, migrations across many sites). Taskdeck-specific caps on
+  top of the skill's: **≤3 concurrent implementation workers** (worktree collisions and this box),
+  and **never two full test suites at once, box-wide**.
 - **Reviewers are read-only** (`reviewer` / `pr-review-toolkit:*` subagents) — they can't edit,
-  so their only output is findings (structurally safe). **You, the coordinator, always own final
-  synthesis, verification, and the merge — never delegate those.** For background subagents,
-  relay only the conclusion, not file dumps; continue a running one with `SendMessage` rather
-  than respawning.
+  so their only output is findings (structurally safe). Review is judgment work: the cheap rung is
+  never eligible for it. **You, the coordinator, always own final synthesis, verification, and the
+  merge — never delegate those.** For background subagents, relay only the conclusion, not file
+  dumps; continue a running one with `SendMessage` rather than respawning.
 - **Budget:** checkpoint often; keep diffs and test runs targeted (`dotnet --filter`,
   `vitest --maxWorkers=2`) to avoid burning time/OOM. Deep in a rabbit hole → stop, record the
   finding, take a cheaper path.

--- a/docs/agentic/OVERNIGHT_LOOP.claude.md
+++ b/docs/agentic/OVERNIGHT_LOOP.claude.md
@@ -141,6 +141,15 @@ express a routing preference: **never Haiku** (standing owner directive, no exce
 **right-size effort → model → agent count, cheapest dial first** — don't reflexively fan out or
 crank the top model on trivia; that drains the run before the hard tasks land.
 
+**If the canonical source is unreachable** — a fresh clone, a different machine, a `~/.claude`
+that was never provisioned — do **not** reconstruct a ladder from memory, and do not fall back to
+whatever this file used to say (that text was wrong, which is why it is gone). The two constraints
+above still bind, and the safe degradation is to **run the session inline at whatever model the
+session is already on, delegating nothing**: a run with no fan-out is slower, not incorrect,
+whereas delegating to guessed rungs is how the wrong model silently gets the hard task. Record it
+in the ledger and raise it in the deferred-questions batch — an unreachable routing source is a
+maintainer-fixable setup gap, not a judgment call for the run to improvise around.
+
 What this file owns is the part the canonical skill cannot know: **which Taskdeck work is hard,
 which is genuinely mechanical, and how the lanes are shaped.**
 

--- a/docs/agentic/OVERNIGHT_LOOP.codex.md
+++ b/docs/agentic/OVERNIGHT_LOOP.codex.md
@@ -88,7 +88,10 @@ Read before editing — do not assume layout:
     actual check runs; don't assume.
   - Merge convention: **merge commits, never squash** — squash-merge destroys commit history and
     count, and it was disabled repo-side across the estate on 2026-07-18, so the option should
-    not even be offered. Rebase keeps the count and is acceptable; a merge commit is preferred.
+    not even be offered. Rebase preserves the count and is acceptable **for a standalone PR only**;
+    a merge commit is preferred everywhere and is **required for a stacked base**, because
+    rebase-merging a base rewrites its commits onto `main` while every child still descends the
+    original hashes — retargeting then loses the shared ancestry and manufactures conflicts.
     **Never `--delete-branch` a stacked base PR** (it cascade-closes children unreopenably). In a
     stack, **merge the oldest/base first**, then retarget/absorb children.
 - **Inventory** open PRs, open issues, red CI, `TODO`/`FIXME`, the failure ledger. This seeds

--- a/docs/agentic/OVERNIGHT_LOOP.codex.md
+++ b/docs/agentic/OVERNIGHT_LOOP.codex.md
@@ -86,9 +86,11 @@ Read before editing — do not assume layout:
     only gate.** Never merge on GitHub's permission; merge only when *your* gate (§5) holds.
   - `ci-required.yml` is the intended PR gate; `ci-nightly.yml` is "CI Extended". Read a PR's
     actual check runs; don't assume.
-  - Merge convention observed here: merge commits for stacked bases, squash acceptable for
-    standalone. **Never `--delete-branch` a stacked base PR** (it cascade-closes children
-    unreopenably). In a stack, **merge the oldest/base first**, then retarget/absorb children.
+  - Merge convention: **merge commits, never squash** — squash-merge destroys commit history and
+    count, and it was disabled repo-side across the estate on 2026-07-18, so the option should
+    not even be offered. Rebase keeps the count and is acceptable; a merge commit is preferred.
+    **Never `--delete-branch` a stacked base PR** (it cascade-closes children unreopenably). In a
+    stack, **merge the oldest/base first**, then retarget/absorb children.
 - **Inventory** open PRs, open issues, red CI, `TODO`/`FIXME`, the failure ledger. This seeds
   the backlog.
 - **Windows/env quirks** (this box): git may resolve to a wrapper — if git misbehaves, use

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -32,12 +32,13 @@ hard-versus-mechanical map for Taskdeck work, and it does not override §3's rul
 ladder is never restated locally — that rule binds both files, and the `model-effort-routing`
 skill outranks both.
 
-The core premise: **your own turns are the scarcest resource in the run.** Fable is reserved by
-**value, not rationed by access** — it is available; it is simply not what most of a run's work
-needs, and there is no expiry to race. Spend Fable turns only where a cheaper rung would plausibly
-get it wrong. Everything else is delegated with an explicit `model`/`effort` per agent, taken from
-the canonical ladder (see COMPUTE ROUTING below). You are an orchestrator that thinks, decides,
-and gates — not the typist.
+The core premise: **your own turns are the scarcest resource in the run.** Spend a coordinator
+turn only where a cheaper rung would plausibly get it wrong — not because the rung above is
+rationed, but because most of a run's work simply does not need it. Whether this variant is the
+right one to be running at all, and on what terms, is the canonical routing source's call and not
+this file's; no availability or expiry claim belongs here. Everything else is delegated with an
+explicit `model`/`effort` per agent, taken from that same source (see COMPUTE ROUTING below). You
+are an orchestrator that thinks, decides, and gates — not the typist.
 
 ## FIRST ACTIONS
 
@@ -96,10 +97,13 @@ and take the actual model and effort for each rung from the skill.
 - Spawn implementation workers at the canonical ladder's **code-implementation rung**, and set
   `model` and `effort` explicitly per worker rather than letting them inherit your session — a
   Fable session that silently propagates itself into every slice is the failure this lane exists
-  to prevent. Inside Workflow scripts, set effort per slice: the ladder's judgment-heavy setting
-  for hard slices (backend concurrency, multi-file features, gnarly test repair), one rung down
-  for standard slices; reach up only when the task earns it. (The plain Agent tool has no effort
-  knob — it inherits the session; use Workflow `agent()` opts when the distinction matters.)
+  to prevent. Inside Workflow scripts, vary **effort, not the rung**: the ladder's judgment-heavy
+  effort setting for hard slices (backend concurrency, multi-file features, gnarly test repair)
+  and a lower one for standard slices, reaching up only when the task earns it. Standard
+  implementation work never leaves the code-implementation rung — the ops rung below is for
+  already-decided mechanics only, so dropping a coding slice into it is a lane violation, not a
+  saving. (The plain Agent tool has no effort knob — it inherits the session; use Workflow
+  `agent()` opts when the distinction matters.)
 - Parallel or collision-prone work runs in **worktree isolation** per
   `docs/WORKTREE_AGENT_PROTOCOL.md` / the `taskdeck-worktree-issue-worker` skill. ≤3 concurrent
   implementation workers; verify `main` is clean after each wave.

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -97,12 +97,17 @@ and take the actual model and effort for each rung from the skill.
 - Spawn implementation workers at the canonical ladder's **code-implementation rung**, and set
   `model` and `effort` explicitly per worker rather than letting them inherit your session — a
   Fable session that silently propagates itself into every slice is the failure this lane exists
-  to prevent. Inside Workflow scripts, vary **effort, not the rung**: the ladder's judgment-heavy
-  effort setting for hard slices (backend concurrency, multi-file features, gnarly test repair)
-  and a lower one for standard slices, reaching up only when the task earns it. Standard
-  implementation work never leaves the code-implementation rung — the ops rung below is for
-  already-decided mechanics only, so dropping a coding slice into it is a lane violation, not a
-  saving. (The plain Agent tool has no effort knob — it inherits the session; use Workflow
+  to prevent. **The rung floor is fixed; the ceiling is not.** Standard implementation work never
+  drops below the code-implementation rung — the ops rung is for already-decided mechanics only, so
+  putting a coding slice there is a lane violation, not a saving — and within that rung you vary
+  effort: the judgment-heavy setting for demanding slices (multi-file features, gnarly test
+  repair), a lower one for routine ones. Upward is different: a slice that falls in **base manual
+  §3's judgment-heavy list** — race/concurrency and permit-lifecycle work, security and
+  auth/permission changes, Clean-Architecture boundary calls, ambiguous multi-file debugging,
+  anything touching the deny floor or the harness gates — routes to the ladder's **top rungs**, not
+  to the implementation rung at higher effort. Escalate effort first, then the rung, and escalate
+  to yourself when the call is really an architecture or security judgment wearing a code-change
+  costume. (The plain Agent tool has no effort knob — it inherits the session; use Workflow
   `agent()` opts when the distinction matters.)
 - Parallel or collision-prone work runs in **worktree isolation** per
   `docs/WORKTREE_AGENT_PROTOCOL.md` / the `taskdeck-worktree-issue-worker` skill. ≤3 concurrent

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -1,7 +1,9 @@
 # Taskdeck — Overnight Orchestrator, Fable 5 variant
 
 **Launch (maintainer):** start Claude Code in this repo with the session model set to **Fable 5**
-(effort high or ultracode), pick the permission mode you trust for unattended work, and paste:
+at the effort the `model-effort-routing` skill assigns it (Fable is worth reaching for *because*
+the problem is hard — low-effort Fable is the worst of both dials), pick the permission mode you
+trust for unattended work, and paste:
 
 > Read the most recent `ORCHESTRATOR.handoff-*.md` at the repo root (if one exists) and resume
 > from it, then `docs/agentic/OVERNIGHT_LOOP.claude.md` (your operating manual — adopt all of
@@ -24,13 +26,18 @@ it (enforcement-ladder rule).
 You are **Claude Fable 5**, sole coordinator of an unattended overnight run on Taskdeck.
 Your operating manual is **`docs/agentic/OVERNIGHT_LOOP.claude.md`** — read it first and adopt
 all of it: §0 ledger/memory, §1 orientation, §2 task selection, §4 review, §5 merge gate,
-§6 safety, §7 deferred questions, §8 runway-clearing, §9 loop control. **This file overrides
-only its §3 compute-routing block** with the Fable-specific division of labor below.
+§6 safety, §7 deferred questions, §8 runway-clearing, §9 loop control. **This file refines only
+its §3 lane assignments** with the division of labor below. It does **not** override §3's
+hard-versus-mechanical map for Taskdeck work, and it does not override §3's rule that the model
+ladder is never restated locally — that rule binds both files, and the `model-effort-routing`
+skill outranks both.
 
-The core premise: **your own inference is the scarcest, most expensive resource in the run**
-(and the access window is finite). Spend Fable turns only where a cheaper model would plausibly
-get it wrong. Everything else is delegated with an explicit `model`/`effort` per agent. You are
-an orchestrator that thinks, decides, and gates — not the typist.
+The core premise: **your own turns are the scarcest resource in the run.** Fable is reserved by
+**value, not rationed by access** — it is available; it is simply not what most of a run's work
+needs, and there is no expiry to race. Spend Fable turns only where a cheaper rung would plausibly
+get it wrong. Everything else is delegated with an explicit `model`/`effort` per agent, taken from
+the canonical ladder (see COMPUTE ROUTING below). You are an orchestrator that thinks, decides,
+and gates — not the typist.
 
 ## FIRST ACTIONS
 
@@ -56,7 +63,26 @@ an orchestrator that thinks, decides, and gates — not the typist.
 
 ## COMPUTE ROUTING — WHO DOES WHAT
 
-### Fable — you, inline; never delegated
+**The model/effort ladder is NOT restated in this file, and must never be.** Its single source of
+truth is the **`model-effort-routing` skill** (`~/.claude/skills/model-effort-routing/SKILL.md`;
+short form in `~/.claude/CLAUDE.md`). Read it before the first delegation and bind every lane to a
+rung from it. **No model name, effort default, price, or access/expiry claim belongs in this
+file.** This section used to hard-code an entire ladder of its own, and every part of it went
+stale at once: a cheap-ops lane routing work to a model the owner had banned outright, a "coding
+workhorse" naming a model that had been superseded as the default reach, reviewers pinned below
+the effort reviews actually require, and a finite "access window" for Fable that no longer
+describes anything real. It stayed wrong for months because the ladder was written down twice and
+only the canonical copy was maintained. Base manual §3 carries the same prohibition; if this file
+and the skill ever appear to disagree about a model, **both local copies are stale and the skill
+wins** — fix the doc, don't route from it.
+
+What this file owns is the **lane structure** — who does what in an unattended Taskdeck run, and
+how the waves are shaped. Which Taskdeck work is hard versus mechanical is base manual §3. Bind
+the lanes to rungs at run start (coordinator = the hardest-calls rung; implementation = the
+code-implementation rung; ops = the cheap rung; reviewers = judgment, so never the cheap rung),
+and take the actual model and effort for each rung from the skill.
+
+### Coordinator lane — you, inline; never delegated
 - Wave planning and task selection; architecture and ADR drafting; security-posture judgment;
   EF migration-snapshot merges; race/concurrency analysis; genuinely ambiguous multi-file
   debugging **after** a cheaper agent has gathered the evidence and failed to crack it.
@@ -66,12 +92,14 @@ an orchestrator that thinks, decides, and gates — not the typist.
 - Keep your turns lean: don't bulk-read what a subagent can summarize; don't sit through long
   test suites inline — delegate the run and take back counts + failure excerpts.
 
-### Opus 4.8 — the coding workhorse (default lane)
-- Spawn implementation workers with `model: "opus"`. Inside Workflow scripts, set effort
-  explicitly: `effort: "high"` for hard slices (backend concurrency, multi-file features,
-  gnarly test repair), `effort: "medium"` for standard slices — medium is the default; reach
-  for high only when the task earns it. (The plain Agent tool has no effort knob — it inherits
-  the session; use Workflow `agent()` opts when the distinction matters.)
+### Implementation lane — the coding workhorse (default lane)
+- Spawn implementation workers at the canonical ladder's **code-implementation rung**, and set
+  `model` and `effort` explicitly per worker rather than letting them inherit your session — a
+  Fable session that silently propagates itself into every slice is the failure this lane exists
+  to prevent. Inside Workflow scripts, set effort per slice: the ladder's judgment-heavy setting
+  for hard slices (backend concurrency, multi-file features, gnarly test repair), one rung down
+  for standard slices; reach up only when the task earns it. (The plain Agent tool has no effort
+  knob — it inherits the session; use Workflow `agent()` opts when the distinction matters.)
 - Parallel or collision-prone work runs in **worktree isolation** per
   `docs/WORKTREE_AGENT_PROTOCOL.md` / the `taskdeck-worktree-issue-worker` skill. ≤3 concurrent
   implementation workers; verify `main` is clean after each wave.
@@ -82,24 +110,27 @@ an orchestrator that thinks, decides, and gates — not the typist.
 - Iterating on a worker's output? **`SendMessage` to the same worker** (context intact), don't
   respawn.
 
-### Cheap ops lane — one dedicated PR-mechanic (Sonnet), Haiku below it
-- Keep **one long-lived Sonnet agent** (continue it via `SendMessage` all night) for
-  fully-specified mechanics where judgment is already done: opening PRs from prepared branches
-  with a body **you authored**, posting your finalized review/fix-evidence comments, polling CI
-  and reporting the exact verdict + failing-job excerpts, freshening stale branches via
-  merge-from-main, docs-governance `Last Updated` bumps.
-- Rule: **Sonnet executes decided work; it never decides.** If the ops task turns out to need a
-  judgment call, it reports back — you or an Opus worker takes over. Anything ambiguous never
-  enters this lane.
-- **Haiku 4.5** for pure mechanical work: formatting, mass renames, dependency-bump PRs,
-  CI-log/`TODO` triage sweeps, link fixes.
+### Ops lane — ONE dedicated PR-mechanic at the ladder's cheap rung
+- Keep **one long-lived ops agent** (continue it via `SendMessage` all night) for fully-specified
+  mechanics where the judgment is already done: opening PRs from prepared branches with a body
+  **you authored**, posting your finalized review/fix-evidence comments, polling CI and reporting
+  the exact verdict + failing-job excerpts, freshening stale branches via merge-from-main,
+  docs-governance `Last Updated` bumps, mass renames, dependency-bump PRs, link fixes.
+- Rule: **the ops lane executes decided work; it never decides.** If an ops task turns out to need
+  a judgment call, it reports back — you or an implementation worker takes over. Anything
+  ambiguous never enters this lane. In particular a `TODO`/CI-log *triage sweep* is not ops work:
+  triage decides what matters, so it belongs on the implementation rung or with you.
+- The cheap rung is the floor of this lane, not a starting point to go below. **There is no lane
+  beneath it** — the owner's standing directive rules out the cheapest model entirely, and a lane
+  that needs something cheaper than the ops lane is a lane that should not exist.
 
-### Reviewers — read-only, Opus medium, distinct lenses
-- Use the `reviewer` subagent type (Read/Grep/Glob only — structurally cannot "fix" anything)
-  at Opus medium. Two independent passes per PR with **distinct lenses** (correctness /
-  security / test-coverage / does-it-reproduce), per base §4; 3-vote adversarial verify for
-  high-stakes findings. You adjudicate; the implementing Opus worker fixes; the ops agent posts
-  the PR comments you finalize.
+### Reviewer lane — read-only, distinct lenses, never the cheap rung
+- Use the `reviewer` subagent type (Read/Grep/Glob only — structurally cannot "fix" anything), at
+  the model and effort the canonical skill assigns to **review**: review is judgment work, so the
+  cheap rung is not eligible and the skill — not this file — sets the effort. Two independent
+  passes per PR with **distinct lenses** (correctness / security / test-coverage /
+  does-it-reproduce), per base §4; 3-vote adversarial verify for high-stakes findings. You
+  adjudicate; the implementing worker fixes; the ops agent posts the PR comments you finalize.
 
 ## ORCHESTRATION PATTERNS
 
@@ -107,9 +138,9 @@ an orchestrator that thinks, decides, and gates — not the typist.
   discovery sweeps, many-site migrations. Prefer `pipeline()` over barriers; use `schema` for
   structured returns; set `model`/`effort` per stage (finders cheap, verifiers stronger).
   Plain `Agent` calls for one-off delegation; a workflow only when the structure earns it.
-- **Wave shape per cycle:** plan (you) → implement (Opus workers, worktrees) → branch/PR
-  mechanics (ops agent) → review (read-only reviewers → your adjudication) → fix (same Opus
-  worker via SendMessage) → gate + merge (**you**, base §5, dependency-safe order) → ledger
+- **Wave shape per cycle:** plan (you) → implement (implementation-lane workers, worktrees) →
+  branch/PR mechanics (ops agent) → review (read-only reviewers → your adjudication) → fix (the
+  same worker via SendMessage) → gate + merge (**you**, base §5, dependency-safe order) → ledger
   checkpoint → pull `main` → next wave.
 - Keep **2–4 tasks in flight**, never a reflexive fleet (`model-effort-routing` skill when
   unsure). While workers run in the background, use your foreground turn for the next wave's
@@ -121,26 +152,26 @@ Engage when the usage window is tight, a reset boundary is near, or the maintain
 frugal run. It tightens the standard division of labor; everything else in this manual still
 applies — the gate is never thinned to save tokens (see STOP CONDITIONS for how to degrade).
 
-- **Coordinator turns go to the Fable lane's never-delegated work** (wave planning, task
+- **Coordinator turns go to the coordinator lane's never-delegated work** (wave planning, task
   selection, adjudication, the gates) **and nothing else.** No inline reading a subagent could
   summarize, no sitting through suites, no drafting mechanics a cheaper lane can execute from
   your finalized text. Required orientation and gate reads are never delegated to save
   tokens: the coordinator still reads the source-of-truth docs (base §1 — STATUS,
   OUTSTANDING_TASKS, the handoff) and every gate input itself.
-- **Opus gate-marshals per lane:** one worker owns a PR's whole fix→verify→settle cycle
-  end-to-end — "verify" meaning the worker's TARGETED runs; full-suite verdicts stay with the
-  ops lane + coordinator per BUDGET & CADENCE — continued via `SendMessage` round after round,
-  never respawned per round, so context (the PR's history, reviewers' phrasing, prior
-  verdicts) is paid for once. Thread settlement (reply + `resolveReviewThread` + report
+- **Gate-marshals per lane (implementation rung):** one worker owns a PR's whole
+  fix→verify→settle cycle end-to-end — "verify" meaning the worker's TARGETED runs; full-suite
+  verdicts stay with the ops lane + coordinator per BUDGET & CADENCE — continued via
+  `SendMessage` round after round, never respawned per round, so context (the PR's history,
+  reviewers' phrasing, prior verdicts) is paid for once. Thread settlement (reply + `resolveReviewThread` + report
   `unresolved == 0`) is owned by exactly ONE lane per PR — default the gate-marshal; the
   coordinator may reassign a PR's settlement to the ops agent in that packet explicitly
   (e.g. the marshal is retired), but never lets both act on the same PR's threads. (Honest
   provenance: the two proving runs actually ran settlement in the ops lane as a standing
   cycle; the marshal default here is a deliberate alignment with the gate sequence below,
   which the single-owner rule preserves either way.)
-- **The Cheap-ops-lane Sonnet agent (the SAME single agent, not a second one) takes on an
-  extended remit** in addition to its standing tasks: full-suite runs under a STOP-on-red
-  decision rule, determinism reruns, and any settlement packet reassigned per the bullet
+- **The ops-lane agent (the SAME single agent, not a second one) takes on an extended remit** in
+  addition to its standing tasks: full-suite runs under a STOP-on-red decision rule, determinism
+  reruns, and any settlement packet reassigned per the bullet
   above (reply texts in a settlement packet are always coordinator-authored — the lane posts
   finalized text, consistent with its standing remit). The lane's standing rule (executes
   decided work, never decides) is unchanged. A "packet" throughout this section = one
@@ -212,7 +243,7 @@ merge → pull `main` → prune worktree+branch (cd out of a worktree before rem
   project-level run; `vitest` targeted specs or `--maxWorkers=2` — full local vitest OOMs on
   this box). The coordinator OWNS the full-suite verdict at gate time (`-m:1`, ~6 min,
   600000ms tool timeout) but should delegate the sitting — a subagent runs the suite in its
-  own foreground turn and returns counts + failure excerpts (consistent with the Fable-lane
+  own foreground turn and returns counts + failure excerpts (consistent with the coordinator-lane
   rule above). Never two full suites concurrently, box-wide.
 - **Box rules (hard-won; also see the latest handoff §7)**: background Bash tasks can be
   killed by the harness — run suites and waits FOREGROUND with explicit timeouts (600000ms is


### PR DESCRIPTION
Docs-only. The three overnight orchestrator manuals each carried their own copy of the model/effort ladder, and every copy had rotted. This removes the local copies, points them at the canonical source, and fixes one stale merge permission found in the same pass.

## Why this mattered

A local copy of a routing table is how the table drifts. All three manuals were maintained independently of `~/.claude/skills/model-effort-routing/SKILL.md`, and the drift was not cosmetic:

- the base manual's ladder routed **mechanical work to Haiku**, months after the owner banned that model outright. The ban has automated enforcement only over *agent definitions*, and only in the `~/.claude` config repo (`tests/check-agent-models.ps1` there) — no check covers routing instructions written as prose, which is exactly how this one survived;
- it named a **superseded model as the default reach**;
- the Fable overlay pinned **reviewers a rung below the effort review actually needs**;
- the Fable overlay's core premise was a **finite Fable access window** that no longer describes anything real — a manual that tells its coordinator to race an expiry teaches a false economy;
- `OVERNIGHT_LOOP.codex.md` told an unattended orchestrator that **squash-merge was acceptable** for standalone PRs. That contradicts the standing preserve-history rule, and squash-merge was disabled repo-side across the estate on 2026-07-18 — the manual was offering an option the orchestrator could no longer take. A stale permission in an unattended prompt is worse than a missing one, because nothing in the run would have questioned it.

These went unnoticed because the ladder was written down twice and only the canonical copy was maintained.

## What changes

- **`OVERNIGHT_LOOP.claude.md` §3** — stops restating the ladder; names the `model-effort-routing` skill as the single source of truth and forbids restating it in this file, the Fable overlay, a Taskdeck skill, or a worker prompt. Keeps only the two constraints that bound a run operationally rather than express a routing preference (never Haiku; cheapest-dial-first). In their place the section now owns the part the canonical skill *cannot* know: **which Taskdeck work is judgment-heavy versus genuinely mechanical**, with "mechanical is a claim to check, not a default" — triaging a CI log or classifying a red decides what matters, so it is judgment.
- **`OVERNIGHT_LOOP.fable.md`** — lanes are renamed from models to **roles** (coordinator / implementation / ops / reviewer) and bind to a ladder rung at run start instead of hard-coding a model. The lane structure, which is what the overlay actually proved out over several runs, is unchanged. The Haiku-shaped hole under the ops lane is closed explicitly rather than deleted: nothing lives below the cheap rung, and a lane needing something cheaper is a lane that should not exist. Triage moves out of ops. Records that when the file and the skill disagree, **the skill wins and the file is what gets fixed**.
- **`OVERNIGHT_LOOP.codex.md`** — merge convention corrected to merge-commit-never-squash (rebase acceptable, merge commit preferred), with the repo-side disable dated. This is the only change to that manual; its compute-routing section is deliberately untouched because it routes on the Codex runtime's own reasoning-effort dial and names no Claude model, so it has nothing to drift out of sync with.

## Scope and risk

Docs only — `docs/agentic/` orchestrator manuals. No code, no workflow files, no gates, no deny floor, and no product canonical docs (`STATUS.md` / `GOLDEN_PRINCIPLES.md` untouched; the delivery-record sweep for this wave is a separate PR).

Risk is that a future run reads a manual that now defers to the skill and the skill is unreachable. Mitigated by the manuals stating the skill path explicitly and by the two operational constraints being restated locally.

## Verification

- `node scripts/check-docs-governance.mjs` — passed
- `node scripts/check-golden-principles.mjs` — passed
- `node scripts/check-github-ops-governance.mjs` — passed
- Required CI on this head.

**Not verified:** nothing here is executable, so there is no behavioral proof to give — the claim is that these documents now agree with the canonical ladder and with the never-squash rule, which is a reading, not a test run.
