### PR TITLE
Release a shutdown-abandoned queue claim instead of charging it a retry

### DIFF
--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -695,23 +695,70 @@ public class LlmQueueToProposalWorker : BackgroundService
         }
 
         var backoff = TimeSpan.FromSeconds(GetRetryBackoffSeconds(item.RetryCount));
-        if (backoff > TimeSpan.Zero)
+        try
         {
-            await Task.Delay(backoff, ct);
-        }
+            if (backoff > TimeSpan.Zero)
+            {
+                await Task.Delay(backoff, ct);
+            }
 
-        item.ResetForRetry();
-        if (retryAsProcessing)
-        {
-            item.MarkAsProcessing();
+            ApplyRetryTransition(item, retryAsProcessing);
+            await unitOfWork.SaveChangesAsync(ct);
         }
-        await unitOfWork.SaveChangesAsync(ct);
+        // The Failed row above is ALREADY COMMITTED, so abandoning the requeue here strands it forever
+        // (#1605): the recovery sweep only scans Processing (GetStuckProcessingNonCaptureAsync), and
+        // nothing else re-enqueues a Failed row. Cancellation can land either in the backoff wait or in
+        // the write itself, so both are inside this guard. Finish the transition with
+        // CancellationToken.None -- the retry was already decided and the budget already charged above;
+        // only the waiting is being cut short, and the shutdown must not change the outcome.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            try
+            {
+                ApplyRetryTransition(item, retryAsProcessing);
+                await unitOfWork.SaveChangesAsync(CancellationToken.None);
+                _logger.LogInformation(
+                    "Queue item {ItemId} requeued for retry attempt {RetryCount} during shutdown",
+                    item.Id,
+                    item.RetryCount + 1);
+            }
+            catch (Exception ex)
+            {
+                // Same reasoning as ReleaseClaimOnShutdownAsync: never mask the cancellation. The row is
+                // left Failed, which is the pre-#1605 outcome for this window.
+                _logger.LogWarning(
+                    "Failed to requeue queue item {ItemId} during shutdown; it stays Failed. {ExceptionSummary}",
+                    item.Id,
+                    SensitiveDataRedactor.SummarizeException(ex));
+            }
+
+            throw;
+        }
 
         _logger.LogInformation(
             "Queue item {ItemId} scheduled for retry attempt {RetryCount}",
             item.Id,
             item.RetryCount + 1);
         return true;
+    }
+
+    /// <summary>
+    /// Moves a just-failed request into its retry state: back to Pending, and on to Processing for the
+    /// capture lane, which reads its queue from Processing. Written to be safe to call twice — the
+    /// shutdown path re-runs it after a write that may have already applied the in-memory transition
+    /// before throwing, and ResetForRetry/MarkAsProcessing both throw outside their source status.
+    /// </summary>
+    private static void ApplyRetryTransition(LlmRequest item, bool retryAsProcessing)
+    {
+        if (item.Status == RequestStatus.Failed)
+        {
+            item.ResetForRetry();
+        }
+
+        if (retryAsProcessing && item.Status == RequestStatus.Pending)
+        {
+            item.MarkAsProcessing();
+        }
     }
 
     private bool IsTransientFailure(string? errorCode)

--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -364,10 +364,10 @@ public class LlmQueueToProposalWorker : BackgroundService
         // Shutdown or caller cancellation is not a processing failure. Without this the
         // planner's rethrow is caught below and converted straight back into an
         // UnexpectedError, which IsTransientFailure treats as retryable — so the item would be
-        // marked Failed and requeued purely because the host was stopping. Leave it in its
-        // current state and let the claim expire.
+        // marked Failed and requeued purely because the host was stopping.
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
+            await ReleaseClaimOnShutdownAsync(unitOfWork, item);
             throw;
         }
         catch (Exception ex)
@@ -386,6 +386,55 @@ public class LlmQueueToProposalWorker : BackgroundService
             outcome = scheduledForRetry ? "failed_retry" : "failed_unhandled";
             stopWatch.Stop();
             RecordWorkerProcessingMetrics(stopWatch.Elapsed.TotalMilliseconds, outcome);
+        }
+    }
+
+    /// <summary>
+    /// Returns a claim abandoned by a graceful shutdown to Pending so the stop does not cost the request
+    /// a retry (#1605). Left in Processing, the row is indistinguishable from a crashed attempt: the next
+    /// run's <see cref="RecoverStuckProcessingItemsAsync"/> finds no proposal for it and charges the
+    /// budget (MarkAsFailed, RetryCount++), so enough restarts fail a healthy request permanently at
+    /// MaxRetries — and it waits out the processing lease before retrying either way. Releasing it
+    /// charges nothing and makes it eligible again on the very next tick. A genuine crash never reaches
+    /// this path, so the sweep's retry accounting (the poison-pill guard) is untouched.
+    /// </summary>
+    /// <remarks>
+    /// Non-capture (proposal) lane only. Capture-triage and transcript rows are READ from Processing, so
+    /// Processing already is their queued state and returning one to Pending would drop it back to
+    /// "untriaged in the inbox" — the wrong state, and one no worker drains.
+    /// </remarks>
+    private async Task ReleaseClaimOnShutdownAsync(IUnitOfWork unitOfWork, LlmRequest item)
+    {
+        // The failure path may already have moved the row on (Failed, or Pending/Processing once
+        // HandleFailureWithRetryAsync completed its own interrupted transition); only a still-claimed row
+        // is ours to release.
+        if (item.Status != RequestStatus.Processing)
+        {
+            return;
+        }
+
+        try
+        {
+            item.ReleaseClaim();
+            // CancellationToken.None: ct is already cancelled, and forwarding it would throw before the
+            // release could commit — leaving exactly the stale-Processing row this exists to avoid. Same
+            // deliberate shutdown-write idiom as AgentRuntime and OutboundWebhookDeliveryWorker's own
+            // ReturnToPending. It is one single-row UPDATE on an open connection (SQLite, local file,
+            // busy_timeout pragma bounds lock waits), so it cannot meaningfully delay shutdown.
+            await unitOfWork.SaveChangesAsync(CancellationToken.None);
+            _logger.LogInformation(
+                "Queue item {ItemId} released back to Pending during shutdown; no retry charged",
+                item.Id);
+        }
+        catch (Exception ex)
+        {
+            // Never let the release write mask the cancellation: log and return so the
+            // OperationCanceledException still propagates and the worker still stops promptly. The row
+            // then simply stays Processing and the recovery sweep handles it as it did before #1605.
+            _logger.LogWarning(
+                "Failed to release queue item {ItemId} during shutdown; it stays Processing for the recovery sweep. {ExceptionSummary}",
+                item.Id,
+                SensitiveDataRedactor.SummarizeException(ex));
         }
     }
 
@@ -531,6 +580,10 @@ public class LlmQueueToProposalWorker : BackgroundService
         // Same discrimination as the proposal lane. CaptureTriageService already rethrows
         // caller cancellation rather than returning an outcome, so without this guard the
         // worker converts that rethrow straight back into a retryable UnexpectedError.
+        // No ReleaseClaimOnShutdownAsync here, deliberately: capture rows are read from
+        // Processing, so an abandoned capture claim is already in its queued state and the next
+        // tick re-claims it with no retry charged. Returning it to Pending would instead mean
+        // "untriaged in the inbox", which no worker drains (see that method's remarks).
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;

--- a/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
+++ b/backend/src/Taskdeck.Api/Workers/LlmQueueToProposalWorker.cs
@@ -419,8 +419,11 @@ public class LlmQueueToProposalWorker : BackgroundService
             // CancellationToken.None: ct is already cancelled, and forwarding it would throw before the
             // release could commit — leaving exactly the stale-Processing row this exists to avoid. Same
             // deliberate shutdown-write idiom as AgentRuntime and OutboundWebhookDeliveryWorker's own
-            // ReturnToPending. It is one single-row UPDATE on an open connection (SQLite, local file,
-            // busy_timeout pragma bounds lock waits), so it cannot meaningfully delay shutdown.
+            // ReturnToPending. Not a single-row write: IUnitOfWork shares this scope's DbContext with the
+            // planner, so the flush commits everything the scope still tracks -- e.g. a proposal graph
+            // left Added when cancellation hit CreateProposalAsync's own save. Deliberate and benign:
+            // that graph is complete (AddAsync on client-generated GUID keys makes no cancellable
+            // round-trip), and the restart's idempotency guard above then completes the item off it.
             await unitOfWork.SaveChangesAsync(CancellationToken.None);
             _logger.LogInformation(
                 "Queue item {ItemId} released back to Pending during shutdown; no retry charged",
@@ -710,7 +713,10 @@ public class LlmQueueToProposalWorker : BackgroundService
         // nothing else re-enqueues a Failed row. Cancellation can land either in the backoff wait or in
         // the write itself, so both are inside this guard. Finish the transition with
         // CancellationToken.None -- the retry was already decided and the budget already charged above;
-        // only the waiting is being cut short, and the shutdown must not change the outcome.
+        // only the waiting is being cut short, and the shutdown must not change the outcome. As in
+        // ReleaseClaimOnShutdownAsync, that flush is not scoped to this row: the scope's DbContext is
+        // shared, so it commits whatever else the scope still tracks. Benign for the same reason -- any
+        // such graph is complete, and the restart's idempotency guard completes the item off it.
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             try

--- a/backend/src/Taskdeck.Domain/Entities/LlmRequest.cs
+++ b/backend/src/Taskdeck.Domain/Entities/LlmRequest.cs
@@ -126,6 +126,27 @@ public class LlmRequest : Entity
         Touch();
     }
 
+    /// <summary>
+    /// Returns a claimed (Processing) request to Pending WITHOUT charging the retry budget, for a
+    /// claim abandoned by a graceful shutdown rather than by a failure (#1605). Deliberately distinct
+    /// from <see cref="MarkAsFailed"/> + <see cref="ResetForRetry"/>, which increments
+    /// <see cref="RetryCount"/> and is the failure/crash path: nothing about this attempt failed, so
+    /// charging it would let enough restarts exhaust a healthy request's budget. Mirrors
+    /// <c>OutboundWebhookDelivery.ReturnToPending</c>, which the webhook worker uses for the same
+    /// shutdown case. ErrorMessage/ProcessedAt are left untouched: a Processing row was claimed from
+    /// Pending, where ResetForRetry has already cleared both.
+    /// </summary>
+    public void ReleaseClaim()
+    {
+        if (Status != RequestStatus.Processing)
+            throw new DomainException(
+                ErrorCodes.ValidationError,
+                "Can only release the claim on a processing request");
+
+        Status = RequestStatus.Pending;
+        Touch();
+    }
+
     public void UpdatePayload(string payload)
     {
         if (string.IsNullOrWhiteSpace(payload))

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -90,11 +90,13 @@ public class LlmQueueToProposalWorkerTests
         FakeLlmQueueRepository queueRepo,
         FakeAutomationPlannerService? planner = null,
         FakeCaptureTriageService? triageService = null,
-        IAutomationProposalRepository? automationProposals = null)
+        IAutomationProposalRepository? automationProposals = null,
+        FakeUnitOfWork? unitOfWork = null)
     {
         var services = new ServiceCollection();
-        var unitOfWork = new FakeUnitOfWork(queueRepo, automationProposals);
-        services.AddSingleton<IUnitOfWork>(unitOfWork);
+        // Tests that need to observe or drive the writes (which token, cancel between saves) build the
+        // unit of work themselves and pass it in; everyone else gets a default one.
+        services.AddSingleton<IUnitOfWork>(unitOfWork ?? new FakeUnitOfWork(queueRepo, automationProposals));
         services.AddSingleton<IAutomationPlannerService>(planner ?? new FakeAutomationPlannerService());
         services.AddSingleton<ICaptureTriageService>(triageService ?? new FakeCaptureTriageService());
         return services.BuildServiceProvider();
@@ -234,8 +236,73 @@ public class LlmQueueToProposalWorkerTests
     }
 
     [Fact]
-    public async Task ProcessBatch_ProposalLaneCallerCancellation_PropagatesAndLeavesItemProcessing()
+    public async Task ProcessBatch_ProposalLaneCallerCancellation_PropagatesAndReleasesClaim()
     {
+        var item = CreatePendingItem();
+        var queueRepo = new FakeLlmQueueRepository([item]);
+        using var cts = new CancellationTokenSource();
+        var planner = new FakeAutomationPlannerService
+        {
+            // Cancel from INSIDE the planner call, never before ProcessBatchAsync: the per-item
+            // Task.Run(body, ct) never invokes its body when ct is already cancelled, which would make
+            // this test vacuous (the worker would never claim the item at all).
+            ResultFactory = _ =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            }
+        };
+        using var sp = BuildServiceProvider(queueRepo, planner);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(retryBackoff: [0]));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeProcessBatchAsync(worker, cts.Token));
+
+        // #1605: a graceful shutdown is not a failed attempt. The claim is released so the next tick
+        // picks the item straight back up, instead of the recovery sweep charging a retry for it after
+        // the processing lease expires.
+        item.Status.Should().Be(RequestStatus.Pending);
+        item.RetryCount.Should().Be(0, "a shutdown mid-item must not consume the retry budget");
+    }
+
+    [Fact]
+    public async Task ProcessBatch_ProposalLaneCallerCancellation_ReleaseWriteUsesUncancelledToken()
+    {
+        // The release is a DB write on the shutdown path: forwarding the caller's cancelled token would
+        // throw before committing and leave exactly the stale Processing row the release exists to
+        // avoid. Only the token proves that -- the status assertion above passes either way, because a
+        // fake has no separate persisted state to diverge from the in-memory entity.
+        var item = CreatePendingItem();
+        var queueRepo = new FakeLlmQueueRepository([item]);
+        var unitOfWork = new FakeUnitOfWork(queueRepo);
+        using var cts = new CancellationTokenSource();
+        var planner = new FakeAutomationPlannerService
+        {
+            ResultFactory = _ =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            }
+        };
+        using var sp = BuildServiceProvider(queueRepo, planner, unitOfWork: unitOfWork);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(retryBackoff: [0]));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeProcessBatchAsync(worker, cts.Token));
+
+        unitOfWork.SaveChangesTokens.Should().ContainSingle("the release is the only write on this path");
+        unitOfWork.SaveChangesTokens[0].IsCancellationRequested.Should().BeFalse(
+            "the release must be persisted with CancellationToken.None, not the cancelled caller token");
+    }
+
+    [Fact]
+    public async Task ProcessBatch_ItemReleasedByShutdown_IsProcessedOnRestartWithFullRetryBudget()
+    {
+        // End-to-end acceptance (#1605): shut down mid-item, then "restart" (a fresh batch on an
+        // uncancelled token) and confirm the item is drained on that very tick with its budget intact --
+        // no lease wait, no retry charged.
         var item = CreatePendingItem();
         var queueRepo = new FakeLlmQueueRepository([item]);
         using var cts = new CancellationTokenSource();
@@ -254,9 +321,11 @@ public class LlmQueueToProposalWorkerTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
             () => InvokeProcessBatchAsync(worker, cts.Token));
 
-        // Discriminating assertion: without the worker cancellation guard, the generic
-        // failure path resets this item to Pending for retry.
-        item.Status.Should().Be(RequestStatus.Processing);
+        planner.ResultFactory = null; // the restarted worker's planner succeeds
+        await InvokeProcessBatchAsync(worker, CancellationToken.None);
+
+        item.Status.Should().Be(RequestStatus.Completed);
+        item.RetryCount.Should().Be(0, "the shutdown cost the item nothing");
     }
 
     #endregion
@@ -1290,8 +1359,24 @@ public class LlmQueueToProposalWorkerTests
         public ITomorrowNoteRepository TomorrowNotes => null!;
         public IMcpToolHashRepository McpToolHashes => null!;
 
+        /// <summary>
+        /// Every token the worker passed to <see cref="SaveChangesAsync"/>, in call order. The
+        /// shutdown-path writes (#1605) MUST use an uncancelled token: with the caller's cancelled token
+        /// EF Core throws before committing, which is precisely the stale row those writes exist to
+        /// avoid. Asserting the token is the only way to see that from a fake.
+        /// </summary>
+        public List<CancellationToken> SaveChangesTokens { get; } = [];
+
+        /// <summary>Invoked after each SaveChangesAsync is recorded, so a test can cancel between writes.</summary>
+        public Action<int>? OnSaveChanges { get; set; }
+
         public Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
         {
+            SaveChangesTokens.Add(cancellationToken);
+            // EF Core's SaveChangesAsync throws on an already-cancelled token; model that, or a
+            // shutdown-path write that forwards the cancelled token would silently pass here.
+            cancellationToken.ThrowIfCancellationRequested();
+            OnSaveChanges?.Invoke(SaveChangesTokens.Count);
             return Task.FromResult(0);
         }
 

--- a/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/LlmQueueToProposalWorkerTests.cs
@@ -444,6 +444,82 @@ public class LlmQueueToProposalWorkerTests
 
     #endregion
 
+    #region Shutdown during the retry backoff (#1605)
+
+    [Fact]
+    public async Task ProcessBatch_CancellationDuringRetryBackoff_PersistsTheRequeueInsteadOfStrandingFailed()
+    {
+        // #1605 (second gap): MarkAsFailed is committed BEFORE the backoff wait. If cancellation lands in
+        // that wait, the row is left persisted as Failed -- and the recovery sweep only scans Processing,
+        // so nothing ever picks it up again. The requeue must therefore complete on the shutdown path.
+        var item = CreatePendingItem();
+        var queueRepo = new FakeLlmQueueRepository([item]);
+        var unitOfWork = new FakeUnitOfWork(queueRepo);
+        using var cts = new CancellationTokenSource();
+        // Cancel from inside the FIRST write (the MarkAsFailed commit) so cancellation lands squarely in
+        // the backoff wait that follows -- deterministic, unlike a timer race, and it keeps the token
+        // uncancelled at Task.Run time so the item is really claimed and processed.
+        unitOfWork.OnSaveChanges = saveNumber =>
+        {
+            if (saveNumber == 1)
+            {
+                cts.Cancel();
+            }
+        };
+        var planner = new FakeAutomationPlannerService
+        {
+            ResultFactory = _ => Result.Failure<ProposalDto>(ErrorCodes.UnexpectedError, "transient failure")
+        };
+        using var sp = BuildServiceProvider(queueRepo, planner, unitOfWork: unitOfWork);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(maxRetries: 3, retryBackoff: [5]));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeProcessBatchAsync(worker, cts.Token));
+
+        item.Status.Should().Be(RequestStatus.Pending, "the interrupted retry transition is completed, not abandoned mid-way");
+        item.RetryCount.Should().Be(1, "the failure itself was genuine, so it still costs a retry");
+        unitOfWork.SaveChangesTokens.Should().HaveCount(2, "the MarkAsFailed commit and the requeue commit");
+        unitOfWork.SaveChangesTokens[1].IsCancellationRequested.Should().BeFalse(
+            "the requeue must be persisted with CancellationToken.None; the caller token is already cancelled");
+    }
+
+    [Fact]
+    public async Task ProcessBatch_CaptureLaneCancellationDuringRetryBackoff_RequeuesAsProcessing()
+    {
+        // Same window on the capture lane, where the retry state is Processing (retryAsProcessing: true).
+        // Leaving a capture row Pending would be just as stranded: the capture lane reads Processing.
+        var item = CreateCaptureTriageItem();
+        var queueRepo = new FakeLlmQueueRepository([], [item]);
+        var unitOfWork = new FakeUnitOfWork(queueRepo);
+        using var cts = new CancellationTokenSource();
+        unitOfWork.OnSaveChanges = saveNumber =>
+        {
+            if (saveNumber == 1)
+            {
+                cts.Cancel();
+            }
+        };
+        var triageService = new FakeCaptureTriageService
+        {
+            ResultFactory = (_, _, _, _, _) =>
+                Result.Failure<CaptureTriageProposalResultDto>(ErrorCodes.UnexpectedError, "transient failure")
+        };
+        using var sp = BuildServiceProvider(queueRepo, triageService: triageService, unitOfWork: unitOfWork);
+        var worker = CreateWorker(sp.GetRequiredService<IServiceScopeFactory>(),
+            DefaultSettings(maxRetries: 3, retryBackoff: [5]));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => InvokeProcessBatchAsync(worker, cts.Token));
+
+        item.Status.Should().Be(RequestStatus.Processing, "the capture lane re-reads its queue from Processing");
+        item.RetryCount.Should().Be(1);
+        unitOfWork.SaveChangesTokens.Should().HaveCount(2);
+        unitOfWork.SaveChangesTokens[1].IsCancellationRequested.Should().BeFalse();
+    }
+
+    #endregion
+
     #region Disabled processing
 
     [Fact]

--- a/backend/tests/Taskdeck.Domain.Tests/Entities/LlmRequestTests.cs
+++ b/backend/tests/Taskdeck.Domain.Tests/Entities/LlmRequestTests.cs
@@ -145,6 +145,65 @@ public class LlmRequestTests
     }
 
     [Fact]
+    public void ReleaseClaim_ShouldReturnToPending_WithoutChargingRetryBudget()
+    {
+        // #1605: a claim abandoned by a graceful shutdown is not a failed attempt, so the request goes
+        // back on the queue with its retry budget intact -- unlike MarkAsFailed + ResetForRetry.
+        var request = new LlmRequest(Guid.NewGuid(), "transcript", "payload");
+        request.MarkAsProcessing();
+
+        request.ReleaseClaim();
+
+        request.Status.Should().Be(RequestStatus.Pending);
+        request.RetryCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void ReleaseClaim_ShouldPreserveAnAlreadyConsumedRetryBudget()
+    {
+        // A request on its second attempt keeps the retry it already spent: releasing a claim neither
+        // charges nor refunds.
+        var request = new LlmRequest(Guid.NewGuid(), "transcript", "payload");
+        request.MarkAsProcessing();
+        request.MarkAsFailed("Temporary error");
+        request.ResetForRetry();
+        request.MarkAsProcessing();
+
+        request.ReleaseClaim();
+
+        request.Status.Should().Be(RequestStatus.Pending);
+        request.RetryCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(RequestStatus.Pending)]
+    [InlineData(RequestStatus.Completed)]
+    [InlineData(RequestStatus.Failed)]
+    public void ReleaseClaim_ShouldThrow_WhenRequestIsNotProcessing(RequestStatus status)
+    {
+        var request = new LlmRequest(Guid.NewGuid(), "transcript", "payload");
+        switch (status)
+        {
+            case RequestStatus.Completed:
+                request.MarkAsProcessing();
+                request.MarkAsCompleted();
+                break;
+            case RequestStatus.Failed:
+                request.MarkAsProcessing();
+                request.MarkAsFailed("error");
+                break;
+        }
+
+        request.Status.Should().Be(status);
+
+        var act = () => request.ReleaseClaim();
+
+        act.Should().Throw<DomainException>()
+            .WithMessage("Can only release the claim on a processing request")
+            .Where(e => e.ErrorCode == ErrorCodes.ValidationError);
+    }
+
+    [Fact]
     public void MarkAsFailed_ShouldThrow_WhenRequestIsCompleted()
     {
         // Arrange


### PR DESCRIPTION
Closes #1605.

## Problem

Two windows in `LlmQueueToProposalWorker` where cancellation interrupts a multi-step state
transition and leaves the row in a state the recovery sweep cannot correct. Both pre-existing;
both are the same underlying shape.

**1. A graceful shutdown consumes a retry.** When the host stops after the proposal lane claimed an
item but before its proposal exists, the row is left `Processing`. The next run's
`RecoverStuckProcessingItemsAsync` finds no proposal and treats it as a crash:
`MarkAsFailed` (RetryCount++) then, if budget remains, `ResetForRetry`. So a clean restart is
indistinguishable from a crash — enough restarts fail a perfectly healthy request permanently at
`MaxRetries`, and the row waits out the processing lease before retrying either way.

**2. A row can be stranded in `Failed` forever** (the second gap, from the independent review of
#1603, recorded as finding 1 in the comment on #1605; source thread:
https://github.com/Chris0Jeky/Taskdeck/pull/1603#issuecomment-5222299513).
`HandleFailureWithRetryAsync` commits `MarkAsFailed`, waits out the retry backoff, then requeues.
If cancellation lands in that window — `Task.Delay(backoff, ct)`, or the requeue's own
`SaveChangesAsync(ct)` — the requeue never happens. `GetStuckProcessingNonCaptureAsync` only scans
`Processing`, and nothing else re-enqueues a `Failed` row, so the item is gone: not retried, not
surfaced.

Both are fixed here because they are one defect wearing two hats — a state transition that is not
atomic under cancellation — and fixing only the first leaves the second live (it is also the one
the issue comment calls "worse than the retry-budget issue this issue was opened for").

## Fix

Issue option 1, plus the same idiom applied to the second window.

- **`LlmRequest.ReleaseClaim()`** (new domain transition): `Processing -> Pending` **without**
  touching `RetryCount`. The only such transition available before was `MarkAsFailed` +
  `ResetForRetry`, which charges the budget. Mirrors `OutboundWebhookDelivery.ReturnToPending`,
  which the webhook worker already uses for exactly this shutdown case.
- **Proposal lane** — the `catch (OperationCanceledException) when (ct.IsCancellationRequested)`
  guard now releases the claim before rethrowing, persisted with `CancellationToken.None` (the
  caller's token is already cancelled and would throw before committing — leaving the very stale
  row the release exists to avoid). Same deliberate shutdown-write idiom as `AgentRuntime` and
  `OutboundWebhookDeliveryWorker`.
- **Capture lane deliberately unchanged**, with a comment saying so: capture and transcript rows are
  *read* from `Processing`, so that already is their queued state and the next tick re-claims them
  with nothing charged. Returning one to `Pending` would mean "untriaged in the inbox" — a state no
  worker drains. The bug is specific to the one lane read solely from `Pending`.
- **`HandleFailureWithRetryAsync`** — the backoff wait and the requeue write are wrapped in one
  cancellation guard that completes the transition with `CancellationToken.None` and then rethrows.
  The retry was already decided and its budget already charged by the committed `MarkAsFailed`;
  only the *waiting* is cut short, so the shutdown must not change the outcome.
  `ApplyRetryTransition` is status-guarded and safe to call twice, because the normal path may
  already have applied the in-memory transition before its write threw.
- Both shutdown writes are wrapped so a write failure **logs and falls through**, never masking the
  `OperationCanceledException` — the worker still stops promptly and the row falls back to exactly
  its pre-#1605 handling.

Crash accounting is untouched: a genuine crash never reaches these handlers, so
`RecoverStuckProcessingItemsAsync` still charges the budget and still fails a poison-pill payload
permanently at `MaxRetries`.

### Scope of the shutdown flush (corrected after review)

Both shutdown writes call `SaveChangesAsync(CancellationToken.None)`, and both code comments now
state what that actually does. `IUnitOfWork` is scoped and shares one `TaskdeckDbContext` with the
scoped planner and proposal services, so the write is **not** a single-row UPDATE: it flushes the
entire change tracker. If cancellation landed inside `CreateProposalAsync`'s own save, the `Added`
proposal graph is still tracked, and the release write commits it as a side effect.

That side effect is deliberate and benign. The graph is complete — `AddAsync` on client-generated
GUID keys performs no cancellable database round-trip — and on restart the idempotency guard
(`GetBySourceReferenceAsync` on `ProposalSourceType.Queue`) finds that proposal and completes the
item instead of reprocessing it, which is exactly the path that guard exists to serve. An earlier
revision of these comments claimed the write was "one single-row UPDATE ... so it cannot
meaningfully delay shutdown"; that mechanism was false and has been replaced.

## Verification

All foreground, exact counts.

| Command | Result |
|---|---|
| `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 --filter "FullyQualifiedName~LlmQueueToProposalWorkerTests"` | **45/45 passed** (41 before this PR) |
| `... --filter "FullyQualifiedName~Worker"` (Api.Tests) | **167/167 passed** |
| `dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1` (full) | **2209 passed, 4 skipped, 0 failed** (6m10s) |
| `dotnet test backend/tests/Taskdeck.Domain.Tests/Taskdeck.Domain.Tests.csproj -c Release -m:1` (full) | **1646 passed, 0 failed** |
| `dotnet test backend/tests/Taskdeck.Architecture.Tests/Taskdeck.Architecture.Tests.csproj -c Release -m:1` | **22 passed, 1 skipped** |

### Tests added or changed

- `ProcessBatch_ProposalLaneCallerCancellation_PropagatesAndLeavesItemProcessing` **renamed** to
  `...PropagatesAndReleasesClaim` and its assertion inverted — the behaviour it pinned is the
  behaviour this PR changes. Now asserts `Pending` **and** `RetryCount == 0`.
- `ProcessBatch_ProposalLaneCallerCancellation_ReleaseWriteUsesUncancelledToken` — the token the
  release write was given.
- `ProcessBatch_ItemReleasedByShutdown_IsProcessedOnRestartWithFullRetryBudget` — end-to-end: shut
  down mid-item, then run a fresh batch on an uncancelled token; the item completes on that tick
  with `RetryCount == 0` (AC: retried promptly, no lease wait).
- `ProcessBatch_CancellationDuringRetryBackoff_PersistsTheRequeueInsteadOfStrandingFailed` and
  `ProcessBatch_CaptureLaneCancellationDuringRetryBackoff_RequeuesAsProcessing` — the second gap, on
  both lanes (the capture lane's retry state is `Processing`, and leaving it `Pending` would strand
  it just as badly).
- `LlmRequestTests`: `ReleaseClaim` returns to Pending without charging, preserves an
  already-spent retry, and throws outside `Processing` (3 statuses).

Two traps were avoided deliberately, and both are commented in the tests:

- `Task.Run(body, ct)` **never invokes its body when `ct` is already cancelled** — cancelling before
  `ProcessBatchAsync` would make every one of these tests vacuous (the item would never be claimed).
  All of them cancel from *inside* the planner/triage call or from inside the first `SaveChangesAsync`.
- The gap-2 tests need cancellation to land *after* the `MarkAsFailed` commit. They drive it from a
  `FakeUnitOfWork.OnSaveChanges` hook on write #1 rather than racing a timer, so the window is
  deterministic.

`FakeUnitOfWork.SaveChangesAsync` now records its token and honours cancellation the way EF Core
does. Without that, a shutdown write that forwarded the cancelled token would pass silently: a fake
has no persisted state to diverge from its in-memory entity, so the status assertions alone cannot
see the difference.

### Mutation evidence — re-measured at `97806b30` after the comment fix

An earlier revision of this table reported A and B against a stale total of 43 while C used 45, so
the three were not comparable. All three mutations were re-applied and re-run at the final head, so
they now share one denominator. Command for every row, foreground, no piping:

```
dotnet test backend/tests/Taskdeck.Api.Tests/Taskdeck.Api.Tests.csproj -c Release -m:1 \
  --filter "FullyQualifiedName~LlmQueueToProposalWorkerTests"
```

| Mutation | Failed | Passed | Total | Killed by |
|---|---|---|---|---|
| **A** — remove `await ReleaseClaimOnShutdownAsync(...)` from the proposal-lane guard | **3** | 42 | 45 | `...ReleaseWriteUsesUncancelledToken`, `...PropagatesAndReleasesClaim`, `ProcessBatch_ItemReleasedByShutdown_IsProcessedOnRestartWithFullRetryBudget`. The gap-2 tests stayed green. |
| **B** — that release save takes `ct` instead of `CancellationToken.None` | **1** | 44 | 45 | `...ReleaseWriteUsesUncancelledToken` only. The status assertions stayed green, confirming the two tests discriminate on *different* things and that the token assertion is the only thing pinning the `None`. |
| **C** — remove the cancellation guard wrapping `HandleFailureWithRetryAsync`'s backoff + requeue | **2** | 43 | 45 | `ProcessBatch_CancellationDuringRetryBackoff_PersistsTheRequeueInsteadOfStrandingFailed`, `ProcessBatch_CaptureLaneCancellationDuringRetryBackoff_RequeuesAsProcessing` — the stranded `Failed` row, reproduced. |
| _(none — unmutated head)_ | **0** | 45 | 45 | — |

Mutation B requires threading a token into `ReleaseClaimOnShutdownAsync`, which takes none in the
shipped code; the mutation added a `CancellationToken ct` parameter and forwarded the caller's token
so the save could receive it. Each mutation was restored before the next, and `git diff` was empty
against the committed fix after the last one, so the pushed head is the unmutated code.

## Not verified / residual risk

- **AC "shutdown is not delayed or deadlocked"** is argued, not measured. There is no timing test and
  no bounded timeout token on the write; the flush is whatever the scope still tracks (see "Scope of
  the shutdown flush" above), not a fixed-size write, and any failure is caught so the cancellation
  still propagates. A bounded CTS was considered and rejected as a new cancellation surface needing
  its own knob; `CancellationToken.None` is the issue's suggestion and the repo idiom
  (`AccountDeletionService`, `AgentRuntime`, `OutboundWebhookDeliveryWorker`).
- **AC "a graceful shutdown mid-item does not increment RetryCount" holds only once execution has
  entered the `try` block.** Cancellation observed by one of the four `ct`-taking awaits in the
  claim window *before* the `try` — `TryClaimProcessingAsync`, the post-claim `GetByIdAsync`, the
  idempotency `GetBySourceReferenceAsync`, and the existing-proposal `SaveChangesAsync` — still
  throws past the release guard and leaves the row `Processing`, so the recovery sweep charges a
  retry exactly as before. That window is pre-existing and strictly narrowed (not widened) by this
  PR, and it is tracked as a third residual on #1632 rather than fixed here.
- **No new telemetry.** Finding 2 of the issue comment — shutdown-abandoned items emit no metric and
  no `abandoned_shutdown` outcome on `WorkerItemsProcessed` — is **not** addressed here. Both new
  paths now emit a `LogInformation`, so the events are visible in logs, but the metric gap remains.
  Deliberately left out to keep this diff to the state-machine defect; worth its own small issue.
- All evidence is against fakes (`FakeUnitOfWork`/`FakeLlmQueueRepository`), which is the existing
  pattern for this worker's tests. No integration test drives a real host stop against SQLite, so
  "the write actually commits during ASP.NET Core shutdown" rests on the DI scope still being alive
  in `StopAsync` (it is, since the host awaits `BackgroundService.StopAsync` before disposing the
  provider) rather than on a measurement.
- `TranscriptTriageWorker` was not examined; it is a separate lane outside this slice's ownership.
  Its rows are read from `Processing`, so gap 1 does not apply to it, but whether it shares gap 2 is
  unchecked.
- No `STATUS.md` / masterplan update: this corrects retry accounting on an existing path and adds no
  surface. `OUTSTANDING_TASKS.md` unchanged.

## Worktree

Built in an isolated worktree, branched `--detach` from `origin/main` at `78be65c6`. Nothing outside
`backend/**` was touched. `git status --porcelain --ignored` shows only regenerable `bin/`+`obj/`
output and the harness's own `.claude/settings.local.json` — **nothing needs to survive removal**.
The tree is spent and ready for a plain `git worktree remove`.
