### PR TITLE
Fix agent-run proposal review deep link

### DIFF
--- a/docs/manual/06_agents.md
+++ b/docs/manual/06_agents.md
@@ -4,7 +4,7 @@ Taskdeck ships an agent-observation surface at `/workspace/agents`. Open it thro
 
 An agent profile records an agent's name, enabled state, workspace or board scope, and template. Profiles are created through the API; this page lists existing profiles rather than configuring new ones.
 
-Select a profile to open its run history. Each run records an objective, status, timestamps, summary, and any failure reason. Select a run to inspect its ordered event timeline and payloads. If the run produced an automation proposal, **View linked proposal** opens the board-scoped Review surface at that proposal, even when it is not on the first page of the queue.
+Select a profile to open its run history. Each run records an objective, status, timestamps, summary, and any failure reason. Select a run to inspect its ordered event timeline and payloads. If the run produced an automation proposal, **View linked proposal** opens Review at that proposal, preserving board context when one is present, even when it is not on the first page of the queue.
 
 Inspecting a run never approves or executes its proposal. Taskdeck's ordinary review-first boundary still applies: a person reviews the proposal, approves it explicitly, and executes it through the same guarded path used for every other capture source.
 

--- a/docs/manual/06_agents.md
+++ b/docs/manual/06_agents.md
@@ -4,7 +4,7 @@ Taskdeck ships an agent-observation surface at `/workspace/agents`. Open it thro
 
 An agent profile records an agent's name, enabled state, workspace or board scope, and template. Profiles are created through the API; this page lists existing profiles rather than configuring new ones.
 
-Select a profile to open its run history. Each run records an objective, status, timestamps, summary, and any failure reason. Select a run to inspect its ordered event timeline and payloads. If the run produced an automation proposal, **View linked proposal** opens the normal review surface.
+Select a profile to open its run history. Each run records an objective, status, timestamps, summary, and any failure reason. Select a run to inspect its ordered event timeline and payloads. If the run produced an automation proposal, **View linked proposal** opens the board-scoped Review surface at that proposal, even when it is not on the first page of the queue.
 
 Inspecting a run never approves or executes its proposal. Taskdeck's ordinary review-first boundary still applies: a person reviews the proposal, approves it explicitly, and executes it through the same guarded path used for every other capture source.
 

--- a/frontend/taskdeck-web/src/tests/views/AgentRunDetailView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/AgentRunDetailView.spec.ts
@@ -33,7 +33,7 @@ const MOCK_RUN_DETAIL: AgentRunDetail = {
   id: 'run-1',
   agentProfileId: 'profile-1',
   userId: 'user-1',
-  boardId: null,
+  boardId: 'board-1',
   triggerType: 'manual',
   objective: 'Triage inbox captures',
   status: 'Completed',
@@ -186,8 +186,23 @@ describe('AgentRunDetailView', () => {
 
     await wrapper.find('.td-run-detail__proposal-link').trigger('click')
     expect(mockPush).toHaveBeenCalledWith({
-      path: '/workspace/review',
-      query: { proposalId: 'proposal-1' },
+      name: 'workspace-review',
+      query: { boardId: 'board-1' },
+      hash: '#proposal-proposal-1',
+    })
+  })
+
+  it('preserves a boardless proposal deep link without adding board context', async () => {
+    mockAgentStore.runDetail = { ...MOCK_RUN_DETAIL, boardId: null }
+    const wrapper = mount(AgentRunDetailView)
+    await waitForUi()
+
+    await wrapper.find('.td-run-detail__proposal-link').trigger('click')
+
+    expect(mockPush).toHaveBeenCalledWith({
+      name: 'workspace-review',
+      query: undefined,
+      hash: '#proposal-proposal-1',
     })
   })
 

--- a/frontend/taskdeck-web/src/views/AgentRunDetailView.vue
+++ b/frontend/taskdeck-web/src/views/AgentRunDetailView.vue
@@ -83,12 +83,14 @@ function goBack() {
 }
 
 function goToProposal() {
-  if (run.value?.proposalId) {
-    void router.push({
-      path: '/workspace/review',
-      query: { proposalId: run.value.proposalId },
-    })
-  }
+  const proposalId = run.value?.proposalId
+  if (!proposalId) return
+
+  void router.push({
+    name: 'workspace-review',
+    query: run.value.boardId ? { boardId: run.value.boardId } : undefined,
+    hash: `#proposal-${encodeURIComponent(proposalId)}`,
+  })
 }
 
 function formatDate(isoDate: string): string {


### PR DESCRIPTION
## Summary

- Route an agent-run's linked proposal to the canonical Review deep-link shape, preserving board context when available and using the proposal hash that retrieves/off-page-reveals the target.
- Add board-scoped and boardless regression coverage.
- Clarify the same behavior in the Agents manual.

## Verification

- [x] `npm run test -- --run src/tests/views/AgentRunDetailView.spec.ts` — 17/17
- [x] Review/Paper/composable focused Vitest review — 180/180
- [x] `npm run typecheck`
- [x] `npm run build` (known ineffective-dynamic-import warning only)
- [x] Targeted ESLint — 0 errors; two pre-existing redundant-role warnings
- [x] `node scripts/check-docs-governance.mjs`
- [x] `git diff --check origin/main...HEAD`
- [ ] Playwright/browser E2E (not run; no new browser surface)

## Documentation

- [x] `docs/manual/06_agents.md` updated.
- [x] `docs/STATUS.md` / `docs/IMPLEMENTATION_MASTERPLAN.md` reviewed; neither has a stale route claim or roadmap change requiring an update.
- [x] `docs/TESTING_GUIDE.md` / `docs/MANUAL_TEST_CHECKLIST.md` reviewed; verification flow is unchanged.

## Tracking

- [x] Closes #1562
- [ ] Linked issue's project item moves to `Review` while this PR is open and `Done` after merge.

## CI Workflow Validation

- [x] Not applicable — no workflow, deployment, script, or project-file changes.

## Risk Notes

- Security impact: preserves the existing authenticated, feature-guarded Review route; no approval or execution semantics change.
- Behavior/regression risk: live browser hard-refresh and real API hydration remain covered by hosted validation, not local E2E.
- Follow-up tasks: none.