### PR TITLE
Clarify queued agent run state

### DIFF
--- a/frontend/taskdeck-web/src/tests/views/AgentRunDetailView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/AgentRunDetailView.spec.ts
@@ -244,6 +244,23 @@ describe('AgentRunDetailView', () => {
     expect(indicator.text()).toContain('Run is in progress')
   })
 
+  it('does not present a queued API-created run as in progress', async () => {
+    mockAgentStore.runDetail = {
+      ...MOCK_RUN_DETAIL,
+      status: 'Queued',
+      events: [],
+      summary: null,
+      proposalId: null,
+      completedAt: null,
+    }
+    const wrapper = mount(AgentRunDetailView)
+    await waitForUi()
+
+    expect(wrapper.text()).toContain('Queued by the API. Execution has not started.')
+    expect(wrapper.text()).toContain('Requested:')
+    expect(wrapper.find('.td-run-detail__live-indicator').exists()).toBe(false)
+  })
+
   it('navigates back to runs list when back button is clicked', async () => {
     const wrapper = mount(AgentRunDetailView)
     await waitForUi()

--- a/frontend/taskdeck-web/src/tests/views/AgentRunsView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/AgentRunsView.spec.ts
@@ -121,6 +121,23 @@ describe('AgentRunsView', () => {
     expect(wrapper.text()).toContain('Proposal linked')
   })
 
+  it('explains that queued API-created runs have not started', async () => {
+    mockAgentStore.runs = [{
+      ...MOCK_RUN,
+      status: 'Queued',
+      stepsExecuted: 0,
+      summary: null,
+      proposalId: null,
+      completedAt: null,
+    }]
+    const wrapper = mount(AgentRunsView)
+    await waitForUi()
+
+    expect(wrapper.text()).toContain('Queued by the API. Execution has not started.')
+    expect(wrapper.text()).toContain('Requested:')
+    expect(wrapper.text()).not.toContain('Started:')
+  })
+
   it('shows failure reason for failed runs', async () => {
     mockAgentStore.runs = [{
       ...MOCK_RUN,

--- a/frontend/taskdeck-web/src/views/AgentRunDetailView.vue
+++ b/frontend/taskdeck-web/src/views/AgentRunDetailView.vue
@@ -109,6 +109,10 @@ function getStatusClass(status: AgentRunStatus): string {
   return `td-run-status--${runStatusVariant[status] ?? 'neutral'}`
 }
 
+function isQueuedStatus(status: AgentRunStatus): boolean {
+  return status === 'Queued'
+}
+
 const EVENT_TYPE_LABELS: Record<string, string> = {
   'run.started': 'Run started',
   'context.gathered': 'Context gathered from workspace',
@@ -190,7 +194,10 @@ function parsePayloadSafe(payload: string): Record<string, unknown> | null {
           <span v-if="run.approxCostUsd !== null" class="td-run-detail__meta">
             Cost: ${{ run.approxCostUsd.toFixed(4) }}
           </span>
-          <span class="td-run-detail__meta">Started: {{ formatDate(run.startedAt) }}</span>
+          <span v-if="isQueuedStatus(run.status)" class="td-run-detail__meta">
+            Requested: {{ formatDate(run.startedAt) }}
+          </span>
+          <span v-else class="td-run-detail__meta">Started: {{ formatDate(run.startedAt) }}</span>
           <span v-if="run.completedAt" class="td-run-detail__meta">
             Completed: {{ formatDate(run.completedAt) }}
           </span>
@@ -198,6 +205,13 @@ function parsePayloadSafe(payload: string): Record<string, unknown> | null {
 
         <p v-if="run.summary" class="td-run-detail__run-summary">{{ run.summary }}</p>
         <p v-if="run.failureReason" class="td-run-detail__failure">{{ run.failureReason }}</p>
+        <p
+          v-if="isQueuedStatus(run.status)"
+          class="td-run-detail__queued-note"
+          role="status"
+        >
+          Queued by the API. Execution has not started.
+        </p>
 
         <button
           v-if="run.proposalId"
@@ -250,7 +264,7 @@ function parsePayloadSafe(payload: string): Record<string, unknown> | null {
       </ol>
 
       <div
-        v-if="run && !isTerminalStatus(run.status)"
+        v-if="run && !isQueuedStatus(run.status) && !isTerminalStatus(run.status)"
         class="td-run-detail__live-indicator"
         role="status"
         aria-live="polite"
@@ -280,6 +294,7 @@ function parsePayloadSafe(payload: string): Record<string, unknown> | null {
 .td-run-detail__meta { font-size: var(--td-font-xs); color: var(--td-text-tertiary); white-space: nowrap; }
 .td-run-detail__run-summary { color: var(--td-text-secondary); font-size: var(--td-font-sm); line-height: 1.5; margin-top: var(--td-space-2); }
 .td-run-detail__failure { color: var(--td-color-error); font-size: var(--td-font-sm); line-height: 1.5; margin-top: var(--td-space-2); }
+.td-run-detail__queued-note { color: var(--td-text-secondary); font-size: var(--td-font-sm); line-height: 1.5; margin-top: var(--td-space-2); }
 .td-run-detail__proposal-link { margin-top: var(--td-space-2); }
 
 /* Run status badge - shared with AgentRunsView */

--- a/frontend/taskdeck-web/src/views/AgentRunsView.vue
+++ b/frontend/taskdeck-web/src/views/AgentRunsView.vue
@@ -63,6 +63,10 @@ function getStatusLabel(status: AgentRunStatus): string {
 function getStatusClass(status: AgentRunStatus): string {
   return `td-run-status--${runStatusVariant[status] ?? 'neutral'}`
 }
+
+function isQueuedStatus(status: AgentRunStatus): boolean {
+  return status === 'Queued'
+}
 </script>
 
 <template>
@@ -79,7 +83,7 @@ function getStatusClass(status: AgentRunStatus): string {
         <span class="td-agent-runs__eyebrow">Agent Runs</span>
         <h1 class="td-page-title">{{ agentName }}</h1>
         <p class="td-agent-runs__subtitle">
-          Each run represents a single agent execution: its objective, status, and outcome.
+          Each record shows an agent run request and, once execution begins, its status and outcome.
         </p>
       </div>
     </header>
@@ -143,12 +147,16 @@ function getStatusClass(status: AgentRunStatus): string {
           <p v-if="run.failureReason" class="td-agent-runs__failure">
             {{ run.failureReason }}
           </p>
+          <p v-if="isQueuedStatus(run.status)" class="td-agent-runs__queued-note">
+            Queued by the API. Execution has not started.
+          </p>
 
           <div class="td-agent-runs__meta">
             <span>Trigger: {{ run.triggerType }}</span>
             <span>Steps: {{ run.stepsExecuted }}</span>
             <span v-if="run.proposalId">Proposal linked</span>
-            <span>Started: {{ formatDate(run.startedAt) }}</span>
+            <span v-if="isQueuedStatus(run.status)">Requested: {{ formatDate(run.startedAt) }}</span>
+            <span v-else>Started: {{ formatDate(run.startedAt) }}</span>
             <span v-if="run.completedAt">Completed: {{ formatDate(run.completedAt) }}</span>
           </div>
         </button>
@@ -189,6 +197,7 @@ function getStatusClass(status: AgentRunStatus): string {
 .td-agent-runs__objective { font-size: var(--td-font-base); font-weight: 600; color: var(--td-text-primary); flex: 1; }
 .td-agent-runs__summary { font-size: var(--td-font-sm); color: var(--td-text-secondary); line-height: 1.5; }
 .td-agent-runs__failure { font-size: var(--td-font-sm); color: var(--td-color-error); line-height: 1.5; }
+.td-agent-runs__queued-note { font-size: var(--td-font-sm); color: var(--td-text-secondary); line-height: 1.5; }
 .td-agent-runs__meta { display: flex; flex-wrap: wrap; gap: var(--td-space-4); font-size: var(--td-font-xs); color: var(--td-text-tertiary); }
 
 .td-run-status { font-size: var(--td-font-xs); font-weight: 700; padding: var(--td-space-1) var(--td-space-3); border-radius: 9999px; text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap; flex-shrink: 0; }


### PR DESCRIPTION
## Summary

- Clarify that API-created agent-run records can be queued before any execution begins.
- Keep active, completed, failed, and review-linked run presentation unchanged.
- Strengthen review-first trust by distinguishing a request from work the runtime has actually performed.

## Verification

- [x] Focused Vitest: `AgentRunsView.spec.ts` + `AgentRunDetailView.spec.ts` — 27 passed.
- [x] Agent Runs views suite — 722 passed (independent reviewer).
- [x] `npm run typecheck`
- [x] `npm run build` (known ineffective dynamic-import warning only)
- [x] Scoped ESLint — 0 errors; 4 pre-existing redundant-role warnings.
- [x] `git diff --check`
- [x] `node scripts/check-docs-governance.mjs`
- [x] `node scripts/check-golden-principles.mjs`
- [ ] Playwright: not run; this is a conditional-copy/status presentation change covered by focused view tests.

## Documentation

- [x] Re-verified `docs/manual/06_agents.md` and `docs/USER_MANUAL.md`; both already state API-only creation and future trigger execution, so no canonical-doc churn was needed.
- [x] No workflow, backend, API, schema, or migration change.

## Tracking

Closes #1572

- [x] Linked issue was `Now / Priority III` before publication; project status and priority will be re-read after PR automation.

## CI Workflow Validation

- [x] Not applicable: no workflow, deploy, script, or project-file changes.

## Risk Notes

- Security impact: none; no authorization or API behavior changed.
- Behavior/regression risk: limited to agent-run status copy. Queued records now say that execution has not started; existing active and terminal paths retain their labels.
- Follow-up tasks: the pre-existing backend timestamp model still uses the request timestamp for later display. This PR does not alter that contract.