### PR TITLE
Harden structured patch discipline

### DIFF
--- a/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -39,7 +39,8 @@ When editing with structured patches:
 - In prose or Unicode-bearing files, anchor hunks on nearby ASCII-stable headings or lines instead of typography-sensitive exact text.
 - After a context rejection, inspect the live target before retrying, then reduce the retry to the smallest independently anchored hunk.
 - Never repeat the same broad multi-file patch after it is rejected.
-- Record every repeated or unresolved patch rejection in the active orchestrator/run ledger and final handoff, including the exact rejected operation and error plus the working invocation or workaround when one exists; record it even when work resumes.
+- Record every repeated or unresolved patch rejection in the active orchestrator/run ledger and final handoff, even when work resumes.
+- Keep the record bounded and sanitized: include target(s), a failure class/error summary, a safe reproduction pointer when available, and the working invocation or workaround. Redact secrets, omit full patch payloads, and truncate oversized error context.
 - Then invoke `taskdeck-failure-capture` to classify the failure and escalate it to the repository failure ledger when that skill's criteria apply.
 
 ## Worker Setup
@@ -52,6 +53,7 @@ For isolated workers:
 4. Assign explicit file/module ownership.
 5. Tell workers they are not alone in the codebase and must not revert others' edits.
 6. Require targeted tests and self-review before handoff.
+7. Require every file-editing worker prompt to restate the structured patch discipline above.
 
 ## Review And CI
 

--- a/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -31,6 +31,16 @@ Split only by non-overlapping ownership:
 
 Avoid concurrent edits to the same view, store, service, migration chain, project file, or canonical doc unless the coordinator controls merge order.
 
+## Structured Patch Discipline
+
+When editing with structured patches:
+
+- Default each `apply_patch` (or equivalent structured patch operation) to one target file. Use a multi-file operation only for a tightly homogeneous mechanical set where every file has its own independently stable anchor.
+- In prose or Unicode-bearing files, anchor hunks on nearby ASCII-stable headings or lines instead of typography-sensitive exact text.
+- After a context rejection, inspect the live target before retrying, then reduce the retry to the smallest independently anchored hunk.
+- Never repeat the same broad multi-file patch after it is rejected.
+- Route repeated or unresolved patch failures through `taskdeck-failure-capture` so the failure and safe workaround remain visible.
+
 ## Worker Setup
 
 For isolated workers:

--- a/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -39,7 +39,8 @@ When editing with structured patches:
 - In prose or Unicode-bearing files, anchor hunks on nearby ASCII-stable headings or lines instead of typography-sensitive exact text.
 - After a context rejection, inspect the live target before retrying, then reduce the retry to the smallest independently anchored hunk.
 - Never repeat the same broad multi-file patch after it is rejected.
-- Route repeated or unresolved patch failures through `taskdeck-failure-capture` so the failure and safe workaround remain visible.
+- Record every repeated or unresolved patch rejection in the active orchestrator/run ledger and final handoff, including the exact rejected operation and error plus the working invocation or workaround when one exists; record it even when work resumes.
+- Then invoke `taskdeck-failure-capture` to classify the failure and escalate it to the repository failure ledger when that skill's criteria apply.
 
 ## Worker Setup
 

--- a/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -65,7 +65,8 @@ When editing with structured patches:
 - In prose or Unicode-bearing files, anchor hunks on nearby ASCII-stable headings or lines instead of typography-sensitive exact text.
 - After a context rejection, inspect the live target before retrying, then reduce the retry to the smallest independently anchored hunk.
 - Never repeat the same broad multi-file patch after it is rejected.
-- Record every repeated or unresolved patch rejection in the active orchestrator/run ledger and final handoff, including the exact rejected operation and error plus the working invocation or workaround when one exists; record it even when work resumes.
+- Record every repeated or unresolved patch rejection in the active orchestrator/run ledger and final handoff, even when work resumes.
+- Keep the record bounded and sanitized: include target(s), a failure class/error summary, a safe reproduction pointer when available, and the working invocation or workaround. Redact secrets, omit full patch payloads, and truncate oversized error context.
 - Then invoke `taskdeck-failure-capture` to classify the failure and escalate it to the repository failure ledger when that skill's criteria apply.
 
 ## Worker setup
@@ -79,6 +80,7 @@ For each issue:
 5. Tell the worker it is not alone in the codebase and must not revert others' edits.
 6. Require small signed-off commits with `git commit -s --no-gpg-sign` when committing.
 7. Require targeted tests before PR.
+8. Require every file-editing worker prompt to restate the structured patch discipline above.
 
 Use `taskdeck-worktree-issue-worker` for implementation workers.
 

--- a/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -57,6 +57,16 @@ Split only when file ownership or concerns do not overlap. Good splits:
 
 Avoid parallel workers on the same view, store, service, migration chain, project file, or canonical doc unless the coordinator plans the merge order.
 
+## Structured patch discipline
+
+When editing with structured patches:
+
+- Default each `apply_patch` (or equivalent structured patch operation) to one target file. Use a multi-file operation only for a tightly homogeneous mechanical set where every file has its own independently stable anchor.
+- In prose or Unicode-bearing files, anchor hunks on nearby ASCII-stable headings or lines instead of typography-sensitive exact text.
+- After a context rejection, inspect the live target before retrying, then reduce the retry to the smallest independently anchored hunk.
+- Never repeat the same broad multi-file patch after it is rejected.
+- Route repeated or unresolved patch failures through `taskdeck-failure-capture` so the failure and safe workaround remain visible.
+
 ## Worker setup
 
 For each issue:

--- a/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -65,7 +65,8 @@ When editing with structured patches:
 - In prose or Unicode-bearing files, anchor hunks on nearby ASCII-stable headings or lines instead of typography-sensitive exact text.
 - After a context rejection, inspect the live target before retrying, then reduce the retry to the smallest independently anchored hunk.
 - Never repeat the same broad multi-file patch after it is rejected.
-- Route repeated or unresolved patch failures through `taskdeck-failure-capture` so the failure and safe workaround remain visible.
+- Record every repeated or unresolved patch rejection in the active orchestrator/run ledger and final handoff, including the exact rejected operation and error plus the working invocation or workaround when one exists; record it even when work resumes.
+- Then invoke `taskdeck-failure-capture` to classify the failure and escalate it to the repository failure ledger when that skill's criteria apply.
 
 ## Worker setup
 


### PR DESCRIPTION
Closes #1507

## Summary
- make one target file the default unit for structured patches
- require independently stable anchors for the narrow homogeneous multi-file exception
- use ASCII-stable anchors around Unicode/prose, inspect live state after rejection, and shrink the retry
- prohibit repeating the same rejected broad patch and route repeated/unresolved failures through `taskdeck-failure-capture`
- keep Codex and Claude batch-orchestrator guidance behaviorally aligned

## Verification
- Codex skill `quick_validate.py` — passed
- Claude skill `quick_validate.py` — passed
- normalized mirror-section parity assertion — passed
- docs governance — passed
- golden-principles governance — passed
- `git show --check` — passed

## Not verified
- no product tests were run because the change is limited to mirrored agent guidance