### PR TITLE
Make DCO verification compatible with Git conflict trailers

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -5,7 +5,7 @@
 # Workflow Topology (see docs/analysis/2026-02-21_ci-github-actions-expansion-plan.md):
 #
 #   ci-required.yml          PR/push/merge_group gate (this file)
-#     ├── KineticCafe/actions-dco              DCO sign-off signal (PR-only, advisory)
+#     ├── native Git + KineticCafe/actions-dco DCO sign-off signal (PR-only, advisory)
 #     ├── reusable-docs-governance.yml        docs + golden-principles + ops governance
 #     ├── reusable-backend-architecture.yml    architecture boundary tests
 #     ├── reusable-backend-unit.yml            domain / application / CLI unit tests (Ubuntu + Windows)
@@ -101,8 +101,20 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - name: Check commit sign-offs
+      - name: Checkout DCO range
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run upstream DCO diagnostic
+        continue-on-error: true
         uses: KineticCafe/actions-dco@5f160e3ee086af8fc0fb567b8add0937d074123e # v3.2.0
+
+      - name: Verify DCO sign-offs with native Git
+        env:
+          DCO_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DCO_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/ci/check-dco-signoffs.sh "$DCO_BASE_SHA" "$DCO_HEAD_SHA"
 
   docs-governance:
     name: Docs Governance

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -1675,11 +1675,16 @@ powershell -File ./scripts/mcp/Test-DockerMcpProfile.ps1 -IncludeOptional -FailO
 Required workflow: `.github/workflows/ci-required.yml`
 
 - `dco`
-  - Checks every pull-request commit for a DCO `Signed-off-by:` trailer with the
-    SHA-pinned `KineticCafe/actions-dco` action
-  - Active for pull requests and currently **advisory**
-    (`continue-on-error: true`); promotion into branch protection remains
-    maintainer-owned under #1173
+  - Checks the explicit pull-request `base.sha..head.sha` range after a full-history checkout.
+    `scripts/ci/check-dco-signoffs.sh` parses only native Git trailer blocks with
+    `git -c core.commentChar=# interpret-trailers --parse --no-divider`, skips multi-parent merge
+    commits, and requires a valid `Signed-off-by: Name <email>` identity matching the commit author
+    or committer case-insensitively. Missing objects and Git/range/parser errors fail closed.
+  - The SHA-pinned `KineticCafe/actions-dco` action remains visible as a step-level non-blocking
+    diagnostic. The repository verifier determines the job step result, while the job itself remains
+    **advisory** (`continue-on-error: true`); promotion into branch protection remains maintainer-owned
+    under #1173.
+  - Local contract: `bash scripts/ci/test-check-dco-signoffs.sh`
 - `docs-governance`
   - Ubuntu `Docs Governance` enforces required active docs, failure-ledger synchronization, Golden
     Principles, and GitHub-operations invariants

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -1677,9 +1677,11 @@ Required workflow: `.github/workflows/ci-required.yml`
 - `dco`
   - Checks the explicit pull-request `base.sha..head.sha` range after a full-history checkout.
     `scripts/ci/check-dco-signoffs.sh` parses only native Git trailer blocks with
-    `git -c core.commentChar=# interpret-trailers --parse --no-divider`, skips multi-parent merge
-    commits, and requires a valid `Signed-off-by: Name <email>` identity matching the commit author
-    or committer case-insensitively. Missing objects and Git/range/parser errors fail closed.
+    `git -c core.commentChar=# interpret-trailers --parse`, checks every submitted commit including
+    multi-parent merges, and requires a nonempty `Signed-off-by: Name <email>` identity matching the
+    commit author or committer case-insensitively. The one repository-established Dependabot mapping
+    (`dependabot[bot]` / GitHub's bot author email to `support@github.com`) remains trailer-required
+    and is not a general bot exemption. Missing objects and Git/range/parser errors fail closed.
   - The SHA-pinned `KineticCafe/actions-dco` action remains visible as a step-level non-blocking
     diagnostic. The repository verifier determines the job step result, while the job itself remains
     **advisory** (`continue-on-error: true`); promotion into branch protection remains maintainer-owned

--- a/scripts/ci/check-dco-signoffs.sh
+++ b/scripts/ci/check-dco-signoffs.sh
@@ -15,28 +15,6 @@ trim_whitespace() {
   printf '%s' "$value"
 }
 
-is_valid_email() {
-  local email="$1"
-  local mailbox
-  local domain
-  local label
-  local local_part_pattern="^[A-Za-z0-9.!#\$%&'*+/=?^_\`{|}~-]+$"
-  local domain_pattern='^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$'
-  local -a labels
-
-  [[ ${#email} -le 254 && "$email" == *@* ]] || return 1
-  mailbox="${email%%@*}"
-  domain="${email#*@}"
-  [[ -n "$mailbox" && ${#mailbox} -le 64 && -n "$domain" && "$domain" != *@* ]] || return 1
-  [[ "$mailbox" != .* && "$mailbox" != *. && "$mailbox" != *..* ]] || return 1
-  [[ "$mailbox" =~ $local_part_pattern && "$domain" =~ $domain_pattern ]] || return 1
-
-  IFS='.' read -r -a labels <<<"$domain"
-  for label in "${labels[@]}"; do
-    [[ -n "$label" && ${#label} -le 63 && "$label" != -* && "$label" != *- ]] || return 1
-  done
-}
-
 if [[ $# -ne 2 ]]; then
   fail 'usage: check-dco-signoffs.sh <base-sha> <head-sha>'
 fi
@@ -66,27 +44,10 @@ fi
 shopt -s nocasematch
 signoff_pattern='^Signed-off-by:[[:space:]]*([^<>]+)[[:space:]]+<([^<>[:space:]]+)>[[:space:]]*$'
 checked_count=0
-skipped_merge_count=0
 failure_count=0
 
 while IFS= read -r commit_sha; do
   [[ -n "$commit_sha" ]] || continue
-
-  if ! parent_line="$("$git_executable" rev-list --parents -n 1 "$commit_sha")"; then
-    fail "cannot inspect parents for commit $commit_sha"
-  fi
-  read -r -a parent_fields <<<"$parent_line"
-  if [[ ${#parent_fields[@]} -lt 1 || "${parent_fields[0]}" != "$commit_sha" ]]; then
-    fail "unexpected parent metadata for commit $commit_sha"
-  fi
-
-  # A commit followed by two or more parent IDs is a merge. DCO applies to all
-  # ordinary commits, including root commits, but merge commits are skipped.
-  if (( ${#parent_fields[@]} > 2 )); then
-    skipped_merge_count=$((skipped_merge_count + 1))
-    printf 'DCO SKIP %s (multi-parent merge commit)\n' "${commit_sha:0:12}"
-    continue
-  fi
 
   if ! identity_block="$("$git_executable" show -s --format='%an%n%ae%n%cn%n%ce' "$commit_sha")"; then
     fail "cannot read author and committer identities for commit $commit_sha"
@@ -102,29 +63,51 @@ while IFS= read -r commit_sha; do
 
   # core.commentChar=# makes native Git ignore the conflict-help comments that
   # `git commit` appends after a valid trailer. --parse restricts the result to
-  # the actual terminal trailer block; arbitrary mentions in the body do not
-  # count. pipefail makes either Git command's error fatal.
+  # the actual terminal trailer block and preserves Git's `---` divider, so
+  # arbitrary body/patch mentions do not count. pipefail makes either Git
+  # command's error fatal.
   if ! parsed_trailers="$("$git_executable" show -s --format='%B' "$commit_sha" |
-    "$git_executable" -c core.commentChar='#' interpret-trailers --parse --no-divider)"; then
+    "$git_executable" -c core.commentChar='#' interpret-trailers --parse)"; then
     fail "cannot parse trailers for commit $commit_sha"
   fi
 
   matching_signoff=false
-  while IFS= read -r trailer_line; do
-    [[ -n "$trailer_line" ]] || continue
-    if [[ "$trailer_line" =~ $signoff_pattern ]]; then
-      signed_name="$(trim_whitespace "${BASH_REMATCH[1]}")"
-      signed_email="${BASH_REMATCH[2]}"
-      [[ -n "$signed_name" ]] || continue
-      is_valid_email "$signed_email" || continue
-
-      if { [[ "$signed_name" == "$author_name" ]] && [[ "$signed_email" == "$author_email" ]]; } ||
-        { [[ "$signed_name" == "$committer_name" ]] && [[ "$signed_email" == "$committer_email" ]]; }; then
+  if [[ "$author_name" == 'dependabot[bot]' ]] &&
+    [[ "$author_email" == '49699333+dependabot[bot]@users.noreply.github.com' ]]; then
+    # GitHub's established Dependabot message puts its stable support@github.com
+    # sign-off after a `---` dependency-metadata divider. Parse through that
+    # divider only for this exact signed bot mapping; human/other-bot commits
+    # retain Git's normal divider boundary and receive no exemption.
+    if ! dependabot_trailers="$("$git_executable" show -s --format='%B' "$commit_sha" |
+      "$git_executable" -c core.commentChar='#' interpret-trailers --parse --no-divider)"; then
+      fail "cannot parse Dependabot trailers for commit $commit_sha"
+    fi
+    while IFS= read -r trailer_line; do
+      if [[ "$trailer_line" =~ $signoff_pattern ]] &&
+        [[ "$(trim_whitespace "${BASH_REMATCH[1]}")" == 'dependabot[bot]' ]] &&
+        [[ "${BASH_REMATCH[2]}" == 'support@github.com' ]]; then
         matching_signoff=true
         break
       fi
-    fi
-  done <<<"$parsed_trailers"
+    done <<<"$dependabot_trailers"
+  fi
+
+  if [[ "$matching_signoff" == false ]]; then
+    while IFS= read -r trailer_line; do
+      [[ -n "$trailer_line" ]] || continue
+      if [[ "$trailer_line" =~ $signoff_pattern ]]; then
+        signed_name="$(trim_whitespace "${BASH_REMATCH[1]}")"
+        signed_email="${BASH_REMATCH[2]}"
+        [[ -n "$signed_name" ]] || continue
+
+        if { [[ "$signed_name" == "$author_name" ]] && [[ "$signed_email" == "$author_email" ]]; } ||
+          { [[ "$signed_name" == "$committer_name" ]] && [[ "$signed_email" == "$committer_email" ]]; }; then
+          matching_signoff=true
+          break
+        fi
+      fi
+    done <<<"$parsed_trailers"
+  fi
 
   checked_count=$((checked_count + 1))
   if [[ "$matching_signoff" == true ]]; then
@@ -140,5 +123,5 @@ if (( failure_count > 0 )); then
   fail "$failure_count ordinary commit(s) failed DCO verification"
 fi
 
-printf 'DCO verification passed: checked=%d skipped_merges=%d range=%s..%s\n' \
-  "$checked_count" "$skipped_merge_count" "$base_sha" "$head_sha"
+printf 'DCO verification passed: checked=%d range=%s..%s\n' \
+  "$checked_count" "$base_sha" "$head_sha"

--- a/scripts/ci/check-dco-signoffs.sh
+++ b/scripts/ci/check-dco-signoffs.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  printf 'DCO verification error: %s\n' "$*" >&2
+  exit 1
+}
+
+trim_whitespace() {
+  local value="$1"
+
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+is_valid_email() {
+  local email="$1"
+  local mailbox
+  local domain
+  local label
+  local local_part_pattern="^[A-Za-z0-9.!#\$%&'*+/=?^_\`{|}~-]+$"
+  local domain_pattern='^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$'
+  local -a labels
+
+  [[ ${#email} -le 254 && "$email" == *@* ]] || return 1
+  mailbox="${email%%@*}"
+  domain="${email#*@}"
+  [[ -n "$mailbox" && ${#mailbox} -le 64 && -n "$domain" && "$domain" != *@* ]] || return 1
+  [[ "$mailbox" != .* && "$mailbox" != *. && "$mailbox" != *..* ]] || return 1
+  [[ "$mailbox" =~ $local_part_pattern && "$domain" =~ $domain_pattern ]] || return 1
+
+  IFS='.' read -r -a labels <<<"$domain"
+  for label in "${labels[@]}"; do
+    [[ -n "$label" && ${#label} -le 63 && "$label" != -* && "$label" != *- ]] || return 1
+  done
+}
+
+if [[ $# -ne 2 ]]; then
+  fail 'usage: check-dco-signoffs.sh <base-sha> <head-sha>'
+fi
+
+base_sha="$1"
+head_sha="$2"
+git_executable="${DCO_GIT_EXECUTABLE:-git}"
+
+# Accept only full object IDs supplied by the pull_request event. Besides making
+# the checked range explicit, this prevents revision-option or symbolic-ref input.
+sha_pattern='^([0-9a-fA-F]{40}|[0-9a-fA-F]{64})$'
+[[ "$base_sha" =~ $sha_pattern ]] || fail 'base SHA must be a full hexadecimal object ID'
+[[ "$head_sha" =~ $sha_pattern ]] || fail 'head SHA must be a full hexadecimal object ID'
+
+command -v "$git_executable" >/dev/null 2>&1 || fail "Git executable not found: $git_executable"
+"$git_executable" --version >/dev/null 2>&1 || fail 'Git is not executable'
+
+"$git_executable" rev-parse --verify --quiet "${base_sha}^{commit}" >/dev/null ||
+  fail "base object is missing or is not a commit: $base_sha"
+"$git_executable" rev-parse --verify --quiet "${head_sha}^{commit}" >/dev/null ||
+  fail "head object is missing or is not a commit: $head_sha"
+
+if ! commit_range="$("$git_executable" rev-list --reverse "${base_sha}..${head_sha}")"; then
+  fail "cannot enumerate explicit pull-request range ${base_sha}..${head_sha}"
+fi
+
+shopt -s nocasematch
+signoff_pattern='^Signed-off-by:[[:space:]]*([^<>]+)[[:space:]]+<([^<>[:space:]]+)>[[:space:]]*$'
+checked_count=0
+skipped_merge_count=0
+failure_count=0
+
+while IFS= read -r commit_sha; do
+  [[ -n "$commit_sha" ]] || continue
+
+  if ! parent_line="$("$git_executable" rev-list --parents -n 1 "$commit_sha")"; then
+    fail "cannot inspect parents for commit $commit_sha"
+  fi
+  read -r -a parent_fields <<<"$parent_line"
+  if [[ ${#parent_fields[@]} -lt 1 || "${parent_fields[0]}" != "$commit_sha" ]]; then
+    fail "unexpected parent metadata for commit $commit_sha"
+  fi
+
+  # A commit followed by two or more parent IDs is a merge. DCO applies to all
+  # ordinary commits, including root commits, but merge commits are skipped.
+  if (( ${#parent_fields[@]} > 2 )); then
+    skipped_merge_count=$((skipped_merge_count + 1))
+    printf 'DCO SKIP %s (multi-parent merge commit)\n' "${commit_sha:0:12}"
+    continue
+  fi
+
+  if ! identity_block="$("$git_executable" show -s --format='%an%n%ae%n%cn%n%ce' "$commit_sha")"; then
+    fail "cannot read author and committer identities for commit $commit_sha"
+  fi
+  mapfile -t identities <<<"$identity_block"
+  if [[ ${#identities[@]} -ne 4 ]]; then
+    fail "unexpected identity metadata for commit $commit_sha"
+  fi
+  author_name="${identities[0]}"
+  author_email="${identities[1]}"
+  committer_name="${identities[2]}"
+  committer_email="${identities[3]}"
+
+  # core.commentChar=# makes native Git ignore the conflict-help comments that
+  # `git commit` appends after a valid trailer. --parse restricts the result to
+  # the actual terminal trailer block; arbitrary mentions in the body do not
+  # count. pipefail makes either Git command's error fatal.
+  if ! parsed_trailers="$("$git_executable" show -s --format='%B' "$commit_sha" |
+    "$git_executable" -c core.commentChar='#' interpret-trailers --parse --no-divider)"; then
+    fail "cannot parse trailers for commit $commit_sha"
+  fi
+
+  matching_signoff=false
+  while IFS= read -r trailer_line; do
+    [[ -n "$trailer_line" ]] || continue
+    if [[ "$trailer_line" =~ $signoff_pattern ]]; then
+      signed_name="$(trim_whitespace "${BASH_REMATCH[1]}")"
+      signed_email="${BASH_REMATCH[2]}"
+      [[ -n "$signed_name" ]] || continue
+      is_valid_email "$signed_email" || continue
+
+      if { [[ "$signed_name" == "$author_name" ]] && [[ "$signed_email" == "$author_email" ]]; } ||
+        { [[ "$signed_name" == "$committer_name" ]] && [[ "$signed_email" == "$committer_email" ]]; }; then
+        matching_signoff=true
+        break
+      fi
+    fi
+  done <<<"$parsed_trailers"
+
+  checked_count=$((checked_count + 1))
+  if [[ "$matching_signoff" == true ]]; then
+    printf 'DCO OK   %s\n' "${commit_sha:0:12}"
+  else
+    printf 'DCO FAIL %s (no parsed Signed-off-by identity matches author or committer)\n' \
+      "${commit_sha:0:12}" >&2
+    failure_count=$((failure_count + 1))
+  fi
+done <<<"$commit_range"
+
+if (( failure_count > 0 )); then
+  fail "$failure_count ordinary commit(s) failed DCO verification"
+fi
+
+printf 'DCO verification passed: checked=%d skipped_merges=%d range=%s..%s\n' \
+  "$checked_count" "$skipped_merge_count" "$base_sha" "$head_sha"

--- a/scripts/ci/test-check-dco-signoffs.sh
+++ b/scripts/ci/test-check-dco-signoffs.sh
@@ -146,10 +146,10 @@ head_sha="$(create_case_commit \
 expect_fail 'malformed sign-off email structure' "$base_sha" "$head_sha"
 
 head_sha="$(create_case_commit \
-  'Alice Example' 'not-an-email' \
+  'Alice Example' 'alice@example.com' \
   'Build Bot' 'bot@example.com' \
-  $'Reject a malformed matching email\n\nSigned-off-by: Alice Example <not-an-email>\n')"
-expect_fail 'malformed bracketed email cannot match the author' "$base_sha" "$head_sha"
+  $'Reject an empty bracketed email\n\nSigned-off-by: Alice Example <>\n')"
+expect_fail 'empty bracketed email cannot match the author' "$base_sha" "$head_sha"
 
 head_sha="$(create_case_commit \
   'Alice Example' 'alice@example.com' \
@@ -188,6 +188,42 @@ head_sha="$(create_case_commit \
 expect_pass 'CRLF commit message' "$base_sha" "$head_sha"
 
 head_sha="$(create_case_commit \
+  'Alice Example' 'alice@localhost' \
+  'Build Bot' 'bot@example.com' \
+  $'Accept a local Git identity\n\nSigned-off-by: Alice Example <alice@localhost>\n')"
+expect_pass 'local email identity matches Git author' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@[192.0.2.1]' \
+  'Build Bot' 'bot@example.com' \
+  $'Accept an address-literal Git identity\n\nSigned-off-by: Alice Example <alice@[192.0.2.1]>\n')"
+expect_pass 'address-literal email identity matches Git author' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'álîçé@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Accept an internationalized Git identity\n\nSigned-off-by: Alice Example <álîçé@example.com>\n')"
+expect_pass 'internationalized email identity matches Git author' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'dependabot[bot]' '49699333+dependabot[bot]@users.noreply.github.com' \
+  'GitHub' 'noreply@github.com' \
+  $'Accept the repository Dependabot identity\n\n---\nupdated-dependencies:\n- dependency-name: example\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\n')"
+expect_pass 'repository Dependabot sign-off alias' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Other Bot' 'other-bot@users.noreply.github.com' \
+  'GitHub' 'noreply@github.com' \
+  $'Reject a copied Dependabot sign-off\n\n---\nupdated-dependencies:\n- dependency-name: example\n...\n\nSigned-off-by: dependabot[bot] <support@github.com>\n')"
+expect_fail 'Dependabot alias is not a general bot exemption' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject patch material as a trailer\n\n---\nSigned-off-by: Alice Example <alice@example.com>\n')"
+expect_fail 'sign-off below a patch divider is not a trailer' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
   'Alice Example' 'alice@example.com' \
   'Build Bot' 'bot@example.com' \
   $'Reject uncommented conflict body text\n\nSigned-off-by: Alice Example <alice@example.com>\n\n# Conflicts:\nbackend/src/Example.cs\n')"
@@ -210,7 +246,17 @@ merge_sha="$(printf '%s' $'Merge fixture branches without a sign-off\n' |
     GIT_COMMITTER_EMAIL='merge-committer@example.com' \
     GIT_COMMITTER_DATE='2000-01-01T00:00:00Z' \
     "$git_executable" -C "$fixture_repo" commit-tree "$tree_sha" -p "$main_sha" -p "$side_sha")"
-expect_pass 'multi-parent merge commit is skipped' "$base_sha" "$merge_sha"
+expect_fail 'unsigned multi-parent merge commit is rejected' "$base_sha" "$merge_sha"
+
+signed_merge_sha="$(printf '%s' $'Merge fixture branches with a sign-off\n\nSigned-off-by: Merge Author <merge-author@example.com>\n' |
+  GIT_AUTHOR_NAME='Merge Author' \
+    GIT_AUTHOR_EMAIL='merge-author@example.com' \
+    GIT_AUTHOR_DATE='2000-01-01T00:00:00Z' \
+    GIT_COMMITTER_NAME='Merge Committer' \
+    GIT_COMMITTER_EMAIL='merge-committer@example.com' \
+    GIT_COMMITTER_DATE='2000-01-01T00:00:00Z' \
+    "$git_executable" -C "$fixture_repo" commit-tree "$tree_sha" -p "$main_sha" -p "$side_sha")"
+expect_pass 'signed multi-parent merge commit is verified' "$base_sha" "$signed_merge_sha"
 
 missing_sha='1111111111111111111111111111111111111111'
 expect_fail 'missing base object fails closed' "$missing_sha" "$base_sha"

--- a/scripts/ci/test-check-dco-signoffs.sh
+++ b/scripts/ci/test-check-dco-signoffs.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+verifier="$script_dir/check-dco-signoffs.sh"
+git_executable="${DCO_TEST_GIT_EXECUTABLE:-git}"
+bash_executable="${BASH:-bash}"
+temp_root="$(mktemp -d)"
+fixture_repo="$temp_root/repo"
+tests_run=0
+
+cleanup() {
+  rm -rf -- "$temp_root"
+}
+trap cleanup EXIT
+
+fail_test() {
+  printf 'not ok %d - %s\n' "$tests_run" "$1" >&2
+  if [[ -n "${2:-}" ]]; then
+    printf '%s\n' "$2" >&2
+  fi
+  exit 1
+}
+
+expect_pass() {
+  local name="$1"
+  local base_sha="$2"
+  local head_sha="$3"
+  local output
+
+  tests_run=$((tests_run + 1))
+  if ! output="$(cd "$fixture_repo" &&
+    DCO_GIT_EXECUTABLE="$git_executable" "$bash_executable" "$verifier" "$base_sha" "$head_sha" 2>&1)"; then
+    fail_test "$name" "$output"
+  fi
+  printf 'ok %d - %s\n' "$tests_run" "$name"
+}
+
+expect_fail() {
+  local name="$1"
+  local base_sha="$2"
+  local head_sha="$3"
+  local output
+
+  tests_run=$((tests_run + 1))
+  if output="$(cd "$fixture_repo" &&
+    DCO_GIT_EXECUTABLE="$git_executable" "$bash_executable" "$verifier" "$base_sha" "$head_sha" 2>&1)"; then
+    fail_test "$name" "unexpected success:\n$output"
+  fi
+  printf 'ok %d - %s\n' "$tests_run" "$name"
+}
+
+expect_missing_tool_failure() {
+  local name="$1"
+  local base_sha="$2"
+  local head_sha="$3"
+  local output
+
+  tests_run=$((tests_run + 1))
+  if output="$(cd "$fixture_repo" &&
+    DCO_GIT_EXECUTABLE="$temp_root/missing-git" "$bash_executable" "$verifier" "$base_sha" "$head_sha" 2>&1)"; then
+    fail_test "$name" "unexpected success:\n$output"
+  fi
+  printf 'ok %d - %s\n' "$tests_run" "$name"
+}
+
+create_commit() {
+  local author_name="$1"
+  local author_email="$2"
+  local committer_name="$3"
+  local committer_email="$4"
+  local message="$5"
+
+  printf '%s' "$message" |
+    GIT_AUTHOR_NAME="$author_name" \
+      GIT_AUTHOR_EMAIL="$author_email" \
+      GIT_AUTHOR_DATE='2000-01-01T00:00:00Z' \
+      GIT_COMMITTER_NAME="$committer_name" \
+      GIT_COMMITTER_EMAIL="$committer_email" \
+      GIT_COMMITTER_DATE='2000-01-01T00:00:00Z' \
+      "$git_executable" -C "$fixture_repo" commit --allow-empty --quiet --cleanup=verbatim --file=-
+  "$git_executable" -C "$fixture_repo" rev-parse HEAD
+}
+
+create_case_commit() {
+  "$git_executable" -C "$fixture_repo" checkout --detach --quiet "$base_sha"
+  create_commit "$@"
+}
+
+command -v "$git_executable" >/dev/null 2>&1 || {
+  printf 'test setup error: Git executable not found: %s\n' "$git_executable" >&2
+  exit 1
+}
+command -v "$bash_executable" >/dev/null 2>&1 || {
+  printf 'test setup error: Bash executable not found: %s\n' "$bash_executable" >&2
+  exit 1
+}
+
+"$git_executable" init --quiet "$fixture_repo"
+base_sha="$(create_commit \
+  'Fixture Owner' 'owner@example.com' \
+  'Fixture Owner' 'owner@example.com' \
+  $'Create fixture base\n\nSigned-off-by: Fixture Owner <owner@example.com>\n')"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Accept a terminal trailer\n\nSigned-off-by: Alice Example <alice@example.com>\n')"
+expect_pass 'ordinary terminal sign-off' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Accept Git conflict comments\n\nSigned-off-by: Alice Example <alice@example.com>\n\n# Conflicts:\n#\tbackend/src/Example.cs\n#\tdocs/EXAMPLE.md\n')"
+expect_pass 'sign-off followed by Git conflict comments' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a non-terminal trailer\n\nSigned-off-by: Alice Example <alice@example.com>\n\nThis ordinary body paragraph follows the trailer.\n')"
+expect_fail 'ordinary body text after sign-off' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a body mention\n\nThis body merely mentions Signed-off-by: Alice Example <alice@example.com>.\n')"
+expect_fail 'arbitrary Signed-off-by body mention' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a missing trailer\n')"
+expect_fail 'missing Signed-off-by trailer' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a missing signatory name\n\nSigned-off-by: <alice@example.com>\n')"
+expect_fail 'malformed sign-off name' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a malformed email shape\n\nSigned-off-by: Alice Example alice@example.com\n')"
+expect_fail 'malformed sign-off email structure' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'not-an-email' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a malformed matching email\n\nSigned-off-by: Alice Example <not-an-email>\n')"
+expect_fail 'malformed bracketed email cannot match the author' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a mismatched name\n\nSigned-off-by: Mallory Example <alice@example.com>\n')"
+expect_fail 'mismatched sign-off name' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject a mismatched email\n\nSigned-off-by: Alice Example <mallory@example.com>\n')"
+expect_fail 'mismatched sign-off email' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'ALICE@EXAMPLE.COM' \
+  'Build Bot' 'bot@example.com' \
+  $'Match the author case-insensitively\n\nsigned-off-by: alice example <alice@example.com>\n')"
+expect_pass 'author identity match is case-insensitive' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'BOT@EXAMPLE.COM' \
+  $'Match the committer case-insensitively\n\nSigned-off-by: build bot <bot@example.com>\n')"
+expect_pass 'committer identity match is case-insensitive' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject an unrelated identity\n\nSigned-off-by: Carol Example <carol@example.com>\n')"
+expect_fail 'sign-off matches neither author nor committer' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Accept CRLF trailers\r\n\r\nSigned-off-by: Alice Example <alice@example.com>\r\n')"
+expect_pass 'CRLF commit message' "$base_sha" "$head_sha"
+
+head_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Reject uncommented conflict body text\n\nSigned-off-by: Alice Example <alice@example.com>\n\n# Conflicts:\nbackend/src/Example.cs\n')"
+expect_fail 'mutating a conflict comment into body text invalidates the trailer' "$base_sha" "$head_sha"
+
+side_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Create the merge side\n\nSigned-off-by: Alice Example <alice@example.com>\n')"
+main_sha="$(create_case_commit \
+  'Alice Example' 'alice@example.com' \
+  'Build Bot' 'bot@example.com' \
+  $'Create the merge mainline\n\nSigned-off-by: Build Bot <bot@example.com>\n')"
+tree_sha="$("$git_executable" -C "$fixture_repo" rev-parse "${main_sha}^{tree}")"
+merge_sha="$(printf '%s' $'Merge fixture branches without a sign-off\n' |
+  GIT_AUTHOR_NAME='Merge Author' \
+    GIT_AUTHOR_EMAIL='merge-author@example.com' \
+    GIT_AUTHOR_DATE='2000-01-01T00:00:00Z' \
+    GIT_COMMITTER_NAME='Merge Committer' \
+    GIT_COMMITTER_EMAIL='merge-committer@example.com' \
+    GIT_COMMITTER_DATE='2000-01-01T00:00:00Z' \
+    "$git_executable" -C "$fixture_repo" commit-tree "$tree_sha" -p "$main_sha" -p "$side_sha")"
+expect_pass 'multi-parent merge commit is skipped' "$base_sha" "$merge_sha"
+
+missing_sha='1111111111111111111111111111111111111111'
+expect_fail 'missing base object fails closed' "$missing_sha" "$base_sha"
+expect_fail 'missing head object fails closed' "$base_sha" "$missing_sha"
+
+blob_sha="$(printf 'not a commit' | "$git_executable" -C "$fixture_repo" hash-object -w --stdin)"
+expect_fail 'non-commit range object fails closed' "$base_sha" "$blob_sha"
+expect_missing_tool_failure 'missing Git tool fails closed' "$base_sha" "$head_sha"
+
+printf 'DCO verifier synthetic tests passed: %d\n' "$tests_run"


### PR DESCRIPTION
## Summary

- keep the SHA-pinned KineticCafe/actions-dco v3.2.0 step visible as a non-blocking diagnostic
- add a repository-owned native Git verifier for the explicit pull-request base/head range
- accept valid author/committer-matching sign-offs followed only by Git conflict comments
- validate every submitted commit, including multi-parent merges
- preserve Git's patch-divider boundary while supporting the repository's exact trailer-required Dependabot identity mapping
- retain the existing job-level advisory posture; #1173 remains the maintainer-owned enforcement decision

This unblocks #1537 without rewriting any published commit or exempting any human author.

## Exact head

- Head: `7fa9835a`
- Base absorbed: `d1ac680b`
- Signed feature, current-main merge, and bounded review-fix commits; no rebase, squash, force-push, or discarded history

## Verification

- [x] synthetic native-DCO contract: 27/27
- [x] exact #1537 event range: all 12 commits accepted, including both signed merges
- [x] real Dependabot commit `01b78028`: accepted only through the exact established signed bot mapping
- [x] ordinary human sign-off below `---`: rejected
- [x] unsigned merge: rejected; signed merge: accepted
- [x] local, address-literal, and internationalized exact Git identities: accepted
- [x] Bash syntax for verifier and harness
- [x] Actionlint 1.7.12 across all 32 workflows on the workflow-changing head: 0 findings
- [x] docs governance, Golden Principles, GitHub operations governance, and `git diff --check`
- [ ] fresh exact-head hosted CI after the logic-fix push
- [ ] focused post-fix independent review is running

## Review fix round

The single bounded fix round addresses all four automatic-review findings together: in-range merge validation, Dependabot identity compatibility, removal of narrower email grammar, and restoration of Git's patch-divider boundary. Any new CRITICAL introduced by these fixes would reopen the pipeline once; otherwise this head ships or parks after the current gate.

## Risk boundaries

- Human and ordinary bot commits use only native Git's terminal trailer block and exact author/committer identity matching.
- Dependabot remains trailer-required and is accepted only for its exact stable author name/email plus `dependabot[bot] <support@github.com>` mapping; it is not a general bot exemption.
- The job remains advisory under the existing #1173 owner gate.

Closes #1619