### PR TITLE
REVIVAL-08: make capture intake discoverable from integrations

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/IntegrationsView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/IntegrationsView.spec.ts
@@ -2,9 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { reactive } from 'vue'
 import IntegrationsView from '../../views/IntegrationsView.vue'
+import type { IntegrationConnector } from '../../types/integration'
 
 const mockIntegrationStore = reactive({
-  connectors: [],
+  connectors: [] as IntegrationConnector[],
   selectedConnector: null,
   loading: false,
   error: null,
@@ -43,5 +44,27 @@ describe('IntegrationsView', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Connector runtime ingestion is not available yet; use the note import or web clip capture routes for content today.')
+    expect(wrapper.get('.td-int__capture-link').attributes('href')).toBe('/workspace/settings/export-import')
+    expect(wrapper.get('.td-int__capture-link').text()).toContain('Markdown import and web clip capture')
+  })
+
+  it('keeps standalone content capture actionable when connectors are registered', async () => {
+    mockIntegrationStore.connectors = [{
+      id: 'connector-1',
+      name: 'Example connector',
+      connectorType: 'Custom',
+      direction: 'Inbound',
+      status: 'Active',
+      configuration: null,
+      createdAt: '2026-08-02T00:00:00.000Z',
+      updatedAt: '2026-08-02T00:00:00.000Z',
+    }]
+
+    const wrapper = mount(IntegrationsView)
+    await flushPromises()
+
+    expect(wrapper.find('.td-int__empty').exists()).toBe(false)
+    expect(wrapper.get('.td-int__capture-link').attributes('href')).toBe('/workspace/settings/export-import')
+    expect(wrapper.get('.td-int__capture-link').text()).toContain('Markdown import and web clip capture')
   })
 })

--- a/frontend/taskdeck-web/src/views/IntegrationsView.vue
+++ b/frontend/taskdeck-web/src/views/IntegrationsView.vue
@@ -170,6 +170,22 @@ onMounted(() => {
       </button>
     </header>
 
+    <section class="td-int__capture-callout" aria-label="Standalone content capture">
+      <div>
+        <h2 class="td-int__capture-title">Capture content without a connector</h2>
+        <p class="td-int__capture-desc">
+          Use Markdown import or web clip capture in Settings → Export &amp; Import.
+          Connector registry entries manage metadata and lifecycle only; they do not ingest content.
+        </p>
+      </div>
+      <a
+        class="td-int__btn td-int__btn--primary td-int__capture-link"
+        href="/workspace/settings/export-import"
+      >
+        Open Markdown import and web clip capture
+      </a>
+    </section>
+
     <!-- Add connector form -->
     <section
       v-if="showAddForm"
@@ -420,6 +436,37 @@ onMounted(() => {
 .td-int__add-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.td-int__capture-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border: 1px solid var(--td-border, #e5e7eb);
+  border-radius: 0.5rem;
+  background: var(--td-surface, #f9fafb);
+}
+
+.td-int__capture-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+  color: var(--td-text-primary, #111827);
+}
+
+.td-int__capture-desc {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  margin: 0;
+  color: var(--td-text-secondary, #6b7280);
+}
+
+.td-int__capture-link {
+  flex-shrink: 0;
+  text-decoration: none;
 }
 
 /* Form */


### PR DESCRIPTION
## Summary

- Add an always-visible standalone Markdown/web-clip capture callout to Integrations.
- Keep registry metadata/lifecycle boundaries explicit: registered connectors do not ingest content.
- Cover both empty and populated registry states.

## Verification

- `npx vitest --run --maxWorkers=2 src/tests/views/IntegrationsView.spec.ts`
- `npx eslint src/views/IntegrationsView.vue src/tests/views/IntegrationsView.spec.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/main...HEAD`

The production build reports only the pre-existing ineffective-dynamic-import warning.

## Follow-up

#1587 tracks the nonblocking narrow-mobile CTA layout and router-navigation follow-up identified during fresh review.

Closes #1568