### PR TITLE
Align MCP create-card column contract

### DIFF
--- a/backend/src/Taskdeck.Api/Mcp/WriteTools.cs
+++ b/backend/src/Taskdeck.Api/Mcp/WriteTools.cs
@@ -21,17 +21,34 @@ public class WriteTools
     private readonly IUserContextProvider _userContext;
     private readonly ICaptureService _captureService;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IAuthorizationService _authorizationService;
 
     public WriteTools(
         IAutomationProposalService proposalService,
         IUserContextProvider userContext,
         ICaptureService captureService,
         IUnitOfWork unitOfWork)
+        : this(
+            proposalService,
+            userContext,
+            captureService,
+            unitOfWork,
+            new AuthorizationService(unitOfWork))
+    {
+    }
+
+    public WriteTools(
+        IAutomationProposalService proposalService,
+        IUserContextProvider userContext,
+        ICaptureService captureService,
+        IUnitOfWork unitOfWork,
+        IAuthorizationService authorizationService)
     {
         _proposalService = proposalService;
         _userContext = userContext;
         _captureService = captureService;
         _unitOfWork = unitOfWork;
+        _authorizationService = authorizationService;
     }
 
     /// <summary>
@@ -83,18 +100,37 @@ public class WriteTools
         if (!Guid.TryParse(board_id, out var boardGuid))
             return Error("Invalid board_id format");
 
+        var canWrite = await _authorizationService.CanWriteBoardAsync(userId, boardGuid);
+        if (!canWrite.IsSuccess)
+            return Error(canWrite.ErrorMessage);
+        if (!canWrite.Value)
+            return Error("Not authorized to create cards on this board");
+
+        Guid? requestedColumnId = null;
+        if (!string.IsNullOrWhiteSpace(column_id))
+        {
+            if (!Guid.TryParse(column_id, out var parsedColumnId))
+                return Error("Invalid column_id format");
+            requestedColumnId = parsedColumnId;
+        }
+
+        var columns = await _unitOfWork.Columns.GetByBoardIdAsync(boardGuid);
+        var column = requestedColumnId.HasValue
+            ? columns.SingleOrDefault(candidate => candidate.Id == requestedColumnId.Value)
+            : columns.OrderBy(candidate => candidate.Position).ThenBy(candidate => candidate.Id).FirstOrDefault();
+        if (column is null)
+        {
+            return string.IsNullOrWhiteSpace(column_id)
+                ? Error("No columns found in board")
+                : Error("column_id not found on board");
+        }
+
         var parameters = new Dictionary<string, object?>
         {
             ["boardId"] = boardGuid,
-            ["title"] = title
+            ["title"] = title,
+            ["columnId"] = column.Id
         };
-
-        if (!string.IsNullOrWhiteSpace(column_id))
-        {
-            if (!Guid.TryParse(column_id, out var columnGuid))
-                return Error("Invalid column_id format");
-            parameters["columnId"] = columnGuid;
-        }
 
         if (!string.IsNullOrWhiteSpace(description))
             parameters["description"] = description;

--- a/backend/tests/Taskdeck.Api.Tests/McpToolsTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpToolsTests.cs
@@ -195,6 +195,95 @@ public class McpToolsTests : IDisposable
     }
 
     [Fact]
+    public async Task CreateCard_OmittedColumn_ResolvesFirstColumnPreviewsAndExecutes()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var (user, boardId, firstColumnId) = await SetupBoardAsync(scope);
+        var columnService = scope.ServiceProvider.GetRequiredService<ColumnService>();
+        await columnService.CreateColumnAsync(new CreateColumnDto(boardId, "Done", null, null));
+        var tools = CreateWriteTools(scope, user.Id);
+
+        var json = await tools.CreateCard(boardId.ToString(), "First-column MCP card");
+
+        using var document = JsonDocument.Parse(json);
+        var proposalId = document.RootElement.GetProperty("proposalId").GetGuid();
+        var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
+        var proposal = await proposalService.GetProposalByIdAsync(proposalId);
+        proposal.IsSuccess.Should().BeTrue(proposal.ErrorMessage);
+        using (var parameters = JsonDocument.Parse(proposal.Value.Operations.Single().Parameters))
+            parameters.RootElement.GetProperty("columnId").GetGuid().Should().Be(firstColumnId);
+
+        (await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().Cards.GetByBoardIdAsync(boardId))
+            .Should().BeEmpty("creating an MCP card must remain review-first");
+        var diff = await proposalService.GetProposalDiffAsync(proposalId);
+        diff.IsSuccess.Should().BeTrue(diff.ErrorMessage);
+
+        await ApproveAndExecuteAsync(scope, user.Id, proposalId);
+
+        var created = (await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().Cards.GetByBoardIdAsync(boardId))
+            .Should().ContainSingle(card => card.Title == "First-column MCP card").Subject;
+        created.ColumnId.Should().Be(firstColumnId);
+    }
+
+    [Fact]
+    public async Task CreateCard_ExplicitColumnFromAnotherBoard_ReturnsErrorAndCreatesNoProposal()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var (user, boardId, _) = await SetupBoardAsync(scope);
+        var boardService = scope.ServiceProvider.GetRequiredService<BoardService>();
+        var columnService = scope.ServiceProvider.GetRequiredService<ColumnService>();
+        var otherBoard = await boardService.CreateBoardAsync(new CreateBoardDto("Other board", null), user.Id);
+        var otherColumn = await columnService.CreateColumnAsync(
+            new CreateColumnDto(otherBoard.Value.Id, "Other column", null, null));
+
+        var json = await CreateWriteTools(scope, user.Id)
+            .CreateCard(boardId.ToString(), "Wrong board column", otherColumn.Value.Id.ToString());
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("error").GetString().Should().Contain("column_id not found on board");
+        (await scope.ServiceProvider.GetRequiredService<IUnitOfWork>().AutomationProposals.GetByBoardIdAsync(boardId))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateCard_BoardWithoutColumns_ReturnsErrorAndCreatesNoProposal()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var (user, _, _) = await SetupBoardAsync(scope);
+        var board = await scope.ServiceProvider.GetRequiredService<BoardService>()
+            .CreateBoardAsync(new CreateBoardDto("Columnless board", null), user.Id);
+
+        var json = await CreateWriteTools(scope, user.Id).CreateCard(board.Value.Id.ToString(), "No destination");
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("error").GetString().Should().Contain("No columns found in board");
+        (await scope.ServiceProvider.GetRequiredService<IUnitOfWork>()
+            .AutomationProposals.GetByBoardIdAsync(board.Value.Id)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateCard_InaccessibleBoard_ReturnsErrorAndCreatesNoProposal()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var (caller, _, _) = await SetupBoardAsync(scope);
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var boardService = scope.ServiceProvider.GetRequiredService<BoardService>();
+        var columnService = scope.ServiceProvider.GetRequiredService<ColumnService>();
+        var owner = new User($"owner-{Guid.NewGuid():N}", $"owner-{Guid.NewGuid():N}@example.com", "Password1!");
+        await unitOfWork.Users.AddAsync(owner);
+        await unitOfWork.SaveChangesAsync();
+        var privateBoard = await boardService.CreateBoardAsync(new CreateBoardDto("Private board", null), owner.Id);
+        await columnService.CreateColumnAsync(new CreateColumnDto(privateBoard.Value.Id, "Private", null, null));
+
+        var json = await CreateWriteTools(scope, caller.Id)
+            .CreateCard(privateBoard.Value.Id.ToString(), "Unauthorized card");
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("error").GetString().Should().Contain("Not authorized");
+        (await unitOfWork.AutomationProposals.GetByBoardIdAsync(privateBoard.Value.Id)).Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task CreateCard_InvalidBoardId_ReturnsError()
     {
         using var scope = _serviceProvider.CreateScope();


### PR DESCRIPTION
## Summary
- Resolve `create_card`'s omitted `column_id` to the board's deterministic first column before proposal persistence.
- Reject inaccessible boards, cross-board columns, and boards with no columns before a proposal can become unusable.
- Keep MCP writes review-first: Preview, Approve, and Apply use the same persisted canonical `columnId`; no board is mutated directly.

## Tests
- Added MCP regressions for omitted-column proposal -> diff -> approve -> execute, wrong-board explicit columns, columnless boards, and inaccessible boards.
- `dotnet test backend/Taskdeck.sln -c Release -m:1 --filter FullyQualifiedName~McpToolsTests` (33 passed)
- `dotnet test backend/Taskdeck.sln -c Release -m:1 --no-restore` (7,527 passed; 33 documented/environment-gated skips)

## Docs
- No canonical docs changed: this is a bounded contract repair with direct executable coverage.

## Risks / follow-up
- The full MCP transport path is covered by the existing tool registration; this PR verifies the direct tool plus SQLite-backed proposal lifecycle.

Closes #1354