### PR TITLE
Propagate caller cancellation out of the automation planner

### DIFF
--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -361,6 +361,15 @@ public class LlmQueueToProposalWorker : BackgroundService
             stopWatch.Stop();
             RecordWorkerProcessingMetrics(stopWatch.Elapsed.TotalMilliseconds, outcome);
         }
+        // Shutdown or caller cancellation is not a processing failure. Without this the
+        // planner's rethrow is caught below and converted straight back into an
+        // UnexpectedError, which IsTransientFailure treats as retryable — so the item would be
+        // marked Failed and requeued purely because the host was stopping. Leave it in its
+        // current state and let the claim expire.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(
@@ -518,6 +527,13 @@ public class LlmQueueToProposalWorker : BackgroundService
             outcome = retryScheduled ? "failed_retry" : "failed_permanent";
             stopWatch.Stop();
             RecordWorkerProcessingMetrics(stopWatch.Elapsed.TotalMilliseconds, outcome);
+        }
+        // Same discrimination as the proposal lane. CaptureTriageService already rethrows
+        // caller cancellation rather than returning an outcome, so without this guard the
+        // worker converts that rethrow straight back into a retryable UnexpectedError.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/backend/src/Taskdeck.Application/Services/AutomationPlannerService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationPlannerService.cs
@@ -456,6 +456,15 @@ public class AutomationPlannerService : IAutomationPlannerService
 
             return Result.Success(result.Value);
         }
+        // Caller-requested cancellation is not a planning failure. Rethrow so the worker can
+        // leave the queue item alone instead of marking it Failed and burning a retry. The
+        // `when` filter is load-bearing: an OperationCanceledException raised by an INTERNAL
+        // budget or provider timeout, where the caller's token is still live, falls through to
+        // the general handler below and keeps its UnexpectedError mapping.
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             return Result.Failure<ProposalDto>(ErrorCodes.UnexpectedError, $"Failed to parse instruction: {ex.Message}");
@@ -575,6 +584,12 @@ public class AutomationPlannerService : IAutomationPlannerService
                 return Result.Failure<ProposalDto>(permissionResult.ErrorCode, permissionResult.ErrorMessage);
 
             return Result.Success(result.Value);
+        }
+        // Same discrimination as the single-instruction path above: caller cancellation
+        // propagates, internal cancellation stays an UnexpectedError.
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationPlannerServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationPlannerServiceTests.cs
@@ -765,6 +765,58 @@ public class AutomationPlannerServiceTests
         result.ErrorCode.Should().Be(ErrorCodes.Forbidden);
     }
 
+    // #1523: the planner's general catch used to convert a caller-token
+    // OperationCanceledException into Result.Failure(UnexpectedError). The worker's
+    // IsTransientFailure treats UnexpectedError as retryable, so a host shutdown marked the
+    // queue item Failed and requeued it. Caller cancellation must propagate instead.
+    [Fact]
+    public async Task ParseInstruction_ShouldPropagateCancellation_WhenCallerTokenCanceled()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _columnRepoMock
+            .Setup(r => r.GetByBoardIdAsync(boardId, cts.Token))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        // Act + Assert. ThrowsAnyAsync, not ThrowsAsync: xUnit's generic overload is
+        // exact-type and a cancelled await can surface the TaskCanceledException subclass.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _service.ParseInstructionAsync("create card 'Test'", userId, boardId, cts.Token));
+
+        // Supporting, not discriminating: the throw aborts before the write either way.
+        _proposalServiceMock.Verify(
+            s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // The guard rail for the fix above: an OperationCanceledException whose origin is an
+    // INTERNAL budget/provider timeout, while the caller's token is still live, must keep its
+    // UnexpectedError mapping. This fails if someone writes an unfiltered
+    // `catch (OperationCanceledException) { throw; }`.
+    [Fact]
+    public async Task ParseInstruction_ShouldReturnUnexpectedError_WhenCancellationIsNotCallerRequested()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+
+        _columnRepoMock
+            .Setup(r => r.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        // Act
+        var result = await _service.ParseInstructionAsync(
+            "create card 'Test'", userId, boardId, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.UnexpectedError);
+    }
+
     #endregion
 
     #region NLP Gap Tests — Documents #570 (Natural Language Parse Failures)


### PR DESCRIPTION
Closes #1523.

## The defect

`AutomationPlannerService` wrapped both proposal paths in a bare `catch (Exception)`. An `OperationCanceledException` raised on the **caller's** token — from the column read (`:87`, `:97`, `:611`, `:670`), `CreateProposalAsync` (`:446`, `:569`), or `ValidatePermissionsAsync` (`:451`, `:573`) — was therefore converted into `Result.Failure(ErrorCodes.UnexpectedError, ...)`. There was no `OperationCanceledException` filter anywhere in the file, so this is plain C# catch semantics, not an inference.

That misclassification has a real downstream consequence. `LlmQueueToProposalWorker` routes a failed planning result into `HandleFailureWithRetryAsync`, and `IsTransientFailure` treats `UnexpectedError` as retryable. So **a host shutdown or a cancelled caller marked the queue item Failed and requeued it**, exactly as if the planner had genuinely failed.

## The fix

A filtered rethrow ahead of the general handler on both planner paths:

```csharp
catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
{
    throw;
}
```

The `when` filter is load-bearing. An `OperationCanceledException` originating from an **internal** budget or provider timeout, while the caller's token is still live, falls through to the general handler and keeps its `UnexpectedError` mapping — so the existing timeout/provider/domain error contract is preserved rather than broadened.

The worker needed the same guard, or the planner's rethrow would simply be re-swallowed one frame up and land back in `HandleFailureWithRetryAsync` with `UnexpectedError`. Applied to both worker lanes; the capture lane needs it for the same reason, since `CaptureTriageService` already rethrows caller cancellation rather than returning an outcome.

This is not a new idiom — the codebase already uses it in `CaptureTriageService`, `AgentRuntime`, `ConnectorExecutionService`, and in this worker's own outer loop. The planner was the seam that violated it, and `ChatServiceResilienceTests` already asserts the caller-side contract for a sibling service.

## Verification

| Check | Result |
|---|---|
| `AutomationPlanner*` (Application.Tests) | **84/84** |
| `LlmQueueToProposalWorker` + `WorkerResilience` (Api.Tests) | **54/54** |

Two tests, and the discriminating one is proven discriminating:

- `ParseInstruction_ShouldPropagateCancellation_WhenCallerTokenCanceled` — asserts the throw. **Mutation-checked**: with the guard removed it fails, because the method returns a `Result` and never throws.
- `ParseInstruction_ShouldReturnUnexpectedError_WhenCancellationIsNotCallerRequested` — the guard rail. It fails if someone drops the `when` filter and makes the rethrow unconditional. Under the same mutation it stayed green, confirming the two tests discriminate on different things.

`Assert.ThrowsAnyAsync` rather than `ThrowsAsync` is deliberate: xUnit's generic overload is exact-type and a cancelled await can surface the `TaskCanceledException` subclass.

The `CreateProposalAsync` `Times.Never` verification is included but deliberately labelled as supporting, not discriminating — it holds identically with and without the fix, since the throw aborts before the write either way.

## Notes

No `STATUS.md` or masterplan update: this corrects error classification on an existing path and adds no surface.

**Adjacent but deliberately not folded in:** #1433 (the planner persists the proposal at `:446` *before* `ValidatePermissionsAsync` at `:451`) touches adjacent lines in these same two methods. It is a separate defect with its own issue and its own unpushed worktree; whichever lands second needs a trivial rebase.

## Correction after Codex review

Codex raised a P1 ([thread](https://github.com/Chris0Jeky/Taskdeck/pull/1603#discussion_r3738815603)) and it is right about one thing I overstated above.

**The claim "leave the queue item alone instead of marking it Failed and burning a retry" is wrong.** The retry *is* still consumed — just later. The row is left in `Processing`, and `RecoverStuckProcessingItemsAsync` finds no proposal for it and calls `MarkAsFailed` (RetryCount++) once the processing lease expires. The item also waits out that lease before retrying.

What the diff does **not** do is make that worse. Verified: before this change the planner returned `Result.Failure(UnexpectedError)`, so the worker took the *normal* failure path at `:353` and called `HandleFailureWithRetryAsync(..., ct)`, whose `SaveChangesAsync(ct)` at `:631` runs with the already-cancelled token and throws. The increment was applied in memory and **never persisted**; the row stayed `Processing` and the sweep recovered it exactly as it does now. The persisted outcome is identical either side of this diff.

So the accurate description of this change is narrower than the original text: it makes caller cancellation propagate as cancellation rather than being laundered into `UnexpectedError`, and it removes two futile in-memory `MarkAsFailed` calls plus a misleading `LogError` on clean shutdown. The retry-budget behaviour is unchanged.

The underlying defect Codex identified — a graceful shutdown costing a retry — is real, pre-existing, and now tracked as **#1605** with three candidate fixes and acceptance criteria. Not folded in here: making it true requires a DB write on the shutdown path using `CancellationToken.None`, which is a design addition to retry accounting outside #1523's scope and needs its own shutdown-write test.

## Verification status

Hosted CI: **37 checks, 0 failing, 0 pending** at `47091255`. Full suites green (see comment above): Application 3615/3615, Api 2184 passed / 4 skipped / 0 failed.
