### PR TITLE
Fix UTF-8 transcript upload byte cap

### DIFF
--- a/frontend/taskdeck-web/src/components/common/CaptureModal.vue
+++ b/frontend/taskdeck-web/src/components/common/CaptureModal.vue
@@ -7,6 +7,8 @@ import { usePerformanceMark } from '../../composables/usePerformanceMark'
 // Mirrors CaptureRequestContract.MaxTranscriptTextLength. Keep this client-side guard source-specific:
 // quick captures retain the backend's smaller general-text limit.
 const MAX_TRANSCRIPT_LENGTH = 200_000
+// UTF-8 transport guard: allow any valid 200,000-code-unit transcript, including three-byte CJK text.
+const MAX_TRANSCRIPT_FILE_BYTES = 600_000
 
 const props = defineProps<{
   boardId?: string | null
@@ -79,8 +81,8 @@ function handleFileUpload(event: Event) {
     return
   }
 
-  if (file.size > MAX_TRANSCRIPT_LENGTH) {
-    inlineError.value = `File is too large. Maximum size is ${MAX_TRANSCRIPT_LENGTH.toLocaleString()} bytes.`
+  if (file.size > MAX_TRANSCRIPT_FILE_BYTES) {
+    inlineError.value = `File is too large. Maximum file size is ${MAX_TRANSCRIPT_FILE_BYTES.toLocaleString()} bytes.`
     target.value = ''
     return
   }

--- a/frontend/taskdeck-web/src/tests/components/CaptureModal.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/CaptureModal.spec.ts
@@ -319,15 +319,15 @@ describe('CaptureModal', () => {
       expect(wrapper.find('.td-capture-modal__file-name').exists()).toBe(false)
     })
 
-    it('rejects file exceeding size limit and shows error', async () => {
+    it('rejects file exceeding the raw byte limit and shows error', async () => {
       const wrapper = mount(CaptureModal)
 
       const transcriptTab = wrapper.findAll('[role="tab"]')[1]
       await transcriptTab.trigger('click')
       await waitForUi()
 
-      // Create a file larger than MAX_TRANSCRIPT_LENGTH (200,000 bytes)
-      const bigContent = 'x'.repeat(200_001)
+      // Create a file larger than the 600,000-byte UTF-8 transport limit.
+      const bigContent = 'x'.repeat(600_001)
       const bigFile = new File([bigContent], 'big.txt', { type: 'text/plain' })
       const fileInput = wrapper.find('input[type="file"]')
       Object.defineProperty(fileInput.element, 'files', {
@@ -337,8 +337,54 @@ describe('CaptureModal', () => {
       await fileInput.trigger('change')
       await waitForUi()
 
-      expect(wrapper.text()).toContain('File is too large. Maximum size is 200,000 bytes.')
+      expect(wrapper.text()).toContain('File is too large. Maximum file size is 600,000 bytes.')
       expect(wrapper.find('.td-capture-modal__file-name').exists()).toBe(false)
+    })
+
+    it('reads a 200,000-character CJK file at the UTF-8 byte limit', async () => {
+      const wrapper = mount(CaptureModal)
+
+      const transcriptTab = wrapper.findAll('[role="tab"]')[1]
+      await transcriptTab.trigger('click')
+      await waitForUi()
+
+      let capturedReader: FileReader | null = null
+      const OriginalFileReader = globalThis.FileReader
+      class MockFileReader extends EventTarget {
+        result: string | null = null
+        onload: ((event: ProgressEvent) => void) | null = null
+        onerror: ((event: ProgressEvent) => void) | null = null
+        readAsText() {
+          capturedReader = this as unknown as FileReader
+        }
+      }
+      globalThis.FileReader = MockFileReader as unknown as typeof FileReader
+
+      try {
+        const cjkContent = '界'.repeat(200_000)
+        const cjkFile = new File([cjkContent], 'cjk-transcript.txt', { type: 'text/plain' })
+        expect(cjkFile.size).toBe(600_000)
+
+        const fileInput = wrapper.find('input[type="file"]')
+        Object.defineProperty(fileInput.element, 'files', {
+          value: [cjkFile],
+          configurable: true,
+        })
+        await fileInput.trigger('change')
+        await waitForUi()
+
+        expect(capturedReader).not.toBeNull()
+        const reader = capturedReader as unknown as { result: string; onload: () => void }
+        reader.result = cjkContent
+        reader.onload?.()
+        await waitForUi()
+
+        expect((wrapper.get('.td-capture-modal__input--transcript').element as HTMLTextAreaElement).value).toBe(cjkContent)
+        expect(wrapper.find('.td-capture-modal__file-name').exists()).toBe(true)
+        expect(wrapper.text()).not.toContain('File is too large')
+      } finally {
+        globalThis.FileReader = OriginalFileReader
+      }
     })
 
     it('loads .txt file content via FileReader and shows file name', async () => {


### PR DESCRIPTION
## Summary

- Separate the raw UTF-8 upload safety ceiling from the 200,000 UTF-16-code-unit transcript limit.
- Allow a full-length 200,000-character CJK transcript file through FileReader while retaining decoded-text validation.
- Keep oversized raw files safely rejected and clarify the byte-limit error.

Closes #1575

## Verification

- [x] `npm test -- src/tests/components/CaptureModal.spec.ts` — 28 passed
- [x] `npx eslint src/components/common/CaptureModal.vue src/tests/components/CaptureModal.spec.ts`
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Full frontend suite — pending hosted CI
- [ ] Playwright — not proportionate for this isolated component validation boundary

## Documentation

- [x] No canonical documentation update is needed; this restores parity with the shipped transcript contract.

## Tracking

- [x] `Closes #1575`
- [x] Issue and PR project items verified as `Review / Priority III`.

## Risk Notes

- Security impact: none.
- Behavior/regression risk: the raw file ceiling intentionally changes from 200,000 to 600,000 bytes; decoded text remains capped at 200,000 UTF-16 code units.
- Follow-up tasks: none.