### PR TITLE
Disable SQLite pooling in tests instead of clearing the pool globally

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewareLastUsedPersistenceTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewareLastUsedPersistenceTests.cs
@@ -98,7 +98,7 @@ public sealed class ApiKeyMiddlewareLastUsedPersistenceTests : IDisposable
     private Task<TaskdeckDbContext> CreateContextAsync()
     {
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={_dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(_dbPath))
             .Options;
         return Task.FromResult(new TaskdeckDbContext(options));
     }
@@ -133,7 +133,6 @@ public sealed class ApiKeyMiddlewareLastUsedPersistenceTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var path = _dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ApiKeyMiddlewarePerKeyRateLimitTests.cs
@@ -338,7 +338,7 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
     private async Task<TaskdeckDbContext> CreateSeededContextAsync()
     {
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={_dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(_dbPath))
             .AddInterceptors(_interceptor)
             .Options;
         var db = new TaskdeckDbContext(options);
@@ -389,7 +389,6 @@ public sealed class ApiKeyMiddlewarePerKeyRateLimitTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var path = _dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/ArtefactExtractionRepositoryBatchIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ArtefactExtractionRepositoryBatchIntegrationTests.cs
@@ -221,7 +221,7 @@ public sealed class ArtefactExtractionRepositoryBatchIntegrationTests
         var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-extraction-batch-{Guid.NewGuid():N}.db");
         var interceptor = new CapturingCommandInterceptor();
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(dbPath))
             .AddInterceptors(interceptor)
             .Options;
         return (options, interceptor, dbPath);
@@ -263,7 +263,6 @@ public sealed class ArtefactExtractionRepositoryBatchIntegrationTests
 
     private static void Cleanup(string dbPath)
     {
-        SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/ConnectorEncryptionKeyFailFastTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ConnectorEncryptionKeyFailFastTests.cs
@@ -92,7 +92,7 @@ public class ConnectorEncryptionKeyFailFastTests
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}",
+                ["ConnectionStrings:DefaultConnection"] = TestSqlite.ConnectionString(dbPath),
                 ["Connectors:EncryptionKey"] = validKey,
                 ["Database:BusyTimeoutMilliseconds"] = "5000",
             })
@@ -128,7 +128,6 @@ public class ConnectorEncryptionKeyFailFastTests
         }
         finally
         {
-            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
             foreach (var suffix in new[] { "", "-wal", "-shm" })
             {
                 var path = dbPath + suffix;
@@ -156,7 +155,7 @@ public class ConnectorEncryptionKeyFailFastTests
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}",
+                ["ConnectionStrings:DefaultConnection"] = TestSqlite.ConnectionString(dbPath),
                 ["Connectors:EncryptionKey"] = validKey,
             })
             .Build();
@@ -186,7 +185,6 @@ public class ConnectorEncryptionKeyFailFastTests
         }
         finally
         {
-            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
             foreach (var suffix in new[] { "", "-wal", "-shm" })
             {
                 var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueRepositoryIntegrationTests.cs
@@ -1236,7 +1236,7 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<HostedWorkerDisa
         try
         {
             var builder = new DbContextOptionsBuilder<TaskdeckDbContext>()
-                .UseSqlite($"Data Source={dbPath}");
+                .UseSqlite(TestSqlite.ConnectionString(dbPath));
             if (interceptor != null)
             {
                 builder.AddInterceptors(interceptor);
@@ -1248,7 +1248,6 @@ public class LlmQueueRepositoryIntegrationTests : IClassFixture<HostedWorkerDisa
         }
         finally
         {
-            SqliteConnection.ClearAllPools();
             foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
             {
                 var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/McpBoardResourcesTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpBoardResourcesTests.cs
@@ -35,7 +35,7 @@ public class McpBoardResourcesTests : IDisposable
             new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
-                    ["ConnectionStrings:DefaultConnection"] = $"Data Source={_dbPath}",
+                    ["ConnectionStrings:DefaultConnection"] = TestSqlite.ConnectionString(_dbPath),
                     ["Connectors:EncryptionKey"] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
                 })
                 .Build());

--- a/backend/tests/Taskdeck.Api.Tests/McpResourcesTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpResourcesTests.cs
@@ -33,7 +33,7 @@ public class McpResourcesTests : IDisposable
             new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
-                    ["ConnectionStrings:DefaultConnection"] = $"Data Source={_dbPath}",
+                    ["ConnectionStrings:DefaultConnection"] = TestSqlite.ConnectionString(_dbPath),
                     ["Connectors:EncryptionKey"] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
                 })
                 .Build());

--- a/backend/tests/Taskdeck.Api.Tests/McpToolsTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpToolsTests.cs
@@ -32,7 +32,7 @@ public class McpToolsTests : IDisposable
             new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string?>
                 {
-                    ["ConnectionStrings:DefaultConnection"] = $"Data Source={_dbPath}",
+                    ["ConnectionStrings:DefaultConnection"] = TestSqlite.ConnectionString(_dbPath),
                     ["Connectors:EncryptionKey"] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
                 })
                 .Build());

--- a/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/MigrationBootstrapTests.cs
@@ -30,7 +30,7 @@ public class MigrationBootstrapTests : IDisposable
             $"taskdeck-migration-test-{Guid.NewGuid():N}.db");
 
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={_dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(_dbPath))
             .Options;
 
         _context = new TaskdeckDbContext(options);

--- a/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/NotificationRepositoryIntegrationTests.cs
@@ -376,7 +376,7 @@ public class NotificationRepositoryIntegrationTests : IClassFixture<TestWebAppli
         try
         {
             var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-                .UseSqlite($"Data Source={dbPath}")
+                .UseSqlite(TestSqlite.ConnectionString(dbPath))
                 .AddInterceptors(interceptor)
                 .Options;
 
@@ -417,7 +417,6 @@ public class NotificationRepositoryIntegrationTests : IClassFixture<TestWebAppli
         }
         finally
         {
-            SqliteConnection.ClearAllPools();
             foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
             {
                 var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/ProposalRevisionRepositoryBatchIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ProposalRevisionRepositoryBatchIntegrationTests.cs
@@ -356,7 +356,7 @@ public sealed class ProposalRevisionRepositoryBatchIntegrationTests
         var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-revision-batch-{Guid.NewGuid():N}.db");
         var interceptor = new CapturingCommandInterceptor();
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(dbPath))
             .AddInterceptors(interceptor)
             .Options;
         return (options, interceptor, dbPath);
@@ -396,7 +396,6 @@ public sealed class ProposalRevisionRepositoryBatchIntegrationTests
 
     private static void Cleanup(string dbPath)
     {
-        SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SerializedMigratorTests.cs
@@ -38,7 +38,7 @@ public sealed class SerializedMigratorTests : IDisposable
     private static TaskdeckDbContext NewFileContext(string dbPath)
     {
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(dbPath))
             // Mirror production: WAL + busy_timeout (#1130) on every connection.
             .AddInterceptors(new SqlitePragmaConnectionInterceptor(BusyTimeoutMs))
             .Options;
@@ -390,7 +390,7 @@ public sealed class SerializedMigratorTests : IDisposable
     /// </summary>
     private static void PreSetWalJournalMode(string dbPath)
     {
-        using var setup = new SqliteConnection($"Data Source={dbPath}");
+        using var setup = new SqliteConnection(TestSqlite.ConnectionString(dbPath));
         setup.Open();
         using var cmd = setup.CreateCommand();
         cmd.CommandText = "PRAGMA journal_mode=WAL";
@@ -400,7 +400,7 @@ public sealed class SerializedMigratorTests : IDisposable
     private static int? WaitForMidChainHistory(
         string dbPath, Task migrator, int releaseWindowMax, TimeSpan timeout)
     {
-        using var pollConnection = new SqliteConnection($"Data Source={dbPath}");
+        using var pollConnection = new SqliteConnection(TestSqlite.ConnectionString(dbPath));
         pollConnection.Open();
 
         // Robust reads under write contention: without this, a transient BUSY would surface as
@@ -621,8 +621,8 @@ public sealed class SerializedMigratorTests : IDisposable
 
     private static void CleanupDbFiles(string dbPath)
     {
-        // Drop pooled connections so file handles release before cleanup.
-        SqliteConnection.ClearAllPools();
+        // No pool to drop: these connections are opened with Pooling=False (TestSqlite, #1609),
+        // so the handles are already released by the time cleanup runs.
         foreach (var suffix in new[] { "", "-wal", "-shm", ".migrate.lock" })
         {
             var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SourceArtefactRepositoryIntegrationTests.cs
@@ -199,7 +199,7 @@ public sealed class SourceArtefactRepositoryIntegrationTests
         var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-artefact-batch-{Guid.NewGuid():N}.db");
         var interceptor = new CapturingCommandInterceptor();
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(dbPath))
             .AddInterceptors(interceptor)
             .Options;
         return (options, interceptor, dbPath);
@@ -235,7 +235,6 @@ public sealed class SourceArtefactRepositoryIntegrationTests
 
     private static void Cleanup(string dbPath)
     {
-        SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var path = dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/SqlitePragmaInterceptorTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/SqlitePragmaInterceptorTests.cs
@@ -27,7 +27,7 @@ public sealed class SqlitePragmaInterceptorTests : IDisposable
     private TaskdeckDbContext NewContext(int busyTimeoutMs)
     {
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={_dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(_dbPath))
             .AddInterceptors(new SqlitePragmaConnectionInterceptor(busyTimeoutMs))
             .Options;
         return new TaskdeckDbContext(options);
@@ -96,7 +96,7 @@ public sealed class SqlitePragmaInterceptorTests : IDisposable
         }
 
         // Hold an exclusive write lock on a separate raw connection.
-        await using var lockConnection = new SqliteConnection($"Data Source={_dbPath}");
+        await using var lockConnection = new SqliteConnection(TestSqlite.ConnectionString(_dbPath));
         await lockConnection.OpenAsync();
         await using (var begin = lockConnection.CreateCommand())
         {
@@ -119,8 +119,8 @@ public sealed class SqlitePragmaInterceptorTests : IDisposable
 
     public void Dispose()
     {
-        // Drop pooled connections so the file handles release before cleanup.
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        // No pool to drop: these connections are opened with Pooling=False (TestSqlite, #1609),
+        // so the handles are already released by the time cleanup runs.
         foreach (var suffix in new[] { "", "-wal", "-shm" })
         {
             var path = _dbPath + suffix;

--- a/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
@@ -66,7 +66,7 @@ public class StandaloneMcpHostFilteringTests
         WebApplication? runningApp = null;
         try
         {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", TestSqlite.ConnectionString(dbPath));
             Environment.SetEnvironmentVariable(
                 "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
             // The exact #1367 fail-open trigger: separator-only, so IsNullOrWhiteSpace is
@@ -278,7 +278,7 @@ public class StandaloneMcpHostFilteringTests
         WebApplication? runningApp = null;
         try
         {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", TestSqlite.ConnectionString(dbPath));
             Environment.SetEnvironmentVariable(
                 "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
             Environment.SetEnvironmentVariable("AllowedHosts", null);
@@ -376,7 +376,7 @@ public class StandaloneMcpHostFilteringTests
     private static async Task SeedApiKeyAsync(string dbPath, string plaintextKey)
     {
         var options = new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(dbPath))
             .AddInterceptors(new SqlitePragmaConnectionInterceptor(5000))
             .Options;
         await using (var db = new TaskdeckDbContext(options))
@@ -388,8 +388,8 @@ public class StandaloneMcpHostFilteringTests
             await db.SaveChangesAsync();
         }
 
-        // Release the pooled seed connection so the host is never blocked on this file handle.
-        SqliteConnection.ClearAllPools();
+        // The seed connection uses Pooling=False (TestSqlite, #1609), so it is fully closed when
+        // the DbContext above is disposed and the host is never blocked on this file handle.
     }
 
     // Fail-fast proof for the standalone host's RateLimiting validation: the co-hosted API runs
@@ -422,7 +422,7 @@ public class StandaloneMcpHostFilteringTests
         using var capturedError = new StringWriter();
         try
         {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", TestSqlite.ConnectionString(dbPath));
             Environment.SetEnvironmentVariable(
                 "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
             Environment.SetEnvironmentVariable("AllowedHosts", null);
@@ -504,7 +504,7 @@ public class StandaloneMcpHostFilteringTests
         WebApplication? runningApp = null;
         try
         {
-            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", $"Data Source={dbPath}");
+            Environment.SetEnvironmentVariable("ConnectionStrings__DefaultConnection", TestSqlite.ConnectionString(dbPath));
             Environment.SetEnvironmentVariable(
                 "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
             // Leave AllowedHosts unset so the standalone guard applies its loopback allowlist; the
@@ -608,8 +608,8 @@ public class StandaloneMcpHostFilteringTests
 
     private static void TryDeleteDatabase(string dbPath)
     {
-        // Release pooled SQLite handles so Windows allows the delete.
-        SqliteConnection.ClearAllPools();
+        // Nothing to release first: Pooling=False (TestSqlite, #1609) means no handle outlives
+        // its connection, so Windows allows the delete.
         foreach (var path in new[] { dbPath, dbPath + "-wal", dbPath + "-shm" })
         {
             try

--- a/backend/tests/Taskdeck.Api.Tests/TestSqlite.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestSqlite.cs
@@ -1,0 +1,47 @@
+namespace Taskdeck.Api.Tests;
+
+/// <summary>
+/// Builds SQLite connection strings for file-backed tests, with pooling disabled.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pooling is off deliberately (<c>#1609</c>), and this helper exists so that decision lives in one
+/// place instead of in a dozen interpolated strings.
+/// </para>
+/// <para>
+/// These tests each create their own <c>{Guid}.db</c> under the temp directory, so they look
+/// mutually isolated. They were not. On Windows a pooled connection keeps the <c>.db</c>/<c>-wal</c>/
+/// <c>-shm</c> files locked after the <see cref="Microsoft.EntityFrameworkCore.DbContext"/> is
+/// disposed, so cleanup could not delete them — and the fix reached for was the pool-clearing API,
+/// which is <b>process-global</b>: it disposes the pooled connections of every SQLite database in
+/// the process, not just the caller's.
+/// </para>
+/// <para>
+/// xUnit runs test classes as parallel collections by default and this assembly declares no
+/// parallelism override, so one class's cleanup could dispose a native handle another class had
+/// just taken from the pool and was about to open. The victim failed with
+/// <c>ObjectDisposedException: 'SQLitePCL.sqlite3'</c> inside <c>SqliteConnection.Open()</c> —
+/// typically on the first connection a migration opens, which is why it surfaced as an unrelated
+/// integration test failing at random.
+/// </para>
+/// <para>
+/// With pooling disabled the handle closes when the connection is disposed, the files unlock
+/// immediately, cleanup can delete them, and there is no pool to clear — so the shared mutable
+/// state is removed rather than timed. Do not reintroduce the pool-clearing call: it would restore
+/// the race for every SQLite test in this assembly, not only the one that calls it.
+/// </para>
+/// <para>
+/// In-memory connection strings (<c>Data Source=:memory:</c>) deliberately do not use this helper.
+/// They back no file, so they never needed the pool cleared, and their lifetime semantics are the
+/// test's own concern.
+/// </para>
+/// </remarks>
+internal static class TestSqlite
+{
+    /// <summary>
+    /// Returns a file-backed SQLite connection string with connection pooling disabled.
+    /// </summary>
+    /// <param name="dbPath">Absolute path to the test's own database file.</param>
+    internal static string ConnectionString(string dbPath) =>
+        $"Data Source={dbPath};Pooling=False";
+}

--- a/backend/tests/Taskdeck.Api.Tests/TestSqlite.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestSqlite.cs
@@ -18,17 +18,37 @@ namespace Taskdeck.Api.Tests;
 /// </para>
 /// <para>
 /// xUnit runs test classes as parallel collections by default and this assembly declares no
-/// parallelism override, so one class's cleanup could dispose a native handle another class had
-/// just taken from the pool and was about to open. The victim failed with
-/// <c>ObjectDisposedException: 'SQLitePCL.sqlite3'</c> inside <c>SqliteConnection.Open()</c> —
-/// typically on the first connection a migration opens, which is why it surfaced as an unrelated
-/// integration test failing at random.
+/// parallelism override, so that call was **shared mutable state reachable from every test class at
+/// once**. A victim failed with <c>ObjectDisposedException: 'SQLitePCL.sqlite3'</c> inside
+/// <c>SqliteConnection.Open()</c> on a migration's first connection, in a PR that changed no backend
+/// code (<c>#1608</c>), and the same shape has been investigated as a one-off three times before
+/// (<c>#1282</c>, <c>#1357</c>, <c>#1512</c>).
 /// </para>
 /// <para>
-/// With pooling disabled the handle closes when the connection is disposed, the files unlock
-/// immediately, cleanup can delete them, and there is no pool to clear — so the shared mutable
+/// **Stated precisely, because the exact window was NOT reproduced:** an adversarial review probed
+/// Microsoft.Data.Sqlite 8.0.29 directly and found that the pool-clearing call does *not* dispose a
+/// connection that is currently checked out, and could not provoke the failure in ~233,000 racing
+/// cycles. So the stack trace is *consistent with* a pooled native handle being disposed under a
+/// concurrent open, and the call was undeniably process-global shared state that no test owned — but
+/// the precise interleaving is inferred, not demonstrated. Do not repeat it downstream as
+/// established mechanism. What is established is that the shared state existed, that the failure was
+/// real and unrelated to the diff that surfaced it, and that removing the state removes the class of
+/// problem.
+/// </para>
+/// <para>
+/// With pooling disabled the handle closes when the connection is disposed, the <c>-wal</c>/<c>-shm</c>
+/// sidecars unlock, cleanup can delete them, and there is no pool to clear — so the shared mutable
 /// state is removed rather than timed. Do not reintroduce the pool-clearing call: it would restore
-/// the race for every SQLite test in this assembly, not only the one that calls it.
+/// the shared state for every SQLite test in this assembly, not only the one that calls it.
+/// </para>
+/// <para>
+/// This does **not** make the assembly leak-free, and the change should not be described as if it
+/// did. Measured on a full-suite run after the change: zero <c>-wal</c>/<c>-shm</c> leaks, but ~199
+/// zero-byte <c>.db.migrate.lock</c> files still accumulate, because
+/// <c>TestWebApplicationFactory.GetDatabaseCleanupTargets</c> enumerates
+/// <c>.db</c>/<c>-wal</c>/<c>-shm</c>/<c>-journal</c> and never <c>.migrate.lock</c> —
+/// a pre-existing gap unrelated to pooling (<c>SerializedMigratorTests</c> and the CLI harness do
+/// clean it). One real <c>.db</c> also survived. Tracked separately; see <c>#1609</c>.
 /// </para>
 /// <para>
 /// In-memory connection strings (<c>Data Source=:memory:</c>) deliberately do not use this helper.

--- a/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TestWebApplicationFactory.cs
@@ -35,7 +35,7 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
         {
             var overrideSettings = new Dictionary<string, string?>
             {
-                ["ConnectionStrings:DefaultConnection"] = $"Data Source={dbPath}",
+                ["ConnectionStrings:DefaultConnection"] = TestSqlite.ConnectionString(dbPath),
                 // Provide a stable test JWT secret so tests do not depend on
                 // appsettings.Development.json or FirstRunBootstrapper side-effects.
                 ["Jwt:SecretKey"] = "TaskdeckTestsOnlySecretKeyMustBeLongEnough123!",
@@ -70,7 +70,7 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             // only the connection string differs (isolated per-factory temp file), so
             // the test registration is structurally unable to drift from production (#1282).
             services.AddDbContext<TaskdeckDbContext>(options =>
-                options.UseTaskdeckSqlite($"Data Source={dbPath}", databaseSettings));
+                options.UseTaskdeckSqlite(TestSqlite.ConnectionString(dbPath), databaseSettings));
             services.AddSingleton(new LlmProviderSettings
             {
                 EnableLiveProviders = false,
@@ -99,11 +99,10 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
             return;
         }
 
-        // Drop pooled connections so WAL/SHM sidecar file handles release before the
-        // delete loop (mirrors SqlitePragmaInterceptorTests.Dispose). Without this, a
-        // pooled connection can hold -wal/-shm open, the delete throws IOException,
-        // and the catch below silently leaks the temp files.
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        // The host's connections use Pooling=False (TestSqlite, #1609), so disposing it above
+        // closes the -wal/-shm handles outright and the delete loop below can succeed. This
+        // previously called the process-global pool-clearing API, which released other test
+        // classes' handles too and raced their concurrent opens.
 
         foreach (var dbPath in _dbPaths)
         {

--- a/backend/tests/Taskdeck.Api.Tests/TranscriptRepositoryIntegrationTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/TranscriptRepositoryIntegrationTests.cs
@@ -77,7 +77,7 @@ public sealed class TranscriptRepositoryIntegrationTests
 
     private static DbContextOptions<TaskdeckDbContext> CreateOptions(string dbPath) =>
         new DbContextOptionsBuilder<TaskdeckDbContext>()
-            .UseSqlite($"Data Source={dbPath}")
+            .UseSqlite(TestSqlite.ConnectionString(dbPath))
             .Options;
 
     private static string CreateDbPath() => Path.Combine(Path.GetTempPath(), $"taskdeck-transcript-{Guid.NewGuid():N}.db");
@@ -101,7 +101,6 @@ public sealed class TranscriptRepositoryIntegrationTests
 
     private static void Cleanup(string dbPath)
     {
-        SqliteConnection.ClearAllPools();
         foreach (var suffix in new[] { "", "-wal", "-shm", "-journal" })
         {
             var path = dbPath + suffix;


### PR DESCRIPTION
Closes #1609.

## The bug

`SqliteConnection.ClearAllPools()` is **process-global**. It disposes the pooled connections of every
SQLite database in the process, not just the caller's.

13 test files called it — including `TestWebApplicationFactory`, which a large share of the API suite
builds on. Each test creates its own `{Guid}.db`, so the tests *look* mutually isolated. They were
not. xUnit runs test classes as parallel collections by default and this assembly declares no
parallelism override, so that call was **shared mutable state reachable from every test class at
once**, and a victim died inside `SqliteConnection.Open()` with
`ObjectDisposedException: 'SQLitePCL.sqlite3'` on a migration's first connection.

(An earlier revision of this body set out a confident three-step interleaving here. The review
falsified part of it — see *What is not proven* below — so it is gone. The shared state and
the failure are facts; the exact window is not.)

That is the CI red on #1608 — a PR that changed **zero** backend files. Any of the 13 could be the
shooter; any SQLite-backed test in the assembly could be the victim, which is why it has read as an
unrelated one-off each time (#1282, #1357, #1512).

## The fix

Route every **file-backed** connection string through a new `TestSqlite.ConnectionString()`, which
appends `Pooling=False`, and delete all `ClearAllPools()` calls — **15 call sites across 13 files** (`ConnectorEncryptionKeyFailFastTests` and `StandaloneMcpHostFilteringTests` have two each; the commit message for `015eafb9` miscounts these as 13 calls).

With pooling off, no handle outlives its connection: the files unlock as soon as the connection is
disposed, cleanup can delete them, and **there is no pool to clear**. The shared mutable state is
removed rather than timed.

The helper exists so the decision has one home and a written rationale, instead of `Pooling=False`
appearing in a dozen interpolated strings where the next person would reasonably delete it as noise.

In-memory connection strings (`Data Source=:memory:`) are deliberately untouched — they back no file,
so they never needed the pool cleared.

## The second bug, which I did not expect

**The old approach was not merely racy — it was not working.**

`ClearAllPools()` was there so Windows would release the `.db`/`-wal`/`-shm` lock and the delete loop
could succeed. It frequently did not, and the delete loop's `catch` swallows the `IOException`
silently. Measured on this box before the change:

> **3,033 leaked `taskdeck*.db` files, 841 MB, dating back to 2026-08-01.**
> Biggest contributor `taskdeck-api-tests-*` (2,049 files — `TestWebApplicationFactory`).
> Disk was at **97%**.

So the call being removed was paying a real correctness cost for a benefit it was not reliably
delivering.

**Corrected after review:** this change does **not** make the assembly leak-free, and an earlier
revision of this body plus the commit message for `015eafb9` said it did ("this run leaked zero").
An independent full-suite run on this branch leaks **zero `-wal`/`-shm`** but still accumulates
**~199 zero-byte `.db.migrate.lock` files and one real `.db`**. The `.migrate.lock` half is
pre-existing and unrelated to pooling: `TestWebApplicationFactory.GetDatabaseCleanupTargets`
enumerates `.db`/`-wal`/`-shm`/`-journal` and never `.migrate.lock`, where `SerializedMigratorTests`
and the CLI harness both do. Filed as a follow-up. History is not rewritten; the commit message
stands uncorrected and this note is the record.

## Verification

**Full suite, this branch:** `dotnet test backend/tests/Taskdeck.Api.Tests -c Release -m:1` →
**2,184 passed / 0 failed / 4 skipped** (7 m 19 s). Same total as `main`, with
`ProposalRevisionRepositoryBatchIntegrationTests.GetRefsByProposalIdsAsync_DoesNotSelectTheRevisionPayload`
— the test that failed on #1608 — now passing.

**Mutation-checked, one variable, same 10 tests.** `taskdeck-revision-batch-*` is owned by exactly one
test class, so it isolates the measurement from everything else:

| | files present | leaked by the run |
|---|---|---|
| baseline (quiesced) | 3 | — |
| **with** `Pooling=False` | 3 | **0** |
| **without** `Pooling=False` (mutation) | 13 | **+10 — exactly one per test** |
| fix restored | 13 | **0** |

Ten tests, ten leaked files without the fix, none with it. The mutation was reverted and the tree
re-proved clean.

### What is *not* proven — narrowed further after review

I originally wrote that "the mechanism" was established from the stack trace plus the documented
process-global semantics of `ClearAllPools()`. **The review falsified part of that**, by probing
Microsoft.Data.Sqlite 8.0.29 directly: the pool-clearing call does **not** dispose a connection that
is currently checked out, and ~233,000 racing cycles produced no failure. A synthetic probe failing
to reproduce is weak evidence of absence — but it is enough that I should not have called the
step-by-step interleaving established, and I had baked it into a permanent code comment. Narrowed in
`32568178`.

What *is* established: the call was **process-global shared mutable state that no test owned**,
reachable from every parallel collection at once; the failure was real, was in a PR that changed no
backend code, and matches three prior one-off investigations (#1282, #1357, #1512); and removing the
shared state removes the class of problem. The *leak* half remains proven by the controlled
experiment above. The precise interleaving is **inferred, not demonstrated** — please do not repeat
it downstream as fact.

Also not run: the other backend test projects. None of them references `TestSqlite` or contained a
`ClearAllPools()` call — `grep -rn "ClearAllPools" backend/ --include=*.cs` now returns **nothing
at all** (the helper's docs say *the pool-clearing call*, never the identifier). Note that
`Taskdeck.Cli.Tests` and `Taskdeck.Application.Tests` still build pooled file-backed connection
strings; they run in separate test-host processes so there is no cross-assembly race, but
"stops new leaks" is true of `Taskdeck.Api.Tests` only.

## Note for the maintainer

The **841 MB of pre-existing leaked files in `%TEMP%` are still there** — this change stops the
`-wal`/`-shm` leaks in `Taskdeck.Api.Tests` (see the corrected scope above) and cleans up none of
the existing files. I deliberately did not bulk-delete them: that is 3,000+ files in your
temp directory and deleting from a listing is exactly the pattern the safety rules forbid. With the
disk at 97% it is probably worth reclaiming, but by your hand, not mine. My own mutation experiment
added 10 more, which I also left in place rather than reach for a wildcard delete.
