### PR TITLE
docs: align review gate state

### DIFF
--- a/docs/agentic/ORCHESTRATION_STATE.md
+++ b/docs/agentic/ORCHESTRATION_STATE.md
@@ -25,12 +25,11 @@ This file is the persistent memory and execution state for Claude Code's autonom
 2. **Implement**: Small, focused commits. One commit per logical unit.
 3. **Test**: Run `dotnet test backend/Taskdeck.sln -c Release -m:1` and/or `cd frontend/taskdeck-web && npx vitest --run`
 4. **PR**: Create with `gh pr create` linking the issue. Include Summary + Test Plan.
-5. **Review Round 1**: Use `adversarial-review` skill or manual review. Post ALL findings as a PR comment. Fix every finding (CRITICAL through LOW). Push fixes.
-6. **Review Round 2**: Fresh adversarial review of the fixes. Post findings. Fix everything. Push.
-7. **Bot Check**: Read ALL PR comments (Gemini Code Assist, Dependabot, any bot). Address anything found.
-8. **Verify**: Run tests again post-fix. Confirm CI passes (check via `gh pr checks <PR#>`).
-9. **Merge gate**: Leave PRs open unless the active user request explicitly authorizes merging after the normal review, bot-comment, test, and CI gates. _(The 2026-05-17 cleanup session WAS merge-authorized after those gates; that authorization was session-scoped and is historical.)_
-10. **Stack if needed**: If the next issue depends on this PR, branch from the PR branch.
+5. **Review**: Follow the authoritative `review-and-ship` pipeline named by root `AGENTS.md`; this snapshot sets no fixed review-round count or fix-all rule.
+6. **Bot Check**: Read ALL PR comments (Gemini Code Assist, Dependabot, any bot). Address anything found.
+7. **Verify**: Run tests again post-fix. Confirm CI passes (check via `gh pr checks <PR#>`).
+8. **Merge gate**: Leave PRs open unless the active user request explicitly authorizes merging after the normal review, bot-comment, test, and CI gates. _(The 2026-05-17 cleanup session WAS merge-authorized after those gates; that authorization was session-scoped and is historical.)_
+9. **Stack if needed**: If the next issue depends on this PR, branch from the PR branch.
 
 ### Parallel Subagent Protocol:
 
@@ -88,7 +87,7 @@ _(Point-in-time snapshot — several items below were **subsequently delivered**
 - PR #1083 `paper/1001-board-kanban-surface`: CI green at last inspection; current-head adversarial review clean.
 - PR #1084 `tst/1081-composable-coverage-part2`: watcher review findings fixed in `a1d3449a`; merge-policy/date cleanup in progress after review findings; CI pending.
 
-User authorizes merging only under the current risk-calibrated `AGENTS.md` gate: green proving checks at the reviewed head, one triage pass over every review comment, confirmed blockers fixed, and other findings tracked or declined.
+Session merge authorization remains subject to the authoritative `review-and-ship` pipeline named by root `AGENTS.md`, plus current exact-head proving, CI, and comment gates as remeasured live.
 
 ### Active PR Stack
 - #1078 -> `main`

--- a/docs/agentic/ORCHESTRATION_STATE.md
+++ b/docs/agentic/ORCHESTRATION_STATE.md
@@ -88,7 +88,7 @@ _(Point-in-time snapshot — several items below were **subsequently delivered**
 - PR #1083 `paper/1001-board-kanban-surface`: CI green at last inspection; current-head adversarial review clean.
 - PR #1084 `tst/1081-composable-coverage-part2`: watcher review findings fixed in `a1d3449a`; merge-policy/date cleanup in progress after review findings; CI pending.
 
-User authorized merging PRs only after green CI/tests, bot comments addressed, every review finding fixed or tracked, and two adversarial review rounds over the current head.
+User authorizes merging only under the current risk-calibrated `AGENTS.md` gate: green proving checks at the reviewed head, one triage pass over every review comment, confirmed blockers fixed, and other findings tracked or declined.
 
 ### Active PR Stack
 - #1078 -> `main`


### PR DESCRIPTION
## Summary
- Replace obsolete fixed-count review instructions in the retained orchestration snapshot with pointers to the authoritative review pipeline.
- Keep current merge authorization tied to that pipeline and remeasured exact-head proving, CI, and comment gates.

## Review fix
- Fixed the confirmed executable-policy finding from independent review: the current Workflow Protocol no longer mandates two review rounds or fixing every LOW finding, and the current merge sentence no longer restates an incomplete `only` gate.
- Historical status rows remain untouched.

## Verification
- `py -3 -B -m unittest discover -s scripts/agent_hooks -p test_render_failure_ledger.py` (11 passed)
- `node scripts/check-docs-governance.mjs`
- `node scripts/check-golden-principles.mjs`
- `node scripts/check-github-ops-governance.mjs`
- `git diff --check`
- Confirmed obsolete live-policy wording is absent.

## Docs
- Updated `docs/agentic/ORCHESTRATION_STATE.md` only.

## Risks / follow-ups
- This is a cross-repository follow-up for claude-config #26 and intentionally does not close that issue.
- This is the sole fix round; no manual review request or merge was made.