### PR TITLE
Sanitize user-controlled log fields

### DIFF
--- a/backend/src/Taskdeck.Api/Middleware/UnhandledExceptionMiddleware.cs
+++ b/backend/src/Taskdeck.Api/Middleware/UnhandledExceptionMiddleware.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.Sqlite;
 using Taskdeck.Api.Contracts;
+using Taskdeck.Api.Telemetry;
 using Taskdeck.Application.Services;
 using Taskdeck.Domain.Exceptions;
 
@@ -33,9 +34,9 @@ public sealed class UnhandledExceptionMiddleware
             _logger.LogInformation(
                 "Request was canceled while processing {Method} {Path} (CorrelationId: {CorrelationId}; " +
                 "ExceptionType: {ExceptionType}).",
-                context.Request.Method,
-                context.Request.Path,
-                context.TraceIdentifier,
+                LogSanitizer.SanitizeForLog(context.Request.Method),
+                LogSanitizer.SanitizeForLog(context.Request.Path.Value),
+                LogSanitizer.SanitizeForLog(context.TraceIdentifier),
                 BoundTypeName(ex.GetType()));
         }
         catch (Exception ex)
@@ -47,9 +48,9 @@ public sealed class UnhandledExceptionMiddleware
                 "ClassificationTruncated: {ClassificationTruncated}; " +
                 "SqliteErrorCode: {SqliteErrorCode}; " +
                 "SqliteExtendedErrorCode: {SqliteExtendedErrorCode}.",
-                context.Request.Method,
-                context.Request.Path,
-                context.TraceIdentifier,
+                LogSanitizer.SanitizeForLog(context.Request.Method),
+                LogSanitizer.SanitizeForLog(context.Request.Path.Value),
+                LogSanitizer.SanitizeForLog(context.TraceIdentifier),
                 classification.ExceptionType,
                 classification.LastInspectedExceptionType,
                 classification.ClassificationTruncated,

--- a/backend/src/Taskdeck.Application/Services/LogQueryService.cs
+++ b/backend/src/Taskdeck.Application/Services/LogQueryService.cs
@@ -37,8 +37,8 @@ public class LogQueryService : ILogQueryService
                 _logger?.LogWarning(
                     "Log query rejected in {DurationMs}ms due to validation failure: {ErrorCode} {ErrorMessage}",
                     stopwatch.ElapsedMilliseconds,
-                    validationResult.ErrorCode,
-                    validationResult.ErrorMessage);
+                    LogValueSanitizer.Sanitize(validationResult.ErrorCode),
+                    LogValueSanitizer.Sanitize(validationResult.ErrorMessage));
                 return Result.Failure<IEnumerable<LogEntryDto>>(validationResult.ErrorCode, validationResult.ErrorMessage);
             }
 
@@ -64,11 +64,11 @@ public class LogQueryService : ILogQueryService
                 "Log query completed in {DurationMs}ms with {ResultCount} entries (level={Level}, source={Source}, correlationId={CorrelationId}, userId={UserId}, boardId={BoardId})",
                 stopwatch.ElapsedMilliseconds,
                 combined.Count,
-                query.Level,
-                query.Source,
-                query.CorrelationId,
-                query.UserId,
-                query.BoardId);
+                LogValueSanitizer.Sanitize(query.Level),
+                LogValueSanitizer.Sanitize(query.Source),
+                LogValueSanitizer.Sanitize(query.CorrelationId),
+                LogValueSanitizer.Sanitize(query.UserId),
+                LogValueSanitizer.Sanitize(query.BoardId));
 
             return Result.Success<IEnumerable<LogEntryDto>>(combined);
         }
@@ -78,11 +78,11 @@ public class LogQueryService : ILogQueryService
                 ex,
                 "Log query failed in {DurationMs}ms (level={Level}, source={Source}, correlationId={CorrelationId}, userId={UserId}, boardId={BoardId})",
                 stopwatch.ElapsedMilliseconds,
-                query.Level,
-                query.Source,
-                query.CorrelationId,
-                query.UserId,
-                query.BoardId);
+                LogValueSanitizer.Sanitize(query.Level),
+                LogValueSanitizer.Sanitize(query.Source),
+                LogValueSanitizer.Sanitize(query.CorrelationId),
+                LogValueSanitizer.Sanitize(query.UserId),
+                LogValueSanitizer.Sanitize(query.BoardId));
             return Result.Failure<IEnumerable<LogEntryDto>>(ErrorCodes.UnexpectedError, ex.Message);
         }
     }

--- a/backend/src/Taskdeck.Application/Services/LogValueSanitizer.cs
+++ b/backend/src/Taskdeck.Application/Services/LogValueSanitizer.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+
+namespace Taskdeck.Application.Services;
+
+internal static class LogValueSanitizer
+{
+    private const int MaxLength = 200;
+
+    public static string Sanitize(object? value)
+    {
+        var text = Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+        var sanitized = text
+            .Replace("\r", string.Empty, StringComparison.Ordinal)
+            .Replace("\n", string.Empty, StringComparison.Ordinal);
+
+        return sanitized.Length <= MaxLength
+            ? sanitized
+            : string.Concat(sanitized.AsSpan(0, MaxLength), "...");
+    }
+}

--- a/backend/src/Taskdeck.Application/Services/TelemetryEventService.cs
+++ b/backend/src/Taskdeck.Application/Services/TelemetryEventService.cs
@@ -55,9 +55,9 @@ public sealed class TelemetryEventService : ITelemetryEventService
 
         _logger.LogInformation(
             "Telemetry event recorded: {EventName} session={SessionId} mode={WorkspaceMode}",
-            telemetryEvent.Event,
-            telemetryEvent.SessionId,
-            telemetryEvent.WorkspaceMode);
+            LogValueSanitizer.Sanitize(telemetryEvent.Event),
+            LogValueSanitizer.Sanitize(telemetryEvent.SessionId),
+            LogValueSanitizer.Sanitize(telemetryEvent.WorkspaceMode));
 
         return true;
     }
@@ -109,13 +109,15 @@ public sealed class TelemetryEventService : ITelemetryEventService
         {
             _logger.LogWarning(
                 "Telemetry event rejected: invalid event name format '{EventName}' (expected noun.verb)",
-                telemetryEvent.Event);
+                LogValueSanitizer.Sanitize(telemetryEvent.Event));
             return false;
         }
 
         if (string.IsNullOrWhiteSpace(telemetryEvent.SessionId))
         {
-            _logger.LogWarning("Telemetry event rejected: empty session ID for event {EventName}", telemetryEvent.Event);
+            _logger.LogWarning(
+                "Telemetry event rejected: empty session ID for event {EventName}",
+                LogValueSanitizer.Sanitize(telemetryEvent.Event));
             return false;
         }
 
@@ -127,7 +129,9 @@ public sealed class TelemetryEventService : ITelemetryEventService
             {
                 _logger.LogWarning(
                     "Telemetry event {EventName}: properties truncated from {Count} to {Max}",
-                    telemetryEvent.Event, telemetryEvent.Properties.Count, MaxPropertyCount);
+                    LogValueSanitizer.Sanitize(telemetryEvent.Event),
+                    telemetryEvent.Properties.Count,
+                    MaxPropertyCount);
             }
 
             var sanitized = new Dictionary<string, object>();
@@ -139,7 +143,8 @@ public sealed class TelemetryEventService : ITelemetryEventService
                 {
                     _logger.LogDebug(
                         "Telemetry event {EventName}: stripped disallowed property key '{Key}'",
-                        telemetryEvent.Event, kvp.Key);
+                        LogValueSanitizer.Sanitize(telemetryEvent.Event),
+                        LogValueSanitizer.Sanitize(kvp.Key));
                     continue;
                 }
 

--- a/backend/tests/Taskdeck.Api.Tests/UnhandledExceptionMiddlewareTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/UnhandledExceptionMiddlewareTests.cs
@@ -92,4 +92,25 @@ public class UnhandledExceptionMiddlewareTests
         entry.Message.Should().NotContain("ordinary board title");
         entry.Message.Should().NotContain("arbitrary user content");
     }
+
+    [Fact]
+    public async Task InvokeAsync_ShouldStripLineBreaksFromRequestMetadata()
+    {
+        var logger = new InMemoryLogger<UnhandledExceptionMiddleware>();
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        context.Request.Method = "POST\r\nforged-method";
+        context.Request.Path = "/api/capture/items";
+        context.TraceIdentifier = "trace\nforged-trace";
+
+        RequestDelegate next = _ => throw new InvalidOperationException("ignored content");
+        var middleware = new UnhandledExceptionMiddleware(next, logger);
+
+        await middleware.InvokeAsync(context);
+
+        var message = logger.Entries.Single(entry => entry.Level == LogLevel.Error).Message;
+        message.Should().NotContain("\r").And.NotContain("\n");
+        message.Should().Contain("POSTforged-method");
+        message.Should().Contain("traceforged-trace");
+    }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/LogQueryServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LogQueryServiceTests.cs
@@ -5,6 +5,7 @@ using Taskdeck.Application.Interfaces;
 using Taskdeck.Application.Services;
 using Taskdeck.Domain.Entities;
 using Taskdeck.Domain.Exceptions;
+using Taskdeck.Tests.Support;
 using Xunit;
 
 namespace Taskdeck.Application.Tests.Services;
@@ -136,5 +137,25 @@ public class LogQueryServiceTests
             It.IsAny<string?>(),
             50,
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task QueryLogsAsync_ShouldStripLineBreaksFromLoggedFilters()
+    {
+        var logger = new InMemoryLogger<LogQueryService>();
+        var service = new LogQueryService(_unitOfWorkMock.Object, logger);
+
+        var result = await service.QueryLogsAsync(new LogQueryDto(
+            Level: "Info\r\nforged-level",
+            Source: "source\nforged-source",
+            CorrelationId: "corr\rforged-correlation",
+            Limit: 50), default);
+
+        result.IsSuccess.Should().BeTrue();
+        var message = logger.Entries.Single().Message;
+        message.Should().NotContain("\r").And.NotContain("\n");
+        message.Should().Contain("Infoforged-level");
+        message.Should().Contain("sourceforged-source");
+        message.Should().Contain("corrforged-correlation");
     }
 }

--- a/backend/tests/Taskdeck.Application.Tests/Services/TelemetryEventServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/TelemetryEventServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Taskdeck.Application.Services;
+using Taskdeck.Tests.Support;
 using Xunit;
 
 namespace Taskdeck.Application.Tests.Services;
@@ -177,5 +178,22 @@ public class TelemetryEventServiceTests
 
         var result = service.RecordEvent(evt);
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RecordEvent_ShouldStripLineBreaksFromLoggedValues()
+    {
+        var logger = new InMemoryLogger<TelemetryEventService>();
+        var service = new TelemetryEventService(_settings, logger);
+        var evt = CreateValidEvent();
+        evt.SessionId = "session\r\nforged-entry";
+        evt.WorkspaceMode = "guided\nforged-mode";
+
+        service.RecordEvent(evt).Should().BeTrue();
+
+        var message = logger.Entries.Single().Message;
+        message.Should().NotContain("\r").And.NotContain("\n");
+        message.Should().Contain("sessionforged-entry");
+        message.Should().Contain("guidedforged-mode");
     }
 }


### PR DESCRIPTION
﻿## Summary
- sanitize user-controlled request metadata before API exception logging
- add a bounded application-layer sanitizer for telemetry and log-query fields
- add regression tests that inject CR/LF sequences into every affected seam

This addresses the 20 open medium CodeQL `cs/log-forging` alerts. Test-only randomness alerts were dismissed with evidence, while the accepted local-first browser-token risk is tracked in #1644 before any hosted multi-user deployment.

## Verification
- application focused tests: 32 passed
- API middleware focused tests: 4 passed
- `git diff --check`
- branch rebased onto GPLv3 main after #1643 merged
