### PR TITLE
Fix standalone MCP HTTP host 500 on every authenticated request (#1602)

### DIFF
--- a/backend/src/Taskdeck.Api/Program.cs
+++ b/backend/src/Taskdeck.Api/Program.cs
@@ -125,6 +125,17 @@ if (args.Contains("--mcp"))
         // MCP telemetry (operation logger, etc.).
         mcpHttpBuilder.Services.AddMcpTelemetry();
 
+        // CORS services with NO policies registered at all -- deliberately not AddTaskdeckCors (#1602).
+        // MapTaskdeckMcpEndpoint stamps the endpoint with DisableCorsAttribute, which is ICorsMetadata,
+        // and ASP.NET Core's EndpointMiddleware refuses to execute an endpoint carrying CORS metadata
+        // unless the CORS middleware ran first -- so without this pair (AddCors here, UseCors below) the
+        // standalone host threw InvalidOperationException and returned a bare 500 on EVERY authenticated
+        // request. Registering the services with an empty policy map satisfies that contract and adds no
+        // cross-origin capability: there is no default policy to resolve, so CorsMiddleware never emits
+        // an Access-Control-* header, and the endpoint's DisableCorsAttribute suppresses CORS handling
+        // for it regardless. Browser-origin MCP clients stay unsupported here by construction.
+        mcpHttpBuilder.Services.AddCors();
+
         // MCP server: HTTP transport + all resources and tools.
         // Stateless is pinned explicitly rather than left to the library default:
         // ModelContextProtocol 2.0.0 flipped that default from false to true, which drops
@@ -163,6 +174,14 @@ if (args.Contains("--mcp"))
         {
             mcpHttpApp.UseForwardedHeaders(mcpForwardedHeadersOptions);
         }
+
+        // CORS middleware with no named policy: required so EndpointMiddleware will execute the MCP
+        // endpoint, which carries DisableCorsAttribute (ICorsMetadata) -- see AddCors above (#1602).
+        // Deny-by-default: no policy is registered, so this emits no Access-Control-* headers and
+        // grants no cross-origin access; it exists purely to satisfy the endpoint's metadata contract.
+        // Positioned to mirror the co-hosted pipeline (forwarded headers -> CORS -> correlation ID),
+        // and after the auto-inserted UseRouting so an endpoint is selected when it runs.
+        mcpHttpApp.UseCors();
 
         // Correlation ID propagation: honours client X-Request-Id header.
         mcpHttpApp.UseMiddleware<Taskdeck.Api.Middleware.CorrelationIdMiddleware>();

--- a/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Security.Cryptography;
+using System.Text;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Data.Sqlite;
@@ -248,12 +249,96 @@ public class StandaloneMcpHostFilteringTests
     // spent) and the second — the same key, now over quota — is rejected with the per-key 429 by
     // ApiKeyMiddleware, before the endpoint. The pre-auth IP budget is raised out of the way so only
     // the per-key budget can reject (a valid key never spends the IP failure budget anyway).
+    //
+    // The first request is a well-formed `initialize` asserted to SUCCEED (#1602). Asserting only
+    // NotBe(401)/NotBe(429) let a bare 500 satisfy both, which is exactly how the missing-CORS-
+    // middleware defect stayed invisible in this class.
     [Fact]
     public async Task StandaloneMcpHttpHost_PerKeyBudget_RejectsOverQuotaValidKey()
     {
-        const string plaintextKey = "tdsk_standalone_perkey_000000000000000000";
+        await RunSeededApiKeyHostAsync(
+            "tdsk_standalone_perkey_000000000000000000",
+            perKeyPermitLimit: 1,
+            async client =>
+            {
+                using (var first = await PostMcpInitializeAsync(client))
+                {
+                    var firstBody = await first.Content.ReadAsStringAsync();
+                    first.StatusCode.Should().Be(HttpStatusCode.OK,
+                        "the first request is inside the per-key budget and must be SERVED by the MCP " +
+                        $"endpoint, not merely not-401/not-429; body was: {firstBody}");
+                }
+
+                using (var second = await client.PostAsync("/mcp", new StringContent("{}")))
+                {
+                    second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
+                        "the same key is now over its per-key budget and rejected by ApiKeyMiddleware");
+                    second.Headers.GetValues("X-RateLimit-Policy").Should().ContainSingle()
+                        .Which.Should().Be(RateLimitingPolicyNames.McpPerApiKey);
+                    second.Headers.TryGetValues("Retry-After", out _).Should().BeTrue();
+                }
+            });
+    }
+
+    // Regression proof for #1602: the standalone MCP HTTP host must be able to SERVE an MCP request,
+    // not only to reject the wrong ones. Every other test in this class stops at a middleware
+    // rejection (400/401/429) or a fail-fast exit, so none of them can observe endpoint execution --
+    // and the host 500'd on EVERY authenticated request because the mapped MCP endpoint carries CORS
+    // metadata (DisableCorsAttribute, McpEndpointMapping.cs) while the standalone pipeline registered
+    // no CORS middleware, so EndpointMiddleware threw before the endpoint ever ran.
+    //
+    // Discriminating by construction: it asserts 200 + a non-empty Mcp-Session-Id + an initialize
+    // RESULT in the body. Removing the UseCors/AddCors registration from the standalone branch in
+    // Program.cs turns this into a 500 with an empty body (verified in both directions).
+    [Fact]
+    public async Task StandaloneMcpHttpHost_ValidKey_ServesSuccessfulInitialize()
+    {
+        await RunSeededApiKeyHostAsync(
+            "tdsk_standalone_initialize_00000000000000",
+            // Well clear of the budget: this test must be able to fail only on endpoint execution.
+            perKeyPermitLimit: 1000,
+            async client =>
+            {
+                using var response = await PostMcpInitializeAsync(client);
+                var body = await response.Content.ReadAsStringAsync();
+
+                response.StatusCode.Should().Be(HttpStatusCode.OK,
+                    "an authenticated, well-formed initialize must be served by the standalone MCP " +
+                    $"host's endpoint (#1602); body was: {body}");
+                response.Headers.TryGetValues("Mcp-Session-Id", out var sessionValues).Should().BeTrue(
+                    "the standalone host pins Stateless=false, so initialize must mint a session id");
+                sessionValues!.Single().Should().NotBeNullOrWhiteSpace();
+                body.Should().Contain("\"protocolVersion\"",
+                    "the body must carry the MCP initialize RESULT, not an empty 500 body");
+
+                // The CORS middleware added for #1602 must grant NO cross-origin access. Same request
+                // with a hostile Origin -- the branch where CorsMiddleware actually evaluates a policy:
+                // it is served (the endpoint runs) but carries no Access-Control-* headers, so a
+                // browser cannot read the response. Registering a permissive policy fails this.
+                using var crossOrigin = await PostMcpInitializeAsync(client, origin: "https://evil.example");
+
+                crossOrigin.StatusCode.Should().Be(HttpStatusCode.OK,
+                    "an Origin header must not change server-side handling");
+                crossOrigin.Headers.Contains("Access-Control-Allow-Origin").Should().BeFalse(
+                    "the standalone MCP host registers CORS with no policy, so no origin is allowed");
+                crossOrigin.Headers.Contains("Access-Control-Allow-Credentials").Should().BeFalse(
+                    "no cross-origin credentials may be authorized on the MCP surface");
+            });
+    }
+
+    /// <summary>
+    /// Boots the real standalone MCP HTTP entry point with a per-key budget of
+    /// <paramref name="perKeyPermitLimit"/> permits / 300s, seeds <paramref name="plaintextKey"/>
+    /// into the host's database, runs <paramref name="assertions"/> against a single-connection
+    /// client presenting that key, then shuts the host down cleanly and restores the environment.
+    /// </summary>
+    private static async Task RunSeededApiKeyHostAsync(
+        string plaintextKey,
+        int perKeyPermitLimit,
+        Func<HttpClient, Task> assertions)
+    {
         var port = ReserveFreeLoopbackPort();
-        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-mcp-perkey-{Guid.NewGuid():N}.db");
+        var dbPath = Path.Combine(Path.GetTempPath(), $"taskdeck-mcp-seededkey-{Guid.NewGuid():N}.db");
         var envKeys = new[]
         {
             "ConnectionStrings__DefaultConnection",
@@ -283,8 +368,9 @@ public class StandaloneMcpHostFilteringTests
                 "Connectors__EncryptionKey", Convert.ToBase64String(RandomNumberGenerator.GetBytes(32)));
             Environment.SetEnvironmentVariable("AllowedHosts", null);
             Environment.SetEnvironmentVariable("RateLimiting__Enabled", "true");
-            // One request per key, long window: the second request from the same key is over quota.
-            Environment.SetEnvironmentVariable("RateLimiting__McpPerApiKey__PermitLimit", "1");
+            // Caller-chosen per-key budget, long window so it cannot replenish mid-test.
+            Environment.SetEnvironmentVariable(
+                "RateLimiting__McpPerApiKey__PermitLimit", perKeyPermitLimit.ToString());
             Environment.SetEnvironmentVariable("RateLimiting__McpPerApiKey__WindowSeconds", "300");
             // Raise the pre-auth IP failure budget out of the way — only the per-key budget must reject.
             Environment.SetEnvironmentVariable("RateLimiting__McpAuthenticationPerIp__PermitLimit", "1000");
@@ -323,26 +409,11 @@ public class StandaloneMcpHostFilteringTests
             // (same PRAGMAs the host uses) let this second connection write while the host is running.
             await SeedApiKeyAsync(dbPath, plaintextKey);
 
+            // Single client => single reused HTTP/1.1 connection => server-side request serialization.
             using (var client = new HttpClient { BaseAddress = new Uri($"http://127.0.0.1:{port}") })
             {
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", plaintextKey);
-
-                using (var first = await client.PostAsync("/mcp", new StringContent("{}")))
-                {
-                    first.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized,
-                        "a valid key must pass API-key authentication");
-                    first.StatusCode.Should().NotBe(HttpStatusCode.TooManyRequests,
-                        "the first request is within the per-key budget");
-                }
-
-                using (var second = await client.PostAsync("/mcp", new StringContent("{}")))
-                {
-                    second.StatusCode.Should().Be(HttpStatusCode.TooManyRequests,
-                        "the same key is now over its per-key budget and rejected by ApiKeyMiddleware");
-                    second.Headers.GetValues("X-RateLimit-Policy").Should().ContainSingle()
-                        .Which.Should().Be(RateLimitingPolicyNames.McpPerApiKey);
-                    second.Headers.TryGetValues("Retry-After", out _).Should().BeTrue();
-                }
+                await assertions(client);
             }
 
             await app.StopAsync();
@@ -583,6 +654,33 @@ public class StandaloneMcpHostFilteringTests
     {
         await task;
         return 0;
+    }
+
+    /// <summary>
+    /// POSTs a well-formed JSON-RPC <c>initialize</c> to <c>/mcp</c> with the Accept pair the
+    /// Streamable HTTP transport requires (<c>application/json</c> + <c>text/event-stream</c>),
+    /// mirroring the co-hosted handshake in <c>McpHttpTransportApiKeyTests</c>. The caller supplies
+    /// the Authorization header on the client. An <paramref name="origin"/> makes it a cross-origin
+    /// request, which is the branch where CORS middleware evaluates a policy.
+    /// </summary>
+    private static async Task<HttpResponseMessage> PostMcpInitializeAsync(HttpClient client, string? origin = null)
+    {
+        const string initializeRequest = """
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"Taskdeck.Api.Tests","version":"1.0"}}}
+            """;
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = new StringContent(initializeRequest, Encoding.UTF8, "application/json")
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        if (origin is not null)
+        {
+            request.Headers.Add("Origin", origin);
+        }
+
+        return await client.SendAsync(request);
     }
 
     private static async Task<HttpResponseMessage> SendForwardedMcpAsync(HttpClient client, string forwardedFor)

--- a/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/StandaloneMcpHostFilteringTests.cs
@@ -312,15 +312,20 @@ public class StandaloneMcpHostFilteringTests
                     "the body must carry the MCP initialize RESULT, not an empty 500 body");
 
                 // The CORS middleware added for #1602 must grant NO cross-origin access. Same request
-                // with a hostile Origin -- the branch where CorsMiddleware actually evaluates a policy:
-                // it is served (the endpoint runs) but carries no Access-Control-* headers, so a
-                // browser cannot read the response. Registering a permissive policy fails this.
+                // with a hostile Origin: it is served (the endpoint runs) but carries no
+                // Access-Control-* headers, so a browser cannot read the response. What this assertion
+                // actually guards is the DisableCorsAttribute latch on the MCP endpoint --
+                // CorsMiddleware sees IDisableCorsAttribute and never evaluates ANY policy, permissive
+                // or not (the co-hosted host behaves identically for an ALLOWED origin, see
+                // McpHttpTransportApiKeyTests). It would fail if a RequireCors/EnableCors were ever
+                // stamped after the latch. The empty policy map is a second, independent latch that
+                // this assertion cannot see through the first one.
                 using var crossOrigin = await PostMcpInitializeAsync(client, origin: "https://evil.example");
 
                 crossOrigin.StatusCode.Should().Be(HttpStatusCode.OK,
                     "an Origin header must not change server-side handling");
                 crossOrigin.Headers.Contains("Access-Control-Allow-Origin").Should().BeFalse(
-                    "the standalone MCP host registers CORS with no policy, so no origin is allowed");
+                    "the MCP endpoint carries DisableCorsAttribute, so no origin may ever be allowed");
                 crossOrigin.Headers.Contains("Access-Control-Allow-Credentials").Should().BeFalse(
                     "no cross-origin credentials may be authorized on the MCP surface");
             });


### PR DESCRIPTION
﻿## Problem

`taskdeck --mcp --transport http` returned **HTTP 500 with an empty body on every authenticated MCP request**. Authentication succeeded (the failing log line carries a resolved `UserId`); the request died at endpoint execution.

Where the CORS metadata comes from — the first thing #1602 asked to establish — is **our own code, not the MCP SDK**:

`backend/src/Taskdeck.Api/Extensions/McpEndpointMapping.cs:22`
```csharp
mcpEndpoint.WithMetadata(new DisableCorsAttribute());
```

`DisableCorsAttribute` implements `IDisableCorsAttribute : ICorsMetadata`, and that is exactly what `EndpointMiddleware` checks: an endpoint carrying `ICorsMetadata` will not be executed unless the CORS middleware ran first and set its marker in `HttpContext.Items`. The standalone branch of `Program.cs` never registered CORS, so `ThrowMissingCorsMiddlewareException` fired before the endpoint. The co-hosted pipeline calls `UseCors("AllowFrontend")` (`PipelineConfiguration.cs:64`) and was unaffected.

## Fix

Option 1 from the issue. Two lines in the standalone `--mcp --transport http` branch only:

- `mcpHttpBuilder.Services.AddCors();` — registers the CORS services with an **empty policy map**. Deliberately *not* `AddTaskdeckCors`, which would bring the credentialed `AllowFrontend` policy.
- `mcpHttpApp.UseCors();` — parameterless, so it resolves the default policy name, finds nothing, and passes through. Placed to mirror the co-hosted order (forwarded headers → CORS → correlation ID).

No default policy exists to resolve, so `CorsMiddleware` never emits an `Access-Control-*` header; the endpoint's own `DisableCorsAttribute` suppresses CORS handling for it regardless. The middleware exists purely to satisfy the endpoint-metadata contract.

### Why not option 3 (strip the metadata in standalone mode)

I investigated it as invited, and rejected it as *not* strictly cleaner:

1. `MapTaskdeckMcpEndpoint` exists specifically to map the endpoint **identically** for both hosts. Parameterizing it to diverge weakens the one thing it guarantees.
2. `DisableCorsAttribute` is a defence-in-depth latch: if the standalone pipeline ever gains a CORS policy, the metadata keeps the MCP endpoint out of it. Dropping the attribute in standalone removes that latch permanently, and silently.

The co-hosted pipeline's CORS behaviour is untouched.

## Named assumption (ratified)

> Assumption: the standalone MCP host registers CORS middleware with a deny-by-default policy (no allowed origins) purely to satisfy the endpoint's CORS metadata; browser-origin MCP clients remain unsupported and any relaxation is a future explicit config decision. Reversible by replacing the policy. Reason: restores endpoint execution with zero loosening of posture.

Implemented exactly as stated — no adaptation needed.

## Verification

All runs foreground, `-c Release -m:1`, on this box.

| Command | Result |
| --- | --- |
| `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~StandaloneMcpHost"` | **25 passed / 0 failed**, 5s |
| `... --filter "FullyQualifiedName~Mcp\|FullyQualifiedName~Cors"` | **173 passed / 0 failed**, 1m21s |
| `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1` (whole project) | **2206 passed / 0 failed / 4 skipped**, 7m02s |

The 4 skips are pre-existing `LlmQuota*ConcurrencyTests` skips, unrelated to this change.

### Mutation check — both directions

The test code was **identical** in both runs; only the `Program.cs` fix differed.

- **Without the fix** (tests added, `Program.cs` untouched): `Failed: 2, Passed: 23, Total: 25`. Both failures were exactly the documented defect —
  `Expected response.StatusCode to be HttpStatusCode.OK {value: 200} ... body was: , but found HttpStatusCode.InternalServerError {value: 500}` — note the **empty body**, matching the issue's report.
- **With the fix**: `Failed: 0, Passed: 25, Total: 25`.

So the new assertions fail for the right reason and pass only because of the change.

### Test changes (all in `StandaloneMcpHostFilteringTests.cs`)

- **New** `StandaloneMcpHttpHost_ValidKey_ServesSuccessfulInitialize` — boots the real entry point, seeds a valid API key, POSTs a well-formed JSON-RPC `initialize` (`protocolVersion` `2025-11-25`, `Accept: application/json` + `text/event-stream`) and asserts **200**, a non-empty `Mcp-Session-Id`, and an initialize *result* in the body — not merely not-401.
- **Cross-origin denial (issue AC 5)**: the same request is re-sent with `Origin: https://evil.example` — the branch where `CorsMiddleware` actually evaluates a policy — asserting the response carries **no** `Access-Control-Allow-Origin` and **no** `Access-Control-Allow-Credentials`. A permissive policy would fail this. Cross-origin browser access is therefore proven closed by test, not just by comment.
- **Tightened** `StandaloneMcpHttpHost_PerKeyBudget_RejectsOverQuotaValidKey` (issue AC 4): its first request is now a real `initialize` asserted to be **200** instead of `NotBe(401)`/`NotBe(429)` — the pair a 500 satisfied.
- The two duplicated host-boot blocks are folded into one `RunSeededApiKeyHostAsync(plaintextKey, perKeyPermitLimit, assertions)` helper, so the file has two boot harnesses rather than three.

## Residual risk

- **Preflight `OPTIONS` is not covered.** *(Corrected after review — the original text here inverted the order.)* `UseCors()` runs **before** `ApiKeyMiddleware` in the standalone pipeline (Program.cs:184 vs :208, mirroring the co-hosted host where `UseCors` at PipelineConfiguration.cs:64 is likewise pre-auth). On the `DisableCorsAttribute` endpoint, `CorsMiddleware` short-circuits a browser preflight (OPTIONS + `Access-Control-Request-Method`) with an empty **204 and no `Access-Control-Allow-Origin`**, so the browser's preflight fails and no cross-origin request proceeds — the same posture as the co-hosted host. Consequences: an unauthenticated preflight is answered 204 (not 401) without touching `ApiKeyMiddleware`, the pre-auth failure limiter, telemetry, or correlation — negligible on a loopback host returning an empty response — and preflight behaviour is asserted nowhere (tracked follow-up).
- The `Mcp-Session-Id` assertion depends on `Stateless = false`, pinned just above the fix in `Program.cs`. If that pin is ever flipped, this test fails loudly — which is the desired coupling, but worth knowing it is deliberate.
- Verified in-process via the real assembly entry point, as the existing tests in this class do. **Not** verified against a separately launched `taskdeck.exe --mcp --transport http` process or a real MCP client (Claude Code / Cursor over HTTP).
- The stdio transport is untouched and was not re-verified.
- No docs were updated: `docs/STATUS.md`, `docs/IMPLEMENTATION_MASTERPLAN.md`, `docs/TESTING_GUIDE.md` and `OUTSTANDING_TASKS.md` are outside this task's ownership. A STATUS line noting the standalone HTTP host is now functional may be worth a follow-up.

## Worktree teardown

Branch is pushed; the worktree is spent and ready for the coordinator to `git worktree remove` (plain, never `--force`). `git status --porcelain --ignored` showed no work product to rescue — the only non-build ignored file is `.claude/settings.local.json`, a per-worktree permissions cache. Nothing was copied out.

Closes #1602

