### PR TITLE
Preserve buffered provider refusals as sanitized degraded chat messages

### DIFF
--- a/backend/src/Taskdeck.Application/Services/ChatService.cs
+++ b/backend/src/Taskdeck.Application/Services/ChatService.cs
@@ -524,7 +524,18 @@ public class ChatService : IChatService
             if (string.IsNullOrWhiteSpace(assistantContent))
             {
                 assistantContent = EmptyAssistantContentPlaceholder;
-                messageType = "degraded";
+
+                // Substituting the placeholder must not destroy a real artifact reference. When a
+                // proposal was actually created (board-scoped tool calling can return a proposal id
+                // with no closing text), the message stays "proposal-reference": the client renders
+                // the "Open in Review" action only for that type paired with a proposalId, so
+                // reclassifying here would strand a live proposal with no way to reach it.
+                // "clarification" deliberately gets no such guard — a clarification with no question
+                // text has nothing for the user to answer and no attached artifact, so "degraded" is
+                // the honest classification for it.
+                if (proposalId == null)
+                    messageType = "degraded";
+
                 if (string.IsNullOrWhiteSpace(degradedReason))
                     degradedReason = EmptyAssistantContentDegradedReason;
             }

--- a/backend/src/Taskdeck.Application/Services/ChatService.cs
+++ b/backend/src/Taskdeck.Application/Services/ChatService.cs
@@ -18,6 +18,11 @@ public class ChatService : IChatService
     private const int MaxChecklistItemCount = 30;
     private const string StreamErrorPlaceholder = "The provider could not complete the response.";
     private const string StreamErrorDegradedReason = "The upstream provider could not complete the response.";
+    // Stand-in text for a provider outcome that carries no assistant text. It is deliberately generic:
+    // the OpenAI-compatible buffered path sanitizes content_filter/refusal responses to empty content
+    // precisely so upstream refusal text never reaches a log, a persisted row, or the client (#1617).
+    private const string EmptyAssistantContentPlaceholder = "The provider ended the response without returning text.";
+    private const string EmptyAssistantContentDegradedReason = "The provider returned no assistant text.";
     private static readonly Regex MentionRegex = new(@"(?<![A-Za-z0-9_.-])@(?<username>[A-Za-z0-9_.-]{3,50})", RegexOptions.Compiled);
     private static readonly string[] PromptInjectionDenylist =
     {
@@ -510,6 +515,20 @@ public class ChatService : IChatService
                 }
             }
 
+            // A provider outcome can legitimately carry no assistant text. The OpenAI-compatible
+            // buffered path sanitizes content_filter and refusal responses to empty content so no
+            // upstream refusal text is surfaced, and a tool-calling result can be textless too.
+            // ChatMessage rejects empty content, so persisting it verbatim throws and the user loses
+            // the assistant-history entry entirely (#1617). Substitute the same non-secret placeholder
+            // the streaming path already uses; the sanitized specifics stay in DegradedReason.
+            if (string.IsNullOrWhiteSpace(assistantContent))
+            {
+                assistantContent = EmptyAssistantContentPlaceholder;
+                messageType = "degraded";
+                if (string.IsNullOrWhiteSpace(degradedReason))
+                    degradedReason = EmptyAssistantContentDegradedReason;
+            }
+
             var persistedDegradedReason = string.IsNullOrWhiteSpace(degradedReason)
                 ? null
                 : degradedReason;
@@ -725,7 +744,7 @@ public class ChatService : IChatService
             if (streamedContent.Length == 0 && persistEmptyTerminalOutcome)
                 streamedContent = terminalHadError
                     ? StreamErrorPlaceholder
-                    : "The provider ended the response without returning text.";
+                    : EmptyAssistantContentPlaceholder;
             if (!string.IsNullOrEmpty(streamedContent))
             {
                 var assistantMessage = new ChatMessage(

--- a/backend/tests/Taskdeck.Application.Tests/Services/ChatServiceOpenAiCompatibleRefusalTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ChatServiceOpenAiCompatibleRefusalTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Taskdeck.Application.DTOs;
+using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services;
+using Taskdeck.Application.Tests.TestUtilities;
+using Taskdeck.Domain.Common;
+using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
+using Xunit;
+
+namespace Taskdeck.Application.Tests.Services;
+
+/// <summary>
+/// Consumer-level regression for issue #1617: the OpenAI-compatible buffered path sanitizes
+/// content_filter and refusal responses to empty content, and ChatMessage rejects empty content.
+/// These tests drive the real <see cref="OpenAiCompatibleLlmProvider"/> through
+/// <see cref="ChatService"/> and prove a valid assistant-history record is persisted, that no
+/// upstream refusal text escapes, and that quota settlement, provenance, and circuit-success
+/// semantics are unchanged.
+/// </summary>
+public class ChatServiceOpenAiCompatibleRefusalTests
+{
+    private const string SanitizedPlaceholder = "The provider ended the response without returning text.";
+
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<IChatSessionRepository> _chatSessionRepoMock = new();
+    private readonly Mock<IChatMessageRepository> _chatMessageRepoMock = new();
+    private readonly Mock<IColumnRepository> _columnRepoMock = new();
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<IAutomationPlannerService> _plannerMock = new();
+    private readonly Mock<IAutomationProposalService> _proposalServiceMock = new();
+    private readonly Mock<IAutomationPolicyEngine> _policyEngineMock = new();
+    private readonly Mock<INotificationService> _notificationServiceMock = new();
+    private readonly Mock<IAuthorizationService> _authorizationServiceMock = new();
+    private readonly List<ChatMessage> _persistedMessages = new();
+    private int _saveChangesCalls;
+
+    public ChatServiceOpenAiCompatibleRefusalTests()
+    {
+        _unitOfWorkMock.SetupGet(u => u.ChatSessions).Returns(_chatSessionRepoMock.Object);
+        _unitOfWorkMock.SetupGet(u => u.ChatMessages).Returns(_chatMessageRepoMock.Object);
+        _unitOfWorkMock.SetupGet(u => u.Columns).Returns(_columnRepoMock.Object);
+        _unitOfWorkMock.SetupGet(u => u.Users).Returns(_userRepoMock.Object);
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(default))
+            .ReturnsAsync(() => ++_saveChangesCalls);
+        _chatMessageRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<ChatMessage>(), default))
+            .ReturnsAsync((ChatMessage message, CancellationToken _) =>
+            {
+                _persistedMessages.Add(message);
+                return message;
+            });
+        _notificationServiceMock
+            .Setup(s => s.PublishAsync(It.IsAny<CreateNotificationRequestDto>(), default))
+            .ReturnsAsync(Result.Success(true));
+    }
+
+    [Theory]
+    [InlineData(
+        """
+        {"choices":[{"message":{"content":null,"content_filter_results":{"hate":{"filtered":true,"detail":"internal moderation detail"}}},"finish_reason":"content_filter"}],"usage":{"total_tokens":4}}
+        """,
+        "content filter",
+        "internal moderation detail")]
+    [InlineData(
+        """
+        {"choices":[{"message":{"content":null,"refusal":"sensitive vendor refusal detail"},"finish_reason":"stop"}],"usage":{"total_tokens":4}}
+        """,
+        "refused",
+        "sensitive vendor refusal detail")]
+    public async Task SendMessageAsync_BufferedRefusalOrContentFilter_PersistsSanitizedDegradedMessage(
+        string responseBody,
+        string expectedReasonFragment,
+        string forbiddenUpstreamText)
+    {
+        var userId = Guid.NewGuid();
+        var session = new ChatSession(userId, "Refusal session");
+        _chatSessionRepoMock
+            .Setup(r => r.GetByIdWithMessagesAsync(session.Id, default))
+            .ReturnsAsync(session);
+        var service = BuildService(CreateProvider(_ => JsonResponse(responseBody)));
+
+        var result = await service.SendMessageAsync(
+            session.Id, userId, new SendChatMessageDto("Summarize the release notes"), default);
+
+        result.IsSuccess.Should().BeTrue(
+            "a sanitized degraded outcome must still produce an assistant message, not a validation failure");
+        result.Value.MessageType.Should().Be("degraded");
+        result.Value.Content.Should().Be(SanitizedPlaceholder);
+        result.Value.DegradedReason.Should().Contain(expectedReasonFragment);
+
+        var assistantMessage = _persistedMessages.Should().ContainSingle(m => m.Role == ChatMessageRole.Assistant).Subject;
+        assistantMessage.SessionId.Should().Be(session.Id);
+        assistantMessage.Content.Should().Be(SanitizedPlaceholder);
+        assistantMessage.MessageType.Should().Be("degraded");
+        assistantMessage.DegradedReason.Should().Contain(expectedReasonFragment);
+        assistantMessage.TokenUsage.Should().Be(4);
+        _saveChangesCalls.Should().BeGreaterThan(0, "the assistant-history record must be committed");
+
+        assistantMessage.Content.Should().NotContain(forbiddenUpstreamText);
+        assistantMessage.DegradedReason.Should().NotContain(forbiddenUpstreamText);
+        result.Value.Content.Should().NotContain(forbiddenUpstreamText);
+        result.Value.DegradedReason.Should().NotContain(forbiddenUpstreamText);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_BufferedRefusal_SettlesQuotaWithProviderProvenance()
+    {
+        var userId = Guid.NewGuid();
+        var session = new ChatSession(userId, "Refusal quota session");
+        _chatSessionRepoMock
+            .Setup(r => r.GetByIdWithMessagesAsync(session.Id, default))
+            .ReturnsAsync(session);
+
+        var reservationId = Guid.NewGuid();
+        var quotaMock = new Mock<ILlmQuotaService>();
+        quotaMock
+            .Setup(q => q.ReserveAsync(userId, LlmSurface.Chat, default))
+            .ReturnsAsync(new QuotaReservationDto(true, null, reservationId, 1000, 10, EstimatedTokens: 50));
+        var service = BuildService(
+            CreateProvider(_ => JsonResponse(
+                """{"choices":[{"message":{"content":null},"finish_reason":"content_filter"}],"usage":{"total_tokens":4}}""")),
+            quotaMock.Object);
+
+        var result = await service.SendMessageAsync(
+            session.Id, userId, new SendChatMessageDto("Summarize the release notes"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        quotaMock.Verify(
+            q => q.CommitReservationAsync(
+                reservationId,
+                userId,
+                LlmSurface.Chat,
+                "OpenAICompatible",
+                "vendor/model",
+                4,
+                0,
+                It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a dispatched refusal still consumed upstream tokens and must be billed with its provenance");
+        quotaMock.Verify(
+            q => q.ReleaseReservationAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_BufferedRefusal_DoesNotOpenTheProviderCircuit()
+    {
+        var userId = Guid.NewGuid();
+        var session = new ChatSession(userId, "Refusal circuit session");
+        _chatSessionRepoMock
+            .Setup(r => r.GetByIdWithMessagesAsync(session.Id, default))
+            .ReturnsAsync(session);
+
+        var dispatches = 0;
+        var tracker = new CircuitBreakerStateTracker();
+        var circuitSettings = new CircuitBreakerSettings { FailureThreshold = 1, BreakDurationSeconds = 60 };
+        var provider = CreateProvider(
+            _ =>
+            {
+                dispatches++;
+                return JsonResponse(
+                    """{"choices":[{"message":{"content":null},"finish_reason":"content_filter"}],"usage":{"total_tokens":4}}""");
+            },
+            tracker,
+            circuitSettings);
+        var service = BuildService(provider);
+        var dto = new SendChatMessageDto("Summarize the release notes");
+
+        var first = await service.SendMessageAsync(session.Id, userId, dto, default);
+        var second = await service.SendMessageAsync(session.Id, userId, dto, default);
+
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+        dispatches.Should().Be(2, "a sanitized refusal is a provider success, so the circuit stays closed");
+        tracker.Get("OpenAICompatible")?.State.Should().NotBe(CircuitState.Open);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_BufferedSuccess_IsUnaffectedByThePlaceholder()
+    {
+        var userId = Guid.NewGuid();
+        var session = new ChatSession(userId, "Normal session");
+        _chatSessionRepoMock
+            .Setup(r => r.GetByIdWithMessagesAsync(session.Id, default))
+            .ReturnsAsync(session);
+        var service = BuildService(CreateProvider(_ => JsonResponse(
+            """{"choices":[{"message":{"content":"Here is the summary."},"finish_reason":"stop"}],"usage":{"total_tokens":6}}""")));
+
+        var result = await service.SendMessageAsync(
+            session.Id, userId, new SendChatMessageDto("Summarize the release notes"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.MessageType.Should().Be("text");
+        result.Value.Content.Should().Be("Here is the summary.");
+        result.Value.DegradedReason.Should().BeNull();
+    }
+
+    private ChatService BuildService(ILlmProvider provider, ILlmQuotaService? quota = null) =>
+        new(
+            _unitOfWorkMock.Object,
+            provider,
+            _plannerMock.Object,
+            _proposalServiceMock.Object,
+            _policyEngineMock.Object,
+            _notificationServiceMock.Object,
+            _authorizationServiceMock.Object,
+            quota);
+
+    /// <summary>
+    /// Builds the real provider behind <see cref="LlmDispatchTrackingHandler"/> so the dispatch phase
+    /// matches production wiring (the phase drives quota settlement).
+    /// </summary>
+    private static OpenAiCompatibleLlmProvider CreateProvider(
+        Func<HttpRequestMessage, HttpResponseMessage> responseFactory,
+        CircuitBreakerStateTracker? tracker = null,
+        CircuitBreakerSettings? circuitSettings = null) =>
+        new(
+            new HttpClient(new LlmDispatchTrackingHandler
+            {
+                InnerHandler = new StubHttpMessageHandler(responseFactory)
+            }),
+            BuildSettings(),
+            NullLogger<OpenAiCompatibleLlmProvider>.Instance,
+            tracker,
+            circuitSettings,
+            new LlmProviderRuntimePolicy(
+                AllowGeneralProviderLocalhost: false,
+                AllowOllamaLocalhost: false));
+
+    private static HttpResponseMessage JsonResponse(string body) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json")
+    };
+
+    private static LlmProviderSettings BuildSettings() => new()
+    {
+        EnableLiveProviders = true,
+        Provider = "OpenAICompatible",
+        OpenAiCompatible = new OpenAiCompatibleProviderSettings
+        {
+            ApiKey = "test-compatible-key",
+            BaseUrl = "https://api.example.test/v1",
+            Model = "vendor/model",
+            TimeoutSeconds = 30
+        }
+    };
+}

--- a/backend/tests/Taskdeck.Application.Tests/Services/ChatServiceResilienceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ChatServiceResilienceTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -7,6 +8,7 @@ using Taskdeck.Application.Services;
 using Taskdeck.Application.Services.Tools;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Enums;
 using Taskdeck.Domain.Exceptions;
 using Xunit;
 
@@ -364,6 +366,99 @@ public class ChatServiceResilienceTests
         _llmProviderMock.Verify(
             p => p.CompleteAsync(It.IsAny<ChatCompletionRequest>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // -----------------------------------------------------------------------
+    // Blank final content + a real proposal (#1617 review)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task SendMessageAsync_WhenToolCallingCreatesProposalButFinalContentIsBlank_KeepsProposalReference()
+    {
+        // Board-scoped tool calling can create a proposal and then return no closing text.
+        // Substituting the empty-content placeholder must not reclassify that message: the
+        // client renders the "Open in Review" action only for messageType "proposal-reference"
+        // paired with a proposalId, so clobbering the type strands a live proposal.
+        var userId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposalId = Guid.NewGuid();
+        var session = new ChatSession(userId, "Textless proposal session", boardId);
+        _chatSessionRepoMock
+            .Setup(r => r.GetByIdWithMessagesAsync(session.Id, default))
+            .ReturnsAsync(session);
+
+        var persistedMessages = new List<ChatMessage>();
+        _chatMessageRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<ChatMessage>(), default))
+            .ReturnsAsync((ChatMessage message, CancellationToken _) =>
+            {
+                persistedMessages.Add(message);
+                return message;
+            });
+
+        // Round 1: the LLM invokes a write tool. Round 2: it completes with no assistant text.
+        var toolArgs = JsonDocument.Parse("""{"title":"Ship the release"}""").RootElement.Clone();
+        var round = 0;
+        _llmProviderMock
+            .Setup(p => p.CompleteWithToolsAsync(
+                It.IsAny<ChatCompletionRequest>(),
+                It.IsAny<IReadOnlyList<TaskdeckToolSchema>>(),
+                It.IsAny<IReadOnlyList<ToolCallResult>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                round++;
+                if (round == 1)
+                {
+                    return new LlmToolCompletionResult(
+                        Content: null,
+                        TokensUsed: 20,
+                        Provider: "Test",
+                        Model: "test-v1",
+                        ToolCalls: new[] { new ToolCallRequest("call-1", "propose_create_card", toolArgs) },
+                        IsComplete: false);
+                }
+
+                return new LlmToolCompletionResult(
+                    Content: "   ",
+                    TokensUsed: 10,
+                    Provider: "Test",
+                    Model: "test-v1",
+                    ToolCalls: null,
+                    IsComplete: true);
+            });
+
+        var toolResultJson = $$"""{"status":"created","full_proposal_id":"{{proposalId}}"}""";
+        var executorMock = new Mock<IToolExecutor>();
+        executorMock.SetupGet(e => e.ToolName).Returns("propose_create_card");
+        executorMock
+            .Setup(e => e.ExecuteAsync(It.IsAny<Guid>(), It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolResultJson);
+        executorMock
+            .Setup(e => e.ExecuteAsync(It.IsAny<ToolExecutionContext>(), It.IsAny<JsonElement>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolResultJson);
+
+        var orchestrator = new ToolCallingChatOrchestrator(
+            _llmProviderMock.Object,
+            new ToolExecutorRegistry(new[] { executorMock.Object }),
+            new Mock<ILogger<ToolCallingChatOrchestrator>>().Object);
+
+        var service = BuildService(orchestrator: orchestrator);
+        var result = await service.SendMessageAsync(
+            session.Id, userId, new SendChatMessageDto("Create a card for the release"), default);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.MessageType.Should().Be("proposal-reference",
+            "a textless completion must not strip the classification the client keys the review action off");
+        result.Value.ProposalId.Should().Be(proposalId);
+        result.Value.Content.Should().Be("The provider ended the response without returning text.");
+
+        var assistantMessage = persistedMessages.Should()
+            .ContainSingle(m => m.Role == ChatMessageRole.Assistant).Subject;
+        assistantMessage.MessageType.Should().Be("proposal-reference");
+        assistantMessage.ProposalId.Should().Be(proposalId);
+        assistantMessage.Content.Should().Be("The provider ended the response without returning text.",
+            "the placeholder still has to replace the blank content so ChatMessage accepts it");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/tests/Taskdeck.Application.Tests/Services/ChatServiceResilienceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/ChatServiceResilienceTests.cs
@@ -127,12 +127,13 @@ public class ChatServiceResilienceTests
     }
 
     [Fact]
-    public async Task SendMessageAsync_WhenProviderReturnsEmptyContent_DomainValidationPreventsEmptyMessage()
+    public async Task SendMessageAsync_WhenProviderReturnsEmptyContent_PersistsExplicitDegradedPlaceholder()
     {
-        // When the provider returns empty content, the ChatMessage domain entity constructor
-        // throws DomainException("Content cannot be empty"). ChatService catches DomainException
-        // in its outer try/catch and returns Result.Failure — it does NOT silently persist an
-        // empty message. This test verifies the failure is surfaced with the correct error code.
+        // Empty provider content is still never persisted verbatim — ChatMessage rejects it. But an
+        // empty degraded outcome is legitimate (the OpenAI-compatible buffered path sanitizes
+        // content_filter/refusal responses to empty content), and losing the whole assistant-history
+        // entry to a validation failure was the defect in #1617. ChatService now substitutes an
+        // explicit non-secret placeholder and classifies the message "degraded".
         var userId = Guid.NewGuid();
         var session = new ChatSession(userId, "Empty content session");
         _chatSessionRepoMock
@@ -151,12 +152,13 @@ public class ChatServiceResilienceTests
         var result = await service.SendMessageAsync(
             session.Id, userId, new SendChatMessageDto("Any question"), default);
 
-        // ChatService catches DomainException and returns a failure result; it never persists
-        // an empty assistant message.
-        result.IsSuccess.Should().BeFalse(
+        result.IsSuccess.Should().BeTrue(
+            "a degraded outcome with no provider text must still produce an assistant-history entry");
+        result.Value.Content.Should().NotBeNullOrWhiteSpace(
             "empty content returned by the provider must never be silently persisted");
-        result.ErrorCode.Should().Be(ErrorCodes.ValidationError,
-            "ChatService wraps the DomainException from ChatMessage into a ValidationError result");
+        result.Value.MessageType.Should().Be("degraded");
+        result.Value.DegradedReason.Should().Be("Empty response.",
+            "the provider's own sanitized reason is preserved verbatim");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/ChatMessageTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/ChatMessageTests.cs
@@ -24,6 +24,27 @@ public class ChatMessageTests
         message.DegradedReason.Should().Be("Live provider request failed.");
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   \t\r\n  ")]
+    public void Constructor_ShouldThrow_WhenContentIsEmpty(string content)
+    {
+        // The empty-content guard is what forces callers to substitute an explicit placeholder
+        // when a provider returns no assistant text (#1617) — an assistant-history row must
+        // never be blank, so this rejection is load-bearing, not incidental.
+        var sessionId = Guid.NewGuid();
+
+        var act = () => new ChatMessage(
+            sessionId,
+            ChatMessageRole.Assistant,
+            content);
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Content cannot be empty")
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
     [Fact]
     public void Constructor_ShouldThrow_WhenMessageTypeIsNotAllowed()
     {


### PR DESCRIPTION
## Problem

The OpenAI-compatible **buffered** path sanitizes `content_filter` and refusal responses to an empty
`LlmCompletionResult.Content` — deliberately, so upstream refusal text never reaches a log, a
persisted row, or the client. `ChatService` settled quota and then passed that empty string to the
`ChatMessage` constructor, which rejects empty content. The caller got a `ValidationError` failure
and **no assistant-history entry at all**, even though the provider outcome was a classified,
non-failing degraded success.

## Fix

An explicit degraded branch in `ChatService.SendMessageAsync`, at the persistence boundary
(`backend/src/Taskdeck.Application/Services/ChatService.cs`): blank assistant content becomes the
same non-secret placeholder the streaming path already uses
(`"The provider ended the response without returning text."`, now a shared constant), classified
`"degraded"`, with the provider's already-sanitized specifics carried in `DegradedReason`
("Response was stopped by the upstream content filter." / "The upstream provider refused this
request.").

Chosen seam, and why not the provider:

- `OpenAiCompatibleLlmProvider` is **untouched**. Its empty-content sanitization is a deliberate,
  separately tested contract (`CompleteAsync_NullContentFilterOrRefusal_IsSanitizedSuccess` asserts
  `Content.Should().BeEmpty()`), and the streamed buffered-fallback path
  (`EmitBufferedFallbackAsync`) relies on that emptiness to reach `ChatService`'s existing
  `persistEmptyTerminalOutcome` placeholder logic. Changing the provider would have broken the
  sanitization contract test and double-substituted on the streamed path. So the
  **streamed-refusal behavior repaired in PR #1537 is bit-for-bit unchanged** — the shared constant
  is the identical string the streaming path already used.
- The branch sits at the persistence boundary, so it is provider-agnostic by construction. The one
  producer of blank content in the repo today is the OpenAI-compatible buffered path;
  `GeminiLlmProvider` is **not** a second case — its degraded paths always emit canned non-empty
  fallback text, so the branch never fires for it. A textless board-scoped tool-calling result is
  the other reachable case, and the review round found it needed more than the placeholder: see
  *Review round 1* below.

No upstream refusal/error text is logged, persisted, or returned. Quota settlement, provider/model
provenance, and circuit-success semantics are unchanged and are asserted directly (below).

One existing test, `ChatServiceResilienceTests.SendMessageAsync_WhenProviderReturnsEmptyContent_…`,
asserted the defect itself (a `ValidationError` on empty degraded content). Its real invariant —
empty provider content is never persisted verbatim — is preserved: it now asserts the explicit
placeholder and the degraded classification.

## Verification

All commands from the repo root in an isolated worktree, foreground, exact head `788e59ca` (the
pre-review head; the review-fix evidence is under *Review round 1*, at head `53c05ee9`).

**New regression** (`ChatServiceOpenAiCompatibleRefusalTests`) drives the **real**
`OpenAiCompatibleLlmProvider` (behind `LlmDispatchTrackingHandler`, so dispatch phase matches
production wiring) through `ChatService` and asserts the persisted `ChatMessage`:

```
dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 \
  --filter "FullyQualifiedName~ChatServiceOpenAiCompatibleRefusalTests"
→ Passed: 5, Failed: 0, Total: 5
```

It covers: content_filter and refusal (Theory) → success + persisted assistant record with
non-empty sanitized content, `"degraded"` type, sanitized reason, `TokenUsage` 4, and neither the
content nor the reason containing the planted upstream secrets (`"sensitive vendor refusal detail"`,
`"internal moderation detail"`); quota commit with `("OpenAICompatible", "vendor/model", 4)` and no
release; two consecutive refusals with `FailureThreshold = 1` leaving the circuit closed
(2 dispatches, state not `Open`); and a normal `stop` response still producing `"text"` with no
`DegradedReason`.

**Mutation check, both directions** — the guard was disabled in place (`if (false && …)`):

- Fix disabled → `Failed: 4, Passed: 1, Total: 5`. All four refusal/quota/circuit tests fail on
  `Expected result.IsSuccess to be True … but found False` — the exact defect. The fifth is the
  deliberate control (normal `stop` response), which correctly still passes.
- Fix restored (`git checkout --`, verified in the live file) → `Passed: 5, Failed: 0`.

**Full test classes touched:**

```
dotnet test … -c Release -m:1 --filter "FullyQualifiedName~ChatService|FullyQualifiedName~OpenAiCompatibleLlmProviderTests"
→ Passed: 141, Failed: 0, Total: 141
```

**Whole Application layer** (the layer changed):

```
dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1
→ Passed: 3729, Failed: 0, Total: 3729   (35s)
```

**Api-layer consumers** of the changed seam:

```
dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 \
  --filter "FullyQualifiedName~ChatApiLiveProviderStubTests|FullyQualifiedName~LlmProviderDegradationTests"
→ Passed: 10, Failed: 0, Total: 10
```

## Review round 1 (head `53c05ee9`)

- **`messageType` no longer clobbered when a proposal exists** (review MEDIUM / Codex P2 on
  `ChatService.cs:527`). The new branch reassigned `messageType = "degraded"` unconditionally.
  Board-scoped tool calling can create a proposal and then return no closing text: the earlier
  branch had already set `"proposal-reference"` with a live `proposalId`, and
  `ChatMessageList.vue:173` renders the "Open in Review" action only for
  `proposalId && messageType === 'proposal-reference'` — so the reassignment stranded a real
  proposal with no way to reach it. The reassignment is now guarded on a null `proposalId`; the
  placeholder substitution and the degraded reason are unchanged. `"clarification"` deliberately
  gets no such guard — a clarification with no question text has nothing for the user to answer and
  no attached artifact, so `"degraded"` is the honest classification for it.
- **Domain guard coverage restored** (review LOW). The rewritten resilience test had left the repo
  with no direct coverage of `ChatMessage`'s empty-content constructor guard — the guard this whole
  change exists to satisfy. `ChatMessageTests.Constructor_ShouldThrow_WhenContentIsEmpty` is a
  Theory over `""`, `" "`, and mixed whitespace.

```
dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 \
  --filter "FullyQualifiedName~ChatServiceOpenAiCompatibleRefusalTests|FullyQualifiedName~ChatServiceResilienceTests"
→ Passed: 16, Failed: 0, Total: 16

dotnet test backend/tests/Taskdeck.Domain.Tests/Taskdeck.Domain.Tests.csproj -c Release -m:1 \
  --filter "FullyQualifiedName~ChatMessageTests"
→ Passed: 7, Failed: 0, Total: 7
```

**Mutation check of the new discriminating test, both directions** —
`SendMessageAsync_WhenToolCallingCreatesProposalButFinalContentIsBlank_KeepsProposalReference`
drives the real `ToolCallingChatOrchestrator` (round 1 calls `propose_create_card`, round 2
completes with whitespace-only content):

- Guard reverted to the unconditional assignment → `Failed: 1, Passed: 0`, failing precisely on the
  classification: `Expected result.Value.MessageType … "degraded" / "proposal-reference"`.
- Guard restored → `Passed: 16, Failed: 0` on the filter above.

## Not verified

- Full `backend/Taskdeck.sln` suite and the Infrastructure/Architecture layers — not run locally;
  CI covers them. Domain is now covered for the touched class only
  (`ChatMessageTests`, 7 passed); `ChatMessage` itself is unchanged and still rejects empty content,
  by design.
- No live provider call; the upstream is a stubbed `HttpMessageHandler`.
- Frontend rendering — no frontend change. `ChatMessageList.vue` was read, not modified, to confirm
  which `messageType` gates the proposal review action; no frontend test was run.

## Residual risk

- **Pre-existing, deliberately not expanded into:** when a client sends `RequestProposal: true` on a
  board-scoped session and the upstream refuses, `shouldAttemptProposal` is still true, so a proposal
  can be parsed from the *user's own* message and `messageType` is then overwritten to
  `"proposal-reference"`, dropping the `"degraded"` classification. That path predates this change
  and is out of scope for #1617 — worth a separate issue if the maintainer agrees it is wrong.
- The placeholder is a fixed English string, consistent with the existing `StreamErrorPlaceholder`;
  it is not localized.
- Branched from `78be65c6`; `origin/main` has since advanced (dependency bumps only, no overlap with
  the changed files). Merge base is clean — the PR diff is exactly 3 files.
- Gitignored files in the worktree were build outputs (`bin/`, `obj/`) and
  `.claude/settings.local.json` only — nothing was copied out, nothing needs to survive teardown.

Closes #1617
