### PR TITLE
docs: clarify agent run creation

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -369,7 +369,7 @@ If `Queue` or `Ops` feels too technical:
 
 ## Current Constraints
 
-- `Agents`, nested `Runs`, and `Integrations` ship; agent profiles and runs are created through APIs or automation triggers, and a standalone `Knowledge` route remains future work
+- `Agents`, nested `Runs`, and `Integrations` ship; agent profiles and runs are API-created today, while automation-trigger execution remains future work until a trigger is wired and tested; a standalone `Knowledge` route remains future work
 - some advanced flows still expose more system detail than a novice-ready product should
 - board-chat automation parsing remains pattern-based and board-centric; transcript-source capture has a separately gated LLM triage path with deterministic fallback
 - review-first behavior is intentional; destructive autonomy is out of scope

--- a/docs/manual/06_agents.md
+++ b/docs/manual/06_agents.md
@@ -10,7 +10,7 @@ Inspecting a run never approves or executes its proposal. Taskdeck's ordinary re
 
 Current boundaries:
 
-- runs are created by API calls or automation triggers, not from this page
+- runs are currently created through the authenticated `POST /api/agents/{agentId}/runs` API, not from this page; automation-trigger execution is future work until a trigger is wired and tested
 - the timeline is an observation and troubleshooting surface, not an execution console
 - a standalone `Knowledge` page does not ship yet
 


### PR DESCRIPTION
## Summary
- document the shipped authenticated API creation path for agent runs
- keep automation-trigger execution explicitly future-facing until it is wired and tested
- reconcile the two active user manuals that stated the old behavior

## Verification
- changed-doc local Markdown link check
- node scripts/check-docs-governance.mjs
- node scripts/check-golden-principles.mjs
- git diff --check

Closes #1563