### PR TITLE
fix: clarify agent-run execution boundary

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/AgentRunsView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/AgentRunsView.spec.ts
@@ -105,6 +105,9 @@ describe('AgentRunsView', () => {
     await waitForUi()
 
     expect(wrapper.text()).toContain('No runs yet')
+    expect(wrapper.text()).toContain('Runs are currently created through the API.')
+    expect(wrapper.text()).toContain('Automation-trigger execution is planned for a future release.')
+    expect(wrapper.text()).not.toContain('via the API or an automation trigger')
   })
 
   it('renders run cards with objective and status', async () => {

--- a/frontend/taskdeck-web/src/views/AgentRunsView.vue
+++ b/frontend/taskdeck-web/src/views/AgentRunsView.vue
@@ -112,8 +112,8 @@ function getStatusClass(status: AgentRunStatus): string {
     >
       <p class="td-agent-runs__empty-title">No runs yet</p>
       <p class="td-agent-runs__empty-body">
-        This agent has not been triggered. Runs are created when the agent is invoked
-        via the API or an automation trigger.
+        This agent has not been invoked. Runs are currently created through the API.
+        Automation-trigger execution is planned for a future release.
       </p>
     </div>
 


### PR DESCRIPTION
## Summary

- Clarifies the Agent Runs empty state: current runs are created through the API, while automation-trigger execution remains future work.
- Keeps the change limited to the rendered empty-state copy and its focused view test.

## Verification

- [x] `npm test -- src/tests/views/AgentRunsView.spec.ts` — 8 passed
- [x] `npm run typecheck`
- [x] `git range-diff befaf3e7..9a5261fb b7996cf1..67356755` — patch identity preserved after base absorption
- [ ] Full frontend suite/build and Playwright were not rerun locally; hosted CI is required.

## Review follow-up

- Non-blocking P2 wording/manual observations are tracked in #1572; no fix-commit cascade was added to this two-file PR.

Closes #1567