### PR TITLE
REVIVAL-08: prevent overlap-adjacent transcript chunk cuts

### DIFF
--- a/backend/src/Taskdeck.Application/Services/TranscriptTriageChunking.cs
+++ b/backend/src/Taskdeck.Application/Services/TranscriptTriageChunking.cs
@@ -44,13 +44,17 @@ public static class TranscriptTriageChunker
         {
             var hardEnd = FindLargestEndWithinBudget(text, start, maxInputTokens);
             // When the next chunk starts inside the previous one for overlap, an earlier preferred
-            // boundary is still inside its input window. Never choose that already-emitted boundary
-            // again: doing so produces tiny repeat chunks and eventually loses overlap altogether.
+            // boundary is still inside its input window. Require meaningful new progress beyond
+            // the carried overlap before choosing a preferred boundary; otherwise a boundary just
+            // past the previous end produces tiny repeat chunks and eventually loses overlap.
             // Preferred boundaries improve forced splits, but must not turn an otherwise
             // under-budget transcript into multiple provider requests.
+            var minimumPreferredEnd = start < previousEnd
+                ? (int)Math.Min(text.Length, (long)previousEnd + (previousEnd - start))
+                : previousEnd;
             var end = hardEnd == text.Length
                 ? hardEnd
-                : FindPreferredEnd(preferredBoundaries, previousEnd, hardEnd) ?? hardEnd;
+                : FindPreferredEnd(preferredBoundaries, minimumPreferredEnd, hardEnd) ?? hardEnd;
             end = AvoidSplittingSurrogatePair(text, start, end);
 
             if (end <= start)

--- a/backend/tests/Taskdeck.Application.Tests/Services/TranscriptTriageChunkingTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/TranscriptTriageChunkingTests.cs
@@ -82,6 +82,43 @@ public class TranscriptTriageChunkingTests
     }
 
     [Fact]
+    public void Chunk_ShouldMakeProgressBeyondCarriedOverlap_WhenPreferredBoundariesAreNearlyAdjacent()
+    {
+        const int targetLength = 200_000;
+        const int lineLength = 11_746;
+        const string speakerPrefix = "Speaker 1:";
+        var fullLine = speakerPrefix + new string('a', lineLength - speakerPrefix.Length - 1) + "\n";
+        var transcript = string.Concat(Enumerable.Repeat(fullLine, 17)) +
+            speakerPrefix + new string('a', targetLength - (fullLine.Length * 17) - speakerPrefix.Length);
+
+        transcript.Should().HaveLength(targetLength);
+
+        const int maxInputTokens = 12_000;
+        const int overlapTokens = 256;
+        var chunks = TranscriptTriageChunker.Chunk(transcript, maxInputTokens, overlapTokens);
+
+        chunks.Should().HaveCountLessThanOrEqualTo(24);
+        chunks.Should().OnlyContain(chunk => chunk.EstimatedTokens <= maxInputTokens);
+
+        for (var offset = 0; offset < transcript.Length; offset++)
+        {
+            chunks.Should().Contain(chunk => chunk.Offset <= offset && chunk.EndOffset > offset,
+                $"source character at {offset} must be included by at least one map chunk");
+        }
+
+        for (var index = 1; index < chunks.Count; index++)
+        {
+            var previous = chunks[index - 1];
+            var current = chunks[index];
+
+            current.Offset.Should().BeGreaterThan(previous.Offset);
+            current.Offset.Should().BeLessThan(previous.EndOffset,
+                "the configured overlap should retain preceding speaker context");
+            (previous.EndOffset - current.Offset).Should().BeLessThanOrEqualTo(overlapTokens);
+        }
+    }
+
+    [Fact]
     public void EstimateTokens_ShouldUseUtf8ByteBoundForAsciiAndNonAsciiText()
     {
         var plain = "review the launch plan";


### PR DESCRIPTION
## Summary

- Prevents a preferred speaker boundary immediately after carried overlap from creating a tiny repeated transcript chunk.
- Requires meaningful new source progress before a preferred cut; otherwise retains the existing hard split.
- Adds the exact 200,000-byte repeated-speaker regression, reducing its plan from 33 to 18 chunks under the default 24-call cap.

## Verification

- [x] `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~TranscriptTriageChunkingTests"` — 7 passed
- [x] `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 --no-restore` — 3,613 passed
- [x] `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~TranscriptTriageLlmGoldenPathIntegrationTests"` — 5 passed
- [x] `git diff --check`
- [ ] Full solution test suite — not run; Application and focused transcript API paths cover this bounded seam.

## Documentation

- [x] No product documentation change needed; this is a bounded chunk-planning correction.
- [x] No roadmap or testing-guide change needed.

## Tracking

- [x] Closes #1577
- [x] Issue project item will be in `Review` while this PR is open.

## CI Workflow Validation

- [x] No workflow, deployment, script, or project-file changes.

## Risk Notes

- Security impact: none; the existing byte budget, overlap cap, and deterministic fallback remain intact.
- Behavior/regression risk: the planner may choose a hard split instead of a near-start speaker cut, trading a weak preference for meaningful forward progress.
- Follow-up tasks: no new follow-up; M3 schema/evidence work remains separately tracked by #1304.