### PR TITLE
Cover queue cancellation propagation

### DIFF
--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -233,6 +233,32 @@ public class LlmQueueToProposalWorkerTests
         item.Status.Should().Be(RequestStatus.Failed);
     }
 
+    [Fact]
+    public async Task ProcessBatch_ProposalLaneCallerCancellation_PropagatesAndLeavesItemProcessing()
+    {
+        var item = CreatePendingItem();
+        var queueRepo = new FakeLlmQueueRepository([item]);
+        using var cts = new CancellationTokenSource();
+        var planner = new FakeAutomationPlannerService
+        {
+            ResultFactory = _ =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            }
+        };
+        using var sp = BuildServiceProvider(queueRepo, planner);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(retryBackoff: [0]));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeProcessBatchAsync(worker, cts.Token));
+
+        // Discriminating assertion: without the worker cancellation guard, the generic
+        // failure path resets this item to Pending for retry.
+        item.Status.Should().Be(RequestStatus.Processing);
+    }
+
     #endregion
 
     #region Unhandled exception in planner
@@ -319,6 +345,32 @@ public class LlmQueueToProposalWorkerTests
         // retryAsProcessing: true means item is reset to Processing, not Pending
         item.Status.Should().Be(RequestStatus.Processing);
         item.RetryCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessBatch_CaptureLaneCallerCancellation_PropagatesAndLeavesItemProcessing()
+    {
+        var item = CreateCaptureTriageItem();
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        using var cts = new CancellationTokenSource();
+        var triageService = new FakeCaptureTriageService
+        {
+            ResultFactory = (_, _, _, _, _) =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            }
+        };
+        using var sp = BuildServiceProvider(queueRepo, triageService: triageService);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(retryBackoff: [0]));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeProcessBatchAsync(worker, cts.Token));
+
+        // Discriminating assertion: without the worker cancellation guard, the generic
+        // failure path records a retry before leaving this item in Processing.
+        item.Status.Should().Be(RequestStatus.Processing);
     }
 
     #endregion

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationPlannerServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationPlannerServiceTests.cs
@@ -793,6 +793,30 @@ public class AutomationPlannerServiceTests
             Times.Never);
     }
 
+    [Fact]
+    public async Task ParseBatchInstruction_ShouldPropagateCancellation_WhenCallerTokenCanceled()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        _columnRepoMock
+            .Setup(r => r.GetByBoardIdAsync(boardId, cts.Token))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        // Act + Assert. ThrowsAnyAsync, not ThrowsAsync: xUnit's generic overload is
+        // exact-type and a cancelled await can surface the TaskCanceledException subclass.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => _service.ParseBatchInstructionAsync(
+                ["create cards: 'Test A', 'Test B'"], userId, boardId, cts.Token));
+
+        _proposalServiceMock.Verify(
+            s => s.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // The guard rail for the fix above: an OperationCanceledException whose origin is an
     // INTERNAL budget/provider timeout, while the caller's token is still live, must keep its
     // UnexpectedError mapping. This fails if someone writes an unfiltered


### PR DESCRIPTION
## Summary
- add batch-parser caller-cancellation propagation coverage
- cover proposal and capture worker-lane cancellation guards with Processing-state assertions

## Tests
- `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 --filter FullyQualifiedName~AutomationPlannerServiceTests` (53 passed)
- `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 --filter FullyQualifiedName~LlmQueueToProposalWorkerTests` (41 passed)
- new worker tests targeted together (2 passed)
- new batch test targeted (1 passed)

## Mutation evidence
- removing the proposal-lane filtered cancellation guard made its targeted test fail: no `OperationCanceledException` was thrown
- removing the capture-lane filtered cancellation guard made its targeted test fail: no `OperationCanceledException` was thrown
- both production guards were restored; production file is absent from the final diff

## Docs and risk
- docs unchanged; this is focused test coverage only
- no production behavior changes

Closes #1606