### PR TITLE
Harden project Codex executable path ordering

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,7 +34,7 @@ inherit = "all"
 sandbox = "elevated"
 
 [shell_environment_policy.set]
-PATH = "C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin;C:\\Users\\Public\\codex-shell-home\\bin;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH"
+PATH = "C:\\Users\\Public\\codex-shell-home\\bin;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
 HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\home'
 DOTNET_CLI_HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\dotnet-home'
 NUGET_PACKAGES = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\nuget\packages'

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,7 +34,7 @@ inherit = "all"
 sandbox = "elevated"
 
 [shell_environment_policy.set]
-PATH = "C:\\Users\\Public\\codex-shell-home\\bin;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
+PATH = "C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Public\\codex-shell-home\\bin;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
 HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\home'
 DOTNET_CLI_HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\dotnet-home'
 NUGET_PACKAGES = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\nuget\packages'


### PR DESCRIPTION
## Summary
- place all user-writable Windows tool directories after trusted Program Files and Windows system entries
- retain `WindowsApps`, shared Codex tools, and repo runtime bins as fallback paths

## Implementation notes
The project-scoped PATH previously allowed user-writable directories to win executable resolution. It now orders trusted Program Files/system paths first, followed by the user-writable fallback tail:

1. `C:\Users\jekyt\AppData\Local\Microsoft\WindowsApps`
2. `C:\Users\Public\codex-shell-home\bin`
3. `C:\Users\jekyt\source\Taskdeck\.runtime-codex\bin`

Live ACL inspection confirmed the current user has FullControl on `WindowsApps` and the repo runtime, while the shared Codex bin grants Modify to Codex sandbox/interactive principals. This fix remains project-scoped and does not change global Codex configuration.

## Tests and verification
- Python `tomllib` parse of `.codex/config.toml`: passed
- static trust-order probe: all `C:\Program Files\` and `C:\Windows\` entries precede all three writable fallback paths
- actual resolution: `git` -> `C:\Program Files\Git\cmd\git.exe`; `gh` -> `C:\Program Files\GitHub CLI\gh.exe`; `jq` remains available from the fallback Codex bin
- isolated adversarial canary: forged `git`, `gh`, and `jq` in all three writable-bin stand-ins resolved after trusted canaries
- `powershell -NoProfile -File scripts/check-git-env.ps1`: passed
- `git diff --check`: passed

## Docs
No canonical docs changed; this is a one-line project configuration hardening fix.

## Risks and follow-ups
Fallback-only tools remain available after trusted paths. The check is deterministic at the configuration/probe boundary; no global user config or issue #1638 work is included.

Closes #1625