### PR TITLE
Allow transcript capture edits to use source cap

### DIFF
--- a/backend/src/Taskdeck.Application/Services/CaptureService.cs
+++ b/backend/src/Taskdeck.Application/Services/CaptureService.cs
@@ -389,10 +389,6 @@ public class CaptureService : ICaptureService
         if (string.IsNullOrWhiteSpace(dto.Text))
             return Result.Failure<CaptureItemDto>(ErrorCodes.ValidationError, "Text cannot be empty");
 
-        if (dto.Text.Length > CaptureRequestContract.MaxRawTextLength)
-            return Result.Failure<CaptureItemDto>(ErrorCodes.ValidationError,
-                $"Text exceeds maximum length of {CaptureRequestContract.MaxRawTextLength} characters");
-
         if (dto.TitleHint != null && dto.TitleHint.Length > CaptureRequestContract.MaxTitleHintLength)
             return Result.Failure<CaptureItemDto>(ErrorCodes.ValidationError,
                 $"Title hint exceeds maximum length of {CaptureRequestContract.MaxTitleHintLength} characters");
@@ -413,6 +409,13 @@ public class CaptureService : ICaptureService
             return Result.Failure<CaptureItemDto>(ErrorCodes.Conflict,
                 $"Capture item in status {currentStatus} cannot be edited");
         }
+
+        var maxTextLength = CaptureRequestContract.IsTranscriptSource(currentPayload.Source)
+            ? CaptureRequestContract.MaxTranscriptTextLength
+            : CaptureRequestContract.MaxRawTextLength;
+        if (dto.Text.Length > maxTextLength)
+            return Result.Failure<CaptureItemDto>(ErrorCodes.ValidationError,
+                $"Text exceeds maximum length of {maxTextLength} characters");
 
         var updatedPayload = new CapturePayloadV1(
             currentPayload.Version,

--- a/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/CaptureApiTests.cs
@@ -619,6 +619,28 @@ public class CaptureApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task UpdateSuggestion_ShouldAllowTranscriptTextAtSourceSpecificLimit()
+    {
+        await AuthenticateAsAsync("capture-edit-transcript");
+
+        var createResponse = await _client.PostAsJsonAsync(
+            "/api/capture/items",
+            new CreateCaptureItemDto(null, "original transcript", "transcriptPaste"));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var created = await createResponse.Content.ReadFromJsonAsync<CaptureItemDto>();
+
+        var response = await _client.PutAsJsonAsync(
+            $"/api/capture/items/{created!.Id}/suggestion",
+            new UpdateCaptureSuggestionDto(
+                new string('t', CaptureRequestContract.MaxTranscriptTextLength)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var updated = await response.Content.ReadFromJsonAsync<CaptureItemDto>();
+        updated.Should().NotBeNull();
+        updated!.RawText.Should().HaveLength(CaptureRequestContract.MaxTranscriptTextLength);
+    }
+
+    [Fact]
     public async Task UpdateSuggestion_ShouldReturnForbidden_WhenItemBelongsToDifferentUser()
     {
         using var ownerClient = _factory.CreateClient();

--- a/backend/tests/Taskdeck.Application.Tests/Services/CaptureServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CaptureServiceTests.cs
@@ -924,6 +924,52 @@ public class CaptureServiceTests
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(default), Times.Once);
     }
 
+    [Theory]
+    [InlineData(CaptureSource.TranscriptPaste)]
+    [InlineData(CaptureSource.TranscriptFile)]
+    public async Task UpdateSuggestionAsync_ShouldAllowTranscriptTextAtSourceSpecificLimit(CaptureSource source)
+    {
+        var userId = Guid.NewGuid();
+        var item = new LlmRequest(userId, CaptureRequestContract.RequestTypeTranscriptV1,
+            CaptureRequestContract.SerializePayload(
+                new CapturePayloadV1(1, source, "original transcript")));
+
+        _llmQueueRepositoryMock
+            .Setup(r => r.GetByIdAsync(item.Id, default))
+            .ReturnsAsync(item);
+
+        var editedText = new string('t', CaptureRequestContract.MaxTranscriptTextLength);
+        var result = await _service.UpdateSuggestionAsync(
+            userId,
+            item.Id,
+            new UpdateCaptureSuggestionDto(editedText));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RawText.Should().HaveLength(CaptureRequestContract.MaxTranscriptTextLength);
+    }
+
+    [Fact]
+    public async Task UpdateSuggestionAsync_ShouldRetainRawTextLimitForNonTranscriptSource()
+    {
+        var userId = Guid.NewGuid();
+        var item = new LlmRequest(userId, CaptureRequestContract.RequestTypeV1,
+            CaptureRequestContract.SerializePayload(
+                new CapturePayloadV1(1, CaptureSource.Typed, "original text")));
+
+        _llmQueueRepositoryMock
+            .Setup(r => r.GetByIdAsync(item.Id, default))
+            .ReturnsAsync(item);
+
+        var result = await _service.UpdateSuggestionAsync(
+            userId,
+            item.Id,
+            new UpdateCaptureSuggestionDto(new string('x', CaptureRequestContract.MaxRawTextLength + 1)));
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain(CaptureRequestContract.MaxRawTextLength.ToString());
+    }
+
     [Fact]
     public async Task UpdateSuggestionAsync_ShouldRejectEmptyText()
     {


### PR DESCRIPTION
## Summary

- Validate capture edits against the persisted source-specific text cap.
- Allow `TranscriptPaste` and `TranscriptFile` edits through the merged 200,000-character transcript limit.
- Preserve the 20,000-character limit for ordinary captures and existing authorization/status checks.

## Tests

- `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj --filter "FullyQualifiedName~CaptureServiceTests"` — 37 passed
- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj --filter "FullyQualifiedName~CaptureApiTests"` — 26 passed
- `git diff --check origin/main...HEAD` — clean

## Docs

No documentation change: this is a narrow service/API consistency repair following the already-documented M2 transcript contract.

## Risks / follow-ups

Focused service and API coverage only; full backend suite and hosted CI remain the PR gate.

Closes #1570