### PR TITLE
Enforce full-transcript evidence uniqueness

### DIFF
--- a/backend/src/Taskdeck.Application/Services/LlmCaptureTriageExtractor.cs
+++ b/backend/src/Taskdeck.Application/Services/LlmCaptureTriageExtractor.cs
@@ -64,7 +64,7 @@ public class LlmCaptureTriageExtractor : ILlmCaptureTriageExtractor
                             ? extraction.EvidenceSpans[index]
                             : null))
                     .ToList())
-            ]);
+            ], payload.Text);
             return extraction with
             {
                 Output = extraction.Output with { Tasks = singleReduced.Tasks },
@@ -146,7 +146,7 @@ public class LlmCaptureTriageExtractor : ILlmCaptureTriageExtractor
                 Model: model);
         }
 
-        var reduced = ReduceMappedTasks(mappedTasks);
+        var reduced = ReduceMappedTasks(mappedTasks, payload.Text);
         var output = new CaptureTriageOutputV2(
             CaptureTriageOutputContract.SchemaVersionV2,
             CaptureTriageOutputContract.PromptVersionLlmV2,
@@ -449,14 +449,20 @@ public class LlmCaptureTriageExtractor : ILlmCaptureTriageExtractor
         IReadOnlyList<(int Start, int End)?> Spans);
 
     private static ReducedTasks ReduceMappedTasks(
-        IReadOnlyList<MappedChunkTasks> mappedTasks)
+        IReadOnlyList<MappedChunkTasks> mappedTasks,
+        string canonicalTranscript)
     {
         // A transcript can yield more than the schema-v2 contract's 20 cards. Do not let an early chunk
         // consume every output slot: take one task from evenly spaced source chunks first, then
         // fill remaining slots in stable chunk/task order. This makes the lossy reduction
         // deterministic while preserving coverage of both the beginning and end of a long meeting.
         var sanitizedByChunk = mappedTasks
-            .Select(chunk => chunk.Tasks.ToList())
+            .Select(chunk => chunk.Tasks
+                .Select(candidate => candidate with
+                {
+                    Span = FindUniqueAbsoluteSpan(canonicalTranscript, candidate.Task.EvidenceQuote, 0)
+                })
+                .ToList())
             .ToList();
         var reduced = new List<CaptureTriageTaskV2>();
         var reducedSpans = new List<(int Start, int End)?>();

--- a/backend/tests/Taskdeck.Application.Tests/Services/LlmCaptureTriageExtractorTests.cs
+++ b/backend/tests/Taskdeck.Application.Tests/Services/LlmCaptureTriageExtractorTests.cs
@@ -269,6 +269,31 @@ public class LlmCaptureTriageExtractorTests
     }
 
     [Fact]
+    public async Task ExtractAsync_ShouldNotLinkAQuoteRepeatedAcrossNonOverlappingMapChunks()
+    {
+        _settings.MaxInputTokensPerChunk = 24;
+        _settings.ChunkOverlapTokens = 0;
+        const string quote = "same evidence";
+        var transcript = $"Alice: {quote}\n\nBob: {quote}";
+        var chunks = TranscriptTriageChunker.Chunk(
+            transcript,
+            _settings.MaxInputTokensPerChunk,
+            _settings.ChunkOverlapTokens);
+        chunks.Should().HaveCount(2);
+        chunks.Should().OnlyContain(chunk => chunk.Text.Contains(quote, StringComparison.Ordinal));
+        SetupCompletionForRequest(request => request.Messages.Single().Content == chunks[0].Text
+            ? V2Completion(("Use evidence", quote))
+            : "{\"tasks\":[]}");
+        var extractor = BuildExtractor();
+
+        var result = await extractor.ExtractAsync(_userId, _boardId, TranscriptPayload(transcript));
+
+        result.Succeeded.Should().BeTrue();
+        result.Output!.Tasks.Should().ContainSingle().Which.Title.Should().Be("Use evidence");
+        result.EvidenceSpans.Should().ContainSingle().Which.Should().BeNull();
+    }
+
+    [Fact]
     public async Task ExtractAsync_ShouldReportProgressBeforeAndAfterEachMapCompletion()
     {
         _settings.MaxInputTokensPerChunk = 64;


### PR DESCRIPTION
## Summary

- re-resolve every mapped evidence quote against the full canonical LF Transcript during final reduction
- keep the proposed task but return null offsets when a second overlapping ordinal occurrence exists anywhere in another chunk
- prove the prior chunk-local false-uniqueness case with two non-overlapping chunks where only one map leg emits the task

Part of #1305

## Stack

Stacked on #1681 (`issue-1305/evidence-spans-api`). Merge #1681 first; do not delete its branch until this child is retargeted and re-proven against `main`.

## Verification

- `dotnet test backend/tests/Taskdeck.Application.Tests/Taskdeck.Application.Tests.csproj -c Release -m:1 --filter 'FullyQualifiedName~LlmCaptureTriageExtractorTests'` — 39/39 passed (writer and coordinator)
- `git diff --check f32bab925cd23fbc69e620cd50e5dae2819d4d23..9650caf36e2fe612c5fafb774047c1e0150fbdc0` — passed
- exact merge-base, DCO, and tracked-clean checks — passed
- fresh exact-diff review — no CRITICAL/HIGH defect

## Boundaries

No provider/schema v2, task/quote output, API, migration, canonical-doc, or Paper UI change. Existing docs already promise global uniqueness, so this makes implementation match the documented contract. A dedicated positive multi-chunk unique-offset/consensus regression remains LOW nonblocking coverage; existing behavior and focused suite stay green.