### PR TITLE
fix(#1123): make the release pipeline rehearsable without pushing a tag

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -291,14 +291,29 @@ jobs:
             exit 1
           fi
 
+      # A bare workflow_dispatch (no tag input, run from a branch) is the REHEARSAL path:
+      # it must build, smoke-test and package without publishing anything. Previously the
+      # `${GITHUB_REF#refs/tags/}` strip silently no-op'd on `refs/heads/main`, so TAG became
+      # "refs/heads/main" and the slashes broke packaging — meaning the pipeline could only
+      # ever be exercised by pushing a real tag (`#1123`).
       - name: Determine version tag
         id: version
         shell: bash
         run: |
           TAG="${{ inputs.tag || '' }}"
-          if [ -z "$TAG" ]; then
+          if [ -z "$TAG" ] && [ "${GITHUB_REF#refs/tags/}" != "$GITHUB_REF" ]; then
             TAG="${GITHUB_REF#refs/tags/}"
           fi
+          if [ -z "$TAG" ]; then
+            TAG="v0.0.0-dryrun+${GITHUB_SHA:0:7}"
+            echo "No tag ref or tag input — rehearsal build, versioned $TAG (no release will be published)."
+          fi
+          case "$TAG" in
+            */*|*' '*)
+              echo "::error::Refusing version tag '$TAG' — it would produce an invalid artifact path."
+              exit 1
+              ;;
+          esac
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Package artifact (zip — Windows)
@@ -339,6 +354,10 @@ jobs:
   create-release:
     name: Create GitHub Release
     needs: build-backend
+    # Publish ONLY for a real release: a tag push, or a dispatch that names an existing tag.
+    # A bare dispatch is a rehearsal and must stop after artifacts — without this guard it
+    # reached `gh release create` and failed there, which is not a safe place to rely on.
+    if: startsWith(github.ref, 'refs/tags/') || inputs.tag != ''
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -372,8 +391,12 @@ jobs:
         id: version
         run: |
           TAG="${{ inputs.tag || '' }}"
-          if [ -z "$TAG" ]; then
+          if [ -z "$TAG" ] && [ "${GITHUB_REF#refs/tags/}" != "$GITHUB_REF" ]; then
             TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag resolved; this job must not run for a rehearsal build."
+            exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Makes the release pipeline **rehearsable without pushing a tag**, so `#1123`'s "exercise the release pipeline" can happen before `#1303`'s irreversible step rather than after it.

`#1303` reserves the tag push to the maintainer and says agents may repair the pipeline but must not publish. Combined with this workflow's actual behaviour, that meant the pipeline **could not be exercised at all** before the one action nobody can take back.

## Two defects

- **The dispatch path produced a garbage version.** `TAG="${GITHUB_REF#refs/tags/}"` silently no-ops on a branch ref, so a bare `workflow_dispatch` from `main` resolved `TAG` to the literal `refs/heads/main`. The slashes then break packaging — `taskdeck-refs/heads/main-win-x64.zip` is not a valid `Compress-Archive` destination — so the run died before proving anything.
- **`create-release` had no `if:`.** A dispatch reached `gh release create` regardless of intent. It happened to fail there on `--verify-tag`, but a publish step should be gated by intent, not saved by a flag on its last command.

## After this change

A bare dispatch is an explicit **rehearsal**: versions the build `v0.0.0-dryrun+<sha>`, builds and smoke-tests every platform, packages and uploads artifacts, then stops. Publishing still requires a tag push or a dispatch naming an existing tag — the human action `#1303` reserves.

Also rejects any resolved tag containing a slash or space rather than letting it corrupt an artifact path, and makes the `create-release` version step fail loudly instead of proceeding with an empty tag.

## Verification — rehearsed for real

Dispatched from this branch: **run [30160400273](https://github.com/Chris0Jeky/Taskdeck/actions/runs/30160400273) — success.**

| job | result |
|---|---|
| Build Frontend | success |
| Build win-x64 | success |
| Build linux-x64 | success |
| Build osx-x64 | success |
| Build osx-arm64 | success |
| Create GitHub Release | **skipped** ← intended |

Each platform job includes the published-executable smoke test, so this exercises the real artifact, not just compilation. Artifacts produced: `release-win-x64` (50MB), `release-linux-x64` (48MB), `release-osx-x64` (48MB), `release-osx-arm64` (46MB).

**Nothing was published:** `gh release list` → 0, `git ls-remote --tags origin` → 0.

Tag resolution tested across all four paths:

| trigger | resolved tag |
|---|---|
| tag push `refs/tags/v0.1.0` | `v0.1.0` |
| bare dispatch from a branch | `v0.0.0-dryrun+abc1234` |
| dispatch with `tag: v0.1.0` | `v0.1.0` |
| input containing a slash | **refused** with an explicit error |

YAML parses; job graph unchanged (3 jobs, `create-release` still the only `contents: write`). `actionlint` is not installed locally — the Workflow Lint lane covers it.

## Merge note

**This touches a workflow file, so it is maintainer-merge-only** per the standing rule from `#1441`. Green and rehearsed, but I am not merging it.

## Tracking

Contributes to `#1123`. No `Closes` keyword — `#1123` also covers the GHCR image, the `render.yaml` repair and the tag itself, none of which are in this diff.
