### PR TITLE
Burn down the frontend spec typecheck quarantine: 64 -> 40 files

### DIFF
--- a/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.paperVariant.spec.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { reactive } from 'vue'
-import { readFileSync } from 'node:fs'
 import AppShell from '../../components/shell/AppShell.vue'
+// Read through Vite's `?raw` loader rather than node:fs — this project deliberately excludes
+// node types (adding them breaks production source), and `?raw` also resolves relative to this
+// file instead of the process CWD.
+import appShellSource from '../../components/shell/AppShell.vue?raw'
 
 const mockRouter = {
   push: vi.fn(),
@@ -230,10 +233,7 @@ describe('AppShell — paper variant routing', () => {
   })
 
   it('keeps Paper phone content padded above the fixed bottom bar', () => {
-    const source = readFileSync(
-      'src/components/shell/AppShell.vue',
-      'utf8',
-    )
+    const source = appShellSource
 
     expect(source).toContain('.td-shell--paper-phone .td-content')
     expect(source).toContain('56px + var(--paper-safe-bottom')

--- a/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/AppShell.spec.ts
@@ -28,7 +28,7 @@ const mockFeatureFlags = {
     newAutomation: true,
     newArchive: true,
   },
-  isEnabled: vi.fn(() => true),
+  isEnabled: vi.fn((_flag: keyof FeatureFlags) => true),
 }
 
 const mockWorkspace = reactive({
@@ -127,7 +127,7 @@ describe('AppShell workspace navigation and command palette', () => {
     mockWorkspace.homeLoading = false
     mockWorkspace.preferenceLoading = false
     mockWorkspace.preferencesHydrated = false
-    mockFeatureFlags.isEnabled = vi.fn(() => true)
+    mockFeatureFlags.isEnabled = vi.fn((_flag: keyof FeatureFlags) => true)
   })
 
   afterEach(() => {
@@ -166,7 +166,7 @@ describe('AppShell workspace navigation and command palette', () => {
 
   it('shows sidebarPrimary items with workbenchBypassesFlag in workbench mode even when flags are off', async () => {
     mockWorkspace.mode = 'workbench'
-    mockFeatureFlags.isEnabled = vi.fn(() => false)
+    mockFeatureFlags.isEnabled = vi.fn((_flag: keyof FeatureFlags) => false)
     mountedWrapper = mountShell()
     const wrapper = mountedWrapper
     const navHrefs = getRenderedNavHrefs(wrapper)

--- a/frontend/taskdeck-web/src/tests/components/BoardCanvas.coverage.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/BoardCanvas.coverage.spec.ts
@@ -10,6 +10,7 @@ function makeColumn(overrides: Partial<Column> = {}): Column {
     name: 'Todo',
     position: 0,
     wipLimit: null,
+    cardCount: 0,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     ...overrides,

--- a/frontend/taskdeck-web/src/tests/components/BoardSettingsModal.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/BoardSettingsModal.spec.ts
@@ -31,7 +31,6 @@ describe('BoardSettingsModal', () => {
       isArchived: false,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-      columns: [],
     }
 
     mockStore = {

--- a/frontend/taskdeck-web/src/tests/components/inbox/inboxUtils.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/inbox/inboxUtils.spec.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
 import { sourceLabel } from '../../../components/inbox/inboxUtils'
+import type { CaptureSourceValue } from '../../../types/capture'
 
 describe('inboxUtils', () => {
-  it.each([
+  it.each<[CaptureSourceValue, string]>([
     ['MarkdownImport', 'Markdown'],
     ['WebClip', 'Web Clip'],
     ['ShareTarget', 'Share Target'],

--- a/frontend/taskdeck-web/src/tests/components/paper/useInkBleed.spec.ts
+++ b/frontend/taskdeck-web/src/tests/components/paper/useInkBleed.spec.ts
@@ -165,7 +165,7 @@ describe('useInkBleed', () => {
 
   it('cancel() clears state without firing done', () => {
     const { exposed } = createHost()
-    const _run = exposed.bleed.start()
+    exposed.bleed.start()
     vi.advanceTimersByTime(1000)
 
     exposed.bleed.cancel()

--- a/frontend/taskdeck-web/src/tests/composables/useEscapeToClose.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useEscapeToClose.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { defineComponent, nextTick, ref } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useEscapeToClose } from '../../composables/useEscapeToClose'
 
 function pressKey(key: string) {

--- a/frontend/taskdeck-web/src/tests/composables/useShortcutContext.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useShortcutContext.spec.ts
@@ -3,6 +3,7 @@ import { defineComponent } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 type ShortcutContextModule = typeof import('../../composables/useShortcutContext')
+type ShortcutContext = import('../../composables/useShortcutContext').ShortcutContext
 
 let shortcutContextModule: ShortcutContextModule
 let wrappers: VueWrapper[] = []
@@ -28,7 +29,7 @@ function pressKey(key: string, opts?: { ctrlKey?: boolean; shiftKey?: boolean; a
 }
 
 function mountContext(
-  context: ShortcutContextModule['ShortcutContext'],
+  context: ShortcutContext,
   shortcuts: Array<{
     key: string
     handler: () => void

--- a/frontend/taskdeck-web/src/tests/composables/useVirtualList.spec.ts
+++ b/frontend/taskdeck-web/src/tests/composables/useVirtualList.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { useVirtualList } from '../../composables/useVirtualList'
+import type { VirtualItem } from '@tanstack/vue-virtual'
 
 /**
  * Note: @tanstack/vue-virtual requires real scroll container dimensions to
@@ -61,9 +62,9 @@ function createTestComponent(itemCount: number, estimateSize = 40) {
                     transform: `translateY(${this.translateY}px)`,
                   },
                 },
-                this.virtualRows.map((row: { key: string | number; index: number }) =>
+                this.virtualRows.map((row: VirtualItem) =>
                   h('div', {
-                    key: row.key,
+                    key: row.key as string | number,
                     'data-index': row.index,
                     ref: 'virtualItemEls',
                     style: { height: `${estimateSize}px` },

--- a/frontend/taskdeck-web/src/tests/store/auditStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/auditStore.spec.ts
@@ -146,7 +146,9 @@ describe('auditStore', () => {
     },
   ])('$method sets loading true during fetch and false after', async ({ call, api }) => {
     const store = useAuditStore()
-    let resolveRequest: ((value: never[]) => void) | null = null
+    // Definite-assignment: the assignment happens inside mockImplementation's callback, which
+    // TypeScript's control-flow analysis cannot see (it would narrow the variable to `null`).
+    let resolveRequest!: (value: never[]) => void
 
     vi.mocked(auditApi[api]).mockImplementation(() => new Promise((resolve) => {
       resolveRequest = resolve as (value: never[]) => void

--- a/frontend/taskdeck-web/src/tests/store/board/boardStoreHelpers.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/board/boardStoreHelpers.spec.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 
 const { mockToastStore, mockGetErrorMessage, mockIsDemoMode } = vi.hoisted(() => ({
   mockToastStore: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
-  mockGetErrorMessage: vi.fn((err: unknown, fallback: string) => fallback),
+  mockGetErrorMessage: vi.fn((_err: unknown, fallback: string) => fallback),
   mockIsDemoMode: { value: false },
 }))
 

--- a/frontend/taskdeck-web/src/tests/store/captureStore.integration.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/captureStore.integration.spec.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import http from '../../api/http'
 import { useCaptureStore } from '../../store/captureStore'
+import type { CaptureItem, CaptureItemSummary } from '../../types/capture'
 
 vi.mock('../../api/http', () => ({
   default: {
@@ -33,7 +34,7 @@ vi.mock('../../utils/demoMode', async (importOriginal) => {
   return { ...actual, isDemoMode: false }
 })
 
-function makeSummaryPayload(overrides: Partial<Record<string, unknown>> = {}) {
+function makeSummaryPayload(overrides: Partial<CaptureItemSummary> = {}): CaptureItemSummary {
   return {
     id: 'c-1',
     userId: 'u-1',
@@ -47,8 +48,8 @@ function makeSummaryPayload(overrides: Partial<Record<string, unknown>> = {}) {
   }
 }
 
-function makeDetailPayload(overrides: Partial<Record<string, unknown>> = {}) {
-  const { rawText, ...summaryOverrides } = overrides as { rawText?: string } & Record<string, unknown>
+function makeDetailPayload(overrides: Partial<CaptureItem> = {}): CaptureItem {
+  const { rawText, ...summaryOverrides } = overrides
   return {
     ...makeSummaryPayload(summaryOverrides),
     rawText: rawText ?? 'full capture text',

--- a/frontend/taskdeck-web/src/tests/store/savedViewStore.spec.ts
+++ b/frontend/taskdeck-web/src/tests/store/savedViewStore.spec.ts
@@ -228,7 +228,8 @@ describe('savedViewStore', () => {
     })
 
     it('should not persist default views', () => {
-      const _store = useSavedViewStore()
+      // Instantiated for its side effects only: the store hydrates from localStorage on create.
+      useSavedViewStore()
 
       const raw = localStorage.getItem('taskdeck_saved_views')
       // Defaults are not persisted unless a custom view triggers persist()

--- a/frontend/taskdeck-web/src/tests/views/ActivityView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ActivityView.spec.ts
@@ -71,9 +71,10 @@ vi.mock('../../composables/useVirtualList', async () => {
   const { computed, ref, shallowRef } = await vueHelpers
   return {
     useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
-      const getCount = typeof options.count === 'function'
-        ? options.count
-        : () => options.count.value
+      const count = options.count
+      const getCount = typeof count === 'function'
+        ? count
+        : () => count.value
       return {
         parentRef: ref(null),
         virtualItemEls: shallowRef([]),

--- a/frontend/taskdeck-web/src/tests/views/AutomationQueueView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/AutomationQueueView.spec.ts
@@ -113,7 +113,7 @@ describe('AutomationQueueView', () => {
 
     expect(wrapper.text()).toContain('Board-scoped instructions')
     expect(wrapper.text()).toContain('Inbox -> Start Triage')
-    expect(wrapper.get('input[aria-label="Board for queue request"]').exists()).toBe(true)
+    expect(wrapper.find('input[aria-label="Board for queue request"]').exists()).toBe(true)
   })
 
   it('submits board id selected via board picker with queue request', async () => {

--- a/frontend/taskdeck-web/src/tests/views/BoardView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/BoardView.spec.ts
@@ -260,7 +260,7 @@ describe('BoardView', () => {
     await addCard?.trigger('click')
     await waitForUi()
 
-    expect(wrapper.get('input[placeholder="Column name"]').exists()).toBe(true)
+    expect(wrapper.find('input[placeholder="Column name"]').exists()).toBe(true)
   })
 
   it('reuses the existing add-card affordance when columns are present', async () => {

--- a/frontend/taskdeck-web/src/tests/views/MetricsView.coverage.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/MetricsView.coverage.spec.ts
@@ -22,7 +22,10 @@ const MOCK_METRICS: BoardMetricsResponse = {
 const MOCK_FORECAST: BoardForecastResponse = {
   boardId: 'board-1',
   remainingCards: 12,
+  completedCards: 30,
   averageThroughputPerDay: 1.5,
+  throughputStdDev: 0.4,
+  averageCycleTimeDays: 2.5,
   estimatedCompletionDate: '2026-04-20T00:00:00Z',
   historyDaysUsed: 30,
   dataPointCount: 28,

--- a/frontend/taskdeck-web/src/tests/views/NotificationInboxView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/NotificationInboxView.spec.ts
@@ -12,9 +12,10 @@ vi.mock('../../composables/useVirtualList', async () => {
   const { computed, ref, shallowRef } = await vueHelpers
   return {
     useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
-      const getCount = typeof options.count === 'function'
-        ? options.count
-        : () => options.count.value
+      const count = options.count
+      const getCount = typeof count === 'function'
+        ? count
+        : () => count.value
       return {
         parentRef: ref(null),
         virtualItemEls: shallowRef([]),

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.coverage.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.coverage.spec.ts
@@ -13,9 +13,10 @@ vi.mock('../../composables/useVirtualList', async () => {
   const { computed, ref, shallowRef } = await vueHelpers
   return {
     useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
-      const getCount = typeof options.count === 'function'
-        ? options.count
-        : () => options.count.value
+      const count = options.count
+      const getCount = typeof count === 'function'
+        ? count
+        : () => count.value
       return {
         parentRef: ref(null),
         virtualItemEls: shallowRef([]),

--- a/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/ReviewView.spec.ts
@@ -13,9 +13,10 @@ vi.mock('../../composables/useVirtualList', async () => {
   const { computed, ref, shallowRef } = await vueHelpers
   return {
     useVirtualList: (options: { count: { value: number } | (() => number); estimateSize: number }) => {
-      const getCount = typeof options.count === 'function'
-        ? options.count
-        : () => options.count.value
+      const count = options.count
+      const getCount = typeof count === 'function'
+        ? count
+        : () => count.value
       return {
         parentRef: ref(null),
         virtualItemEls: shallowRef([]),

--- a/frontend/taskdeck-web/src/tests/views/paper/PaperBoardView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/PaperBoardView.spec.ts
@@ -250,7 +250,7 @@ describe('PaperBoardView', () => {
     targetLane.element.dispatchEvent(makeDragEvent('dragover'))
     await nextTick()
 
-    expect(wrapper.getComponent(PaperBoardColumn).exists()).toBe(true)
+    expect(wrapper.findComponent(PaperBoardColumn).exists()).toBe(true)
     expect(targetLane.classes()).toContain('paper-board-view__lane--drop-target')
 
     targetLane.element.dispatchEvent(makeDragEvent('drop'))

--- a/frontend/taskdeck-web/src/tests/views/paper/inbox/PaperTriageTable.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/inbox/PaperTriageTable.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { mount } from '@vue/test-utils'
 import PaperTriageTable from '../../../../views/paper/inbox/PaperTriageTable.vue'
-import type { CaptureItemSummary } from '../../../../types/capture'
+import type { CaptureItemSummary, CaptureStatusValue } from '../../../../types/capture'
 
 function makeItems(): CaptureItemSummary[] {
   const createdAt = new Date('2026-04-25T09:42:00Z').toISOString()
@@ -59,7 +59,10 @@ describe('PaperTriageTable', () => {
 
   it('prioritizes failed/error status tone over triage wording', () => {
     const items = makeItems()
-    items[0] = { ...items[0], status: 'Triage Failed' }
+    // Deliberately outside the CaptureStatus union: this asserts statusTone()'s ordering
+    // (failed/error wins over triage wording) for an unrecognised status string from the server.
+    const outOfContractStatus = 'Triage Failed' as unknown as CaptureStatusValue
+    items[0] = { ...items[0], status: outOfContractStatus }
     const wrapper = mount(PaperTriageTable, { props: { items } })
 
     expect(wrapper.find('.tagstamp').attributes('data-tone')).toBe('overdue')

--- a/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/PaperReviewView.spec.ts
@@ -785,7 +785,7 @@ describe('PaperReviewView', () => {
             targetId: 'card-1',
             parameters: '{"columnId":"done"}',
             idempotencyKey: 'k-2',
-            expectedVersion: 7,
+            expectedVersion: '7',
           },
           {
             id: 'op-2',

--- a/frontend/taskdeck-web/src/tests/views/paper/review/ReviewProvenance.spec.ts
+++ b/frontend/taskdeck-web/src/tests/views/paper/review/ReviewProvenance.spec.ts
@@ -15,7 +15,7 @@ const rows: ProvenanceRow[] = [
 describe('ReviewProvenance', () => {
   it('describes provenance honestly for both deterministic captures and LLM chat automation (#1273)', () => {
     const wrapper = mount(ReviewProvenance, {
-      props: { rows },
+      props: { rows, proposalId: 'proposal-001' },
     })
 
     const text = wrapper.text()

--- a/frontend/taskdeck-web/tsconfig.vitest.json
+++ b/frontend/taskdeck-web/tsconfig.vitest.json
@@ -34,13 +34,19 @@
   // mostly TS7016 (untyped `.mjs` imports), TS7006 and TS2503. Covering them is a separate project
   // with a separate type environment, tracked in #1607.
   //
-  // The `exclude` list is the QUARANTINE, tracked in #1468. Every file listed had type errors when
-  // this project was introduced: 415 errors across 64 of the 286 TypeScript files under
-  // `src/tests/` (284 specs plus `setup.ts` and one mock), measured 2026-08-07. That leaves **220
-  // of the 302 spec files Vitest runs** type-checked; the 82 that are not are these 64 plus the 18
-  // in the frontend-root `tests/` directory. New spec files under `src/tests/` are checked by
-  // default — they are not in this list. The list may only shrink: delete an entry once its file is
-  // fixed; never add one to make a red build green.
+  // The `exclude` list is the QUARANTINE, created in #1468 and burned down in #1607. Every file
+  // listed had type errors when this project was introduced: 415 errors across 64 of the 286
+  // TypeScript files under `src/tests/` (284 specs plus `setup.ts` and one mock), measured
+  // 2026-08-07.
+  //
+  // CURRENT: **40 files remain.** The 24 files that carried exactly one error each were fixed and
+  // un-quarantined in #1607 (24 of the 415 errors cleared; 391 remain across the 40). That leaves
+  // **244 of the 302 spec files Vitest runs** type-checked; the 58 that are not are these 40 plus
+  // the 18 in the frontend-root `tests/` directory.
+  //
+  // New spec files under `src/tests/` are checked by default — they are not in this list. The list
+  // may only shrink: delete an entry once its file is fixed; never add one to make a red build
+  // green.
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
@@ -63,68 +69,44 @@
   ],
   "exclude": [
     "src/tests/api/http.spec.ts",
-    "src/tests/components/AppShell.paperVariant.spec.ts",
-    "src/tests/components/AppShell.spec.ts",
-    "src/tests/components/BoardCanvas.coverage.spec.ts",
     "src/tests/components/BoardCanvas.spec.ts",
     "src/tests/components/BoardDialogHost.spec.ts",
-    "src/tests/components/BoardSettingsModal.spec.ts",
     "src/tests/components/CaptureModal.spec.ts",
     "src/tests/components/CardItem.coverage.spec.ts",
     "src/tests/components/CardModal.spec.ts",
     "src/tests/components/FilterPanel.spec.ts",
     "src/tests/components/LabelManagerModal.spec.ts",
-    "src/tests/components/inbox/inboxUtils.spec.ts",
-    "src/tests/components/paper/useInkBleed.spec.ts",
     "src/tests/components/review/CohortDashboard.spec.ts",
     "src/tests/composables/useAnalyticsScript.spec.ts",
     "src/tests/composables/useBoardRealtime.spec.ts",
     "src/tests/composables/useCaptureQueueSync.spec.ts",
-    "src/tests/composables/useEscapeToClose.spec.ts",
     "src/tests/composables/useReviewActions.spec.ts",
     "src/tests/composables/useReviewProposals.spec.ts",
-    "src/tests/composables/useShortcutContext.spec.ts",
     "src/tests/composables/useStarterPackCatalog.spec.ts",
     "src/tests/composables/useStarterPackImport.spec.ts",
     "src/tests/composables/useStarterPackResult.spec.ts",
-    "src/tests/composables/useVirtualList.spec.ts",
     "src/tests/composables/useVoiceCapture.spec.ts",
     "src/tests/config/PaperBranding.spec.ts",
     "src/tests/property/storeResilience.spec.ts",
     "src/tests/public/shareTargetHandler.spec.ts",
     "src/tests/store/agentStore.spec.ts",
-    "src/tests/store/auditStore.spec.ts",
-    "src/tests/store/board/boardStoreHelpers.spec.ts",
     "src/tests/store/board/cardFilterStore.spec.ts",
     "src/tests/store/boardStore.columnReorder.spec.ts",
     "src/tests/store/boardStore.integration.spec.ts",
     "src/tests/store/boardStore.spec.ts",
-    "src/tests/store/captureStore.integration.spec.ts",
     "src/tests/store/captureStore.spec.ts",
     "src/tests/store/queueStore.integration.spec.ts",
     "src/tests/store/queueStore.polling.spec.ts",
     "src/tests/store/queueStore.spec.ts",
-    "src/tests/store/savedViewStore.spec.ts",
     "src/tests/store/workspaceStore.spec.ts",
     "src/tests/theme/authFocusRing.spec.ts",
     "src/tests/theme/paperEmberContrast.spec.ts",
     "src/tests/utils/chat.spec.ts",
     "src/tests/utils/scenarioSchema.spec.ts",
     "src/tests/utils/traceReplay.spec.ts",
-    "src/tests/views/ActivityView.spec.ts",
     "src/tests/views/AutomationChatView.spec.ts",
-    "src/tests/views/AutomationQueueView.spec.ts",
-    "src/tests/views/BoardView.spec.ts",
     "src/tests/views/InboxView.spec.ts",
-    "src/tests/views/MetricsView.coverage.spec.ts",
-    "src/tests/views/NotificationInboxView.spec.ts",
-    "src/tests/views/ReviewView.coverage.spec.ts",
-    "src/tests/views/ReviewView.spec.ts",
     "src/tests/views/ShareTargetView.spec.ts",
-    "src/tests/views/paper/PaperBoardView.spec.ts",
-    "src/tests/views/paper/inbox/PaperTriageTable.spec.ts",
-    "src/tests/views/paper/review/PaperReviewView.spec.ts",
-    "src/tests/views/paper/review/ReviewKeymap.spec.ts",
-    "src/tests/views/paper/review/ReviewProvenance.spec.ts"
+    "src/tests/views/paper/review/ReviewKeymap.spec.ts"
   ]
 }


### PR DESCRIPTION
## Problem

`tsconfig.vitest.json` (ADR-0049, #1608) type-checks the frontend spec tree but quarantines
64 files in its `exclude` array that carried 415 pre-existing type errors. #1607 tracks burning
that list down. This is the first chunk.

## Chunk selection

The **24 files that carry exactly one error each** — the issue's own suggested starting order
("the 24 one-error files first (cheap, proves the workflow)"). They are mechanical rather than
structural, and they span 7 distinct error classes, so this batch also establishes a fix pattern
for each class that later chunks can reuse. The 7 heavy hitters (227 errors, 55%) are deliberately
left for dedicated PRs.

Measured before starting: removing exactly these 24 from `exclude` produced exactly 24 errors,
one per file — the issue's per-file table reproduces precisely.

### Fixes by class, one commit each

| Class | Files | Fix |
|---|---|---|
| TS6133 unused binding | 3 | drop the unused local (keeping the call it was made for); `_`-prefix the unused *parameter* |
| TS2339 `.value` on a union | 4 | bind `options.count` to a local so the `typeof` narrowing survives into the closure |
| TS2339 `.exists()` | 3 | `get`/`getComponent` are typed `Omit<Wrapper, "exists">`; switched to `find`/`findComponent` so the explicit assertion survives |
| fixture literals (TS2322/2739/2353/2345) | 8 | make the fixture a valid domain object; type two payload builders instead of `Partial<Record<string, unknown>>` |
| misc one-offs | 6 | missing `afterEach` import; type-only export aliased; mock signature; definite-assignment; `VirtualItem`; `node:fs` -> Vite `?raw` |

Two judgement calls worth a reviewer's eye:

- **`PaperTriageTable`** asserts on `status: 'Triage Failed'`, deliberately outside the
  `CaptureStatus` union — it exercises `statusTone()`'s failed-before-triage ordering for an
  unrecognised server status. I kept the value behind a documented `as unknown as CaptureStatusValue`
  rather than substituting a valid status, which would have silently deleted what the test covers.
- **`AppShell.paperVariant`** imported `readFileSync` from `node:fs` (TS2591). Adding `"node"` to
  `types` is forbidden — it breaks `PaperHomeView.vue`. Replaced with Vite's `?raw` loader, typed by
  `vite/client`, which is already in this project's `types`. Same string, same assertions, and it now
  resolves relative to the spec instead of the process CWD.

No production source under `src/` was touched. No test was weakened: no assertion was deleted and no
`as any` blanket was added.

## Verification

From `frontend/taskdeck-web`, after `npm ci`:

- `npm run typecheck` — **exits 0**. Also re-run as `npx vue-tsc -b --force` so incremental
  build-info could not mask a stale result: also clean.
- `npx vitest --run --maxWorkers=2 <the 24 paths>` — **24 files, 409 tests, all passing**
  (162 + 247 across two batches).
- **Behaviour-identical, measured not assumed.** I restored the base (`78be65c6`) spec content into
  the worktree and re-ran the same 24 files: **24 files, 409 tests, all passing — identical counts**,
  then restored the fixed versions. So the fixes changed types, not behaviour.
- Baseline control: `npm run typecheck` was green *before* any edit, and removing the 24 files from
  `exclude` produced exactly 24 errors.

### Constraints (all four on #1607 hold, provably)

`git diff` on `tsconfig.vitest.json` touches **no** `compilerOptions` key, **no** `types` entry and
**no** `include` entry — only the comment block and the `exclude` list. So: no `"node"`, no
`"vitest/globals"`, `noUnusedLocals`/`noUnusedParameters`/`erasableSyntaxOnly` all still on, and
`src/**/*.d.ts` still in `include`.

## Counts

| | Before | After |
|---|---|---|
| Quarantined files | 64 | **40** |
| Errors in quarantine | 415 | **391** |
| Gated spec files (of the 302 Vitest runs) | 220 | **244** |
| Not covered | 82 (64 + 18) | **58 (40 + 18)** |

**Residual quarantine: 40 files / 391 errors.** The burn-down continues — the 7 heavy hitters
(ReviewKeymap 48, useStarterPackCatalog 42, useStarterPackImport 36, useReviewActions 33,
PaperBranding 25, scenarioSchema 24, boardStore 19) are the natural next PRs, one each.

The config's own header comment is updated to these numbers; it would otherwise have been left
stating a false count. Canonical docs (`STATUS.md`, `TESTING_GUIDE.md`, ADR-0049) are deliberately
untouched here — the coordinator reconciles those, and the acceptance criterion for the testing-guide
note is "when the list empties", which it has not.

Refs #1607
