### PR TITLE
Use trusted-only Codex executable paths

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,7 +34,7 @@ inherit = "all"
 sandbox = "elevated"
 
 [shell_environment_policy.set]
-PATH = "C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin;C:\\Users\\Public\\codex-shell-home\\bin;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH"
+PATH = "C:\\Users\\Public\\codex-shell-home\\bin;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
 HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\home'
 DOTNET_CLI_HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\dotnet-home'
 NUGET_PACKAGES = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\nuget\packages'

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,7 +34,10 @@ inherit = "all"
 sandbox = "elevated"
 
 [shell_environment_policy.set]
-PATH = "C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Public\\codex-shell-home\\bin;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
+# The project PATH contains only ACL-protected executable roots. Optional tools without
+# a trusted installation intentionally remain unavailable; verify after tool changes
+# with scripts/check-codex-path-trust.ps1.
+PATH = "C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH"
 HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\home'
 DOTNET_CLI_HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\dotnet-home'
 NUGET_PACKAGES = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\nuget\packages'

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -34,7 +34,7 @@ inherit = "all"
 sandbox = "elevated"
 
 [shell_environment_policy.set]
-PATH = "C:\\Users\\Public\\codex-shell-home\\bin;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
+PATH = "C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH;C:\\Users\\jekyt\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Users\\Public\\codex-shell-home\\bin;C:\\Users\\jekyt\\source\\Taskdeck\\.runtime-codex\\bin"
 HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\home'
 DOTNET_CLI_HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\dotnet-home'
 NUGET_PACKAGES = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\nuget\packages'

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -37,7 +37,7 @@ sandbox = "elevated"
 # The project PATH contains only ACL-protected executable roots. Optional tools without
 # a trusted installation intentionally remain unavailable; verify after tool changes
 # with scripts/check-codex-path-trust.ps1.
-PATH = "C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH"
+PATH = "C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\dotnet;C:\\Program Files\\nodejs;C:\\Program Files\\GitHub CLI;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0;C:\\Windows\\System32\\OpenSSH"
 HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\home'
 DOTNET_CLI_HOME = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\dotnet-home'
 NUGET_PACKAGES = 'C:\Users\jekyt\source\Taskdeck\.runtime-codex\nuget\packages'

--- a/scripts/check-codex-path-trust.ps1
+++ b/scripts/check-codex-path-trust.ps1
@@ -106,6 +106,12 @@ function Assert-NoWeakAllow {
         [string]$Boundary
     )
 
+    $acl = Get-Acl -LiteralPath $Path
+    $owner = New-Object System.Security.Principal.NTAccount($acl.Owner)
+    if (Test-WeakIdentity -Identity $owner) {
+        Throw-TrustFailure "$Boundary is owned by a weak identity at ${Path}: $($acl.Owner)"
+    }
+
     $weakAces = @(Get-WeakAllowAces -Path $Path -RightsMask $RightsMask)
     if ($weakAces.Count -gt 0) {
         $details = ($weakAces | ForEach-Object {

--- a/scripts/check-codex-path-trust.ps1
+++ b/scripts/check-codex-path-trust.ps1
@@ -1,0 +1,382 @@
+[CmdletBinding()]
+param(
+    [string]$ConfigPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($ConfigPath)) {
+    $ConfigPath = Join-Path (Split-Path -Parent $PSScriptRoot) '.codex\config.toml'
+}
+
+function Throw-TrustFailure {
+    param([string]$Message)
+
+    throw "[codex-path-trust] $Message"
+}
+
+function Get-ConfiguredPath {
+    param([string]$Path)
+
+    $content = [System.IO.File]::ReadAllText($Path)
+    $sectionMatches = [regex]::Matches(
+        $content,
+        '(?ms)^\[shell_environment_policy\.set\]\s*\r?\n(?<body>.*?)(?=^\[|\z)'
+    )
+    if ($sectionMatches.Count -ne 1) {
+        Throw-TrustFailure "Expected one [shell_environment_policy.set] section in $Path."
+    }
+
+    $pathMatches = [regex]::Matches(
+        $sectionMatches[0].Groups['body'].Value,
+        '(?m)^\s*PATH\s*=\s*(?<literal>"(?:\\.|[^"\\])*")\s*(?:#.*)?$'
+    )
+    if ($pathMatches.Count -ne 1) {
+        Throw-TrustFailure "Expected one basic-string PATH assignment in $Path."
+    }
+
+    try {
+        return ($pathMatches[0].Groups['literal'].Value | ConvertFrom-Json)
+    }
+    catch {
+        Throw-TrustFailure "Could not decode the PATH basic string in ${Path}: $($_.Exception.Message)"
+    }
+}
+
+$script:CurrentUserSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$script:WeakSids = @(
+    'S-1-1-0',       # Everyone
+    'S-1-5-4',       # Interactive
+    'S-1-5-11',      # Authenticated Users
+    'S-1-5-32-545',  # BUILTIN\Users
+    $script:CurrentUserSid
+)
+$script:WriteMask =
+    [System.Security.AccessControl.FileSystemRights]::WriteData -bor
+    [System.Security.AccessControl.FileSystemRights]::AppendData -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::WriteExtendedAttributes -bor
+    [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::Delete -bor
+    [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+$script:DeleteChildMask =
+    [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles
+
+function Test-WeakIdentity {
+    param([System.Security.Principal.IdentityReference]$Identity)
+
+    $sid = $null
+    try {
+        $sid = $Identity.Translate([System.Security.Principal.SecurityIdentifier]).Value
+    }
+    catch {
+        # Unresolved local identities still receive the conservative name check below.
+    }
+
+    if ($sid -and $script:WeakSids -contains $sid) {
+        return $true
+    }
+
+    return $Identity.Value -match '(?i)(^|\\)(Everyone|Users|Authenticated Users|INTERACTIVE|.*CodexSandbox.*)$'
+}
+
+function Get-WeakAllowAces {
+    param(
+        [string]$Path,
+        [System.Security.AccessControl.FileSystemRights]$RightsMask
+    )
+
+    foreach ($ace in (Get-Acl -LiteralPath $Path).Access) {
+        if (
+            $ace.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
+            ($ace.FileSystemRights -band $RightsMask) -ne 0 -and
+            (Test-WeakIdentity -Identity $ace.IdentityReference)
+        ) {
+            $ace
+        }
+    }
+}
+
+function Assert-NoWeakAllow {
+    param(
+        [string]$Path,
+        [System.Security.AccessControl.FileSystemRights]$RightsMask,
+        [string]$Boundary
+    )
+
+    $weakAces = @(Get-WeakAllowAces -Path $Path -RightsMask $RightsMask)
+    if ($weakAces.Count -gt 0) {
+        $details = ($weakAces | ForEach-Object {
+            "$($_.IdentityReference.Value):$($_.FileSystemRights)"
+        }) -join ', '
+        Throw-TrustFailure "$Boundary is writable by a weak identity at ${Path}: $details"
+    }
+}
+
+function Assert-TrustedDirectory {
+    param([string]$Path)
+
+    if (-not [System.IO.Path]::IsPathRooted($Path)) {
+        Throw-TrustFailure "PATH entry is not absolute: $Path"
+    }
+    if ($Path.IndexOfAny([char[]]'*?') -ge 0) {
+        Throw-TrustFailure "PATH entry contains a wildcard: $Path"
+    }
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+    if ($fullPath.StartsWith('\\', [System.StringComparison]::Ordinal)) {
+        Throw-TrustFailure "UNC PATH entries are not allowed: $Path"
+    }
+    if ($fullPath.Length -gt 2 -and $fullPath.Substring(2).Contains(':')) {
+        Throw-TrustFailure "PATH entry contains an alternate data stream or device suffix: $Path"
+    }
+
+    foreach ($blockedRoot in @('C:\Users', 'C:\ProgramData')) {
+        if (
+            $fullPath.Equals($blockedRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $fullPath.StartsWith("$blockedRoot\", [System.StringComparison]::OrdinalIgnoreCase)
+        ) {
+            Throw-TrustFailure "PATH entry is inside a user-writable root: $Path"
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Container)) {
+        Throw-TrustFailure "PATH entry must be an existing directory: $Path"
+    }
+
+    $root = [System.IO.Path]::GetPathRoot($fullPath)
+    $rootItem = Get-Item -LiteralPath $root -Force
+    if (($rootItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Throw-TrustFailure "PATH root is a reparse point: $root"
+    }
+
+    $current = $root
+    $relative = $fullPath.Substring($root.Length).Trim('\')
+    foreach ($segment in $relative.Split([char]'\', [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        $parent = $current
+        $current = Join-Path $current $segment
+        $item = Get-Item -LiteralPath $current -Force
+        if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+            Throw-TrustFailure "PATH chain contains a reparse point: $current"
+        }
+
+        Assert-NoWeakAllow -Path $current -RightsMask $script:WriteMask -Boundary 'PATH directory'
+        Assert-NoWeakAllow -Path $parent -RightsMask $script:DeleteChildMask -Boundary 'PATH parent replacement boundary'
+    }
+}
+
+function Assert-TrustedFile {
+    param([string]$Path)
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        Throw-TrustFailure "Required executable is missing: $fullPath"
+    }
+
+    Assert-TrustedDirectory -Path (Split-Path -Parent $fullPath)
+    $item = Get-Item -LiteralPath $fullPath -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        Throw-TrustFailure "Executable is a reparse point: $fullPath"
+    }
+    Assert-NoWeakAllow -Path $fullPath -RightsMask $script:WriteMask -Boundary 'Executable'
+}
+
+function Resolve-ApplicationPath {
+    param([string]$Name)
+
+    $commands = @(Get-Command -Name $Name -CommandType Application -All -ErrorAction SilentlyContinue)
+    if ($commands.Count -eq 0) {
+        return $null
+    }
+    return [System.IO.Path]::GetFullPath($commands[0].Source)
+}
+
+function Assert-ApplicationResolution {
+    param(
+        [string]$Name,
+        [string]$ExpectedPath
+    )
+
+    $actualPath = Resolve-ApplicationPath -Name $Name
+    if (-not $actualPath) {
+        Throw-TrustFailure "Required command '$Name' did not resolve."
+    }
+    if (-not $actualPath.Equals($ExpectedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Throw-TrustFailure "Command '$Name' resolved to '$actualPath', expected '$ExpectedPath'."
+    }
+    Assert-TrustedFile -Path $actualPath
+}
+
+function Assert-ApplicationAbsent {
+    param([string]$Name)
+
+    $actualPath = Resolve-ApplicationPath -Name $Name
+    if ($actualPath) {
+        Throw-TrustFailure "Optional command '$Name' must fail closed but resolved to '$actualPath'."
+    }
+}
+
+function Invoke-CheckedNative {
+    param(
+        [string]$Path,
+        [string[]]$Arguments
+    )
+
+    $global:LASTEXITCODE = $null
+    $output = @(& $Path @Arguments 2>&1)
+    $exitCode = $global:LASTEXITCODE
+    if ($null -eq $exitCode -or $exitCode -ne 0) {
+        Throw-TrustFailure "'$Path $($Arguments -join ' ')' failed with exit '$exitCode': $($output -join ' ')"
+    }
+    Write-Host "OK [codex-path-trust]: $([System.IO.Path]::GetFileName($Path)) $($output[0])"
+}
+
+$resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
+$configuredPath = Get-ConfiguredPath -Path $resolvedConfig
+$pathEntries = @($configuredPath.Split([System.IO.Path]::PathSeparator))
+if ($pathEntries.Count -eq 0 -or $pathEntries -contains '') {
+    Throw-TrustFailure 'Configured PATH must not contain empty entries.'
+}
+
+$seen = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($entry in $pathEntries) {
+    if (-not $seen.Add([System.IO.Path]::GetFullPath($entry).TrimEnd('\'))) {
+        Throw-TrustFailure "Configured PATH contains a duplicate entry: $entry"
+    }
+    Assert-TrustedDirectory -Path $entry
+}
+
+$originalPath = $env:PATH
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath()).TrimEnd('\')
+$forgedBin = Join-Path $tempBase ("taskdeck-codex-path-canary-{0}" -f [guid]::NewGuid().ToString('N'))
+
+try {
+    [void](New-Item -ItemType Directory -Path $forgedBin)
+    $weakCanaryAces = @(Get-WeakAllowAces -Path $forgedBin -RightsMask $script:WriteMask)
+    if ($weakCanaryAces.Count -eq 0) {
+        Throw-TrustFailure "Writable canary directory did not expose a weak write ACL: $forgedBin"
+    }
+    $canaryRejected = $false
+    try {
+        Assert-TrustedDirectory -Path $forgedBin
+    }
+    catch {
+        $canaryRejected = $_.Exception.Message -match 'user-writable root|writable by a weak identity'
+    }
+    if (-not $canaryRejected) {
+        Throw-TrustFailure "Verifier did not reject the writable canary directory: $forgedBin"
+    }
+
+    $canarySource = 'C:\Windows\System32\where.exe'
+    foreach ($name in @('git', 'gh', 'jq', 'python', 'python3', 'node', 'npm', 'npx', 'powershell')) {
+        Copy-Item -LiteralPath $canarySource -Destination (Join-Path $forgedBin "$name.exe")
+    }
+
+    $env:PATH = "$forgedBin$([System.IO.Path]::PathSeparator)$configuredPath"
+    foreach ($name in @('git', 'gh', 'jq', 'python', 'python3', 'node', 'npm', 'npx', 'powershell')) {
+        $positiveControl = Resolve-ApplicationPath -Name $name
+        $expectedCanary = [System.IO.Path]::GetFullPath((Join-Path $forgedBin "$name.exe"))
+        if (
+            -not $positiveControl -or
+            -not $positiveControl.Equals($expectedCanary, [System.StringComparison]::OrdinalIgnoreCase)
+        ) {
+            Throw-TrustFailure "Forged '$name' positive control could not win from the prepended writable bin."
+        }
+    }
+
+    $env:PATH = $configuredPath
+
+    $expectedApplications = @(
+        @{ Name = 'git';        Path = 'C:\Program Files\Git\cmd\git.exe' },
+        @{ Name = 'gh';         Path = 'C:\Program Files\GitHub CLI\gh.exe' },
+        @{ Name = 'dotnet';     Path = 'C:\Program Files\dotnet\dotnet.exe' },
+        @{ Name = 'node';       Path = 'C:\Program Files\nodejs\node.exe' },
+        @{ Name = 'npm';        Path = 'C:\Program Files\nodejs\npm.cmd' },
+        @{ Name = 'npx';        Path = 'C:\Program Files\nodejs\npx.cmd' },
+        @{ Name = 'py';         Path = 'C:\Windows\py.exe' },
+        @{ Name = 'powershell'; Path = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' }
+    )
+    foreach ($expected in $expectedApplications) {
+        Assert-ApplicationResolution -Name $expected.Name -ExpectedPath $expected.Path
+    }
+
+    foreach ($name in @('jq', 'python', 'python3')) {
+        Assert-ApplicationAbsent -Name $name
+    }
+
+    foreach ($packageManager in @('npm', 'npx')) {
+        $candidates = @(Get-Command -Name $packageManager -All -ErrorAction Stop | Where-Object {
+            $_.CommandType -eq 'Application' -or $_.CommandType -eq 'ExternalScript'
+        })
+        if ($candidates.Count -eq 0) {
+            Throw-TrustFailure "Bare '$packageManager' did not resolve to a script or application."
+        }
+        foreach ($candidate in $candidates) {
+            Assert-TrustedFile -Path $candidate.Source
+        }
+    }
+
+    Invoke-CheckedNative -Path 'C:\Program Files\Git\cmd\git.exe' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Program Files\GitHub CLI\gh.exe' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Program Files\dotnet\dotnet.exe' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Program Files\nodejs\node.exe' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Program Files\nodejs\npm.cmd' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Program Files\nodejs\npx.cmd' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe' -Arguments @(
+        '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', '$PSVersionTable.PSVersion.ToString()'
+    )
+
+    $pythonProbe = @'
+import json
+import pathlib
+import sys
+import tomllib
+
+config_path = pathlib.Path(sys.argv[1])
+with config_path.open('rb') as config_file:
+    config = tomllib.load(config_file)
+print(json.dumps({
+    'executable': sys.executable,
+    'path': config['shell_environment_policy']['set']['PATH'],
+    'version': sys.version.split()[0],
+}))
+'@
+    $global:LASTEXITCODE = $null
+    $pythonProbeOutput = @(& 'C:\Windows\py.exe' -3 -B -c $pythonProbe $resolvedConfig 2>&1)
+    $pythonProbeExit = $global:LASTEXITCODE
+    if ($null -eq $pythonProbeExit -or $pythonProbeExit -ne 0) {
+        Throw-TrustFailure "Trusted py -3 TOML probe failed with exit '$pythonProbeExit': $($pythonProbeOutput -join ' ')"
+    }
+    try {
+        $pythonInfo = $pythonProbeOutput[-1] | ConvertFrom-Json
+    }
+    catch {
+        Throw-TrustFailure "Trusted py -3 TOML probe returned invalid JSON: $($pythonProbeOutput -join ' ')"
+    }
+    if ($pythonInfo.path -cne $configuredPath) {
+        Throw-TrustFailure 'The full TOML parse disagrees with the bootstrap PATH extraction.'
+    }
+    Assert-TrustedFile -Path $pythonInfo.executable
+    Write-Host "OK [codex-path-trust]: py -3 $($pythonInfo.version) -> $($pythonInfo.executable)"
+
+    Write-Host "OK [codex-path-trust]: $($pathEntries.Count) existing PATH roots are protected."
+    Write-Host 'OK [codex-path-trust]: forged writable-bin executables cannot participate in the configured PATH.'
+    Write-Host 'OK [codex-path-trust]: jq, python, and python3 fail closed; use py -3 for Windows Python.'
+}
+finally {
+    $env:PATH = $originalPath
+    if (Test-Path -LiteralPath $forgedBin) {
+        $resolvedCanary = [System.IO.Path]::GetFullPath($forgedBin)
+        if (
+            $resolvedCanary.StartsWith("$tempBase\", [System.StringComparison]::OrdinalIgnoreCase) -and
+            -not $resolvedCanary.Equals($tempBase, [System.StringComparison]::OrdinalIgnoreCase)
+        ) {
+            Remove-Item -LiteralPath $resolvedCanary -Recurse -Force
+        }
+        else {
+            Throw-TrustFailure "Refusing to remove unexpected canary path: $resolvedCanary"
+        }
+    }
+}

--- a/scripts/check-codex-path-trust.ps1
+++ b/scripts/check-codex-path-trust.ps1
@@ -44,14 +44,22 @@ function Get-ConfiguredPath {
     }
 }
 
-$script:CurrentUserSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
-$script:WeakSids = @(
+$script:CurrentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$script:CurrentPrincipal = [System.Security.Principal.WindowsPrincipal]::new($script:CurrentIdentity)
+$script:CurrentUserSid = $script:CurrentIdentity.User.Value
+$script:AlwaysWeakSids = @(
     'S-1-1-0',       # Everyone
     'S-1-5-4',       # Interactive
     'S-1-5-11',      # Authenticated Users
     'S-1-5-32-545',  # BUILTIN\Users
     $script:CurrentUserSid
 )
+$script:EnabledTokenGroupSids = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($group in $script:CurrentIdentity.Groups) {
+    if ($script:CurrentPrincipal.IsInRole($group)) {
+        [void]$script:EnabledTokenGroupSids.Add($group.Value)
+    }
+}
 $script:WriteMask =
     [System.Security.AccessControl.FileSystemRights]::WriteData -bor
     [System.Security.AccessControl.FileSystemRights]::AppendData -bor
@@ -75,8 +83,13 @@ function Test-WeakIdentity {
         # Unresolved local identities still receive the conservative name check below.
     }
 
-    if ($sid -and $script:WeakSids -contains $sid) {
-        return $true
+    if ($sid) {
+        if ($script:AlwaysWeakSids -contains $sid) {
+            return $true
+        }
+        if ($script:EnabledTokenGroupSids.Contains($sid)) {
+            return $true
+        }
     }
 
     return $Identity.Value -match '(?i)(^|\\)(Everyone|Users|Authenticated Users|INTERACTIVE|.*CodexSandbox.*)$'
@@ -239,6 +252,32 @@ function Invoke-CheckedNative {
     Write-Host "OK [codex-path-trust]: $([System.IO.Path]::GetFileName($Path)) $($output[0])"
 }
 
+function Select-PythonInterpreterFromInventory {
+    param([object[]]$Inventory)
+
+    foreach ($line in $Inventory) {
+        $text = [string]$line
+        if ($text -match '^\s*-(?:V:)?3(?:\.\d+)*(?:\s+\*)?\s+(?<path>[A-Za-z]:\\.+?\.exe)\s*$') {
+            return [System.IO.Path]::GetFullPath($Matches['path'])
+        }
+    }
+
+    Throw-TrustFailure "Python launcher did not enumerate a Python 3 interpreter: $($Inventory -join ' ')"
+}
+
+function Get-SelectedPythonInterpreter {
+    param([string]$LauncherPath)
+
+    $global:LASTEXITCODE = $null
+    $inventory = @(& $LauncherPath -0p 2>&1)
+    $exitCode = $global:LASTEXITCODE
+    if ($null -eq $exitCode -or $exitCode -ne 0) {
+        Throw-TrustFailure "Trusted Python launcher inventory failed with exit '$exitCode': $($inventory -join ' ')"
+    }
+
+    return Select-PythonInterpreterFromInventory -Inventory $inventory
+}
+
 $resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
 $configuredPath = Get-ConfiguredPath -Path $resolvedConfig
 $pathEntries = @($configuredPath.Split([System.IO.Path]::PathSeparator))
@@ -257,6 +296,7 @@ foreach ($entry in $pathEntries) {
 $originalPath = $env:PATH
 $tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath()).TrimEnd('\')
 $forgedBin = Join-Path $tempBase ("taskdeck-codex-path-canary-{0}" -f [guid]::NewGuid().ToString('N'))
+$aclCanary = Join-Path $tempBase ("taskdeck-codex-acl-canary-{0}" -f [guid]::NewGuid().ToString('N'))
 
 try {
     [void](New-Item -ItemType Directory -Path $forgedBin)
@@ -276,12 +316,12 @@ try {
     }
 
     $canarySource = 'C:\Windows\System32\where.exe'
-    foreach ($name in @('git', 'gh', 'jq', 'python', 'python3', 'node', 'npm', 'npx', 'powershell')) {
+    foreach ($name in @('git', 'gh', 'docker', 'jq', 'python', 'python3', 'node', 'npm', 'npx', 'powershell')) {
         Copy-Item -LiteralPath $canarySource -Destination (Join-Path $forgedBin "$name.exe")
     }
 
     $env:PATH = "$forgedBin$([System.IO.Path]::PathSeparator)$configuredPath"
-    foreach ($name in @('git', 'gh', 'jq', 'python', 'python3', 'node', 'npm', 'npx', 'powershell')) {
+    foreach ($name in @('git', 'gh', 'docker', 'jq', 'python', 'python3', 'node', 'npm', 'npx', 'powershell')) {
         $positiveControl = Resolve-ApplicationPath -Name $name
         $expectedCanary = [System.IO.Path]::GetFullPath((Join-Path $forgedBin "$name.exe"))
         if (
@@ -294,9 +334,77 @@ try {
 
     $env:PATH = $configuredPath
 
+    [void](New-Item -ItemType Directory -Path $aclCanary)
+    $delegatedGroupSid = @($script:CurrentIdentity.Groups | Where-Object {
+        $script:CurrentPrincipal.IsInRole($_) -and
+        $script:AlwaysWeakSids -notcontains $_.Value
+    } | Select-Object -First 1)
+    if ($delegatedGroupSid.Count -ne 1) {
+        Throw-TrustFailure 'Current token did not expose an enabled non-baseline group for the delegated-group ACL control.'
+    }
+    $delegatedGroupSid = $delegatedGroupSid[0]
+
+    $acl = Get-Acl -LiteralPath $aclCanary
+    $delegatedWriteRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $delegatedGroupSid,
+        [System.Security.AccessControl.FileSystemRights]::WriteData,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+    [void]$acl.AddAccessRule($delegatedWriteRule)
+    Set-Acl -LiteralPath $aclCanary -AclObject $acl
+
+    $delegatedGroupDetected = @(Get-WeakAllowAces -Path $aclCanary -RightsMask $script:WriteMask | Where-Object {
+        try {
+            $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value -eq $delegatedGroupSid.Value
+        }
+        catch {
+            $false
+        }
+    })
+    if ($delegatedGroupDetected.Count -eq 0) {
+        Throw-TrustFailure "Verifier did not reject write access delegated through enabled token group $($delegatedGroupSid.Value)."
+    }
+
+    $ownerRejected = $false
+    try {
+        Assert-NoWeakAllow -Path $aclCanary -RightsMask $script:WriteMask -Boundary 'ACL owner control'
+    }
+    catch {
+        $ownerRejected = $_.Exception.Message -match 'owned by a weak identity'
+    }
+    if (-not $ownerRejected) {
+        Throw-TrustFailure 'Verifier did not reject effective owner rights on the ACL control directory.'
+    }
+
+    $administratorsSid = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-32-544')
+    $administratorsExpectedWeak = $script:CurrentPrincipal.IsInRole($administratorsSid)
+    if ((Test-WeakIdentity -Identity $administratorsSid) -ne $administratorsExpectedWeak) {
+        Throw-TrustFailure 'Enabled-group control misclassified the Administrators SID for the current token.'
+    }
+
+    $untrustedPython = Join-Path $aclCanary 'python.exe'
+    Copy-Item -LiteralPath $canarySource -Destination $untrustedPython
+    $selectedCanaryPython = Select-PythonInterpreterFromInventory -Inventory @(" -V:3.13 *        $untrustedPython")
+    if (-not $selectedCanaryPython.Equals($untrustedPython, [System.StringComparison]::OrdinalIgnoreCase)) {
+        Throw-TrustFailure 'Python inventory control did not select the forged interpreter path.'
+    }
+    $untrustedPythonRejected = $false
+    try {
+        Assert-TrustedFile -Path $selectedCanaryPython
+    }
+    catch {
+        $untrustedPythonRejected = $_.Exception.Message -match 'user-writable root|owned by a weak identity|writable by a weak identity'
+    }
+    if (-not $untrustedPythonRejected) {
+        Throw-TrustFailure 'Verifier did not reject the forged Python interpreter before execution.'
+    }
+
     $expectedApplications = @(
         @{ Name = 'git';        Path = 'C:\Program Files\Git\cmd\git.exe' },
         @{ Name = 'gh';         Path = 'C:\Program Files\GitHub CLI\gh.exe' },
+        @{ Name = 'docker';     Path = 'C:\Program Files\Docker\Docker\resources\bin\docker.exe' },
         @{ Name = 'dotnet';     Path = 'C:\Program Files\dotnet\dotnet.exe' },
         @{ Name = 'node';       Path = 'C:\Program Files\nodejs\node.exe' },
         @{ Name = 'npm';        Path = 'C:\Program Files\nodejs\npm.cmd' },
@@ -326,6 +434,7 @@ try {
 
     Invoke-CheckedNative -Path 'C:\Program Files\Git\cmd\git.exe' -Arguments @('--version')
     Invoke-CheckedNative -Path 'C:\Program Files\GitHub CLI\gh.exe' -Arguments @('--version')
+    Invoke-CheckedNative -Path 'C:\Program Files\Docker\Docker\resources\bin\docker.exe' -Arguments @('--version')
     Invoke-CheckedNative -Path 'C:\Program Files\dotnet\dotnet.exe' -Arguments @('--version')
     Invoke-CheckedNative -Path 'C:\Program Files\nodejs\node.exe' -Arguments @('--version')
     Invoke-CheckedNative -Path 'C:\Program Files\nodejs\npm.cmd' -Arguments @('--version')
@@ -349,8 +458,11 @@ print(json.dumps({
     'version': sys.version.split()[0],
 }))
 '@
+    $selectedPython = Get-SelectedPythonInterpreter -LauncherPath 'C:\Windows\py.exe'
+    Assert-TrustedFile -Path $selectedPython
+
     $global:LASTEXITCODE = $null
-    $pythonProbeOutput = @(& 'C:\Windows\py.exe' -3 -B -c $pythonProbe $resolvedConfig 2>&1)
+    $pythonProbeOutput = @(& $selectedPython -I -B -c $pythonProbe $resolvedConfig 2>&1)
     $pythonProbeExit = $global:LASTEXITCODE
     if ($null -eq $pythonProbeExit -or $pythonProbeExit -ne 0) {
         Throw-TrustFailure "Trusted py -3 TOML probe failed with exit '$pythonProbeExit': $($pythonProbeOutput -join ' ')"
@@ -364,17 +476,30 @@ print(json.dumps({
     if ($pythonInfo.path -cne $configuredPath) {
         Throw-TrustFailure 'The full TOML parse disagrees with the bootstrap PATH extraction.'
     }
+    if (
+        -not ([System.IO.Path]::GetFullPath($pythonInfo.executable)).Equals(
+            $selectedPython,
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
+    ) {
+        Throw-TrustFailure "Isolated Python probe executed '$($pythonInfo.executable)', expected '$selectedPython'."
+    }
     Assert-TrustedFile -Path $pythonInfo.executable
-    Write-Host "OK [codex-path-trust]: py -3 $($pythonInfo.version) -> $($pythonInfo.executable)"
+    Write-Host "OK [codex-path-trust]: py -3 selection $($pythonInfo.version) -> $($pythonInfo.executable) (absolute -I execution)"
 
     Write-Host "OK [codex-path-trust]: $($pathEntries.Count) existing PATH roots are protected."
+    Write-Host 'OK [codex-path-trust]: untrusted Python selection was rejected before execution.'
+    Write-Host "OK [codex-path-trust]: enabled-group ACL mutation and deny-only-group control passed."
     Write-Host 'OK [codex-path-trust]: forged writable-bin executables cannot participate in the configured PATH.'
     Write-Host 'OK [codex-path-trust]: jq, python, and python3 fail closed; use py -3 for Windows Python.'
 }
 finally {
     $env:PATH = $originalPath
-    if (Test-Path -LiteralPath $forgedBin) {
-        $resolvedCanary = [System.IO.Path]::GetFullPath($forgedBin)
+    foreach ($canaryPath in @($forgedBin, $aclCanary)) {
+        if (-not (Test-Path -LiteralPath $canaryPath)) {
+            continue
+        }
+        $resolvedCanary = [System.IO.Path]::GetFullPath($canaryPath)
         if (
             $resolvedCanary.StartsWith("$tempBase\", [System.StringComparison]::OrdinalIgnoreCase) -and
             -not $resolvedCanary.Equals($tempBase, [System.StringComparison]::OrdinalIgnoreCase)


### PR DESCRIPTION
## Merge status

PARKED at exact head `625529c6687580637b5cccf1fdb7a07487f3bbb9`; do not merge. The bounded fix round closed the token-group ACL, pre-validation Python execution, and Docker blockers, but fix-only security review confirmed two residual HIGHs: inventory selection can differ from the exact interpreter chosen by user-controlled `PY_PYTHON3` / `py.ini`, and ACL masks ignore `GENERIC_ALL` / `GENERIC_WRITE`. #1651 owns both trust fixes.

## Summary

Supersedes parked draft #1646 without reopening its two-round review loop.

- removes every user-writable/user-specific fallback directory from Taskdeck's project Codex PATH
- keeps only existing ACL-protected Program Files and Windows executable roots, including the protected Docker CLI root
- adds a focused Windows verifier for ACL, token-group ownership/access, reparse, parent-replacement, resolution, execution, and forged-bin resistance

## Implementation

The successor preserves #1646's two commits through signed merge `402196d7`, then replaces its “trusted first, writable fallbacks later” posture with a trusted-only PATH.

`scripts/check-codex-path-trust.ps1`:

- parses the configured TOML PATH and rejects empty, duplicate, relative, wildcard, UNC, user-root, missing, reparse-backed, weakly owned, weakly writable, or parent-replaceable entries
- treats the current user and enabled non-deny-only token groups as weak principals for write, delete, ownership, and DACL checks
- validates the resolved executable file and directory boundary for required commands
- proves a writable forged directory can shadow an unsafe PATH, then proves no forged executable participates in the configured PATH
- enumerates the preferred Python 3 interpreter through trusted `py.exe -0p`, validates its absolute path and ACL chain before execution, then runs it with `-I -B`
- executes `docker`, `git`, `gh`, `dotnet`, `node`, `npm.cmd`, `npx.cmd`, Windows PowerShell, and the validated Python interpreter
- fails closed when `jq`, bare `python`, or `python3` would resolve

## Verification

Exact range: `867e87cc74d0d8ca6796f7989a998b05e25ede4d..625529c6687580637b5cccf1fdb7a07487f3bbb9`

- `powershell -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/check-codex-path-trust.ps1` — passed; 10 protected roots and all resolution/execution/forgery controls green
- delegated-group write/owner, deny-only Administrator, forged Python-selection, and forged PATH controls — passed
- effective configured-PATH resolution — required commands passed; `jq`, `rg`, bare `python`, and `python3` absent
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-git-env.ps1` under the configured PATH — passed, including LF shell-script checks
- exact-range DCO — 6/6 commits passed
- `git diff --check` — passed
- tracked, untracked, and ignored worktree inventories — empty

Hosted CI runs on this exact ready successor head. Fix-only review is complete: operability is clean, while the unresolved Python launcher-selection and generic-rights ACL HIGHs keep the PR parked.

## Docs

No canonical docs changed. The Windows Python contract remains `py -3`; no product/runtime behavior changed.

## Risks and follow-ups

- Native `rg` has no executable protected installation on this machine. It remains unavailable rather than being restored through a writable shim path; existing #1651 owns that availability criterion and generalized drive-root/mapped-drive hardening.
- `jq` remains an optional manual prerequisite and is not used by repository automation.
- The ACL verifier must map or explicitly reject `GENERIC_ALL` / `GENERIC_WRITE`; current bit masks can false-pass those writable ACEs. #1651 owns the repair.
- Existing hard-coded HOME/NuGet/Git-config values are outside this PATH-only security repair.

Closes #1625
Refs #1651
Supersedes #1646