### PR TITLE
Stabilize Ops template selection

### DIFF
--- a/frontend/taskdeck-web/tests/e2e/automation-ops.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/automation-ops.spec.ts
@@ -5,6 +5,7 @@ import { API_BASE_URL, registerAndAttachSession, type AuthResult } from './suppo
 import { expectDialog } from './support/dialogs'
 import { createBoardWithColumn } from './support/boardHelpers'
 import { assertOk } from './support/httpAsserts'
+import { selectOpsTemplate } from './support/opsConsole'
 import { pollUntil } from './support/polling'
 
 interface ChatMessageDto {
@@ -79,8 +80,7 @@ test('ops cli should run health.check template', async ({ page }) => {
 
   await expect(page.getByRole('heading', { name: 'Ops Console' })).toBeVisible()
 
-  const templateInput = page.getByRole('combobox', { name: 'Command template' })
-  await templateInput.fill('health.check')
+  await selectOpsTemplate(page, 'health.check')
   await page.getByRole('button', { name: 'Run Template' }).click()
 
   await expect(page.getByText('Health check: OK')).toBeVisible()

--- a/frontend/taskdeck-web/tests/e2e/support/opsConsole.ts
+++ b/frontend/taskdeck-web/tests/e2e/support/opsConsole.ts
@@ -1,0 +1,17 @@
+import { expect, type Page } from '@playwright/test'
+
+export async function selectOpsTemplate(page: Page, templateName: string): Promise<void> {
+  const toolbar = page.locator('.td-cli-toolbar')
+  const templateInput = toolbar.getByRole('combobox', { name: 'Command template' })
+
+  await expect(page.locator('.td-template-meta')).toBeVisible()
+  await templateInput.fill(templateName)
+
+  if (await templateInput.getAttribute('aria-expanded') === 'true') {
+    await templateInput.press('Enter')
+  }
+
+  await expect(templateInput).toHaveValue(templateName)
+  await expect(templateInput).toHaveAttribute('aria-expanded', 'false')
+  await expect(toolbar.locator('[role="listbox"]:visible')).toHaveCount(0)
+}

--- a/frontend/taskdeck-web/tests/e2e/validation-ops-logs-health.spec.ts
+++ b/frontend/taskdeck-web/tests/e2e/validation-ops-logs-health.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { API_BASE_URL, API_ORIGIN, registerAndAttachSession, type AuthResult } from './support/authSession'
 import { assertOk } from './support/httpAsserts'
+import { selectOpsTemplate } from './support/opsConsole'
 
 let auth: AuthResult
 
@@ -24,8 +25,7 @@ test.describe('Ops Console — CLI Runner', () => {
   test('should execute health.check and show output', async ({ page }) => {
     await page.goto('/workspace/ops/cli')
 
-    const templateInput = page.getByRole('combobox', { name: 'Command template' })
-    await templateInput.fill('health.check')
+    await selectOpsTemplate(page, 'health.check')
     await page.getByRole('button', { name: 'Run Template' }).click()
 
     await expect(page.getByText('Health check: OK')).toBeVisible()
@@ -37,8 +37,7 @@ test.describe('Ops Console — CLI Runner', () => {
   test('should show error for invalid parameters', async ({ page }) => {
     await page.goto('/workspace/ops/cli')
 
-    const templateInput = page.getByRole('combobox', { name: 'Command template' })
-    await templateInput.fill('health.check')
+    await selectOpsTemplate(page, 'health.check')
 
     // Fill invalid parameters
     await page.locator('#cli-parameters').fill('{"unexpected": "value"}')


### PR DESCRIPTION
## Summary
- add one Ops Console helper that waits for loaded template metadata before selection
- commit the exact suggestion when the InputAssist panel remains expanded
- assert exact value, closed combobox state, and no visible toolbar listbox before Run
- replace only the three vulnerable health.check E2E sequences; production behavior is unchanged

## Verification
- InputAssist component unit tests: 5 passed (`--maxWorkers=2`)
- historically failing success case: 20/20 Chromium fresh-server repeats passed
- both affected specs: 20/20 Chromium tests passed
- frontend typecheck, lint, and build: passed (six pre-existing accessibility warnings)
- `git diff --check` and DCO: passed

## Boundary
No timeout increase, retry, force click, double click, direct API substitution, production edit, or canonical-doc change.

Closes #1380