### PR TITLE
Keep integrations capture CTA responsive

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/IntegrationsView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/IntegrationsView.spec.ts
@@ -17,9 +17,24 @@ const mockIntegrationStore = reactive({
   deleteConnector: vi.fn(),
 })
 
+const routerLinkStub = {
+  props: ['to'],
+  template: '<a :data-route-name="to.name"><slot /></a>',
+}
+
 vi.mock('../../store/integrationStore', () => ({
   useIntegrationStore: () => mockIntegrationStore,
 }))
+
+function mountView() {
+  return mount(IntegrationsView, {
+    global: {
+      stubs: {
+        'router-link': routerLinkStub,
+      },
+    },
+  })
+}
 
 describe('IntegrationsView', () => {
   beforeEach(() => {
@@ -31,7 +46,7 @@ describe('IntegrationsView', () => {
   })
 
   it('describes the page as registry management rather than connector ingestion', async () => {
-    const wrapper = mount(IntegrationsView)
+    const wrapper = mountView()
     await flushPromises()
 
     expect(wrapper.text()).toContain('Register and manage connector definitions for future integrations.')
@@ -40,11 +55,11 @@ describe('IntegrationsView', () => {
   })
 
   it('keeps standalone note import and web clip capture distinct from connector registration', async () => {
-    const wrapper = mount(IntegrationsView)
+    const wrapper = mountView()
     await flushPromises()
 
     expect(wrapper.text()).toContain('Connector runtime ingestion is not available yet; use the note import or web clip capture routes for content today.')
-    expect(wrapper.get('.td-int__capture-link').attributes('href')).toBe('/workspace/settings/export-import')
+    expect(wrapper.get('.td-int__capture-link').attributes('data-route-name')).toBe('workspace-settings-export-import')
     expect(wrapper.get('.td-int__capture-link').text()).toContain('Markdown import and web clip capture')
   })
 
@@ -60,11 +75,11 @@ describe('IntegrationsView', () => {
       updatedAt: '2026-08-02T00:00:00.000Z',
     }]
 
-    const wrapper = mount(IntegrationsView)
+    const wrapper = mountView()
     await flushPromises()
 
     expect(wrapper.find('.td-int__empty').exists()).toBe(false)
-    expect(wrapper.get('.td-int__capture-link').attributes('href')).toBe('/workspace/settings/export-import')
+    expect(wrapper.get('.td-int__capture-link').attributes('data-route-name')).toBe('workspace-settings-export-import')
     expect(wrapper.get('.td-int__capture-link').text()).toContain('Markdown import and web clip capture')
   })
 })

--- a/frontend/taskdeck-web/src/views/IntegrationsView.vue
+++ b/frontend/taskdeck-web/src/views/IntegrationsView.vue
@@ -178,12 +178,12 @@ onMounted(() => {
           Connector registry entries manage metadata and lifecycle only; they do not ingest content.
         </p>
       </div>
-      <a
+      <router-link
         class="td-int__btn td-int__btn--primary td-int__capture-link"
-        href="/workspace/settings/export-import"
+        :to="{ name: 'workspace-settings-export-import' }"
       >
         Open Markdown import and web clip capture
-      </a>
+      </router-link>
     </section>
 
     <!-- Add connector form -->
@@ -467,6 +467,19 @@ onMounted(() => {
 .td-int__capture-link {
   flex-shrink: 0;
   text-decoration: none;
+}
+
+@media (max-width: 640px) {
+  .td-int__capture-callout {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .td-int__capture-link {
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+  }
 }
 
 /* Form */


### PR DESCRIPTION
## Summary

- Keep the standalone Markdown/web-clip capture CTA fully usable at narrow viewport widths.
- Use the existing named Export & Import route rather than a root-relative anchor, preserving deployment-base behavior.
- Retain the connector-registry boundary: registration manages metadata/lifecycle and does not ingest content.

## Verification

- [x] Focused Vitest: `npx vitest run src/tests/views/IntegrationsView.spec.ts --reporter=dot` — 3/3 passing
- [x] `npm run typecheck`
- [x] Focused ESLint: `npx eslint src/views/IntegrationsView.vue src/tests/views/IntegrationsView.spec.ts`
- [x] `npm run build` — passes; existing ineffective-dynamic-import warning only
- [x] Real-browser viewport probe with mocked registry data: empty and populated states at 320px, 375px, and 390px; CTA remained fully inside its callout with zero horizontal overflow and navigated to Export & Import
- [x] `git diff --check`
- [ ] Full backend suite — not applicable to this frontend-only slice
- [ ] Full Playwright suite — not run; targeted real-browser probe above exercises the changed viewport and navigation boundary

## Documentation

- [x] No canonical documentation update is needed; visible product copy and destination remain truthful and unchanged.
- [x] No roadmap or testing-guide update is needed.

## Tracking

Closes #1587

- [x] Linked issue Project item is `Review` while this PR is open (set immediately after creation).

## CI Workflow Validation

- [x] Not applicable: no workflow, deployment, script, or project-file change.

## Risk Notes

- Security impact: none.
- Behavior/regression risk: low; the view uses the existing named route and scoped responsive CSS only.
- Follow-up tasks: the focused unit spec stubs `router-link`, so non-root-base href generation is not separately automated; this is nonblocking because the real-browser probe and configured RouterLink base cover the delivered behavior.