### PR TITLE
Restore the sensitive-surface flag to the Claude review-lens skill

### DIFF
--- a/.claude/skills/taskdeck-pr-review-loop/SKILL.md
+++ b/.claude/skills/taskdeck-pr-review-loop/SKILL.md
@@ -32,6 +32,17 @@ the entry point. Read only the relevant section of `docs/STATUS.md` (source of t
 - docs drift in `docs/STATUS.md` / `docs/IMPLEMENTATION_MASTERPLAN.md`
 - CI, scripts, or project-automation breakage
 
+## Sensitive-Surface Flag
+
+Flag these surfaces as Taskdeck risk context for the global pipeline:
+
+- security/auth/session/token behavior
+- migrations or data deletion/retention
+- MCP or external agent write surfaces
+- capture/review/proposal execution
+- GitHub workflows/project automation
+- broad frontend route or state flow
+
 ## Targeted Verification
 
 - Backend: `dotnet test backend/Taskdeck.sln -c Release --filter "FullyQualifiedName~RelevantTest"`


### PR DESCRIPTION
Closes #1532.

## Most of #1532 was already fixed — this is the one live remainder

#1532 listed eight regressions from PR #1531. Seven are already gone from `main`, absorbed by PR #1560 (issue #1544, merged 2026-08-01) and the hook retirement `66881d48` (#1552). Verified at `f897a8c3`:

| # | Regression | State on main |
|---|---|---|
| HIGH-1 | `issue-to-pr` skill entered the review pipeline itself | **Fixed** — `SKILL.md:100-107` hands the ready PR to the coordinator, with a guardrail at `:117-118` |
| HIGH-2 | batch-orchestrator restated reviewer counts | **Fixed by deletion** — both mirrors now say these "remain in the global pipeline" |
| MEDIUM-1/3/5 | doctrine copies in overnight manuals | **Fixed** — a grep for `two review\|30-60\|aging\|no aging requirement` across `.claude/skills`, `.codex/skills`, all three OVERNIGHT_LOOP manuals, `AGENTS.md`, `CLAUDE.md` and `CODEX_AUTONOMY_RUNBOOK.md` returns zero doctrine copies |
| MEDIUM-4 / AC5 | `scripts/agent_hooks/post_tool_use.py`, `smoke_test.py` | **Moot** — `66881d48` deleted both files |
| **MEDIUM-2 / AC4** | **Claude review-lens skill lost its sensitive-surface section** | **live — fixed here** |

Blocker 3 from the issue's own parking comment (closing OID / mergeability re-read) never landed on main and is now owned by #1547 with two open PRs (#1555, #1557). Out of scope here.

## The fix

`f47c4046` (inside PR #1531) rewrote both `taskdeck-pr-review-loop` wrappers in one pass. It gave the Codex mirror a policy-neutral sensitive-surface section but dropped the Claude side's equivalent entirely. #1291 (mirror retirement) is still open, so both mirrors are live and the asymmetry is real.

This adds the section to the Claude mirror using the Codex mirror's exact wording and the same six surfaces.

**The framing is deliberately policy-neutral** — "Taskdeck risk context for the global pipeline". It states no reviewer count, no aging rule, and no second-review trigger. The pre-#1531 "Run a second fresh review when..." wording is **not** restored: that is exactly the local review doctrine #1544 deleted under its ratified delete-don't-restate approach, and global law 2 keeps reviewer counts and severity in one home. This skill contributes risk *context* only.

## Verification

**Mirror parity** — `diff -u .claude/skills/taskdeck-pr-review-loop/SKILL.md .codex/skills/taskdeck-pr-review-loop/SKILL.md`, filtered to the section: the only remaining difference is heading case (`## Sensitive-Surface Flag` vs `## Sensitive-surface flag`). The Claude file uses Title Case for every heading (`Read First`, `Taskdeck Lenses`, `Targeted Verification`), so that is the legitimate per-mirror framing difference, not drift. All six surface bullets are byte-identical.

**Negative check** — the doctrine grep above still returns zero real hits. (It reports some `capture-review-loop` paths, but only because `captu`**`re-review`**`-loop` contains the literal substring `re-review`; none are doctrine copies.)

**Governance** — `node scripts/check-docs-governance.mjs` and `node scripts/check-golden-principles.mjs` both pass.

## No test, deliberately

This is agent-instruction prose. `check-docs-governance.mjs` and `check-golden-principles.mjs` contain zero references to `.claude`, `.codex`, or `SKILL` (verified by grep), and #1544's ratified non-goal is explicit: *do not add another enforcement layer for prose drift; do not manufacture a new policy-parity framework.* So the evidence is the one-time mirror diff above rather than a new check. Saying so plainly beats pretending to test coverage.

## Note on classification

Per global law 2 this is **not** documentation-only despite being Markdown — agent instructions are classified by executable effect. It is nonetheless additive risk context with no authority change, so the surface it moves is small.

**AC6 not done:** #1532 asks for a canonical-docs note, and no `#1531`/`#1532`/`#1534` reference exists in `STATUS.md` or `IMPLEMENTATION_MASTERPLAN.md`. `MASTERPLAN:24` already records the #1544 reconciliation that actually shipped, so this reads as a low-value residual rather than a defect. Happy to add a line if you want AC6 closed literally — it would drag in the `Last Updated: YYYY-MM-DD` format rule and a docs-governance re-run, which is why I left it out of a one-file change.
