### PR TITLE
Make create-column proposals executable

### DIFF
--- a/backend/src/Taskdeck.Api/Mcp/WriteTools.cs
+++ b/backend/src/Taskdeck.Api/Mcp/WriteTools.cs
@@ -441,14 +441,49 @@ public class WriteTools
         if (!Guid.TryParse(board_id, out var boardGuid))
             return Error("Invalid board_id format");
 
+        var canWrite = await _authorizationService.CanWriteBoardAsync(userId, boardGuid);
+        if (!canWrite.IsSuccess)
+            return Error(canWrite.ErrorMessage);
+        if (!canWrite.Value)
+            return Error("Not authorized to create columns on this board");
+
+        var columns = (await _unitOfWork.Columns.GetByBoardIdAsync(boardGuid)).ToList();
+        var appendPositionResult = ProposalOperationContractValidator.ResolveAppendPosition(columns);
+        if (!appendPositionResult.IsSuccess)
+            return Error(appendPositionResult.ErrorMessage);
+
         var parameters = new Dictionary<string, object?>
         {
             ["boardId"] = boardGuid,
-            ["name"] = name
+            ["name"] = name,
+            ["position"] = appendPositionResult.Value
         };
 
         if (wip_limit.HasValue)
             parameters["wipLimit"] = wip_limit.Value;
+
+        var createOperation = new CreateProposalOperationDto(
+            Sequence: 0,
+            ActionType: "create",
+            TargetType: "column",
+            Parameters: JsonSerializer.Serialize(parameters, BoardResources.SerializerOptions),
+            IdempotencyKey: Guid.NewGuid().ToString());
+        var operation = new ProposalOperationDto(
+            Guid.Empty,
+            Guid.Empty,
+            createOperation.Sequence,
+            createOperation.ActionType,
+            createOperation.TargetType,
+            createOperation.TargetId,
+            createOperation.Parameters,
+            createOperation.IdempotencyKey,
+            createOperation.ExpectedVersion);
+        var contractValidation = await ProposalOperationContractValidator.ValidateAsync(
+            _unitOfWork,
+            boardGuid,
+            new[] { operation });
+        if (!contractValidation.IsSuccess)
+            return Error(contractValidation.ErrorMessage);
 
         var dto = new CreateProposalDto(
             SourceType: ProposalSourceType.Manual,
@@ -459,12 +494,7 @@ public class WriteTools
             BoardId: boardGuid,
             Operations: new List<CreateProposalOperationDto>
             {
-                new(
-                    Sequence: 0,
-                    ActionType: "create",
-                    TargetType: "column",
-                    Parameters: JsonSerializer.Serialize(parameters, BoardResources.SerializerOptions),
-                    IdempotencyKey: Guid.NewGuid().ToString())
+                createOperation
             });
 
         var result = await _proposalService.CreateProposalAsync(dto);

--- a/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
+++ b/backend/src/Taskdeck.Application/Services/AutomationProposalService.cs
@@ -1280,6 +1280,21 @@ public class AutomationProposalService : IAutomationProposalService
             return $"{operation.Sequence}. {verb} label {labelDisplay} {preposition} card {cardDisplay}";
         }
 
+        if (string.Equals(operation.TargetType, "column", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(operation.ActionType, "create", StringComparison.OrdinalIgnoreCase))
+        {
+            var columnName = ExtractStringParameter(operation.Parameters, "name") ?? "(unspecified)";
+            var position = ExtractInt32Parameter(operation.Parameters, "position");
+            var wipLimit = ExtractInt32Parameter(operation.Parameters, "wipLimit");
+            var wipLimitDescription = wipLimit.HasValue
+                ? $"WIP limit {wipLimit.Value}"
+                : "no WIP limit";
+
+            return position.HasValue
+                ? $"{operation.Sequence}. {verb} column \"{columnName}\" at position {position.Value}; {wipLimitDescription}"
+                : $"{operation.Sequence}. {verb} column \"{columnName}\"; {wipLimitDescription}";
+        }
+
         // Column reorder: surface the CLAMPED effective destination so the approval
         // preview shows what Apply will do (the position is the whole point of the op).
         // ColumnService.ReorderColumnAsync inserts at Math.Min(position, columnCount - 1),

--- a/backend/src/Taskdeck.Application/Services/Pipeline/OperationHandlerRegistry.cs
+++ b/backend/src/Taskdeck.Application/Services/Pipeline/OperationHandlerRegistry.cs
@@ -381,12 +381,45 @@ public class OperationHandlerRegistry
 
         switch (actionType)
         {
+            case "create":
+                return await CreateColumnAsync(operation, parameters, cancellationToken);
+
             case "reorder":
                 return await ReorderColumnAsync(parameters, cancellationToken);
 
             default:
                 return Result.Failure(ErrorCodes.ValidationError, $"Unsupported column action: {actionType}");
         }
+    }
+
+    private async Task<Result> CreateColumnAsync(
+        ProposalOperationDto operation,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        // Preview/approve/apply all parse the same canonical payload. Recheck the
+        // live position immediately inside execution as well, narrowing the
+        // race between Apply's permission validation and the actual insert.
+        var validationResult = await ProposalOperationContractValidator.ValidateCreateColumnForExecutionAsync(
+            _unitOfWork,
+            operation,
+            parameters,
+            cancellationToken);
+        if (!validationResult.IsSuccess)
+            return Result.Failure(validationResult.ErrorCode, validationResult.ErrorMessage);
+
+        var contract = validationResult.Value;
+        var result = await _columnService.CreateColumnAsync(
+            new CreateColumnDto(
+                contract.BoardId,
+                contract.Name,
+                contract.Position,
+                contract.WipLimit),
+            cancellationToken);
+
+        return result.IsSuccess
+            ? Result.Success()
+            : Result.Failure(result.ErrorCode, result.ErrorMessage);
     }
 
     private async Task<Result> ReorderColumnAsync(JsonElement parameters, CancellationToken cancellationToken)

--- a/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationContractValidator.cs
+++ b/backend/src/Taskdeck.Application/Services/Pipeline/ProposalOperationContractValidator.cs
@@ -20,6 +20,14 @@ public static class ProposalOperationContractValidator
     private const int MaxCardDescriptionLength = 2000;
     private const int MaxBoardNameLength = 100;
     private const int MaxBoardDescriptionLength = 1000;
+    private const int MaxColumnNameLength = 50;
+    private static readonly HashSet<string> CreateColumnParameterNames = new(StringComparer.Ordinal)
+    {
+        "boardId",
+        "name",
+        "position",
+        "wipLimit"
+    };
 
     public static async Task<Result> ValidateAsync(
         IUnitOfWork unitOfWork,
@@ -219,7 +227,13 @@ public static class ProposalOperationContractValidator
             return Task.FromResult(ValidateBoardFields(operation, parameters));
 
         if (operation.TargetType.Equals("column", StringComparison.OrdinalIgnoreCase))
-            return Task.FromResult(ValidateColumnFields(operation, parameters));
+        {
+            return ValidateColumnFieldsAsync(
+                validationContext,
+                operation,
+                parameters,
+                cancellationToken);
+        }
 
         return Task.FromResult(Result.Failure(
             ErrorCodes.ValidationError,
@@ -387,24 +401,171 @@ public static class ProposalOperationContractValidator
             : Result.Success();
     }
 
-    private static Result ValidateColumnFields(ProposalOperationDto operation, JsonElement parameters)
+    private static async Task<Result> ValidateColumnFieldsAsync(
+        BoardValidationContext validationContext,
+        ProposalOperationDto operation,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
     {
-        if (!operation.ActionType.Equals("reorder", StringComparison.OrdinalIgnoreCase))
+        if (operation.ActionType.Equals("create", StringComparison.OrdinalIgnoreCase))
         {
-            return Result.Failure(
-                ErrorCodes.ValidationError,
-                $"Unsupported column action: {operation.ActionType}");
+            var contractResult = ParseCreateColumnParameters(operation, parameters);
+            if (!contractResult.IsSuccess)
+                return Result.Failure(contractResult.ErrorCode, contractResult.ErrorMessage);
+
+            return await validationContext.ValidateAndRegisterNewColumnAsync(
+                contractResult.Value,
+                cancellationToken);
         }
 
-        if (!OperationParameterParser.TryGetRequiredGuid(parameters, "columnId", out _, out var columnIdError))
-            return Result.Failure(ErrorCodes.ValidationError, columnIdError);
+        if (operation.ActionType.Equals("reorder", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!OperationParameterParser.TryGetRequiredGuid(parameters, "columnId", out _, out var columnIdError))
+                return Result.Failure(ErrorCodes.ValidationError, columnIdError);
+
+            if (!OperationParameterParser.TryGetRequiredInt32(parameters, "position", out var position, out var positionError))
+                return Result.Failure(ErrorCodes.ValidationError, positionError);
+
+            return position < 0
+                ? Result.Failure(ErrorCodes.ValidationError, "Invalid position: must be non-negative")
+                : Result.Success();
+        }
+
+        return Result.Failure(
+            ErrorCodes.ValidationError,
+            $"Unsupported column action: {operation.ActionType}");
+    }
+
+    internal static Result<CreateColumnOperationParameters> ParseCreateColumnParameters(
+        ProposalOperationDto operation,
+        JsonElement parameters)
+    {
+        if (operation.TargetId is not null)
+        {
+            return Result.Failure<CreateColumnOperationParameters>(
+                ErrorCodes.ValidationError,
+                "Create column operation must not specify targetId");
+        }
+
+        var seenParameterNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var property in parameters.EnumerateObject())
+        {
+            if (!CreateColumnParameterNames.Contains(property.Name))
+            {
+                return Result.Failure<CreateColumnOperationParameters>(
+                    ErrorCodes.ValidationError,
+                    $"Unsupported create column parameter '{property.Name}'");
+            }
+
+            if (!seenParameterNames.Add(property.Name))
+            {
+                return Result.Failure<CreateColumnOperationParameters>(
+                    ErrorCodes.ValidationError,
+                    $"Duplicate create column parameter '{property.Name}'");
+            }
+        }
+
+        if (!OperationParameterParser.TryGetRequiredGuid(parameters, "boardId", out var boardId, out var boardIdError))
+            return Result.Failure<CreateColumnOperationParameters>(ErrorCodes.ValidationError, boardIdError);
+        if (boardId == Guid.Empty)
+        {
+            return Result.Failure<CreateColumnOperationParameters>(
+                ErrorCodes.ValidationError,
+                "Parameter 'boardId' must be a non-empty identifier");
+        }
+
+        if (!OperationParameterParser.TryGetRequiredString(parameters, "name", out var name, out var nameError))
+            return Result.Failure<CreateColumnOperationParameters>(ErrorCodes.ValidationError, nameError);
+        if (name.Length > MaxColumnNameLength)
+        {
+            return Result.Failure<CreateColumnOperationParameters>(
+                ErrorCodes.ValidationError,
+                $"Column name cannot exceed {MaxColumnNameLength} characters");
+        }
 
         if (!OperationParameterParser.TryGetRequiredInt32(parameters, "position", out var position, out var positionError))
-            return Result.Failure(ErrorCodes.ValidationError, positionError);
+            return Result.Failure<CreateColumnOperationParameters>(ErrorCodes.ValidationError, positionError);
+        if (position < 0)
+        {
+            return Result.Failure<CreateColumnOperationParameters>(
+                ErrorCodes.ValidationError,
+                "Invalid position: must be non-negative");
+        }
 
-        return position < 0
-            ? Result.Failure(ErrorCodes.ValidationError, "Invalid position: must be non-negative")
-            : Result.Success();
+        int? wipLimit = null;
+        if (parameters.TryGetProperty("wipLimit", out var wipLimitProperty) &&
+            wipLimitProperty.ValueKind != JsonValueKind.Null)
+        {
+            if (wipLimitProperty.ValueKind != JsonValueKind.Number ||
+                !wipLimitProperty.TryGetInt32(out var parsedWipLimit))
+            {
+                return Result.Failure<CreateColumnOperationParameters>(
+                    ErrorCodes.ValidationError,
+                    "Parameter 'wipLimit' must be an integer or null");
+            }
+
+            if (parsedWipLimit <= 0)
+            {
+                return Result.Failure<CreateColumnOperationParameters>(
+                    ErrorCodes.ValidationError,
+                    "WIP limit must be greater than 0");
+            }
+
+            wipLimit = parsedWipLimit;
+        }
+
+        return Result.Success(new CreateColumnOperationParameters(boardId, name, position, wipLimit));
+    }
+
+    internal static Result ValidateCreateColumnPositionAvailability(
+        IEnumerable<Taskdeck.Domain.Entities.Column> columns,
+        CreateColumnOperationParameters parameters)
+    {
+        if (columns.Any(column => column.Position == parameters.Position))
+        {
+            return Result.Failure(
+                ErrorCodes.Conflict,
+                $"Column position {parameters.Position} is already occupied on board {parameters.BoardId}");
+        }
+
+        return Result.Success();
+    }
+
+    internal static Result<int> ResolveAppendPosition(IEnumerable<Taskdeck.Domain.Entities.Column> columns)
+    {
+        var materializedColumns = columns as IReadOnlyCollection<Taskdeck.Domain.Entities.Column> ?? columns.ToList();
+        if (materializedColumns.Count == 0)
+            return Result.Success(0);
+
+        var maximumPosition = materializedColumns.Max(column => column.Position);
+        return maximumPosition == int.MaxValue
+            ? Result.Failure<int>(ErrorCodes.Conflict, "Cannot append a column because the board has no higher position available")
+            : Result.Success(maximumPosition + 1);
+    }
+
+    internal static async Task<Result<CreateColumnOperationParameters>> ValidateCreateColumnForExecutionAsync(
+        IUnitOfWork unitOfWork,
+        ProposalOperationDto operation,
+        JsonElement parameters,
+        CancellationToken cancellationToken)
+    {
+        var contractResult = ParseCreateColumnParameters(operation, parameters);
+        if (!contractResult.IsSuccess)
+        {
+            return Result.Failure<CreateColumnOperationParameters>(
+                contractResult.ErrorCode,
+                contractResult.ErrorMessage);
+        }
+
+        var columns = await unitOfWork.Columns.GetByBoardIdAsync(
+            contractResult.Value.BoardId,
+            cancellationToken);
+        var availabilityResult = ValidateCreateColumnPositionAvailability(columns, contractResult.Value);
+        return availabilityResult.IsSuccess
+            ? contractResult
+            : Result.Failure<CreateColumnOperationParameters>(
+                availabilityResult.ErrorCode,
+                availabilityResult.ErrorMessage);
     }
 
     private static async Task<Result> ValidateLabelsAsync(
@@ -454,6 +615,8 @@ public static class ProposalOperationContractValidator
         private readonly Dictionary<Guid, Guid?> _cardBoardIds = [];
         private readonly Dictionary<Guid, Guid?> _columnBoardIds = [];
         private readonly HashSet<Guid> _plannedCardIds = [];
+        private readonly HashSet<int> _plannedColumnPositions = [];
+        private IReadOnlyCollection<Taskdeck.Domain.Entities.Column>? _boardColumns;
         private HashSet<Guid>? _labelIds;
         private Dictionary<string, int>? _labelNameCounts;
 
@@ -518,6 +681,32 @@ public static class ProposalOperationContractValidator
                 : ScopeFailure("Operation column is outside the proposal board scope");
         }
 
+        public async Task<Result> ValidateAndRegisterNewColumnAsync(
+            CreateColumnOperationParameters parameters,
+            CancellationToken cancellationToken)
+        {
+            if (!BoardId.HasValue || parameters.BoardId != BoardId.Value)
+                return ScopeFailure("Operation boardId is outside the proposal board scope");
+
+            _boardColumns ??= (await unitOfWork.Columns.GetByBoardIdAsync(
+                parameters.BoardId,
+                cancellationToken)).ToList();
+
+            var availabilityResult = ValidateCreateColumnPositionAvailability(_boardColumns, parameters);
+            if (!availabilityResult.IsSuccess)
+                return availabilityResult;
+
+            if (_plannedColumnPositions.Contains(parameters.Position))
+            {
+                return Result.Failure(
+                    ErrorCodes.Conflict,
+                    $"Column position {parameters.Position} is duplicated within the proposal");
+            }
+
+            _plannedColumnPositions.Add(parameters.Position);
+            return Result.Success();
+        }
+
         public async Task<bool> ContainsLabelIdAsync(Guid labelId, CancellationToken cancellationToken)
         {
             await EnsureLabelsLoadedAsync(cancellationToken);
@@ -551,3 +740,9 @@ public static class ProposalOperationContractValidator
 
     private static Result ScopeFailure(string message) => Result.Failure(ErrorCodes.Forbidden, message);
 }
+
+internal sealed record CreateColumnOperationParameters(
+    Guid BoardId,
+    string Name,
+    int Position,
+    int? WipLimit);

--- a/backend/src/Taskdeck.Application/Services/Tools/ProposeCreateColumnExecutor.cs
+++ b/backend/src/Taskdeck.Application/Services/Tools/ProposeCreateColumnExecutor.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Taskdeck.Application.DTOs;
 using Taskdeck.Application.Interfaces;
+using Taskdeck.Application.Services.Pipeline;
 using Taskdeck.Domain.Entities;
 
 namespace Taskdeck.Application.Services.Tools;
@@ -38,21 +39,37 @@ public sealed class ProposeCreateColumnExecutor : IToolExecutor
 
     public async Task<string> ExecuteAsync(ToolExecutionContext context, JsonElement arguments, CancellationToken ct = default)
     {
-        var name = arguments.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
-
-        if (string.IsNullOrWhiteSpace(name))
+        if (arguments.ValueKind != JsonValueKind.Object)
         {
             return JsonSerializer.Serialize(new
             {
-                error = "name is required",
+                error = "arguments must be a JSON object",
+                suggestion = "Provide a name for the new column"
+            }, ToolJsonOptions.Default);
+        }
+
+        if (!OperationParameterParser.TryGetRequiredString(arguments, "name", out var name, out var nameError))
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = !arguments.TryGetProperty("name", out _) ? "name is required" : nameError,
                 suggestion = "Provide a name for the new column"
             }, ToolJsonOptions.Default);
         }
 
         int? position = null;
-        if (arguments.TryGetProperty("position", out var p) && p.ValueKind == JsonValueKind.Number)
+        if (arguments.TryGetProperty("position", out var positionProperty))
         {
-            var rawPosition = p.GetInt32();
+            if (positionProperty.ValueKind != JsonValueKind.Number ||
+                !positionProperty.TryGetInt32(out var rawPosition))
+            {
+                return JsonSerializer.Serialize(new
+                {
+                    error = "position must be an integer",
+                    suggestion = "Use a non-negative whole number or omit to append at end"
+                }, ToolJsonOptions.Default);
+            }
+
             if (rawPosition < 0)
             {
                 return JsonSerializer.Serialize(new
@@ -64,12 +81,10 @@ public sealed class ProposeCreateColumnExecutor : IToolExecutor
             position = rawPosition;
         }
 
-        // Check for duplicate column name
-        var columns = await _unitOfWork.Columns.GetByBoardIdAsync(context.BoardId, ct);
-        var existing = columns.FirstOrDefault(c =>
-            string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
-
-        if (existing != null)
+        var columns = (await _unitOfWork.Columns.GetByBoardIdAsync(context.BoardId, ct)).ToList();
+        // Preserve the chat surface's existing convenience warning. Column names
+        // are not a domain uniqueness invariant, so preview/apply do not repeat it.
+        if (columns.Any(column => string.Equals(column.Name, name, StringComparison.OrdinalIgnoreCase)))
         {
             return JsonSerializer.Serialize(new
             {
@@ -78,14 +93,33 @@ public sealed class ProposeCreateColumnExecutor : IToolExecutor
             }, ToolJsonOptions.Default);
         }
 
-        // If no position specified, append at end
-        var resolvedPosition = position ?? columns.Count();
+        if (!position.HasValue)
+        {
+            var appendPositionResult = ProposalOperationContractValidator.ResolveAppendPosition(columns);
+            if (!appendPositionResult.IsSuccess)
+            {
+                return JsonSerializer.Serialize(new { error = appendPositionResult.ErrorMessage }, ToolJsonOptions.Default);
+            }
+
+            position = appendPositionResult.Value;
+        }
+
+        var contract = new CreateColumnOperationParameters(context.BoardId, name, position.Value, null);
+        var availabilityResult = ProposalOperationContractValidator.ValidateCreateColumnPositionAvailability(columns, contract);
+        if (!availabilityResult.IsSuccess)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = availabilityResult.ErrorMessage,
+                suggestion = "Choose an unoccupied position or omit to append at end"
+            }, ToolJsonOptions.Default);
+        }
 
         var parameters = JsonSerializer.Serialize(new
         {
             boardId = context.BoardId,
             name,
-            position = resolvedPosition
+            position = position.Value
         });
 
         var operations = new List<CreateProposalOperationDto>
@@ -100,7 +134,22 @@ public sealed class ProposeCreateColumnExecutor : IToolExecutor
 
         var riskLevel = _policyEngine.ClassifyRisk(operationDtos);
 
-        var summary = $"Create column '{name}' at position {resolvedPosition}";
+        // The chat tool must not persist a proposal the same preview/apply contract
+        // would reject. This also pins requester existence and board write access.
+        var validationResult = await _policyEngine.ValidatePermissionsAsync(
+            context.UserId,
+            context.BoardId,
+            operationDtos,
+            ct);
+        if (!validationResult.IsSuccess)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                error = validationResult.ErrorMessage
+            }, ToolJsonOptions.Default);
+        }
+
+        var summary = $"Create column '{name}' at position {position.Value}";
         if (summary.Length > 500) summary = summary[..497] + "...";
 
         var createDto = new CreateProposalDto(

--- a/backend/tests/Taskdeck.Api.Tests/ChatApiTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/ChatApiTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using FluentAssertions;
 using Taskdeck.Api.Tests.Support;
 using Taskdeck.Application.DTOs;
+using Taskdeck.Domain.Entities;
 using Xunit;
 
 namespace Taskdeck.Api.Tests;
@@ -263,6 +264,69 @@ public class ChatApiTests : IClassFixture<TestWebApplicationFactory>
     }
 
     [Fact]
+    public async Task CreateColumnProposal_ShouldRequireReviewBeforeApplyingToBoard()
+    {
+        var userId = await AuthenticateAsync("chat-create-column");
+        var boardId = await CreateOwnedBoardWithColumnAsync(userId);
+
+        var createSessionResponse = await _client.PostAsJsonAsync(
+            "/api/llm/chat/sessions",
+            new CreateChatSessionDto("Create column proposal flow", boardId));
+        createSessionResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+        var session = await createSessionResponse.Content.ReadFromJsonAsync<ChatSessionDto>();
+        session.Should().NotBeNull();
+
+        (await GetColumnsAsync(boardId)).Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new { Name = "Backlog", Position = 0 });
+
+        var sendMessageResponse = await _client.PostAsJsonAsync(
+            $"/api/llm/chat/sessions/{session!.Id}/messages",
+            new SendChatMessageDto("create column called 'Review'"));
+
+        sendMessageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var assistant = await sendMessageResponse.Content.ReadFromJsonAsync<ChatMessageDto>();
+        assistant.Should().NotBeNull();
+        assistant!.MessageType.Should().Be("proposal-reference");
+        assistant.ProposalId.Should().NotBeNull();
+        var proposalId = assistant.ProposalId!.Value;
+
+        (await GetColumnsAsync(boardId)).Should().ContainSingle()
+            .Which.Name.Should().Be("Backlog", "proposing must not mutate the board");
+
+        var diffResponse = await _client.GetAsync($"/api/automation/proposals/{proposalId}/diff");
+        diffResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await diffResponse.Content.ReadAsStringAsync()).Should().Contain("Review");
+
+        var approveResponse = await _client.PostAsync(
+            $"/api/automation/proposals/{proposalId}/approve",
+            content: null);
+        approveResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var approved = await approveResponse.Content.ReadFromJsonAsync<ProposalDto>();
+        approved.Should().NotBeNull();
+        approved!.Status.Should().Be(ProposalStatus.Approved);
+        (await GetColumnsAsync(boardId)).Should().ContainSingle()
+            .Which.Name.Should().Be("Backlog", "approval must not apply the proposal");
+
+        using var executeRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            $"/api/automation/proposals/{proposalId}/execute");
+        executeRequest.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        var executeResponse = await _client.SendAsync(executeRequest);
+        executeResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var executed = await executeResponse.Content.ReadFromJsonAsync<ProposalDto>();
+        executed.Should().NotBeNull();
+        executed!.Status.Should().Be(ProposalStatus.Applied);
+
+        (await GetColumnsAsync(boardId))
+            .OrderBy(column => column.Position)
+            .Select(column => new { column.Name, column.Position })
+            .Should()
+            .Equal(
+                new { Name = "Backlog", Position = 0 },
+                new { Name = "Review", Position = 1 });
+    }
+
+    [Fact]
     public async Task SendMessage_ShouldReturnError_ForChecklistBootstrapRequestWithoutBoardScope()
     {
         await AuthenticateAsync("chat-checklist-noboard");
@@ -334,5 +398,14 @@ public class ChatApiTests : IClassFixture<TestWebApplicationFactory>
         result.BoardId.Should().NotBeNull();
 
         return result.BoardId!.Value;
+    }
+
+    private async Task<List<ColumnDto>> GetColumnsAsync(Guid boardId)
+    {
+        var response = await _client.GetAsync($"/api/boards/{boardId}/columns");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var columns = await response.Content.ReadFromJsonAsync<List<ColumnDto>>();
+        columns.Should().NotBeNull();
+        return columns!;
     }
 }

--- a/backend/tests/Taskdeck.Api.Tests/McpToolsTests.cs
+++ b/backend/tests/Taskdeck.Api.Tests/McpToolsTests.cs
@@ -647,22 +647,92 @@ public class McpToolsTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateColumn_ReturnsProposalId()
+    public async Task CreateColumn_UsesCanonicalAppendContractAndAppliesOnlyAfterApprovalAndExecution()
     {
         using var scope = _serviceProvider.CreateScope();
         var (user, boardId, _) = await SetupBoardAsync(scope);
-
-        var tools = new WriteTools(
-            scope.ServiceProvider.GetRequiredService<IAutomationProposalService>(),
-            new McpBoardResourcesTests.FixedUserContextProvider(user.Id),
-            scope.ServiceProvider.GetRequiredService<ICaptureService>(),
-            scope.ServiceProvider.GetRequiredService<IUnitOfWork>());
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var columnService = scope.ServiceProvider.GetRequiredService<ColumnService>();
+        (await columnService.CreateColumnAsync(new CreateColumnDto(boardId, "Sparse", 4, null)))
+            .IsSuccess.Should().BeTrue();
+        var tools = CreateWriteTools(scope, user.Id);
 
         var json = await tools.CreateColumn(boardId.ToString(), "In Progress", wip_limit: 3);
 
-        using var doc = JsonDocument.Parse(json);
-        doc.RootElement.TryGetProperty("proposalId", out _).Should().BeTrue();
-        doc.RootElement.GetProperty("status").GetString().Should().Be("Pending");
+        using var document = JsonDocument.Parse(json);
+        var proposalId = document.RootElement.GetProperty("proposalId").GetGuid();
+        document.RootElement.GetProperty("status").GetString().Should().Be("Pending");
+        var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
+        var proposal = await proposalService.GetProposalByIdAsync(proposalId);
+        proposal.IsSuccess.Should().BeTrue(proposal.ErrorMessage);
+        proposal.Value.Operations.Should().ContainSingle();
+        using (var parameters = JsonDocument.Parse(proposal.Value.Operations.Single().Parameters))
+        {
+            parameters.RootElement.GetProperty("boardId").GetGuid().Should().Be(boardId);
+            parameters.RootElement.GetProperty("name").GetString().Should().Be("In Progress");
+            parameters.RootElement.GetProperty("position").GetInt32().Should().Be(5);
+            parameters.RootElement.GetProperty("wipLimit").GetInt32().Should().Be(3);
+        }
+
+        (await proposalService.GetProposalDiffAsync(proposalId)).IsSuccess.Should().BeTrue();
+        (await unitOfWork.Columns.GetByBoardIdAsync(boardId))
+            .Should().NotContain(column => column.Name == "In Progress");
+
+        (await proposalService.ApproveProposalAsync(proposalId, user.Id)).IsSuccess.Should().BeTrue();
+        (await unitOfWork.Columns.GetByBoardIdAsync(boardId))
+            .Should().NotContain(column => column.Name == "In Progress");
+
+        var executor = new AutomationExecutorService(
+            unitOfWork,
+            proposalService,
+            new AutomationPolicyEngine(unitOfWork),
+            scope.ServiceProvider.GetRequiredService<CardService>(),
+            scope.ServiceProvider.GetRequiredService<BoardService>(),
+            columnService);
+        var executionResult = await executor.ExecuteProposalAsync(proposalId, Guid.NewGuid().ToString());
+
+        executionResult.IsSuccess.Should().BeTrue(executionResult.ErrorMessage);
+        var created = (await unitOfWork.Columns.GetByBoardIdAsync(boardId))
+            .Should().ContainSingle(column => column.Name == "In Progress").Subject;
+        created.Position.Should().Be(5);
+        created.WipLimit.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task CreateColumn_DuplicateNameCreatesProposalAtNextAvailablePosition()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var (user, boardId, _) = await SetupBoardAsync(scope);
+        var json = await CreateWriteTools(scope, user.Id).CreateColumn(boardId.ToString(), "backlog");
+
+        using var document = JsonDocument.Parse(json);
+        var proposalId = document.RootElement.GetProperty("proposalId").GetGuid();
+        var proposalService = scope.ServiceProvider.GetRequiredService<IAutomationProposalService>();
+        var proposal = await proposalService.GetProposalByIdAsync(proposalId);
+        proposal.IsSuccess.Should().BeTrue(proposal.ErrorMessage);
+        using var parameters = JsonDocument.Parse(proposal.Value.Operations.Single().Parameters);
+        parameters.RootElement.GetProperty("name").GetString().Should().Be("backlog");
+        parameters.RootElement.GetProperty("position").GetInt32().Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateColumn_InaccessibleBoardReturnsErrorAndCreatesNoProposal()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var (caller, _, _) = await SetupBoardAsync(scope);
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+        var owner = new User($"owner-{Guid.NewGuid():N}", $"owner-{Guid.NewGuid():N}@example.com", "Password1!");
+        await unitOfWork.Users.AddAsync(owner);
+        await unitOfWork.SaveChangesAsync();
+        var privateBoard = await scope.ServiceProvider.GetRequiredService<BoardService>()
+            .CreateBoardAsync(new CreateBoardDto("Private board", null), owner.Id);
+
+        var json = await CreateWriteTools(scope, caller.Id)
+            .CreateColumn(privateBoard.Value.Id.ToString(), "Review");
+
+        using var document = JsonDocument.Parse(json);
+        document.RootElement.GetProperty("error").GetString().Should().Contain("Not authorized");
+        (await unitOfWork.AutomationProposals.GetByBoardIdAsync(privateBoard.Value.Id)).Should().BeEmpty();
     }
 
     // ── ProposalTools tests ──────────────────────────────────────────────────

--- a/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/AutomationProposalServiceTests.cs
@@ -1850,6 +1850,65 @@ public class AutomationProposalServiceTests
     }
 
     [Fact]
+    public async Task GetProposalDiffAsync_ShouldDiscloseCanonicalCreateColumnEffects()
+    {
+        // The approval preview must disclose every field execution passes to
+        // ColumnService.CreateColumnAsync: name, position, and either the WIP
+        // limit value or the explicit no-limit state.
+        var proposalId = Guid.NewGuid();
+        var boardId = Guid.NewGuid();
+        var proposal = new AutomationProposal(
+            ProposalSourceType.Chat,
+            Guid.NewGuid(),
+            "Create review columns",
+            RiskLevel.Low,
+            Guid.NewGuid().ToString(),
+            boardId);
+
+        var limitedParameters = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            boardId,
+            name = "In Review",
+            position = 2,
+            wipLimit = 3
+        });
+        var unlimitedParameters = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            boardId,
+            name = "Done",
+            position = 3
+        });
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 0, "create", "column", limitedParameters, Guid.NewGuid().ToString()));
+        proposal.AddOperation(new AutomationProposalOperation(
+            proposal.Id, 1, "create", "column", unlimitedParameters, Guid.NewGuid().ToString()));
+
+        _proposalRepoMock.Setup(r => r.GetByIdAsync(proposalId, default))
+            .ReturnsAsync(proposal);
+
+        var columnRepoMock = new Mock<IColumnRepository>();
+        columnRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default))
+            .ReturnsAsync(Array.Empty<Column>());
+        _unitOfWorkMock.Setup(u => u.Columns).Returns(columnRepoMock.Object);
+
+        var cardRepoMock = new Mock<ICardRepository>();
+        cardRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default))
+            .ReturnsAsync(Array.Empty<Card>());
+        _unitOfWorkMock.Setup(u => u.Cards).Returns(cardRepoMock.Object);
+
+        var labelRepoMock = new Mock<ILabelRepository>();
+        labelRepoMock.Setup(r => r.GetByBoardIdAsync(boardId, default))
+            .ReturnsAsync(Array.Empty<Label>());
+        _unitOfWorkMock.Setup(u => u.Labels).Returns(labelRepoMock.Object);
+
+        var result = await _service.GetProposalDiffAsync(proposalId);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        result.Value.Should().Contain("0. Create column \"In Review\" at position 2; WIP limit 3");
+        result.Value.Should().Contain("1. Create column \"Done\" at position 3; no WIP limit");
+    }
+
+    [Fact]
     public async Task GetProposalDiffAsync_ShouldSurfaceDestinationPosition_ForColumnReorderOperations()
     {
         // Arrange: a 3-column board with a STRICTLY INTERIOR destination (position 1;

--- a/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/OperationHandlerRegistryTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/OperationHandlerRegistryTests.cs
@@ -164,6 +164,96 @@ public class OperationHandlerRegistryTests
     }
 
     [Fact]
+    public async Task ExecuteOperationAsync_ShouldCreateColumnThroughColumnServiceWithCanonicalContract()
+    {
+        var board = TestDataBuilder.CreateBoard();
+        Column? createdColumn = null;
+        _boardRepoMock.Setup(repository => repository.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _columnRepoMock.Setup(repository => repository.GetByBoardIdAsync(board.Id, default))
+            .ReturnsAsync(Array.Empty<Column>());
+        _columnRepoMock.Setup(repository => repository.AddAsync(It.IsAny<Column>(), default))
+            .Callback<Column, CancellationToken>((column, _) => createdColumn = column)
+            .ReturnsAsync((Column column, CancellationToken _) => column);
+        var operation = new ProposalOperationDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0,
+            "create",
+            "column",
+            null,
+            JsonSerializer.Serialize(new { boardId = board.Id, name = "Review", position = 3, wipLimit = 2 }),
+            "create-column",
+            null);
+
+        var result = await _registry.ExecuteOperationAsync(operation, default);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        createdColumn.Should().NotBeNull();
+        createdColumn!.BoardId.Should().Be(board.Id);
+        createdColumn.Name.Should().Be("Review");
+        createdColumn.Position.Should().Be(3);
+        createdColumn.WipLimit.Should().Be(2);
+        _unitOfWorkMock.Verify(unitOfWork => unitOfWork.SaveChangesAsync(default), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteOperationAsync_ShouldRecheckCreateColumnPositionImmediatelyBeforeInsert()
+    {
+        var boardId = Guid.NewGuid();
+        _columnRepoMock.Setup(repository => repository.GetByBoardIdAsync(boardId, default))
+            .ReturnsAsync(new[] { new Column(boardId, "Backlog", 0) });
+        var operation = new ProposalOperationDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0,
+            "create",
+            "column",
+            null,
+            JsonSerializer.Serialize(new { boardId, name = "Review", position = 0 }),
+            "create-column-conflict",
+            null);
+
+        var result = await _registry.ExecuteOperationAsync(operation, default);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("position 0");
+        _columnRepoMock.Verify(
+            repository => repository.AddAsync(It.IsAny<Column>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteOperationAsync_ShouldAllowDuplicateColumnNameAtAvailablePosition()
+    {
+        var board = TestDataBuilder.CreateBoard();
+        Column? createdColumn = null;
+        _boardRepoMock.Setup(repository => repository.GetByIdAsync(board.Id, default)).ReturnsAsync(board);
+        _columnRepoMock.Setup(repository => repository.GetByBoardIdAsync(board.Id, default))
+            .ReturnsAsync(new[] { new Column(board.Id, "Review", 0) });
+        _columnRepoMock.Setup(repository => repository.AddAsync(It.IsAny<Column>(), default))
+            .Callback<Column, CancellationToken>((column, _) => createdColumn = column)
+            .ReturnsAsync((Column column, CancellationToken _) => column);
+        var operation = new ProposalOperationDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0,
+            "create",
+            "column",
+            null,
+            JsonSerializer.Serialize(new { boardId = board.Id, name = "review", position = 1 }),
+            "create-column-duplicate-name",
+            null);
+
+        var result = await _registry.ExecuteOperationAsync(operation, default);
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+        createdColumn.Should().NotBeNull();
+        createdColumn!.Name.Should().Be("review");
+        createdColumn.Position.Should().Be(1);
+    }
+
+    [Fact]
     public async Task ExecuteOperationAsync_ShouldReturnFailure_ForUpdateCardWithoutTitleOrDescription()
     {
         var cardId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationContractValidatorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/Pipeline/ProposalOperationContractValidatorTests.cs
@@ -310,6 +310,188 @@ public class ProposalOperationContractValidatorTests
     }
 
     [Fact]
+    public async Task ValidateAsync_ShouldAcceptCanonicalCreateColumnContract()
+    {
+        var boardId = Guid.NewGuid();
+        var (unitOfWork, _, columns, _) = CreateMocks();
+        columns.Setup(repository => repository.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Column>());
+        var operation = CreateOperation(
+            0,
+            "create",
+            null,
+            new { boardId, name = "Review", position = 3, wipLimit = 2 },
+            targetType: "column");
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            new[] { operation });
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+    }
+
+    [Theory]
+    [InlineData("{\"name\":\"Review\",\"position\":1}", "'boardId'")]
+    [InlineData("{\"boardId\":\"00000000-0000-0000-0000-000000000001\",\"position\":1}", "'name'")]
+    [InlineData("{\"boardId\":\"00000000-0000-0000-0000-000000000001\",\"name\":\"Review\"}", "'position'")]
+    [InlineData("{\"boardId\":\"00000000-0000-0000-0000-000000000001\",\"name\":\"Review\",\"position\":-1}", "non-negative")]
+    [InlineData("{\"boardId\":\"00000000-0000-0000-0000-000000000001\",\"name\":\"Review\",\"position\":1.5}", "integer")]
+    [InlineData("{\"boardId\":\"00000000-0000-0000-0000-000000000001\",\"name\":\"Review\",\"position\":1,\"wipLimit\":0}", "greater than 0")]
+    [InlineData("{\"boardId\":\"00000000-0000-0000-0000-000000000001\",\"name\":\"Review\",\"position\":1,\"extra\":true}", "Unsupported")]
+    public async Task ValidateAsync_ShouldRejectMalformedCreateColumnContract(string rawParameters, string expectedMessage)
+    {
+        var operation = new ProposalOperationDto(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            0,
+            "create",
+            "column",
+            null,
+            rawParameters,
+            Guid.NewGuid().ToString(),
+            null);
+        var unitOfWork = new Mock<IUnitOfWork>();
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            Guid.Parse("00000000-0000-0000-0000-000000000001"),
+            new[] { operation });
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain(expectedMessage);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ShouldRejectCreateColumnTargetIdAndCrossBoardRedirect()
+    {
+        var boardId = Guid.NewGuid();
+        var otherBoardId = Guid.NewGuid();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var targetIdOperation = CreateOperation(
+            0,
+            "create",
+            Guid.NewGuid(),
+            new { boardId, name = "Review", position = 1 },
+            targetType: "column");
+        var redirectOperation = CreateOperation(
+            0,
+            "create",
+            null,
+            new { boardId = otherBoardId, name = "Review", position = 1 },
+            targetType: "column");
+
+        var targetResult = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            new[] { targetIdOperation });
+        var redirectResult = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            new[] { redirectOperation });
+
+        targetResult.IsSuccess.Should().BeFalse();
+        targetResult.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        targetResult.ErrorMessage.Should().Contain("must not specify targetId");
+        redirectResult.IsSuccess.Should().BeFalse();
+        redirectResult.ErrorCode.Should().Be(ErrorCodes.Forbidden);
+        redirectResult.ErrorMessage.Should().Contain("outside the proposal board scope");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ShouldRejectCreateColumnNameBeyondDomainLimit()
+    {
+        var boardId = Guid.NewGuid();
+        var unitOfWork = new Mock<IUnitOfWork>();
+        var operation = CreateOperation(
+            0,
+            "create",
+            null,
+            new { boardId, name = new string('x', 51), position = 1 },
+            targetType: "column");
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            new[] { operation });
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.ValidationError);
+        result.ErrorMessage.Should().Contain("Column name cannot exceed 50");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ShouldRejectOccupiedCreateColumnPosition()
+    {
+        var boardId = Guid.NewGuid();
+        var existingColumn = new Column(boardId, "Backlog", 0);
+        var (unitOfWork, _, columns, _) = CreateMocks();
+        columns.Setup(repository => repository.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { existingColumn });
+        var operation = CreateOperation(
+            0,
+            "create",
+            null,
+            new { boardId, name = "Review", position = 0 },
+            targetType: "column");
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            new[] { operation });
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("position 0");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ShouldRejectDuplicateCreateColumnPositionsWithinProposal()
+    {
+        var boardId = Guid.NewGuid();
+        var (unitOfWork, _, columns, _) = CreateMocks();
+        columns.Setup(repository => repository.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Column>());
+        var operations = new[]
+        {
+            CreateOperation(0, "create", null, new { boardId, name = "Review", position = 1 }, targetType: "column"),
+            CreateOperation(1, "create", null, new { boardId, name = "Ready", position = 1 }, targetType: "column")
+        };
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            operations);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorCode.Should().Be(ErrorCodes.Conflict);
+        result.ErrorMessage.Should().Contain("duplicated within the proposal");
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ShouldAllowDuplicateColumnNamesAtDifferentPositions()
+    {
+        var boardId = Guid.NewGuid();
+        var (unitOfWork, _, columns, _) = CreateMocks();
+        columns.Setup(repository => repository.GetByBoardIdAsync(boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new Column(boardId, "Review", 0) });
+        var operation = CreateOperation(
+            0,
+            "create",
+            null,
+            new { boardId, name = "review", position = 1 },
+            targetType: "column");
+
+        var result = await ProposalOperationContractValidator.ValidateAsync(
+            unitOfWork.Object,
+            boardId,
+            new[] { operation });
+
+        result.IsSuccess.Should().BeTrue(result.ErrorMessage);
+    }
+
+    [Fact]
     public async Task ValidateAsync_ShouldRequireAnUpdateFieldForBoardUpdate()
     {
         var boardId = Guid.NewGuid();

--- a/backend/tests/Taskdeck.Application.Tests/Services/WriteToolExecutorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/WriteToolExecutorTests.cs
@@ -8,6 +8,7 @@ using Taskdeck.Application.Services;
 using Taskdeck.Application.Services.Tools;
 using Taskdeck.Domain.Common;
 using Taskdeck.Domain.Entities;
+using Taskdeck.Domain.Exceptions;
 
 namespace Taskdeck.Application.Tests.Services;
 
@@ -31,6 +32,12 @@ public class WriteToolExecutorTests
 
         _policyEngine.Setup(p => p.ClassifyRisk(It.IsAny<IReadOnlyList<ProposalOperationDto>>()))
             .Returns(RiskLevel.Low);
+        _policyEngine.Setup(p => p.ValidatePermissionsAsync(
+                _userId,
+                _boardId,
+                It.IsAny<IEnumerable<ProposalOperationDto>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
     }
 
     private ToolExecutionContext MakeContext() => new(_boardId, _userId);
@@ -464,8 +471,15 @@ public class WriteToolExecutorTests
     [Fact]
     public async Task ProposeCreateColumn_WithValidName_CreatesProposal()
     {
-        SetupColumns("Backlog", "Done");
-        SetupProposalCreation(Guid.NewGuid());
+        var columns = new[]
+        {
+            new Column(_boardId, "Backlog", 0),
+            new Column(_boardId, "Done", 4)
+        };
+        _columnRepo.Setup(r => r.GetByBoardIdAsync(_boardId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(columns);
+        CreateProposalDto? captured = null;
+        SetupProposalCreation(Guid.NewGuid(), dto => captured = dto);
 
         var executor = new ProposeCreateColumnExecutor(_proposalService.Object, _policyEngine.Object, _unitOfWork.Object);
         var args = ParseArgs("""{"name": "In Review"}""");
@@ -475,6 +489,13 @@ public class WriteToolExecutorTests
 
         doc.RootElement.GetProperty("proposal_id").GetString().Should().NotBeNullOrEmpty();
         doc.RootElement.GetProperty("summary").GetString().Should().Contain("In Review");
+        captured.Should().NotBeNull();
+        captured!.Operations.Should().ContainSingle();
+        using var parameters = JsonDocument.Parse(captured.Operations![0].Parameters);
+        parameters.RootElement.GetProperty("boardId").GetGuid().Should().Be(_boardId);
+        parameters.RootElement.GetProperty("name").GetString().Should().Be("In Review");
+        parameters.RootElement.GetProperty("position").GetInt32().Should().Be(5,
+            "omitted position must use ColumnService's max-plus-one append semantics");
     }
 
     [Fact]
@@ -501,6 +522,62 @@ public class WriteToolExecutorTests
         var doc = JsonDocument.Parse(result);
 
         doc.RootElement.GetProperty("error").GetString().Should().Contain("name is required");
+    }
+
+    [Theory]
+    [InlineData("1.5")]
+    [InlineData("\"1\"")]
+    [InlineData("null")]
+    public async Task ProposeCreateColumn_NonIntegerPosition_ReturnsErrorAndCreatesNoProposal(string positionJson)
+    {
+        SetupColumns("Backlog");
+        var executor = new ProposeCreateColumnExecutor(_proposalService.Object, _policyEngine.Object, _unitOfWork.Object);
+        var args = ParseArgs($"{{\"name\":\"Review\",\"position\":{positionJson}}}");
+
+        var result = await executor.ExecuteAsync(MakeContext(), args);
+        using var doc = JsonDocument.Parse(result);
+
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("integer");
+        _proposalService.Verify(
+            service => service.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProposeCreateColumn_OccupiedPosition_ReturnsConflictAndCreatesNoProposal()
+    {
+        SetupColumns("Backlog", "Done");
+        var executor = new ProposeCreateColumnExecutor(_proposalService.Object, _policyEngine.Object, _unitOfWork.Object);
+        var args = ParseArgs("""{"name":"Review","position":1}""");
+
+        var result = await executor.ExecuteAsync(MakeContext(), args);
+        using var doc = JsonDocument.Parse(result);
+
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("position 1 is already occupied");
+        _proposalService.Verify(
+            service => service.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProposeCreateColumn_PermissionFailure_ReturnsErrorAndCreatesNoProposal()
+    {
+        SetupColumns("Backlog");
+        _policyEngine.Setup(p => p.ValidatePermissionsAsync(
+                _userId,
+                _boardId,
+                It.IsAny<IEnumerable<ProposalOperationDto>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(ErrorCodes.Forbidden, "User does not have access to board"));
+        var executor = new ProposeCreateColumnExecutor(_proposalService.Object, _policyEngine.Object, _unitOfWork.Object);
+
+        var result = await executor.ExecuteAsync(MakeContext(), ParseArgs("""{"name":"Review"}"""));
+        using var doc = JsonDocument.Parse(result);
+
+        doc.RootElement.GetProperty("error").GetString().Should().Contain("does not have access");
+        _proposalService.Verify(
+            service => service.CreateProposalAsync(It.IsAny<CreateProposalDto>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- make `create/column` a supported proposal operation and apply it through `ColumnService.CreateColumnAsync`
- share one strict preview/apply contract for required `boardId`, `name`, and `position`, with the existing optional `wipLimit`
- resolve omitted chat/MCP positions with max-plus-one semantics and fail safely on malformed, wrong-board, unauthorized, or occupied-position input
- preserve proposal-first behavior: creation and approval do not mutate the board; only explicit execute applies the column
- preserve existing domain semantics that duplicate column names are allowed

## Verification
- focused Application contract/tool/handler tests: 102 passed, 0 failed, 0 skipped
- focused MCP plus SQLite Chat API lifecycle tests: 4 passed, 0 failed, 0 skipped
- broad Application suite: 3,753 passed, 0 failed, 0 skipped
- broad API suite: 2,214 passed, 0 failed, 4 intentional skips
- `git diff --check`: passed

A serialized solution attempt with `--no-restore` also completed the affected Application/API suites above, then exited because untouched Domain/CLI/Architecture/Integration projects did not yet have fresh-worktree NuGet asset files. No dependency or project-reference files changed.

## Docs
Canonical status/masterplan files were intentionally not edited in this worker-owned slice.

## Residual risk
The validator rejects an occupied position at preview and the handler rechecks immediately before insert. A truly simultaneous insert after that recheck remains protected by the existing `(BoardId, Position)` database uniqueness constraint and follows the existing executor exception path; this slice does not redesign concurrency.

Closes #1353