### PR TITLE
Validate board access before capture extraction

### DIFF
--- a/backend/src/Taskdeck.Application/Services/CaptureTriageService.cs
+++ b/backend/src/Taskdeck.Application/Services/CaptureTriageService.cs
@@ -135,6 +135,21 @@ public class CaptureTriageService : ICaptureTriageService
                 reuseModel));
         }
 
+        // Re-check current board access before service-level board/column reads or transcript extraction. A queued
+        // capture may outlive a membership change; avoid provider/quota work for a requester who
+        // can no longer target this board. The final operation-level validation below remains the
+        // TOCTOU guard immediately before proposal persistence.
+        var boardAccessResult = await _policyEngine.ValidateBoardAccessAsync(
+            userId,
+            boardId,
+            cancellationToken);
+        if (!boardAccessResult.IsSuccess)
+        {
+            return Result.Failure<CaptureTriageProposalResultDto>(
+                boardAccessResult.ErrorCode,
+                boardAccessResult.ErrorMessage);
+        }
+
         var board = await _unitOfWork.Boards.GetByIdAsync(boardId.Value, cancellationToken);
         if (board == null)
         {

--- a/backend/tests/Taskdeck.Application.Tests/Services/CaptureTriageServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/CaptureTriageServiceTests.cs
@@ -41,6 +41,11 @@ public class CaptureTriageServiceTests
             .ReturnsAsync((AutomationProposal?)null);
         _policyEngineMock.Setup(p => p.ClassifyRisk(It.IsAny<IEnumerable<ProposalOperationDto>>()))
             .Returns(RiskLevel.Low);
+        _policyEngineMock.Setup(p => p.ValidateBoardAccessAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
         _policyEngineMock.Setup(p => p.ValidatePermissionsAsync(
                 It.IsAny<Guid>(),
                 It.IsAny<Guid?>(),
@@ -725,6 +730,84 @@ public class CaptureTriageServiceTests
     }
 
     [Fact]
+    public async Task CreateProposalFromCaptureAsync_ShouldRejectRevokedBoardAccessBeforeLlmExtraction()
+    {
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var captureId = Guid.NewGuid();
+        _policyEngineMock.Setup(p => p.ValidateBoardAccessAsync(userId, boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(ErrorCodes.Forbidden, "User does not have access to board"));
+
+        var extractorMock = new Mock<ILlmCaptureTriageExtractor>(MockBehavior.Strict);
+        var service = BuildServiceWithExtractor(extractorMock);
+
+        var result = await service.CreateProposalFromCaptureAsync(captureId, userId, boardId, TranscriptPayload());
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _policyEngineMock.Verify(
+            p => p.ValidateBoardAccessAsync(userId, boardId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        extractorMock.Verify(
+            e => e.ExtractAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CapturePayloadV1>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _boardsMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _columnsMock.Verify(r => r.GetByBoardIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _policyEngineMock.Verify(
+            p => p.ValidatePermissionsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<IEnumerable<ProposalOperationDto>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _proposalServiceMock.Verify(
+            s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateProposalFromCaptureAsync_ShouldKeepFinalPermissionGateAfterLlmExtraction()
+    {
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var captureId = Guid.NewGuid();
+        SetupBoardAndProposalCreation(userId, boardId, captureId);
+        _policyEngineMock.Setup(p => p.ValidatePermissionsAsync(
+                userId,
+                boardId,
+                It.IsAny<IEnumerable<ProposalOperationDto>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(ErrorCodes.Forbidden, "Board access was revoked during extraction"));
+
+        var extractorMock = new Mock<ILlmCaptureTriageExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractAsync(userId, boardId, It.IsAny<CapturePayloadV1>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessfulExtraction(("Send the report", "Alice: send the report.")));
+        var service = BuildServiceWithExtractor(extractorMock);
+
+        var result = await service.CreateProposalFromCaptureAsync(captureId, userId, boardId, TranscriptPayload());
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        _policyEngineMock.Verify(
+            p => p.ValidateBoardAccessAsync(userId, boardId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _policyEngineMock.Verify(
+            p => p.ValidatePermissionsAsync(
+                userId,
+                boardId,
+                It.IsAny<IEnumerable<ProposalOperationDto>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        extractorMock.Verify(
+            e => e.ExtractAsync(userId, boardId, It.IsAny<CapturePayloadV1>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _proposalServiceMock.Verify(
+            s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task CreateProposalFromCaptureAsync_ShouldUseLlmOutputAndRecordRealProviderProvenance_WhenExtractionSucceeds()
     {
         var userId = Guid.NewGuid();
@@ -909,6 +992,18 @@ public class CaptureTriageServiceTests
         extractorMock.Verify(
             e => e.ExtractAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CapturePayloadV1>(), It.IsAny<CancellationToken>()),
             Times.Never);
+        _policyEngineMock.Verify(
+            p => p.ValidateBoardAccessAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _policyEngineMock.Verify(
+            p => p.ValidatePermissionsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<IEnumerable<ProposalOperationDto>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _boardsMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _columnsMock.Verify(r => r.GetByBoardIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Validate current board access after existing-proposal replay reuse and before service-level board reads or transcript LLM extraction.
- Preserve the final operation-level permission check immediately before proposal persistence, retaining TOCTOU protection.
- Prevent revoked users from consuming transcript chunking, quota, or provider work while preserving proposal-first review semantics.

Closes #1576

## Verification

- [x] `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~CaptureTriageServiceTests"` — 28 passed
- [x] `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1` — 3,600 passed
- [x] `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~CaptureApiTests"` — 26 passed
- [x] Independent review reran `AutomationPolicyEngineTests` — 31 passed
- [x] `git diff --check origin/main...HEAD`
- [ ] Full backend solution — pending hosted CI
- [ ] Browser E2E — not proportionate for application-service authorization ordering

## Documentation

- [x] No canonical documentation update is needed; this preserves the existing capture/review contract while closing a provider-spend gap.

## Tracking

- [x] `Closes #1576`
- [x] Issue and PR project items verified as `Review / Priority III`.

## Risk Notes

- Security impact: restores an early current-board-access check before external provider work; the existing final permission gate remains intact.
- Behavior/regression risk: crash-replay reuse deliberately stays before both access gates, and no proposal/board write occurs on either early or late denial.
- Follow-up tasks: none.