### PR TITLE
Route core Taskdeck review instructions to global canon

### DIFF
--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -81,10 +81,13 @@ EOF
 )"
 ```
 
-### 7. Review
+### 7. Coordinator handoff
 
-Open the PR ready-for-review, then run the global `review-and-ship` skill (global laws 2 and 11).
-Taskdeck-specific lenses: `taskdeck-pr-review-loop`.
+Open the PR ready-for-review, capture its exact head/base identity and verification evidence, then
+return it to the coordinator. Only the coordinator enters or re-enters the global
+`review-and-ship` pipeline (global laws 2 and 11) with the Taskdeck-specific
+`taskdeck-pr-review-loop` lenses. Resume implementation only for pipeline-directed fixes returned
+by the coordinator.
 
 ### 8. Report back
 
@@ -95,5 +98,5 @@ Provide the PR URL and the handoff summary from `taskdeck-verification-doc-sync`
 - do not skip tests
 - if the issue is ambiguous, ask the user before implementing
 - if the issue is too large for one PR, propose a split and implement the first slice
-- hand the ready PR to the global `review-and-ship` pipeline through
-  `taskdeck-pr-review-loop`, then report the pipeline state without adding local review or merge rules
+- hand the ready PR and exact evidence to the coordinator; do not enter the review pipeline or
+  decide merge disposition from this implementation skill

--- a/.claude/skills/issue-to-pr/SKILL.md
+++ b/.claude/skills/issue-to-pr/SKILL.md
@@ -92,8 +92,8 @@ Provide the PR URL and the handoff summary from `taskdeck-verification-doc-sync`
 
 ## Guardrails
 
-- do not merge the PR -- leave it for human review
 - do not skip tests
 - if the issue is ambiguous, ask the user before implementing
 - if the issue is too large for one PR, propose a split and implement the first slice
-- always self-review and post findings on the PR before reporting done
+- hand the ready PR to the global `review-and-ship` pipeline through
+  `taskdeck-pr-review-loop`, then report the pipeline state without adding local review or merge rules

--- a/.claude/skills/pre-merge-gate/SKILL.md
+++ b/.claude/skills/pre-merge-gate/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: pre-merge-gate
-description: "Final validation gate before merging a PR: tests, lint, type-check, build, self-review, CI green check. Use before merging."
+description: "Collect Taskdeck-local readiness evidence for the canonical review pipeline: tests, lint, type-check, build, diff inspection, comments, and exact-head CI."
 user-invocable: true
 ---
 
 # Pre-Merge Gate
 
-Run all validation checks before a PR can be merged. Execute as one atomic operation.
+Collect the Taskdeck-local validation packet that the global `review-and-ship` pipeline consumes.
+Execute the local checks as one atomic operation; this skill does not decide review or merge policy.
 
 ## Arguments
 
@@ -36,7 +37,8 @@ Check for unaddressed findings from any source:
 - CI bot failure messages
 - Previous adversarial review comments not yet resolved
 
-If actionable comments exist, fix them before proceeding.
+Return the comment bodies and resolution state to the global pipeline for triage. If that pipeline
+directs a fix, rerun the checks affected by the fix before returning the updated packet.
 
 ## Step 3: Run local checks
 
@@ -48,9 +50,9 @@ dotnet test backend/Taskdeck.sln -c Release -m:1
 cd frontend/taskdeck-web && npm run build && npx vitest --run --reporter=verbose
 ```
 
-Report any failures immediately — do not proceed to merge.
+Report any failures immediately and do not mark the local evidence packet complete.
 
-## Step 4: Self-review
+## Step 4: Taskdeck diff inspection
 
 Read the full diff (`gh pr diff $ARGUMENTS`) and check for:
 
@@ -64,7 +66,8 @@ Read the full diff (`gh pr diff $ARGUMENTS`) and check for:
 - HTTP semantics violations (wrong status codes)
 - Unused `using` statements or dead code
 
-If any issues found, fix them, commit, and push before proceeding.
+Return any issues as Taskdeck-lens findings to the global pipeline. If it directs a fix, commit and
+push the fix, then rerun the affected local checks before returning the updated packet.
 
 ## Step 5: CI status
 
@@ -72,30 +75,31 @@ If any issues found, fix them, commit, and push before proceeding.
 gh pr checks $ARGUMENTS
 ```
 
-All checks must be green. If any are failing, diagnose and fix.
+Report the exact-head state of every check. A red required check makes the local packet incomplete;
+route diagnosis and recovery through `taskdeck-ci-conflict-recovery`.
 
 ## Step 6: Report
 
-Output a merge-readiness summary:
+Output a Taskdeck evidence summary:
 
 ```
-## Merge Readiness: PR #XXX
+## Taskdeck Evidence: PR #XXX
 
 - [ ] Backend build: PASS/FAIL
 - [ ] Backend tests: PASS/FAIL (N passed, M failed)
 - [ ] Frontend build: PASS/FAIL
 - [ ] Frontend tests: PASS/FAIL
 - [ ] CI checks: GREEN/RED
-- [ ] Self-review: CLEAN/ISSUES FIXED
-- [ ] Bot comments: ADDRESSED/NONE
+- [ ] Diff inspection: CLEAN/FINDINGS RETURNED
+- [ ] PR feedback surfaces: CAPTURED
 - [ ] Secrets scan: CLEAN
 
-**Verdict**: READY TO MERGE / BLOCKED (reason)
+**Evidence state**: COMPLETE / INCOMPLETE (reason)
+**Canonical pipeline state**: <state returned by `review-and-ship`, or NOT YET RUN>
 ```
 
 ## Rules
 
-- Do NOT merge the PR — only validate and report readiness
-- If CI is red, attempt to fix — only report "blocked" if the fix is non-trivial
-- Finding severity, comment triage, and how many review rounds are owed: the global
-  `review-and-ship` skill and global laws 2 and 11. This skill only runs the local checks.
+- This skill only collects local evidence; it never decides review or merge disposition.
+- Finding severity, comment triage, reviewer invocation, convergence, and merge disposition belong
+  only to the global `review-and-ship` skill and global laws 2 and 11.

--- a/.claude/skills/pre-merge-gate/SKILL.md
+++ b/.claude/skills/pre-merge-gate/SKILL.md
@@ -13,13 +13,48 @@ Execute the local checks as one atomic operation; this skill does not decide rev
 
 `$ARGUMENTS` is a PR number or empty (current branch's PR).
 
-## Step 1: Identify PR and branch
+## Step 1: Prove the exact PR head and base
 
 ```bash
-gh pr view $ARGUMENTS --json number,headRefName,baseRefName,mergeable,statusCheckRollup
+set -euo pipefail
+
+pr_args=()
+if [[ -n "${ARGUMENTS:-}" ]]; then
+  pr_args=("$ARGUMENTS")
+fi
+
+pr_fields="$(gh pr view "${pr_args[@]}" \
+  --json number,headRefName,headRefOid,baseRefName,baseRefOid,mergeable \
+  --jq '[.number,.headRefName,.headRefOid,.baseRefName,.baseRefOid,.mergeable] | @tsv')"
+IFS=$'\t' read -r pr_number pr_head_ref pr_head_oid pr_base_ref pr_base_oid pr_mergeable \
+  <<<"$pr_fields"
+
+local_head_oid="$(git rev-parse HEAD)"
+if [[ "$local_head_oid" != "$pr_head_oid" ]]; then
+  echo "BLOCKED: local HEAD $local_head_oid is not PR head $pr_head_oid" >&2
+  exit 1
+fi
+if [[ -n "$(git status --porcelain=v1)" ]]; then
+  echo "BLOCKED: exact-head evidence requires a clean worktree" >&2
+  exit 1
+fi
+
+git fetch --no-tags origin "$pr_base_ref"
+fetched_base_oid="$(git rev-parse FETCH_HEAD)"
+if [[ "$fetched_base_oid" != "$pr_base_oid" ]]; then
+  echo "BLOCKED: fetched base $fetched_base_oid is not PR base $pr_base_oid" >&2
+  exit 1
+fi
+
+merge_base_oid="$(git merge-base HEAD FETCH_HEAD)"
+if [[ "$merge_base_oid" != "$pr_base_oid" ]]; then
+  echo "BLOCKED: PR head does not incorporate exact base $pr_base_oid (merge base: $merge_base_oid)" >&2
+  exit 1
+fi
 ```
 
-If mergeable is "CONFLICTING", stop and report — do not auto-resolve.
+Any lookup, fetch, or identity mismatch stops the gate before tests. Run this skill only from the
+PR's exact-head worktree. If `pr_mergeable` is `CONFLICTING`, stop and report; do not auto-resolve.
 
 ## Step 2: Check bot comments
 
@@ -85,6 +120,10 @@ Output a Taskdeck evidence summary:
 ```
 ## Taskdeck Evidence: PR #XXX
 
+- [ ] Local HEAD equals remote PR head OID: PASS/FAIL
+- [ ] Exact-head worktree is clean: PASS/FAIL
+- [ ] Fetched base equals remote PR base OID: PASS/FAIL
+- [ ] Merge base equals current remote base OID: PASS/FAIL
 - [ ] Backend build: PASS/FAIL
 - [ ] Backend tests: PASS/FAIL (N passed, M failed)
 - [ ] Frontend build: PASS/FAIL

--- a/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.claude/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: taskdeck-issue-batch-orchestrator
-description: Coordinate high-autonomy Taskdeck issue batches from selection through worktrees, PRs, review, CI recovery, docs reconciliation, and handoff. Use when asked to take care of many issues, pick next issues, coordinate agents, run review loops, or reconcile GitHub project status.
+description: Coordinate high-autonomy Taskdeck issue batches from selection through worktrees, PRs, canonical review handoff, CI recovery, docs reconciliation, and handoff. Use when asked to take care of many issues, pick next issues, coordinate agents, or reconcile GitHub project status.
 ---
 
 # Taskdeck Issue Batch Orchestrator
@@ -15,7 +15,9 @@ Read as needed: `docs/GITHUB_PROJECT_AUTOMATION.md` (Status/Priority project-boa
 
 ## Coordinator Responsibilities
 
-The coordinator owns issue selection, dependency checks, worktree prompts, conflict resolution, PR quality, project status/priority sync, adversarial review assignment, CI/comment loops, docs rehydration, and final handoff.
+The coordinator owns issue selection, dependency checks, worktree prompts, conflict resolution, PR
+quality, project status/priority sync, canonical review-pipeline evidence handoff, CI/comment
+recovery, docs rehydration, and final handoff.
 
 Do not delegate final synthesis. Do not silently defer work.
 
@@ -26,7 +28,7 @@ Split only by non-overlapping ownership:
 - one backend issue per worker
 - one frontend issue per worker
 - one docs-only issue per worker
-- one reviewer per PR
+- review workers only when the global pipeline requests Taskdeck lenses
 - one CI/conflict worker per failing PR
 
 Avoid concurrent edits to the same view, store, service, migration chain, project file, or canonical doc unless the coordinator controls merge order.
@@ -52,12 +54,13 @@ For isolated workers:
 3. Require the first command from `docs/WORKTREE_AGENT_PROTOCOL.md` or `powershell -File scripts/worktree_guard.ps1`.
 4. Assign explicit file/module ownership.
 5. Tell workers they are not alone in the codebase and must not revert others' edits.
-6. Require targeted tests and self-review before handoff.
+6. Require targeted tests and handoff into the canonical review pipeline.
 7. Require every file-editing worker prompt to restate the structured patch discipline above.
 
 ## Review And CI
 
-Review rounds, severity bar, and comment triage: the global `review-and-ship` skill (laws 2 and 11). Flag these surfaces so the coordinator can decide whether an extra independent lens is warranted:
+Enter ready PRs into the global `review-and-ship` pipeline (laws 2 and 11). Supply these surfaces
+as Taskdeck-specific risk context:
 
 - auth, sessions, tokens, security, secrets, redaction
 - migrations, persistence, deletion, import/export
@@ -66,7 +69,9 @@ Review rounds, severity bar, and comment triage: the global `review-and-ship` sk
 - CI, project automation, scripts
 - broad frontend route/store/shell changes
 
-Use `taskdeck-pr-review-loop` and `taskdeck-ci-conflict-recovery` for review and recovery work.
+Use `taskdeck-pr-review-loop` and `taskdeck-ci-conflict-recovery` for Taskdeck lenses and recovery
+work. Reviewer invocation, counts, severity, convergence, aging, and merge disposition remain in
+the global pipeline.
 
 ## Final Reconciliation
 

--- a/.claude/skills/taskdeck-worktree-issue-worker/SKILL.md
+++ b/.claude/skills/taskdeck-worktree-issue-worker/SKILL.md
@@ -36,8 +36,9 @@ Own only the files/modules assigned by the coordinator. You are not alone in the
 5. Run targeted checks first.
 6. Update docs only if current reality, roadmap, testing expectations, or operator workflow changed.
 7. Open a PR with summary, linked issue, tests, docs impact, and risks.
-8. Enter the global `review-and-ship` pipeline through `taskdeck-pr-review-loop`, then return its
-   state to the coordinator.
+8. Return the ready PR, exact head/base identity, and verification evidence to the coordinator.
+   Only the coordinator enters or re-enters `review-and-ship`; resume this worker only for fixes
+   that the coordinator returns from that pipeline.
 
 ## Stop Conditions
 

--- a/.claude/skills/taskdeck-worktree-issue-worker/SKILL.md
+++ b/.claude/skills/taskdeck-worktree-issue-worker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: taskdeck-worktree-issue-worker
-description: Implement one Taskdeck issue in an isolated Claude or git worktree with narrow ownership, tests, PR creation, and self-review.
+description: Implement one Taskdeck issue in an isolated Claude or git worktree with narrow ownership, tests, PR creation, and canonical review handoff.
 ---
 
 # Taskdeck Worktree Issue Worker
@@ -36,7 +36,8 @@ Own only the files/modules assigned by the coordinator. You are not alone in the
 5. Run targeted checks first.
 6. Update docs only if current reality, roadmap, testing expectations, or operator workflow changed.
 7. Open a PR with summary, linked issue, tests, docs impact, and risks.
-8. Perform a self-review and fix findings before handoff.
+8. Enter the global `review-and-ship` pipeline through `taskdeck-pr-review-loop`, then return its
+   state to the coordinator.
 
 ## Stop Conditions
 

--- a/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
+++ b/.codex/skills/taskdeck-issue-batch-orchestrator/SKILL.md
@@ -38,8 +38,8 @@ The coordinator must own:
 - final conflict resolution
 - PR body quality and linked issues
 - GitHub project status/priority sync
-- adversarial-review assignment
-- CI/comment/conflict loops
+- canonical review-pipeline evidence handoff
+- CI/comment/conflict recovery
 - docs and testing-guide rehydration
 - final handoff
 
@@ -52,7 +52,7 @@ Split only when file ownership or concerns do not overlap. Good splits:
 - one backend issue per worker
 - one frontend issue per worker
 - one docs-only issue per worker
-- one reviewer worker per PR
+- review workers only when the global pipeline requests Taskdeck lenses
 - one CI/conflict worker per failing PR
 
 Avoid parallel workers on the same view, store, service, migration chain, project file, or canonical doc unless the coordinator plans the merge order.
@@ -84,28 +84,26 @@ For each issue:
 
 Use `taskdeck-worktree-issue-worker` for implementation workers.
 
-## Review loop
+## Review pipeline handoff
 
-Every PR needs:
+Enter every ready PR into the global `review-and-ship` pipeline. This skill contributes only the
+Taskdeck handoff packet: the coordinator checks the PR body, linked issue, test evidence, docs
+impact, and these repo-specific risk surfaces before entry:
 
-1. Worker self-review after opening the PR.
-2. Coordinator review of PR body, linked issue, test evidence, and docs impact.
-3. Flag these surfaces so the coordinator can decide whether an extra independent lens is warranted (round count and severity bar: the global `review-and-ship` skill):
-   - auth/authz/security
-   - migrations/persistence
-   - capture/review/proposal execution
-   - CI/workflows/project automation
-   - broad frontend flow changes
-   - flaky or failing tests
-4. Posted review findings or explicit no-finding comment.
-5. Fix commits for findings.
-6. Re-review after fixes.
+- auth/authz/security
+- migrations/persistence
+- capture/review/proposal execution
+- CI/workflows/project automation
+- broad frontend flow changes
+- flaky or failing tests
 
-Use `taskdeck-pr-review-loop` for review workers.
+Use `taskdeck-pr-review-loop` for Taskdeck lenses and record the state returned by the global
+pipeline. Reviewer invocation, counts, severity, fix/re-review convergence, aging, and merge
+disposition are not defined here.
 
 ## CI and comments
 
-After PR creation and after every fix push:
+After PR creation and after any pipeline-directed fix push:
 
 - inspect CI status
 - inspect review comments and bot comments

--- a/.codex/skills/taskdeck-pr-review-loop/SKILL.md
+++ b/.codex/skills/taskdeck-pr-review-loop/SKILL.md
@@ -32,8 +32,7 @@ Do not spend review energy on unrelated style unless it creates risk.
 
 ## Sensitive-surface flag
 
-Flag these surfaces in the review so the coordinator can decide whether the change warrants the
-extra independent lens its tier allows:
+Flag these surfaces as Taskdeck risk context for the global pipeline:
 
 - security/auth/session/token behavior
 - migrations or data deletion/retention
@@ -50,6 +49,5 @@ extra independent lens its tier allows:
 ## Tooling
 
 Use GitHub MCP for issue/PR metadata and comments when available; `gh api` REST as fallback.
-
-Do not merge PRs. Do not change repo settings, secrets, protections, environments, or workflow
-permissions.
+Do not change repo settings, secrets, protections, environments, or workflow permissions while
+performing this review lens.

--- a/.codex/skills/taskdeck-pr-review-loop/agents/openai.yaml
+++ b/.codex/skills/taskdeck-pr-review-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Taskdeck PR Review Loop"
   short_description: "Review PRs and address feedback"
-  default_prompt: "Use $taskdeck-pr-review-loop to perform adversarial review, post findings, address comments, and re-review Taskdeck PRs."
+  default_prompt: "Use $taskdeck-pr-review-loop to apply Taskdeck-specific lenses inside the canonical global review pipeline and report evidence-backed findings."

--- a/.codex/skills/taskdeck-worktree-issue-worker/SKILL.md
+++ b/.codex/skills/taskdeck-worktree-issue-worker/SKILL.md
@@ -81,7 +81,8 @@ PR body must include:
 - risks/follow-ups
 - `Closes #<issue>`
 
-After opening the PR, run a deliberate self-review using `taskdeck-pr-review-loop`. Fix findings before handing back to the coordinator.
+After opening the ready PR, enter the global `review-and-ship` pipeline through
+`taskdeck-pr-review-loop`, then hand the returned pipeline state back to the coordinator.
 
 ## Handoff
 
@@ -92,5 +93,5 @@ Report:
 - tests added
 - commands run and results
 - docs changed
-- review findings fixed or explicit no-finding result
+- canonical review-pipeline state and any finding disposition it returned
 - any deferred follow-up issue numbers or blocked seeding notes

--- a/.codex/skills/taskdeck-worktree-issue-worker/SKILL.md
+++ b/.codex/skills/taskdeck-worktree-issue-worker/SKILL.md
@@ -81,8 +81,10 @@ PR body must include:
 - risks/follow-ups
 - `Closes #<issue>`
 
-After opening the ready PR, enter the global `review-and-ship` pipeline through
-`taskdeck-pr-review-loop`, then hand the returned pipeline state back to the coordinator.
+After opening the ready PR, return its exact head/base identity and verification evidence to the
+coordinator. Only the coordinator enters or re-enters `review-and-ship` through
+`taskdeck-pr-review-loop`; resume this worker only for fixes the coordinator returns from that
+pipeline.
 
 ## Handoff
 
@@ -93,5 +95,6 @@ Report:
 - tests added
 - commands run and results
 - docs changed
-- canonical review-pipeline state and any finding disposition it returned
+- exact PR head/base identity and verification evidence
+- any pipeline-directed fix evidence from a resumed worker turn
 - any deferred follow-up issue numbers or blocked seeding notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ Shared facts — what Taskdeck is, architecture, the per-seam proving checks, DC
 pitfalls, tier/authority — live in **`CLAUDE.md`** and are not repeated here. Review doctrine has one
 home: global laws 2 and 11 in `~/.claude/CLAUDE.md` plus the `review-and-ship` skill. Do not restate
 either in this file.
+Ownership boundaries: [agent-harness#101](https://github.com/Chris0Jeky/agent-harness/issues/101)
+owns estate-wide consolidation, [#1291](https://github.com/Chris0Jeky/Taskdeck/issues/1291) owns
+Taskdeck control-plane/mirror retirement, and [#1269](https://github.com/Chris0Jeky/Taskdeck/issues/1269)
+owns any Taskdeck-specific intake and review design that remains after consolidation.
 
 ## Start here
 

--- a/docs/agentic/OVERNIGHT_LOOP.claude.md
+++ b/docs/agentic/OVERNIGHT_LOOP.claude.md
@@ -180,9 +180,10 @@ which is genuinely mechanical, and how the lanes are shaped.**
   and **never two full test suites at once, box-wide**.
 - **Reviewers are read-only** (`reviewer` / `pr-review-toolkit:*` subagents) — they can't edit,
   so their only output is findings (structurally safe). Review is judgment work: the cheap rung is
-  never eligible for it. **You, the coordinator, always own final synthesis, verification, and the
-  merge — never delegate those.** For background subagents, relay only the conclusion, not file
-  dumps; continue a running one with `SendMessage` rather than respawning.
+  never eligible for it. **You, the coordinator, always own pipeline entry or re-entry, final
+  evidence synthesis, and the verification handoff — never delegate those.** For background
+  subagents, relay only the conclusion, not file dumps; continue a running one with `SendMessage`
+  rather than respawning.
 - **Budget:** checkpoint often; keep diffs and test runs targeted (`dotnet --filter`,
   `vitest --maxWorkers=2`) to avoid burning time/OOM. Deep in a rabbit hole → stop, record the
   finding, take a cheaper path.

--- a/docs/agentic/OVERNIGHT_LOOP.claude.md
+++ b/docs/agentic/OVERNIGHT_LOOP.claude.md
@@ -74,13 +74,12 @@ Prefer the **`taskdeck-repo-onramp`** skill to orient fast. Read before editing:
   `check-golden-principles.mjs` (STATUS/GOLDEN need an exact `Last Updated: YYYY-MM-DD` line —
   don't append after the date); EF migration merges verified by
   `dotnet ef migrations has-pending-model-changes ...` = "No changes".
-- **VCS / CI reality (READ TWICE):** `gh` for PRs; default branch `main`. **Branch protection is
-  fully lenient — `strict=false`, zero required checks, zero required reviews. GitHub will let
-  you merge a red/unreviewed PR. YOU are the only gate** — merge only when *your* gate (§5)
-  holds, never on GitHub's permission. `ci-required.yml` is the intended gate; `ci-nightly.yml`
-  is "CI Extended" (has had systemic `startup_failure` modes — understand a red, don't assume).
-  Use merge commits for stacked bases; **never `--delete-branch` a stacked base** (cascade-
-  closes children); **merge base/oldest first** then retarget children.
+- **VCS / CI reality (READ TWICE):** `gh` for PRs; default branch `main`. Branch protection is
+  lenient and therefore is not evidence of eligibility; enter the canonical global review
+  pipeline for review and merge disposition. `ci-required.yml` is the Taskdeck gate;
+  `ci-nightly.yml` is "CI Extended" (has had systemic `startup_failure` modes — understand a red,
+  don't assume). Preserve merge commits for stacked bases; **never `--delete-branch` a stacked
+  base** (cascade-closes children); **oldest/base first**, then retarget children.
 - **Inventory** open PRs, issues, red CI, `TODO`/`FIXME`, the failure ledger → seeds the backlog.
 - **Windows/env:** if git misbehaves, use `C:\Program Files\Git\cmd\git.exe`; PowerShell `&&` is
   a parser error (use `;` + `$LASTEXITCODE`, or the Bash tool); `reset --hard`/force-push are
@@ -190,53 +189,47 @@ which is genuinely mechanical, and how the lanes are shaped.**
 
 ---
 
-## 4) REVIEW — run the global pipeline, once
+## 4) REVIEW — enter the canonical pipeline
 
-**Doctrine has one home: global laws 2 and 11 and the global `review-and-ship` skill.** Round
-count, severity bar, comment triage, and when to reopen or park all live there — do not restate
-them in this manual. Taskdeck's tier row (T3 per `.agent-harness/tier.json`): push free, merge free on
-green CI at the head plus one comment-triage pass and one independent review pass.
+Run global laws 2 and 11 through the global `review-and-ship` skill. That pipeline exclusively
+owns reviewer invocation, reviewer count, severity, comment disposition, fix/re-review
+convergence, post-push eligibility, and merge disposition; do not restate any of them here.
 
-What this manual adds: use **`taskdeck-pr-review-loop`** for the Taskdeck lenses, prefer a
-**distinct lens** over a duplicate pass when a second reviewer is warranted, and record the
-round in the findings ledger.
+This manual contributes the **`taskdeck-pr-review-loop`** lenses, exact head/base evidence, and the
+findings-ledger location. When the global pipeline returns a state, carry that state into §5.
 
 ---
 
-## 5) VERIFY & MERGE GATE — merge only when ALL hold (you are the gate)
+## 5) TASKDECK EVIDENCE — return it to the global pipeline
 
-Use **`pre-merge-gate`** + **`verification-closeout`**. Gate:
-1. Exact diff builds; **targeted tests + lint + type-check + docs-gates pass locally** — state
-   the commands run and real counts; never claim a test passed unless it ran (drive the actual
-   behavior via `/verify` when there's a runtime surface, not just green tests).
-2. **CI green on the exact head.** Investigate *every* red; never dismiss as flaky without proof
-   (rerun; passes on identical code ⇒ flaky ⇒ **track as an issue and move on**, don't ignore).
-3. The review round owed by law 2 has run and every comment is triaged once — **verified by
-   CONTENT**: read unresolved threads AND top-level PR comments AND review-summary bodies posted
-   since the final push; findings land in all three places, not just inline threads. Never gate
-   on reviewer names or review-event presence; a "review" with no findings looks identical to
-   one carrying P2s until read. Applies to docs-only PRs too. There is no aging requirement —
-   waiting for bots to weigh in is not a gate.
-4. No unresolved blockers; back-compat preserved; canonical docs synced if reality changed
-   (**`docs-sweep`** / **`taskdeck-verification-doc-sync`**).
+Use **`pre-merge-gate`** + **`verification-closeout`** to assemble the repo-specific packet:
 
-Merge in **dependency-safe order** (base-first; never delete a stacked base; pull `main`; after
-a wave **verify `main` clean + CI green**). **Strategic direction docs or security/deny-floor
-gates that flip project posture are maintainer decisions — stage + defer (Q-N), don't
-self-merge.**
+1. Exact diff/head/base identity and the **targeted tests + lint + type-check + docs gates** that
+   exercise it — state commands and real counts; use `/verify` for runtime surfaces.
+2. Exact-head `ci-required.yml` state plus the understood status of any relevant extended lane.
+3. Feedback content from unresolved threads, top-level PR comments, and review-summary bodies;
+   supply the content to the global pipeline without inventing local triage rules.
+4. Backward-compatibility and canonical-doc impact (`docs-sweep` /
+   `taskdeck-verification-doc-sync`).
+
+Return that packet to `review-and-ship`; it determines the next action. For any action it permits,
+preserve **dependency-safe order** (base-first; never delete a stacked base; pull `main`; after a
+wave verify `main` clean + CI green). Authority and stop disposition come from
+`.agent-harness/tier.json`, the global laws, and explicit task scope — not local hold classes.
 
 ---
 
 ## 6) SAFETY GUARDRAILS (hard rules)
 
 Never force-push / rebase shared branches / amend-after-push / `reset --hard`-discard without
-approval (`git merge --abort` / `git stash` are fine). Never commit secrets (found one → STOP, propose
-rotation). Don't touch prod creds/data, branch protections, release tags, licensing/legal, or
-trademark — maintainer-owned; the deny-floor/harness gates are T4-class (PR only, never
-self-merge). Confirm irreversible/outward-facing actions unless authorized. Never pipe listings
-into deletion or delete with bare wildcards. Classify honestly: blocker / non-blocking risk /
-pre-existing noise / invalid signal — don't swallow failures. Use **`safe-shell`** before
-anything destructive; **`taskdeck-failure-capture`** to record friction.
+approval (`git merge --abort` / `git stash` are fine). Never commit secrets (found one → STOP,
+propose rotation). Production credentials/data, branch protections, release tags,
+licensing/legal, trademark, and deny-floor/harness changes follow the global laws, declared
+authority, and explicit task scope; this manual adds no merge-ownership rule. Confirm
+irreversible/outward-facing actions unless authorized. Never pipe listings into deletion or delete
+with bare wildcards. Classify honestly: blocker / non-blocking risk / pre-existing noise / invalid
+signal — don't swallow failures. Use **`safe-shell`** before anything destructive;
+**`taskdeck-failure-capture`** to record friction.
 
 ---
 

--- a/docs/agentic/OVERNIGHT_LOOP.codex.md
+++ b/docs/agentic/OVERNIGHT_LOOP.codex.md
@@ -81,9 +81,8 @@ Read before editing — do not assume layout:
     "No changes" is the definitive proof a hand-merged model snapshot is correct.
 - **VCS / CI reality (READ THIS TWICE):**
   - Use `gh` for PRs/issues/reviews. Default branch is `main`.
-  - **Branch protection is fully lenient** — `strict=false`, **zero required checks, zero
-    required reviews.** GitHub will happily let you merge a red or unreviewed PR. **You are the
-    only gate.** Never merge on GitHub's permission; merge only when *your* gate (§5) holds.
+  - Branch protection is lenient and therefore is not evidence of eligibility. Enter the
+    canonical global review pipeline for review and merge disposition.
   - `ci-required.yml` is the intended PR gate; `ci-nightly.yml` is "CI Extended". Read a PR's
     actual check runs; don't assume.
   - Merge convention: **merge commits, never squash** — squash-merge destroys commit history and
@@ -163,10 +162,10 @@ before the hard tasks.
   triage, doc-link fixes, obvious one-line fixes. Racing through these cheaply leaves budget
   for the hard ones.
 - **Parallelize** only when the work is genuinely disjoint (separate files/regions), when you
-  need an independent perspective (two reviewers who don't share conclusions), or when one
+  need an independent perspective (reviewers with independent context), or when one
   context can't hold the scope. A few focused agents (≤3–5; ≤8–12 for a broad sweep), never a
   reflexive swarm. **You (the coordinator) always own final synthesis, verification, and the
-  merge decision — never delegate those.** Read-only reviewers are structurally safer (no tools
+  evidence handoff to the global pipeline.** Read-only reviewers are structurally safer (no tools
   to mutate, so their only output is findings).
 - **Budget awareness:** checkpoint often; keep diffs and test runs targeted (targeted `dotnet
   --filter`, `vitest --maxWorkers=2`) to avoid burning time/OOM. If you're deep in a rabbit
@@ -174,41 +173,33 @@ before the hard tasks.
 
 ---
 
-## 4) REVIEW — run the global pipeline, once
+## 4) REVIEW — enter the canonical pipeline
 
-**Doctrine has one home: global laws 2 and 11 and the global `review-and-ship` skill.** Round
-count, severity bar, comment triage, and when to reopen or park all live there — do not restate
-them in this manual. Taskdeck's tier row (T3 per `.agent-harness/tier.json`): push free, merge free on
-green CI at the head plus one comment-triage pass and one independent review pass.
+Run global laws 2 and 11 through the global `review-and-ship` skill. That pipeline exclusively
+owns reviewer invocation, reviewer count, severity, comment disposition, fix/re-review
+convergence, post-push eligibility, and merge disposition; do not restate any of them here.
 
-What this manual adds:
-
-- Use `taskdeck-pr-review-loop` for the Taskdeck lenses; prefer a **distinct lens** over a
-  duplicate pass when a second reviewer is warranted.
-- Request the `@codex` review on the exact head at ready-for-review and once more after the
-  final fix round; batch fixes rather than chasing round-by-round.
-- Record each finding and its resolution in the findings ledger.
+This manual contributes `taskdeck-pr-review-loop` lenses, exact head/base evidence, and the
+findings-ledger location. When the global pipeline returns a state, carry that state into §5.
 
 ---
 
-## 5) VERIFY & MERGE GATE — merge only when ALL hold (you are the gate)
+## 5) TASKDECK EVIDENCE — return it to the global pipeline
 
-1. The **exact diff** builds and its **targeted tests + lint + type-check + docs-gates pass
-   locally** — state the commands you ran and their real counts. Never claim a test passed
-   unless it actually ran.
-2. **CI is green** on the PR's exact head. Investigate *every* red — never dismiss as flaky
-   without proof (rerun; if it passes on identical code it's flaky → **track it as an issue and
-   move on**, don't silently ignore). Because CI Extended (`ci-nightly.yml`) has had systemic
-   `startup_failure` modes before, confirm the failure is understood, not just "red".
-3. The review round owed by law 2 has run; every human + bot thread triaged once. There is no
-   aging requirement — waiting for bots to weigh in is not a gate.
-4. No unresolved blockers; backward compatibility preserved; canonical docs synced if reality
-   changed (`STATUS.md` for current state, `MASTERPLAN` for delivery history — via docs gate).
+Assemble the repo-specific packet:
 
-Then merge in **dependency-safe order** (base-first in a stack; never delete a stacked base;
-pull `main`; after a wave, **verify `main` is clean and its CI green**). If merging strategic
-direction docs or a security gate that flips project posture, that's a **maintainer decision**
-— stage it and defer (Q-N), don't self-merge.
+1. Exact diff/head/base identity and the **targeted tests + lint + type-check + docs gates** that
+   exercise it, with real commands and counts.
+2. Exact-head `ci-required.yml` state plus the understood status of any relevant extended lane.
+3. Feedback content from unresolved threads, top-level PR comments, and review-summary bodies;
+   supply the content to the global pipeline without inventing local triage rules.
+4. Backward-compatibility and canonical-doc impact (`STATUS.md` for current state, `MASTERPLAN`
+   for delivery history).
+
+Return that packet to `review-and-ship`; it determines the next action. For any action it permits,
+preserve **dependency-safe order** (base-first in a stack; never delete a stacked base; pull
+`main`; after a wave verify `main` is clean and its CI green). Authority and stop disposition come
+from `.agent-harness/tier.json`, the global laws, and explicit task scope — not local hold classes.
 
 ---
 
@@ -217,9 +208,9 @@ direction docs or a security gate that flips project posture, that's a **maintai
 - Never force-push, rebase shared branches, amend after pushing, or `reset --hard`/discard work
   without approval. `git merge --abort` / `git stash` are fine.
 - Never commit secrets. If you find one in-repo, **STOP** and propose rotation.
-- Don't touch production credentials/data, branch protections, release tags, licensing/legal
-  posture, or trademark decisions — those are maintainer-owned. (The deny-floor / harness
-  security gates are T4-class: propose via PR, never self-merge.)
+- Production credentials/data, branch protections, release tags, licensing/legal posture,
+  trademark decisions, and deny-floor/harness changes follow the global laws, declared authority,
+  and explicit task scope; this manual adds no merge-ownership rule.
 - Confirm before irreversible or outward-facing actions unless already authorized.
 - Never pipe file listings into deletion, never delete with bare wildcards.
 - Classify every problem honestly: **blocker / non-blocking risk / pre-existing noise / invalid

--- a/docs/agentic/OVERNIGHT_LOOP.fable.md
+++ b/docs/agentic/OVERNIGHT_LOOP.fable.md
@@ -45,7 +45,7 @@ are an orchestrator that thinks, decides, and gates — not the typist.
 1. **Resume from the latest `ORCHESTRATOR.handoff-*.md`** at the repo root if one exists — it
    carries the previous run's holds, gate precedents, backlog, and box rules. Verify its claims
    against reality before acting on them (re-inventory PRs/issues, confirm main CI on HEAD,
-   check whether maintainer-gated PRs it references have since merged — **reality wins**; when
+   check whether held PRs it references have since changed state — **reality wins**; when
    a hold has merged, the assumptions built on it expire and you say so in the ledger).
 2. Read the base manual (`OVERNIGHT_LOOP.claude.md`) and orient per its §1 (or the
    `taskdeck-repo-onramp` skill): `docs/STATUS.md`, `OUTSTANDING_TASKS.md`,
@@ -55,12 +55,11 @@ are an orchestrator that thinks, decides, and gates — not the typist.
    REVIVAL/GEN wave lists; with NO handoff, seed directly from `OUTSTANDING_TASKS.md`, the
    ratified wave lists, open issues by priority label, and base §2's queue-generation rule —
    off-list work is not taken either way.
-4. Pin the standing human-gated holds in the ledger: **the hold PRs named in the latest
-   handoff** (never merge them), plus the durable classes — workflow-file PRs are
-   maintainer-merge-only (stage green, put in the Q batch); never push release tags, touch
-   branch protection, trademark/legal, or self-ratify a strategic ADR. Even absent a handoff,
-   treat any open deny-floor/harness-gate, licensing, or trademark PR as a standing hold
-   discovered during inventory. Defer all as Q-N items.
+4. Pin hold PRs named in the latest handoff until live state proves the hold expired. Classify
+   outward-facing or irreversible boundaries — release tags, branch protection,
+   trademark/legal, strategic ADR ratification, deny-floor/harness changes — through the global
+   laws, declared authority, and explicit task scope. Record confirmed blockers as Q-N items;
+   do not create Fable-specific merge classes.
 
 ## COMPUTE ROUTING — WHO DOES WHAT
 
@@ -87,9 +86,9 @@ and take the actual model and effort for each rung from the skill.
 - Wave planning and task selection; architecture and ADR drafting; security-posture judgment;
   EF migration-snapshot merges; race/concurrency analysis; genuinely ambiguous multi-file
   debugging **after** a cheaper agent has gathered the evidence and failed to crack it.
-- Adjudicating review findings: every CRITICAL/HIGH, and any conflict between reviewers.
-- **Final synthesis, the verification verdict, and every merge decision.** These are never
-  delegated — branch protection is lenient, so you are the only real gate (base §5).
+- Adjudicating evidence conflicts returned by review lenses.
+- **Final synthesis, the verification verdict, and the evidence handoff to the global
+  pipeline.** These are never delegated.
 - Keep your turns lean: don't bulk-read what a subagent can summarize; don't sit through long
   test suites inline — delegate the run and take back counts + failure excerpts.
 
@@ -136,10 +135,10 @@ and take the actual model and effort for each rung from the skill.
 ### Reviewer lane — read-only, distinct lenses, never the cheap rung
 - Use the `reviewer` subagent type (Read/Grep/Glob only — structurally cannot "fix" anything), at
   the model and effort the canonical skill assigns to **review**: review is judgment work, so the
-  cheap rung is not eligible and the skill — not this file — sets the effort. Round count is set
-  by base §4 (global laws 2 and 11), not here; where a pass is owed, prefer a **distinct lens**
-  (correctness / security / test-coverage / does-it-reproduce) over a duplicate. You adjudicate;
-  the implementing worker fixes; the ops agent posts the PR comments you finalize.
+  cheap rung is not eligible and the skill — not this file — sets the effort. When the global
+  pipeline requests a lens, choose Taskdeck context from `taskdeck-pr-review-loop`; this file does
+  not decide invocation or count. You adjudicate the returned evidence; the implementing worker
+  performs pipeline-directed fixes; the ops agent posts text you finalize.
 
 ## ORCHESTRATION PATTERNS
 
@@ -148,9 +147,9 @@ and take the actual model and effort for each rung from the skill.
   structured returns; set `model`/`effort` per stage (finders cheap, verifiers stronger).
   Plain `Agent` calls for one-off delegation; a workflow only when the structure earns it.
 - **Wave shape per cycle:** plan (you) → implement (implementation-lane workers, worktrees) →
-  branch/PR mechanics (ops agent) → review (read-only reviewers → your adjudication) → fix (the
-  same worker via SendMessage) → gate + merge (**you**, base §5, dependency-safe order) → ledger
-  checkpoint → pull `main` → next wave.
+  branch/PR mechanics (ops agent) → canonical review pipeline (Taskdeck lenses + your evidence
+  synthesis) → pipeline-directed work → dependency-safe disposition → ledger checkpoint → pull
+  `main` when applicable → next wave.
 - Keep **2–4 tasks in flight**, never a reflexive fleet (`model-effort-routing` skill when
   unsure). While workers run in the background, use your foreground turn for the next wave's
   planning or adjudication — don't idle, and don't poll what will notify you.
@@ -167,17 +166,12 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
   your finalized text. Required orientation and gate reads are never delegated to save
   tokens: the coordinator still reads the source-of-truth docs (base §1 — STATUS,
   OUTSTANDING_TASKS, the handoff) and every gate input itself.
-- **Gate-marshals per lane (implementation rung):** one worker owns a PR's whole
-  fix→verify→settle cycle end-to-end — "verify" meaning the worker's TARGETED runs; full-suite
-  verdicts stay with the ops lane + coordinator per BUDGET & CADENCE — continued via
-  `SendMessage` round after round, never respawned per round, so context (the PR's history,
-  reviewers' phrasing, prior verdicts) is paid for once. Thread settlement (reply + `resolveReviewThread` + report
-  `unresolved == 0`) is owned by exactly ONE lane per PR — default the gate-marshal; the
-  coordinator may reassign a PR's settlement to the ops agent in that packet explicitly
-  (e.g. the marshal is retired), but never lets both act on the same PR's threads. (Honest
-  provenance: the two proving runs actually ran settlement in the ops lane as a standing
-  cycle; the marshal default here is a deliberate alignment with the gate sequence below,
-  which the single-owner rule preserves either way.)
+- **Evidence marshals per lane (implementation rung):** one worker owns targeted verification and
+  any fix or thread-settlement mechanics that the global pipeline assigns. Continue that worker
+  via `SendMessage` so context is retained; the global pipeline, not this overlay, sets
+  convergence. Thread settlement (`reply` + `resolveReviewThread` + reported state) belongs to
+  exactly one lane per PR; the coordinator may reassign it explicitly, but never lets two lanes
+  act on the same thread.
 - **The ops-lane agent (the SAME single agent, not a second one) takes on an extended remit** in
   addition to its standing tasks: full-suite runs under a STOP-on-red decision rule, determinism
   reruns, and any settlement packet reassigned per the bullet
@@ -198,45 +192,28 @@ applies — the gate is never thinned to save tokens (see STOP CONDITIONS for ho
   the excerpts) for the exact head — never a sampled slice of it (branch protection is
   lenient, so a misreported red has no other backstop). A packet that fails its spot-check
   is re-verified in full. Everything decision-bearing is verified in full, never sampled
-  — in particular:
-  reviewer packets (every returned finding read and adjudicated individually per base §4,
-  which defers to global laws 2 and 11 for the severity bar); settlement packets (the coordinator
-  verifies each settled thread carries its reply and its finding→commit fix-evidence
-  mapping, not just the unresolved count — a thread resolved without evidence is unsettled);
-  and the merge gate (the full base §5 feedback-by-content sweep — unresolved threads AND
-  top-level comments AND review-summary bodies since the final push — plus the suite/CI
-  verdict, all coordinator-owned). Sampling is a mechanics-lane shortcut, nothing else.
-- **Flake adjudication stays evidence-priced:** full-suite red → ops STOPs per its decision
-  rule → isolated reruns (4–6×, branch AND main) → root-cause read → ruled flaky ⇒ tracked
-  issue/evidence comment, and the gate proceeds with the flake carved out BY NAME in the next
-  packet's decision rule.
+  — in particular reviewer and settlement packets, plus the exact-head suite/CI and
+  feedback-content packet sent to the global pipeline. Review classification, convergence, and
+  merge disposition stay canonical. Sampling is a mechanics-lane shortcut, nothing else.
+- **Flake adjudication stays evidence-priced:** follow the global check-attempt ceiling, compare
+  branch and main when useful, root-cause the signal, and return the evidence without inventing a
+  Fable-specific retry rule.
 - **Near a usage-reset boundary, sequence reviewer fan-outs after it.** A reviewer killed by
   a limit produces an untrustworthy partial verdict — rerun it, never salvage it.
 
-## PER-PR GATE SEQUENCE (proven across 20+ merges; run it every time)
+## PER-PR TASKDECK EVIDENCE HANDOFF
 
-worker round → 2 read-only reviewers (distinct lenses) → coordinator adjudication → ONE
-batched fix push to the same worker → full backend suite on the EXACT head (coordinator owns
-the verdict; delegate the run to a subagent that executes it in its OWN foreground turn, or
-run it inline — never as background Bash; serialize so only ONE full suite runs box-wide at a
-time) → CI green on that head →
-30–60 min bot window from the FINAL push → **feedback check by CONTENT** (unresolved review
-threads AND top-level PR comments AND review-summary bodies posted since the final push) →
-merge → pull `main` → prune worktree+branch (cd out of a worktree before removing it).
+Run the canonical global pipeline. This overlay supplies only:
 
-- **Feedback check by content, never by reviewer names**: query `reviewThreads` (count
-  `isResolved == false` and READ the bodies), AND sweep top-level PR comments and
-  review-summary bodies since the final push — bots put findings in all three places, and a
-  "review" entry with no findings looks identical to one with two P2s until you read it. This applies to docs-only PRs too (a docs sweep has been merged
-  over two valid unresolved P2s before; the fix cost a follow-up PR).
-- **Review-loop discipline**: batch fixes into ONE push per round; every worker — or the PR's
-  designated settlement lane, when FRUGALITY MODE has reassigned it — replies AND
-  resolves threads via GraphQL `resolveReviewThread` and reports `unresolved == 0`; new bot
-  findings on a final head are reported to the coordinator, never cycled unilaterally. When
-  bot rounds keep finding new interleavings in one seam, issue ONE structural redesign
-  directive with a hard timebox ("further findings → report and hand off").
-- **Merge order**: when a wide (many-file / frontend-touching) PR and narrow PRs approach the
-  gate together, land the wide one first.
+- exact head/base identity, targeted checks, exact-head CI, and full-suite results when the
+  touched seam requires them; serialize full suites box-wide
+- feedback content from unresolved threads, top-level comments, and review-summary bodies, without
+  classifying it locally
+- pipeline-assigned fix or thread-settlement mechanics through one owning lane
+- dependency-safe ordering and worktree cleanup mechanics from the base manual
+
+Reviewer invocation/count, severity, bot triggers or waits, fix/re-review convergence, and merge
+disposition stay in the global pipeline.
 - **Generated files**: `docs/agentic/FAILURE_LEDGER.md` is rendered from `failure_ledger.jsonl`
   by `scripts/agent_hooks/render_failure_ledger.py` (first ~160 chars of `future_fix` become
   the cell). Never hand-edit the rendered md — front-load the essential text in the jsonl and


### PR DESCRIPTION
## Summary

- routes the core Claude, Codex, and Fable review entry/return paths through global laws 2 and 11 plus the global `review-and-ship` skill
- keeps Taskdeck-specific exact-head/base evidence, local proving checks, risk lenses, dependency ordering, and stop mechanics
- adds ownership links to agent-harness#101, Taskdeck #1291, and Taskdeck #1269

## Implementation notes

- removes local reviewer counts, severity bars, fix/re-review rules, bot triggers/waits, tier-row copies, and merge-action ownership from the approved 12-file first slice
- makes implementation workers return a ready PR plus exact evidence to the coordinator; only the coordinator enters or re-enters the canonical pipeline, and workers resume only for pipeline-directed fixes
- changes `pre-merge-gate` into a Taskdeck evidence collector that fails closed unless local HEAD, a clean worktree, the remote PR head, the fetched current base, and the merge base all match exactly
- does not add a scanner, parity gate, meta-gate, or strategic policy

## Tests added or updated

- none; this is an instruction/routing cleanup

## Commands run and results

- before inventory: one broad `rg -n -i` sweep over active root/runtime/agentic instructions returned 287 candidate lines
- after inventory: targeted `rg -n -i` obsolete-signature sweep over the original 12 changed paths returned `AFTER_RG_OBSOLETE_MATCHES=0`
- refreshed onto exact green base `333d0ba25df53b9b2900840dc2e234e4fc72e84c` with signed merge `b7b4d09ef6ddfe3b44d44aa68e43641c80015331`; no conflicts and the pre-fix stable patch ID remained `618f6ba59841284e9da1c40ffc3f9b21b2d28b5f`
- exact fix head: `6ea024d7a78b83a7eda636211e4d2ca200d7f061`; tree `2f9a19334ca0a09f166c342e52b858d1333f522c`
- `node scripts/check-docs-governance.mjs` — passed on exact fix head
- `node scripts/check-golden-principles.mjs` — passed on exact fix head
- `node scripts/check-github-ops-governance.mjs` — passed on exact fix head
- `py -3 -B scripts/agent_hooks/smoke_test.py` — passed on exact fix head
- `git diff --check origin/main...HEAD` — passed on exact fix head
- Codex `quick_validate.py` for affected `taskdeck-worktree-issue-worker` — valid on exact fix head
- extracted `pre-merge-gate` Bash block — syntax passed; dirty-worktree and wrong-PR-head deny canaries passed; exact-head/current-base allow canary passed after push
- DCO: all branch commits `f39f0cc3a3c3e70a35659e4296e814b2925a28f0`, `b7b4d09ef6ddfe3b44d44aa68e43641c80015331`, and `6ea024d7a78b83a7eda636211e4d2ca200d7f061` contain `Signed-off-by:`

## Docs updated

- updated active agent manuals, workflow skills, and the root canonical-policy pointer
- did not update `docs/STATUS.md` or `docs/IMPLEMENTATION_MASTERPLAN.md`; shipped product reality and roadmap sequencing did not change in this PR

## Risks and follow-ups

This is intentionally a bounded first slice. #1544 remains open.

Confirmed mechanical remainder (11 files):

1. `CLAUDE.md`
2. `.claude/README.md`
3. `.claude/settings.json`
4. `docs/ISSUE_EXECUTION_GUIDE.md`
5. `docs/tooling/CODEX_AUTONOMY_RUNBOOK.md`
6. `.codex/config.toml`
7. `docs/WORKTREE_AGENT_PROTOCOL.md`
8. `docs/QA_STRATEGY.md`
9. `docs/STATUS.md`
10. `docs/IMPLEMENTATION_MASTERPLAN.md`
11. `CODEOWNERS`

Also tracked for later under #1544:

- three nonblocking stale phrases in the same changed overnight manual; they were intentionally not changed in this blocker-only fix round
- decision surface: the #1510/#1511 workflow exception
- decision surface: the human-review policy in `docs/ops/DEPENDENCY_UPDATE_POLICY.md`

The legacy Claude skill files retain their pre-existing `user-invocable` frontmatter, which the generic Codex skill validator does not accept; Codex mirrors were validated with that tool, while Claude files are covered by the repository docs checks, Bash syntax/canary proof where applicable, and focused manual inspection.

Refs #1544
Refs Chris0Jeky/agent-harness#101
Refs #1291
Refs #1269