### PR TITLE
Fail closed on skipped container integration

### DIFF
--- a/.github/workflows/reusable-container-integration.yml
+++ b/.github/workflows/reusable-container-integration.yml
@@ -40,13 +40,40 @@ jobs:
       - name: Verify Docker is available
         run: docker info
 
+      - name: Verify Docker-required contract fails closed
+        shell: bash
+        run: |
+          set +e
+          TASKDECK_REQUIRE_DOCKER=true TASKDECK_FORCE_DOCKER_UNAVAILABLE=true \
+            dotnet test backend/tests/Taskdeck.Integration.Tests/Taskdeck.Integration.Tests.csproj \
+              --configuration Release --no-restore \
+              --filter "FullyQualifiedName~BoardCrudIntegrationTests" \
+              --logger "trx;LogFileName=container-integration-negative.trx" \
+              --results-directory "backend/TestResults/container-integration-negative"
+          test_exit=$?
+          set -e
+
+          if [ "$test_exit" -eq 0 ]; then
+            echo "Forced Docker-unavailable contract unexpectedly passed."
+            exit 1
+          fi
+
+          python3 scripts/ci/assert_container_integration_results.py \
+            --trx "backend/TestResults/container-integration-negative/container-integration-negative.trx" \
+            --mode negative
+
       - name: Run container-backed integration tests
+        env:
+          TASKDECK_REQUIRE_DOCKER: "true"
         run: dotnet test backend/tests/Taskdeck.Integration.Tests/Taskdeck.Integration.Tests.csproj --configuration Release --no-restore --logger "trx;LogFileName=container-integration.trx" --results-directory "backend/TestResults/container-integration"
+
+      - name: Verify PostgreSQL integration results
+        run: python3 scripts/ci/assert_container_integration_results.py --trx "backend/TestResults/container-integration/container-integration.trx" --mode positive --minimum-postgres-results 28
 
       - name: Upload container integration test results
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: container-integration-trx
-          path: backend/TestResults/container-integration
+          path: backend/TestResults/container-integration*
           if-no-files-found: ignore

--- a/backend/tests/Taskdeck.Integration.Tests/Fixtures/DockerAvailableCheck.cs
+++ b/backend/tests/Taskdeck.Integration.Tests/Fixtures/DockerAvailableCheck.cs
@@ -10,6 +10,12 @@ namespace Taskdeck.Integration.Tests.Fixtures;
 /// </summary>
 public static class DockerAvailableCheck
 {
+    public const string RequireDockerEnvironmentVariable = "TASKDECK_REQUIRE_DOCKER";
+    public const string ForceDockerUnavailableEnvironmentVariable = "TASKDECK_FORCE_DOCKER_UNAVAILABLE";
+    public const string RequiredDockerFailureMessage =
+        "Docker is required for this test run but is unavailable. " +
+        "Clear TASKDECK_REQUIRE_DOCKER for ordinary Dockerless local runs.";
+
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan ReapTimeout = TimeSpan.FromSeconds(2);
     private static readonly Lazy<bool> IsAvailableLazy = new(CheckDocker);
@@ -18,12 +24,38 @@ public static class DockerAvailableCheck
     /// Returns true if Docker is available and responsive on the host.
     /// The result is cached for the lifetime of the process.
     /// </summary>
-    public static bool IsAvailable => IsAvailableLazy.Value;
+    public static bool IsAvailable =>
+        IsEnvironmentFlagEnabled(Environment.GetEnvironmentVariable(ForceDockerUnavailableEnvironmentVariable))
+            ? false
+            : IsAvailableLazy.Value;
+
+    /// <summary>
+    /// Whether the caller explicitly requires Docker-backed coverage instead of the
+    /// ordinary local graceful-skip contract.
+    /// </summary>
+    internal static bool IsDockerRequired =>
+        IsEnvironmentFlagEnabled(Environment.GetEnvironmentVariable(RequireDockerEnvironmentVariable));
 
     /// <summary>
     /// Skip message for use with xUnit's Skip property.
     /// </summary>
     public const string SkipReason = "Docker is not available on this machine";
+
+    /// <summary>
+    /// Turns an unavailable Docker probe into a test failure when the caller has
+    /// explicitly requested Docker-backed verification.
+    /// </summary>
+    internal static void EnsureRequiredDockerIsAvailable(bool isAvailable, bool dockerRequired)
+    {
+        if (dockerRequired && !isAvailable)
+        {
+            throw new InvalidOperationException(RequiredDockerFailureMessage);
+        }
+    }
+
+    internal static bool IsEnvironmentFlagEnabled(string? value) =>
+        string.Equals(value, "1", StringComparison.Ordinal) ||
+        bool.TryParse(value, out var enabled) && enabled;
 
     private static bool CheckDocker()
     {

--- a/backend/tests/Taskdeck.Integration.Tests/Fixtures/PostgresIntegrationTestBase.cs
+++ b/backend/tests/Taskdeck.Integration.Tests/Fixtures/PostgresIntegrationTestBase.cs
@@ -91,6 +91,10 @@ public abstract class PostgresIntegrationTestBase : IAsyncLifetime
     /// </summary>
     protected static void SkipIfDockerUnavailable()
     {
-        Skip.If(!DockerAvailableCheck.IsAvailable, DockerAvailableCheck.SkipReason);
+        var isDockerAvailable = DockerAvailableCheck.IsAvailable;
+        DockerAvailableCheck.EnsureRequiredDockerIsAvailable(
+            isDockerAvailable,
+            DockerAvailableCheck.IsDockerRequired);
+        Skip.If(!isDockerAvailable, DockerAvailableCheck.SkipReason);
     }
 }

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -730,7 +730,12 @@ dotnet test backend/Taskdeck.sln -c Release -m:1
 
 Current project count: 35 tests — 28 PostgreSQL-backed cases covering Board CRUD, Card operations, proposal lifecycle, cross-class isolation, parallel execution, and repository parity; plus 7 Docker-independent fixture/native checks. Guide at `docs/testing/TESTCONTAINERS_GUIDE.md`.
 
-CI: `reusable-container-integration.yml` in extended CI (testing label). A positive PostgreSQL result has zero skips; a green run with all 28 container cases skipped proves only graceful Dockerless gating.
+CI: `reusable-container-integration.yml` in extended CI (testing label). The hosted lane sets
+`TASKDECK_REQUIRE_DOCKER=true`, first forces Docker unavailable as a negative control, and requires
+the resulting TRX to contain the explicit Docker-required failure. Its real run then verifies the
+TRX has zero skipped tests and at least 28 passing PostgreSQL-backed results. A normal local green
+run with all 28 container cases skipped proves only graceful Dockerless gating; do not set the
+required-mode flag for that local contract.
 
 ## Product-Coherence Testing Priorities (2026-03-07)
 

--- a/scripts/ci/assert_container_integration_results.py
+++ b/scripts/ci/assert_container_integration_results.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fail closed on PostgreSQL container-integration test result contracts."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as element_tree
+from pathlib import Path
+
+
+POSTGRES_TEST_NAMESPACE = "Taskdeck.Integration.Tests."
+FIXTURE_TEST_NAMESPACE = "Taskdeck.Integration.Tests.Fixtures."
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def read_results(path: Path) -> list[dict[str, str]]:
+    root = element_tree.parse(path).getroot()
+    results: list[dict[str, str]] = []
+
+    for element in root.iter():
+        if _local_name(element.tag) != "UnitTestResult":
+            continue
+
+        message = "\n".join(text.strip() for text in element.itertext() if text.strip())
+        results.append(
+            {
+                "name": element.attrib.get("testName", ""),
+                "outcome": element.attrib.get("outcome", ""),
+                "message": message,
+            }
+        )
+
+    if not results:
+        raise ValueError(f"{path} contains no UnitTestResult records")
+
+    return results
+
+
+def assert_positive(results: list[dict[str, str]], minimum_postgres_results: int) -> None:
+    skipped = [result for result in results if result["outcome"] in {"NotExecuted", "Skipped"}]
+    postgres_results = [
+        result
+        for result in results
+        if result["name"].startswith(POSTGRES_TEST_NAMESPACE)
+        and not result["name"].startswith(FIXTURE_TEST_NAMESPACE)
+    ]
+    non_passing_postgres = [result for result in postgres_results if result["outcome"] != "Passed"]
+
+    if skipped:
+        raise ValueError(f"expected zero skipped tests, found {len(skipped)}")
+    if len(postgres_results) < minimum_postgres_results:
+        raise ValueError(
+            "expected at least "
+            f"{minimum_postgres_results} PostgreSQL test results, found {len(postgres_results)}"
+        )
+    if non_passing_postgres:
+        names = ", ".join(result["name"] for result in non_passing_postgres)
+        raise ValueError(f"PostgreSQL tests did not all pass: {names}")
+
+
+def assert_negative(results: list[dict[str, str]], required_message: str) -> None:
+    failures = [result for result in results if result["outcome"] == "Failed"]
+    if not failures:
+        raise ValueError("expected the forced Docker-unavailable control to fail")
+    if not any(required_message in result["message"] for result in failures):
+        raise ValueError("forced Docker-unavailable control failed for an unexpected reason")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trx", required=True, type=Path)
+    parser.add_argument("--mode", choices=("positive", "negative"), required=True)
+    parser.add_argument("--minimum-postgres-results", type=int, default=28)
+    parser.add_argument("--required-message", default="Docker is required for this test run but is unavailable.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        results = read_results(args.trx)
+        if args.mode == "positive":
+            assert_positive(results, args.minimum_postgres_results)
+        else:
+            assert_negative(results, args.required_message)
+    except (OSError, ValueError, element_tree.ParseError) as error:
+        print(f"Container integration result contract failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Container integration {args.mode} contract passed for {args.trx}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/assert_container_integration_results.py
+++ b/scripts/ci/assert_container_integration_results.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 
 POSTGRES_TEST_NAMESPACE = "Taskdeck.Integration.Tests."
-FIXTURE_TEST_NAMESPACE = "Taskdeck.Integration.Tests.Fixtures."
+NON_POSTGRES_TEST_PREFIXES = (
+    "Taskdeck.Integration.Tests.Fixtures.",
+    "Taskdeck.Integration.Tests.SQLiteNativeVersionTests.",
+)
 
 
 def _local_name(tag: str) -> str:
@@ -46,7 +49,10 @@ def assert_positive(results: list[dict[str, str]], minimum_postgres_results: int
         result
         for result in results
         if result["name"].startswith(POSTGRES_TEST_NAMESPACE)
-        and not result["name"].startswith(FIXTURE_TEST_NAMESPACE)
+        and not any(
+            result["name"].startswith(prefix)
+            for prefix in NON_POSTGRES_TEST_PREFIXES
+        )
     ]
     non_passing_postgres = [result for result in postgres_results if result["outcome"] != "Passed"]
 

--- a/scripts/ci/test_assert_container_integration_results.py
+++ b/scripts/ci/test_assert_container_integration_results.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+from assert_container_integration_results import assert_negative, assert_positive, read_results
+
+
+class ContainerIntegrationResultTests(unittest.TestCase):
+    def test_positive_contract_accepts_passing_postgres_results_without_skips(self) -> None:
+        assert_positive(
+            [
+                {
+                    "name": "Taskdeck.Integration.Tests.BoardCrudIntegrationTests.CreateBoard",
+                    "outcome": "Passed",
+                    "message": "",
+                }
+                for _ in range(28)
+            ],
+            minimum_postgres_results=28,
+        )
+
+    def test_positive_contract_rejects_skips(self) -> None:
+        with self.assertRaisesRegex(ValueError, "zero skipped"):
+            assert_positive(
+                [
+                    {
+                        "name": "Taskdeck.Integration.Tests.BoardCrudIntegrationTests.CreateBoard",
+                        "outcome": "NotExecuted",
+                        "message": "",
+                    }
+                ],
+                minimum_postgres_results=1,
+            )
+
+    def test_negative_contract_requires_the_docker_required_failure(self) -> None:
+        assert_negative(
+            [
+                {
+                    "name": "Taskdeck.Integration.Tests.BoardCrudIntegrationTests.CreateBoard",
+                    "outcome": "Failed",
+                    "message": "Docker is required for this test run but is unavailable.",
+                }
+            ],
+            "Docker is required for this test run but is unavailable.",
+        )
+
+    def test_trx_reader_accepts_namespaced_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "result.trx"
+            path.write_text(
+                """<TestRun xmlns=\"http://microsoft.com/schemas/VisualStudio/TeamTest/2010\">\n"
+                "<Results><UnitTestResult testName=\"Example\" outcome=\"Passed\" />"
+                "</Results></TestRun>""",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(read_results(path), [{"name": "Example", "outcome": "Passed", "message": ""}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_assert_container_integration_results.py
+++ b/scripts/ci/test_assert_container_integration_results.py
@@ -36,6 +36,26 @@ class ContainerIntegrationResultTests(unittest.TestCase):
                 minimum_postgres_results=1,
             )
 
+    def test_positive_contract_does_not_count_host_native_sqlite_results(self) -> None:
+        results = [
+            {
+                "name": "Taskdeck.Integration.Tests.BoardCrudIntegrationTests.CreateBoard",
+                "outcome": "Passed",
+                "message": "",
+            }
+            for _ in range(27)
+        ]
+        results.append(
+            {
+                "name": "Taskdeck.Integration.Tests.SQLiteNativeVersionTests.MeetsSecurityFloor",
+                "outcome": "Passed",
+                "message": "",
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "found 27"):
+            assert_positive(results, minimum_postgres_results=28)
+
     def test_negative_contract_requires_the_docker_required_failure(self) -> None:
         assert_negative(
             [


### PR DESCRIPTION
## Summary
- make Docker unavailability a test failure only when the caller explicitly requests Docker-backed coverage
- add a reusable-workflow negative control that forces Docker unavailable and verifies the specific failure through TRX
- require the hosted positive TRX to contain zero skipped tests and at least 28 passing PostgreSQL-backed results

## Implementation notes
Ordinary Dockerless runs keep the existing graceful-skip path. The reusable Ubuntu workflow sets `TASKDECK_REQUIRE_DOCKER=true`; a forced-unavailable process is expected to fail before the real Docker-backed run.

## Tests
- `py -3 -B -m unittest scripts/ci/test_assert_container_integration_results.py` — 5 passed
- Docker-required negative control — 5 failed as expected; TRX contract verifier passed
- Dockerless integration project — 7 passed / 28 skipped / 0 failed; positive verifier rejected it as expected
- `node scripts/check-github-ops-governance.mjs` — passed
- Git Bash shell syntax canary — passed
- Real Dockerless TRX classification — 35 total, 28 PostgreSQL, 1 host-native SQLite; SQLite excluded from the PostgreSQL minimum
- Exact-head hosted Container Integration (PostgreSQL) — passed, including positive PostgreSQL startup/migrations/tests/teardown
- Exact-head hosted rollup — 36 successes / 5 intentional skips / 0 pending / 0 failed
- DCO trailers — 3/3 commits

## Docs
`docs/TESTING_GUIDE.md` now records the hosted required-mode flag, forced-unavailable negative control, and positive TRX zero-skip/minimum-PostgreSQL contract. `docs/STATUS.md` and `docs/IMPLEMENTATION_MASTERPLAN.md` remain unchanged because this PR is not yet shipped.

## Verification boundary
Local Docker Desktop's Linux engine was unavailable, so local positive container startup was not verified. The equivalent exact-head hosted Container Integration job passed and is the authoritative positive PostgreSQL proof. The local full backend run had one unrelated nondeterministic SignalR stress-test failure; its focused rerun passed, and the exact recurrence was recorded on existing owner #1521.

Closes #1520
