### PR TITLE
Update aligned backend dependency packages

### DIFF
--- a/backend/Directory.Packages.props
+++ b/backend/Directory.Packages.props
@@ -26,8 +26,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
 
     <!-- ── Identity / JWT ──────────────────────────────────────── -->
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.19.2" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
+    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.21.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.21.0" />
 
     <!-- ── MCP (Model Context Protocol) ────────────────────────── -->
     <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
@@ -41,7 +41,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
 
     <!-- ── Error tracking ──────────────────────────────────────── -->
-    <PackageVersion Include="Sentry.AspNetCore" Version="6.7.0" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.8.0" />
 
     <!-- ── API documentation ───────────────────────────────────── -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
@@ -62,8 +62,8 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentAssertions" Version="7.2.2" />
-    <PackageVersion Include="FsCheck" Version="3.3.3" />
-    <PackageVersion Include="FsCheck.Xunit" Version="3.3.3" />
+    <PackageVersion Include="FsCheck" Version="3.3.4" />
+    <PackageVersion Include="FsCheck.Xunit" Version="3.3.4" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />


### PR DESCRIPTION
## Summary

- update the aligned `Microsoft.IdentityModel.Tokens` and `System.IdentityModel.Tokens.Jwt` packages from 8.19.2 to 8.21.0
- update `Sentry.AspNetCore` from 6.7.0 to 6.8.0
- update test-only `FsCheck` and `FsCheck.Xunit` from 3.3.3 to 3.3.4
- supersede #1527 with the same five-line package diff on current `main`, because the old shared merge commit lacked the repository's literal DCO trailer even though the advisory hosted check passed

The replacement head contains one signed commit and does not rewrite the Dependabot branch.

## Verification

- [x] `dotnet build backend/Taskdeck.sln -c Release -m:1` — passed, 0 errors (11 existing warnings)
- [x] `dotnet test backend/Taskdeck.sln -c Release -m:1 --no-build` — 7,551 passed / 5 intentionally skipped / 0 failed
- [x] `dotnet list backend/Taskdeck.sln package --vulnerable --include-transitive` — no vulnerable packages reported
- [x] `node scripts/check-docs-governance.mjs`
- [x] `node scripts/check-golden-principles.mjs`
- [x] `node scripts/check-github-ops-governance.mjs`
- [x] `git diff --check origin/main...HEAD`
- [x] Frontend typecheck/build/Vitest — not applicable; no frontend files or packages changed
- [x] Playwright smoke/E2E — not applicable; no UI or cross-surface behavior changed

The full local run was performed on tree `29a611182f812579b254b8734b704a8d7bcd31d3`. This PR's signed head has that exact tree.

## Documentation

- [x] `docs/STATUS.md` — no shipped behavior changed
- [x] `docs/IMPLEMENTATION_MASTERPLAN.md` — no roadmap or priority changed
- [x] `docs/TESTING_GUIDE.md` / `docs/MANUAL_TEST_CHECKLIST.md` — no verification flow changed

## Tracking

- [x] No product issue is closed; this is a history-clean replacement for #1527
- [x] Project item is `Review / Priority V` (no linked issue, so the documented fallback applies)

## CI Workflow Validation

- [x] No workflow, deploy, script, or project file changed; ordinary required CI remains the hosted merge gate

## Risk Notes

- Security impact: JWT validation libraries move together to preserve version alignment.
- Behavior/regression risk: low-to-moderate package-update risk, bounded by the full backend suite and vulnerability audit.
- Follow-up tasks: close #1527 as superseded after this replacement lands if Dependabot does not close it automatically.
